### PR TITLE
Fix 128

### DIFF
--- a/src/spark_wlan.cpp
+++ b/src/spark_wlan.cpp
@@ -418,6 +418,10 @@ void SPARK_WLAN_Setup(void (*presence_announcement_callback)(void))
 		/* Delete all previously stored wlan profiles */
 		wlan_ioctl_del_profile(255);
 
+		/* EEPROM because Spark file IO on old TI Driver was corrupting nvmem
+		 * Let's Remove entry for Spark File in CC3000  */
+                nvmem_create_entry(NVMEM_SPARK_FILE_ID, 0);
+
                 /* Create new entry for Spark File in CC3000 EEPROM */
                 nvmem_create_entry(NVMEM_SPARK_FILE_ID, NVMEM_SPARK_FILE_SIZE);
 


### PR DESCRIPTION
The Spark Cores that have seen a lot of NVMEM writes get corrupted (old TI) and USER FILE #14  could not be written. Added nvmem_create_entry(NVMEM_SPARK_FILE_ID, 0); to release file and recreate it
