### PR TITLE
Provide an acceptable implementation of __cxa_guard_acquire and friends

### DIFF
--- a/src/newlib_stubs.cpp
+++ b/src/newlib_stubs.cpp
@@ -270,4 +270,12 @@ int _read(int file, char *ptr, int len) {
 /* Default implementation for call made to pure virtual function. */
 void __cxa_pure_virtual() { while (1); }
 
+/* Provide default implemenation for __cxa_guard_acquire() and
+ * __cxa_guard_release(). Note: these must be revisited if a multitasking
+ * OS is ported to this platform. */
+__extension__ typedef int __guard __attribute__((mode (__DI__)));
+int __cxa_guard_acquire(__guard *g) {return !*(char *)(g);};
+void __cxa_guard_release (__guard *g) {*(char *)g = 1;};
+void __cxa_guard_abort (__guard *) {};
+
 } /* extern "C" */


### PR DESCRIPTION
The following code fails to compile with linker errors due to default (libstdc++) implementation of __cxa_guard_acquire(), __cxa_guard_release() which pull in large link dependencies. The attached patch fixes this by providing acceptable defaults. Note that if a multitasking OS is implemented for the spark-core, these implementations will need to be revisited.

Compiles OK:

```
class A {
    uint8_t a;
public:
    A() : a(0) {}
    void beA() {++a;}
};

static A a;

void setup() {
    a.beA();
}

void loop() {
}
```

While 

```
class A {
    uint8_t a;
public:
    A() : a(0) {}
    void beA() {++a;}
};

void setup() {
    static A a;
    a.beA();
}

void loop() {
}
```

fails with:

```
/opt/gcc_arm/bin/../lib/gcc/arm-none-eabi/4.7.4/../../../../arm-none-eabi/bin/ld: 68c052164109e4a9717a31d585718ed28c0a724531c5b4b69b8f62aced7c.elf section `.text' will not fit in region `FLASH'
```
