### PR TITLE
Fix SPARK_ACCESS_KEY comment

### DIFF
--- a/build/makefile
+++ b/build/makefile
@@ -1,4 +1,3 @@
-
 # Define the compiler/tools prefix
 GCC_PREFIX = arm-none-eabi-
 
@@ -115,7 +114,7 @@ program-dfu: $(TARGET).bin
 	@echo Flashing using dfu:
 	$(DFU) -d 1d50:607f -a 0 -s 0x08005000:leave -D $<
 
-# Program the core using the cloud. SPARK_CORE_ID and SPARK_ACCESS_KEY must
+# Program the core using the cloud. SPARK_CORE_ID and SPARK_ACCESS_TOKEN must
 # have been defined in the environment before invoking 'make program-cloud'
 program-cloud: $(TARGET).bin
 	@echo Flashing using cloud API, CORE_ID=$(SPARK_CORE_ID):


### PR DESCRIPTION
In the makefile `core-framework/build/makefile` there is a comment just before the `program-cloud:` recipe:

```
# Program the core using the cloud. SPARK_CORE_ID and SPARK_ACCESS_KEY must
# have been defined in the environment before invoking 'make program-cloud'
program-cloud: $(TARGET).bin
```

As it turns out the text should say SPARK_ACCESS_TOKEN the clue being:

```
# URL to invoke cloud flashing
CLOUD_FLASH_URL = https://api.spark.io/v1/devices/$(SPARK_CORE_ID)\?access_token=$(SPARK_ACCESS_TOKEN)
```
