### PR TITLE
Updated common and communication libs - make OTA Update more reliable (should help #124)

### DIFF
--- a/src/spark_utilities.cpp
+++ b/src/spark_utilities.cpp
@@ -393,7 +393,7 @@ void Spark_Finish_Firmware_Update(void)
   FLASH_End();
 }
 
-bool Spark_Save_Firmware_Chunk(unsigned char *buf, long unsigned int buflen)
+uint16_t Spark_Save_Firmware_Chunk(unsigned char *buf, long unsigned int buflen)
 {
   TimingFlashUpdateTimeout = 0;
   return FLASH_Update(buf, buflen);


### PR DESCRIPTION
Use with latest core-common-lib(branch: bug-fixes) and core-communication-lib(branch: bug-fixes) 
return the FLASH_Update() status within Spark_Save_Firmware_Chunk()
