### PR TITLE
Reduce size of TCPClient buffer

### DIFF
--- a/inc/spark_wiring_tcpclient.h
+++ b/inc/spark_wiring_tcpclient.h
@@ -29,7 +29,7 @@
 #include "spark_wiring_client.h"
 #include "spark_wiring.h"
 
-#define TCPCLIENT_BUF_MAX_SIZE	512
+#define TCPCLIENT_BUF_MAX_SIZE	128
 
 class TCPClient : public Client {
 


### PR DESCRIPTION
Since TCPServer has an internal TCPClient object and user code typically also has a statically allocated TCPClient, this reduces RAM usage for a single TCPServer by 768 bytes.
