### PR TITLE
override SS pin and reduce bus glitches

### DIFF
--- a/inc/spark_wiring_spi.h
+++ b/inc/spark_wiring_spi.h
@@ -54,6 +54,7 @@ private:
 
 public:
 	static void begin();
+	static void begin(uint16_t);
 	static void end();
 
 	static void setBitOrder(uint8_t);

--- a/src/spark_wiring_spi.cpp
+++ b/src/spark_wiring_spi.cpp
@@ -35,14 +35,23 @@ bool SPIClass::SPI_Clock_Divider_Set = false;
 bool SPIClass::SPI_Enabled = false;
 
 void SPIClass::begin() {
+	begin(SS);
+}
+
+void SPIClass::begin(uint16_t ss_pin) {
+	if (ss_pin >= TOTAL_PINS )
+	{
+		return;
+	}
+
 	RCC_APB2PeriphClockCmd(RCC_APB2Periph_SPI1, ENABLE);
 
 	pinMode(SCK, AF_OUTPUT_PUSHPULL);
 	pinMode(MOSI, AF_OUTPUT_PUSHPULL);
 	pinMode(MISO, INPUT);
 
-	pinMode(SS, OUTPUT);
-	digitalWrite(SS, HIGH);
+	pinMode(ss_pin, OUTPUT);
+	digitalWrite(ss_pin, HIGH);
 
 	/* SPI configuration */
 	SPI_InitStructure.SPI_Direction = SPI_Direction_2Lines_FullDuplex;
@@ -84,11 +93,6 @@ void SPIClass::end() {
 
 void SPIClass::setBitOrder(uint8_t bitOrder)
 {
-	if(SPI_Enabled != false)
-	{
-		SPI_Cmd(SPI1, DISABLE);
-	}
-
 	if(bitOrder == LSBFIRST)
 	{
 		SPI_InitStructure.SPI_FirstBit = SPI_FirstBit_LSB;
@@ -99,11 +103,6 @@ void SPIClass::setBitOrder(uint8_t bitOrder)
 	}
 
 	SPI_Init(SPI1, &SPI_InitStructure);
-
-	if(SPI_Enabled != false)
-	{
-		SPI_Cmd(SPI1, ENABLE);
-	}
 
 	SPI_Bit_Order_Set = true;
 }
@@ -150,19 +149,9 @@ void SPIClass::setDataMode(uint8_t mode)
 
 void SPIClass::setClockDivider(uint8_t rate)
 {
-	if(SPI_Enabled != false)
-	{
-		SPI_Cmd(SPI1, DISABLE);
-	}
-
 	SPI_InitStructure.SPI_BaudRatePrescaler = rate;
 
 	SPI_Init(SPI1, &SPI_InitStructure);
-
-	if(SPI_Enabled != false)
-	{
-		SPI_Cmd(SPI1, ENABLE);
-	}
 
 	SPI_Clock_Divider_Set = true;
 }


### PR DESCRIPTION
It's very easy to use your own pin without this fix, but the code will always set A2 to an OUTPUT and set it HIGH even if you don't want it to.  Added a constructor to SPI Class to allow for overriding the SS pin.  If not defined, code will use A2 as usual.  If defined, code will use new pin.

Also found that the bus was glitching when changing `SPI.setClockDivider(); SPI.setBitOrder(); or  SPI.setDataMode();` after SPI has been enabled.  Simply removing the disabling/enabling of the SPE bit during `SPI.setClockDivider();` and `SPI.setBitOrder();` allows them to be changed on the fly without a glitch.  Due to the nature of how `SPI.setDataMode();` changes the way the bus works, it cannot be changed without disabling the SPE bit first (without consequences).

Here is some test code that iterates through the different modes.  Note only the first 4 tests do not glitch the bus, while the remaining ones involving DataMode do still glitch the bus.  This is unavoidable.

``` cpp
#include <application.h>

bool s = true;
uint8_t test = 1;

void setup() {
  SPI.setClockDivider(SPI_CLOCK_DIV16);
  SPI.setBitOrder(MSBFIRST);
  SPI.setDataMode(SPI_MODE0);
  SPI.begin(A0); // A2 is not affected anymore
  pinMode(D7,OUTPUT);
}

void loop() {
  if(s) {
    switch(test) {
    case 1:
      SPI.setClockDivider(SPI_CLOCK_DIV16); // #2 fixed, #4 broke
      break;
    case 3:
      SPI.setBitOrder(MSBFIRST); // #6 fixed, #8 broke
      break;
    case 5:
      SPI.setDataMode(SPI_MODE0); // #11 unavoidable glitch
      // the worst glitch is when you set MODE0 over and over, because it pulses the SCLK
      break;
    case 7:
      SPI.setDataMode(SPI_MODE1); // #10 unavoidable glitch
      break;
    case 9:
      SPI.setDataMode(SPI_MODE2); // unavoidable glitch
      break;
    case 11:
      SPI.setDataMode(SPI_MODE3); // unavoidable glitch
      break;
    case 13:
      SPI.setDataMode(SPI_MODE0); // cycle MODE0, 1, 2, 3 in sequence
      break;
    case 15:
      SPI.setDataMode(SPI_MODE2); // ...
      break;
    }
  }
  else {
    switch(test) {
    case 2:
      SPI.setClockDivider(SPI_CLOCK_DIV8); // #3 fixed, #5 broke
      break;
    case 4:
      SPI.setBitOrder(LSBFIRST); // #7 fixed, #9 broke
      break;
    case 6:
      SPI.setDataMode(SPI_MODE0); // #11 unavoidable glitch
      // The worst glitch is when you set MODE0 over and over, because it pulses the SCLK
      break;
    case 8:
      SPI.setDataMode(SPI_MODE1); // #10 unavoidable glitch
      break;
    case 10:
      SPI.setDataMode(SPI_MODE2); // unavoidable glitch
      break;
    case 12:
      SPI.setDataMode(SPI_MODE3); // unavoidable glitch
      break;
    case 14:
      SPI.setDataMode(SPI_MODE1); // ...
      break;
    case 16:
      SPI.setDataMode(SPI_MODE3); // ...
      break;
    }
  }

  digitalWrite(A0, LOW);
  SPI.transfer(0xCC);
  digitalWrite(A0, HIGH);

  digitalWrite(D7,s);
  s = !s;
  test++;
  if(test > 16) test = 1;
  delay(1000);
}
```
# 's in the comments refer to the number of some scope plots found here: http://d.pr/f/GHHI

Signed the CLA form already ;-)
