### PR TITLE
Added NetworkClass::RSSI

### DIFF
--- a/inc/spark_wiring_network.h
+++ b/inc/spark_wiring_network.h
@@ -2,8 +2,8 @@
  ******************************************************************************
  * @file    spark_wiring_network.h
  * @author  Satish Nair, Timothy Brown
- * @version V1.0.1
- * @date    15-Mar-2014
+ * @version V1.0.3
+ * @date    18-Mar-2014
  * @brief   Header for spark_wiring_network.cpp module
  ******************************************************************************
   Copyright (c) 2014 Spark Labs, Inc.  All rights reserved.
@@ -44,7 +44,7 @@ public:
 	friend class TCPServer;
 
 private:
-	uint32_t _functionTimeout;
+	uint32_t _functionStart;
 	uint8_t _loopCount;
 	int8_t _returnValue;
 };


### PR DESCRIPTION
This function gives access to Relative Signal Strength Indicator (RSSI)
data from the CC3000’s scan table, which is refreshed every few
minutes. It returns signal strength in the range of -127 to 0 dB. Error Codes: 1 [CC3000 Error]; 2 [Timeout/No Data].
