### PR TITLE
Provide an acceptable implementation for __cxa_pure_virtual()

### DIFF
--- a/src/newlib_stubs.cpp
+++ b/src/newlib_stubs.cpp
@@ -142,4 +142,7 @@ int _getpid(void)
 	return 1;
 }
 
+/* Default implementation for call made to pure virtual function. */
+void __cxa_pure_virtual() { while (1); }
+
 } /* extern "C" */


### PR DESCRIPTION
Fix for issue reported in the forum related to pure virtual methods:
https://community.sparkdevices.com/t/compiler-linker-fail-virtual-destructors/1320/2.

Without a default implementation of __cxa_pure_virtual, code is pulled from libstdc++ which exceeds the size of available flash.

This change implements a default handler for __cxa_pure_virtual that waits in an infinite loop, similar to that of an unimplemented interrupt.

Tested with the test case from forum post and resolves the problem.
