### PR TITLE
Changed flush() to flush all bytes in buffer

### DIFF
--- a/src/spark_wiring_usartserial.cpp
+++ b/src/spark_wiring_usartserial.cpp
@@ -183,7 +183,9 @@ int USARTSerial::read(void)
 void USARTSerial::flush()
 {
 	// Loop until USART DR register is empty
-	while (transmitting && (USART_GetFlagStatus(USART2, USART_FLAG_TXE) == RESET));
+	while ( _tx_buffer->head != _tx_buffer->tail );
+	// Loop until last frame transmission complete
+	while (transmitting && (USART_GetFlagStatus(USART2, USART_FLAG_TC) == RESET));
 	transmitting = false;
 }
 


### PR DESCRIPTION
Flush was changed to wait until the ring buffer is empty and to wait for the final frame to have been transmitted before being complete.

or:

flush()
    wait for ring buffer to empty;
    wait for final frame to be transmitted;
    unset transmitting;
