### PR TITLE
Do not enter smart config mode when wlan profiles fail to connect : #144

### DIFF
--- a/src/spark_wlan.cpp
+++ b/src/spark_wlan.cpp
@@ -294,9 +294,9 @@ void WLAN_Async_Callback(long lEventType, char *data, unsigned char length)
 			break;
 
 		case HCI_EVNT_WLAN_UNSOL_DISCONNECT:
-			//What if AP is Off or Out Of Range, do we still need to ARM_WLAN_WD?
-			//ARM_WLAN_WD(DISCONNECT_TO_RECONNECT);
-			CLR_WLAN_WD();
+			if (WLAN_CONNECTED) {
+				ARM_WLAN_WD(DISCONNECT_TO_RECONNECT);
+			}
 			LED_SetRGBColor(RGB_COLOR_GREEN);
 			LED_On(LED_RGB);
 			WLAN_CONNECTED = 0;


### PR DESCRIPTION
With this update, smart config will be triggered only when there are no profiles stored during bootup or by pressing the mode button for > 3sec. Users can store upto 7 profiles. CC3000 will cycle through available profiles and attempt reconnection.
