### PR TITLE
Use common-lib 1 ms tick as timer source. System1MsTick() is called off

### DIFF
--- a/inc/spark_wiring.h
+++ b/inc/spark_wiring.h
@@ -160,7 +160,7 @@ void analogWrite(uint16_t pin, uint8_t value);
 /*
 * Timing
 */
-unsigned long millis(void);
+system_tick_t millis(void);
 unsigned long micros(void);
 void delay(unsigned long ms);
 void delayMicroseconds(unsigned int us);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,7 +42,6 @@ extern "C" {
 /* Private macro -------------------------------------------------------------*/
 
 /* Private variables ---------------------------------------------------------*/
-volatile uint32_t TimingMillis;
 volatile uint32_t TimingCloudSocketTimeout;
 volatile uint32_t TimingFlashUpdateTimeout;
 
@@ -188,7 +187,6 @@ int main(void)
  *******************************************************************************/
 void Timing_Decrement(void)
 {
-	TimingMillis++;
 
 	if (TimingDelay != 0x00)
 	{

--- a/src/spark_utilities.cpp
+++ b/src/spark_utilities.cpp
@@ -36,7 +36,7 @@ sockaddr tSocketAddr;
 
 //char digits[] = "0123456789";
 
-extern unsigned int millis();
+system_tick_t millis();
 extern uint8_t LED_RGB_BRIGHTNESS;
 
 // LED_Signaling_Override

--- a/src/spark_wiring.cpp
+++ b/src/spark_wiring.cpp
@@ -490,9 +490,9 @@ void analogWrite(uint16_t pin, uint8_t value)
  * 		  For now, let's not worry about what happens when this overflows (which should happen after 49 days).
  * 		  At some point we'll have to figure that out, though.
  */
-unsigned long millis(void)
+system_tick_t millis(void)
 {
-	return TimingMillis;
+	return GetSystem1MsTick();
 }
 
 /*

--- a/src/stm32_it.cpp
+++ b/src/stm32_it.cpp
@@ -169,6 +169,9 @@ void PendSV_Handler(void)
  *******************************************************************************/
 void SysTick_Handler(void)
 {
+	if (System1MsTick) {
+		System1MsTick();
+	}
 	Timing_Decrement();
 }
 


### PR DESCRIPTION
the void SysTick_Handler(void) to update the systems 1 ms tick.
Define millis() as returning system_tick_t and millis() just calls the 
GetSystem1MsTick(); Removed old TimingMillis
