### PR TITLE
Support Spark.publish() with String objects for eventName and data

### DIFF
--- a/inc/spark_utilities.h
+++ b/inc/spark_utilities.h
@@ -84,6 +84,10 @@ public:
 	static void publish(const char *eventName, const char *eventData);
 	static void publish(const char *eventName, const char *eventData, int ttl);
 	static void publish(const char *eventName, const char *eventData, int ttl, Spark_Event_TypeDef eventType);
+	static void publish(String eventName);
+	static void publish(String eventName, String eventData);
+	static void publish(String eventName, String eventData, int ttl);
+	static void publish(String eventName, String eventData, int ttl, Spark_Event_TypeDef eventType);
 	static void sleep(Spark_Sleep_TypeDef sleepMode, long seconds);
 	static void sleep(long seconds);
 	static bool connected(void);

--- a/src/spark_utilities.cpp
+++ b/src/spark_utilities.cpp
@@ -200,6 +200,26 @@ void SparkClass::publish(const char *eventName, const char *eventData, int ttl, 
   spark_protocol.send_event(eventName, eventData, ttl, (eventType ? EventType::PRIVATE : EventType::PUBLIC));
 }
 
+void SparkClass::publish(String eventName)
+{
+  publish(eventName.c_str());
+}
+
+void SparkClass::publish(String eventName, String eventData)
+{
+  publish(eventName.c_str(), eventData.c_str());
+}
+
+void SparkClass::publish(String eventName, String eventData, int ttl)
+{
+  publish(eventName.c_str(), eventData.c_str(), ttl);
+}
+
+void SparkClass::publish(String eventName, String eventData, int ttl, Spark_Event_TypeDef eventType)
+{
+  publish(eventName.c_str(), eventData.c_str(), ttl, eventType);
+}
+
 void SparkClass::sleep(Spark_Sleep_TypeDef sleepMode, long seconds)
 {
 #if defined (SPARK_RTC_ENABLE)


### PR DESCRIPTION
With this feature, Arduino String object users will not have to call `.c_str()` unless they specifically want to pass one `char *` and one `String` for the event name and data.
