### PR TITLE
Fix itoa() for other than negative numbers

### DIFF
--- a/src/spark_wiring_string.cpp
+++ b/src/spark_wiring_string.cpp
@@ -135,8 +135,10 @@ char* itoa(int a, char* buffer, unsigned char radix){
 	if(a<0){
 		*buffer = '-';
 		a = -a;
+		ultoa(a, buffer + 1, radix);
+	}else{
+		ultoa(a, buffer, radix);
 	}
-	ultoa(a, buffer + 1, radix);
 	return buffer;
 }
 


### PR DESCRIPTION
Previously it skipped one character in buffer even if there was no minus sign added.
