### PR TITLE
BUGFIX: Wrog data returned becuase read(buff,n) was not using  offset in buffer

### DIFF
--- a/src/spark_wiring_tcpclient.cpp
+++ b/src/spark_wiring_tcpclient.cpp
@@ -126,7 +126,7 @@ int TCPClient::available()
     int avail = 0;
 
     // At EOB => Flush it
-    if (_total && _offset == _total)
+    if (_total && (_offset == _total))
     {
       flush();
     }
@@ -176,7 +176,7 @@ int TCPClient::read(uint8_t *buffer, size_t size)
         if (bufferCount() || available())
         {
           read = (size > (size_t) bufferCount()) ? bufferCount() : size;
-          memcpy(buffer, _buffer, read);
+          memcpy(buffer, &_buffer[_offset], read);
           _offset += read;
         }
         return read;

--- a/src/spark_wiring_udp.cpp
+++ b/src/spark_wiring_udp.cpp
@@ -199,7 +199,7 @@ int UDP::read(unsigned char* buffer, size_t len)
         if (available())
 	{
           read = (len > (size_t) available()) ? available() : len;
-          memcpy(buffer, _buffer, read);
+          memcpy(buffer, &_buffer[_offset], read);
           _offset += read;
 	}
 	return read;


### PR DESCRIPTION
BUGFIX: read(buff,n) was not using offset in buffer, hence interleaving read() with read(buf,n) calls would return the wrong data!
