### PR TITLE
Add intensity control for RGB led

### DIFF
--- a/inc/spark_utilities.h
+++ b/inc/spark_utilities.h
@@ -65,6 +65,7 @@ public:
 	static bool controlled(void);
 	static void control(bool);
 	static void color(int, int, int);
+  static void intensity(uint8_t);
 };
 
 class SparkClass {

--- a/src/spark_utilities.cpp
+++ b/src/spark_utilities.cpp
@@ -44,6 +44,7 @@ int total_bytes_received = 0;
 uint32_t chunkIndex;
 
 extern unsigned int millis();
+extern uint8_t LED_INTENSITY;
 
 // LED_Signaling_Override
 __IO uint8_t LED_Spark_Signal;
@@ -125,9 +126,16 @@ void RGBClass::color(int red, int green, int blue)
 	if (true != _control)
 		return;
 
-	TIM1->CCR2 = (uint16_t)(red   * (TIM1->ARR + 1) / 255);	// Red LED
-	TIM1->CCR3 = (uint16_t)(green * (TIM1->ARR + 1) / 255);	// Green LED
-	TIM1->CCR1 = (uint16_t)(blue  * (TIM1->ARR + 1) / 255);	// Blue LED
+	TIM1->CCR2 = (uint16_t)((red   * LED_INTENSITY * (TIM1->ARR + 1)) >> 16);	// Red LED
+	TIM1->CCR3 = (uint16_t)((green * LED_INTENSITY * (TIM1->ARR + 1)) >> 16);	// Green LED
+	TIM1->CCR1 = (uint16_t)((blue  * LED_INTENSITY * (TIM1->ARR + 1)) >> 16);	// Blue LED
+#endif
+}
+
+void RGBClass::intensity(uint8_t intensity)
+{
+#if !defined (RGB_NOTIFICATIONS_ON)
+  LED_SetIntensity(intensity);
 #endif
 }
 


### PR DESCRIPTION
Please consider the following patch which adds intensity control for the RGB led. The default intensity is set at 1/4 off the peak power and can be modified by the user using either LED_SetIntensity() or RGB.intensity(). Values are set from 0 (off) to 255 (max). Intensity is taken into account for the LED_Fade / breathing LED.

To handle the color resolution during different levels of fade, the dynamic range of TIM1 has been increased 100x from 0-100 to 0-10000. The TIM1 interrupt remains at 100Hz.

These changes have been tested on hardware and look Ok to me. If you pull mattande/core-firmware:rgb_intensity (mattande/core-firmware@159ba033665d7e7a334949d8e6ad84f4d71fb121), application.cpp implements a short demo/test application which cycles through several user override color and fade at different intensity settings.

Note that changes in both core-firmware and core-common-lib are required for this change.
