### PR TITLE
Fixes 3 cases

### DIFF
--- a/src/spark_wiring_usartserial.cpp
+++ b/src/spark_wiring_usartserial.cpp
@@ -248,12 +248,9 @@ void Wiring_USART2_Interrupt_Handler(void)
 		}
 		else
 		{
-		        // Keep the Transmitter full
-		        do {
-		            // There is more data in the output buffer. Send the next byte
-			USART_SendData(USART2,  tx_buffer.buffer[tx_buffer.tail++]);
-                        tx_buffer.tail %= SERIAL_BUFFER_SIZE;
-		        } while(tx_buffer.head != tx_buffer.tail && USART_GetFlagStatus(USART2, USART_FLAG_TXE));
+	            // There is more data in the output buffer. Send the next byte
+		    USART_SendData(USART2,  tx_buffer.buffer[tx_buffer.tail++]);
+                    tx_buffer.tail %= SERIAL_BUFFER_SIZE;
 		}
 	}
 }


### PR DESCRIPTION
1) Fast baud rate keep tx and tx shift full.
2) Fast baud ensure the ints are on if there is data in the queue
3) If called from a higher priority interrupt manualy empty the queue.
