### PR TITLE
Allow 64-char long passwords for wifi credentials setup via USB.

### DIFF
--- a/inc/wifi_credentials_reader.h
+++ b/inc/wifi_credentials_reader.h
@@ -39,7 +39,7 @@ class WiFiCredentialsReader
     USBSerial serial;
     ConnectCallback connect_callback;
     char ssid[33];
-    char password[33];
+    char password[65];
     char security_type_string[2];
 
     void print(const char *s);

--- a/src/wifi_credentials_reader.cpp
+++ b/src/wifi_credentials_reader.cpp
@@ -39,7 +39,7 @@ void WiFiCredentialsReader::read(void)
     if ('w' == c)
     {
       memset(ssid, 0, 33);
-      memset(password, 0, 33);
+      memset(password, 0, 65);
       memset(security_type_string, 0, 2);
 
       print("SSID: ");
@@ -59,7 +59,7 @@ void WiFiCredentialsReader::read(void)
       unsigned long security_type = security_type_string[0] - '0';
       if (0 < security_type) {
         print("Password: ");
-        read_line(password, 32);
+        read_line(password, 64);
       }
 
       print("Thanks! Wait about 7 seconds while I save those credentials...\r\n\r\n");


### PR DESCRIPTION
When the using the App-based setup (CC3000 Smart Config), WiFi passwords cannot be longer than 32 chars. This is a limitation of CC3000.
This limitation of CC3000 does not apply to API based setup (only SSID name is limited to 32 chars), but was artificially imposed in the current credential reader implementation.
This patch enables to setup Spark core on networks with long passwords, by using USB. Max length of password is set to 64 chars (instead of previously 32).
Tested with success on my home network where password length is 63.
