### PR TITLE
Add Support for Network.ping()

### DIFF
--- a/inc/spark_wiring_network.h
+++ b/inc/spark_wiring_network.h
@@ -39,6 +39,8 @@ public:
 	IPAddress gatewayIP();
 	char* SSID();
 	int8_t RSSI();
+	uint32_t ping(IPAddress remoteIP);
+	uint32_t ping(IPAddress remoteIP, uint8_t nTries);
 
 	friend class TCPClient;
 	friend class TCPServer;

--- a/inc/spark_wlan.h
+++ b/inc/spark_wlan.h
@@ -70,6 +70,8 @@ extern int Spark_Process_API_Response(void);
 extern volatile uint32_t TimingFlashUpdateTimeout;
 
 extern tNetappIpconfigRetArgs ip_config;
+extern netapp_pingreport_args_t ping_report;
+extern int ping_report_num;
 
 extern volatile uint8_t WLAN_DHCP;
 extern volatile uint8_t SPARK_WLAN_SETUP;

--- a/src/spark_wiring_network.cpp
+++ b/src/spark_wiring_network.cpp
@@ -113,4 +113,28 @@ int8_t NetworkClass::RSSI()
  the same way.
  *****************************************************************************/
 
+uint32_t NetworkClass::ping(IPAddress remoteIP)
+{
+  return ping(remoteIP, 5);
+}
+
+uint32_t NetworkClass::ping(IPAddress remoteIP, uint8_t nTries)
+{
+  uint32_t result = 0;
+  uint32_t pingIPAddr = remoteIP[3] << 24 | remoteIP[2] << 16 | remoteIP[1] << 8 | remoteIP[0];
+  unsigned long pingSize = 32UL;
+  unsigned long pingTimeout = 500UL; // in milliseconds
+
+  memset(&ping_report,0,sizeof(netapp_pingreport_args_t));
+  ping_report_num = 0;	 
+
+  long psend = netapp_ping_send(&pingIPAddr, (unsigned long)nTries, pingSize, pingTimeout);
+  unsigned long lastTime = millis();
+  while( ping_report_num==0 && (millis() < lastTime+2*nTries*pingTimeout)) {}
+  if (psend==0L && ping_report_num) {
+    result = ping_report.packets_received;
+  }
+  return result;
+}
+
 NetworkClass Network;

--- a/src/spark_wlan.cpp
+++ b/src/spark_wlan.cpp
@@ -53,6 +53,8 @@ static uint32_t lastEvent = 0;
 #define ON_EVENT_DELTA()
 #endif
 tNetappIpconfigRetArgs ip_config;
+netapp_pingreport_args_t ping_report;
+int ping_report_num;
 
 volatile uint8_t WLAN_MANUAL_CONNECT = 0; //For Manual connection, set this to 1
 volatile uint8_t WLAN_DELETE_PROFILES;
@@ -266,7 +268,7 @@ void Start_Smart_Config(void)
 	LED_On(LED_RGB);
 
 	/* Mask out all non-required events */
-	wlan_set_event_mask(HCI_EVNT_WLAN_KEEPALIVE | HCI_EVNT_WLAN_UNSOL_INIT | HCI_EVNT_WLAN_ASYNC_PING_REPORT);
+	wlan_set_event_mask(HCI_EVNT_WLAN_KEEPALIVE | HCI_EVNT_WLAN_UNSOL_INIT);
 
 	Set_NetApp_Timeout();
 
@@ -341,6 +343,11 @@ void WLAN_Async_Callback(long lEventType, char *data, unsigned char length)
 			WLAN_CAN_SHUTDOWN = 1;
 			break;
 
+                case HCI_EVNT_WLAN_ASYNC_PING_REPORT:
+		        memcpy(&ping_report,data,length);
+		        ping_report_num++;
+			break;
+
 		case HCI_EVNT_BSD_TCP_CLOSE_WAIT:
                       long socket = -1;
 		      STREAM_TO_UINT32(data,0,socket);
@@ -403,7 +410,7 @@ void SPARK_WLAN_Setup(void (*presence_announcement_callback)(void))
 	SPARK_LED_FADE = 0;
 
 	/* Mask out all non-required events from CC3000 */
-	wlan_set_event_mask(HCI_EVNT_WLAN_KEEPALIVE | HCI_EVNT_WLAN_UNSOL_INIT | HCI_EVNT_WLAN_ASYNC_PING_REPORT);
+	wlan_set_event_mask(HCI_EVNT_WLAN_KEEPALIVE | HCI_EVNT_WLAN_UNSOL_INIT);
 
 	if(NVMEM_SPARK_Reset_SysFlag == 0x0001 || nvmem_read(NVMEM_SPARK_FILE_ID, NVMEM_SPARK_FILE_SIZE, 0, NVMEM_Spark_File_Data) != NVMEM_SPARK_FILE_SIZE)
 	{


### PR DESCRIPTION
We might want to have some discussion about the while loop that polls for either a report struct or timeout.  If the user asks for 5000 pings, especially for a host that is unreachable, the Spark loop could timeout but I am not sure we want to call the Spark loop here.

Here's the test program:
# include "application.h"

IPAddress google(74,125,225,52);
IPAddress yahoo(98,139,180,149);
IPAddress spark(62,116,130,8);

void setup() {
    Serial.begin(9600);
    delay(2000);
}

void loop() {
  Serial.print("G: ");
  Serial.println(Network.ping(google));
  Serial.print(" Y: ");
  Serial.println(Network.ping(yahoo));
  Serial.print(" S: ");
  Serial.println(Network.ping(spark));  
  Serial.print(" Fail: ");
  Serial.println(Network.ping(IPAddress(10,0,0,200)));    // picked to fail
  delay(10000);
}
