### PR TITLE
Prevent i2c reads from hanging forever on failures by adding a timeout

### DIFF
--- a/src/spark_wiring_i2c.cpp
+++ b/src/spark_wiring_i2c.cpp
@@ -183,7 +183,7 @@ uint8_t TwoWire::requestFrom(uint8_t address, uint8_t quantity, uint8_t sendStop
 			/* Decrement the read bytes counter */
 			numByteToRead--;
 
-			/* Reset our last read for timeout */
+			/* Reset timeout to our last read */
 			_millis = millis();
 		}
 	}


### PR DESCRIPTION
I've had a lot of issues with my mag3110 hanging forever during i2c reads.  This patch makes the read timeout if a read takes too long.  I'm a little concerned that I'm having so many issues with i2c reads but I think this is good protection anyhow.  I'm not 100% sure if re-using the EVENT_TIMEOUT is the right amount of time to wait.
