### PR TITLE
Improvement to ADC_SampleTime 1.5 to 41.5 cycles

### DIFF
--- a/inc/spark_wiring.h
+++ b/inc/spark_wiring.h
@@ -117,7 +117,7 @@
 #define SDA  0
 #define SCL  1
 
-#define ADC_SAMPLING_TIME ADC_SampleTime_1Cycles5 //ADC_SampleTime_239Cycles5
+#define ADC_SAMPLING_TIME ADC_SampleTime_41Cycles5 // ~8.5us conversion time (37.2k max input impedance)
 #define TIM_PWM_FREQ 500 //500Hz
 
 #define LSBFIRST 0


### PR DESCRIPTION
After doing some testing it appears this will improve the analog to digital converter accuracy without increasing the conversion time by much (5us to 8.5us ... measured with micros() in code).  Effective max. input impedance will go from 600 ohms to 37.2k ohms, which will allow for a much broader range of sensors to be sampled by the ADC.  Please see more testing and information here: https://community.spark.io/t/odd-analog-readings-part-2/2718 along with recommendations to further increase ADC accuracy.  :smile: 
