### PR TITLE
input and output enum was reversed, fixes #282

### DIFF
--- a/inc/spark_wiring.h
+++ b/inc/spark_wiring.h
@@ -134,8 +134,8 @@
 typedef unsigned char byte;
 
 typedef enum PinMode {
-  OUTPUT,
   INPUT,
+  OUTPUT,
   INPUT_PULLUP,
   INPUT_PULLDOWN,
   AF_OUTPUT_PUSHPULL,	//Used internally for Alternate Function Output PushPull(TIM, UART, SPI etc)


### PR DESCRIPTION
In arduino world the enum for input is canonically 0, however spark swapped them and made theirs 1.

Over the years developers have been somewhat lazy and might just use pinmode(pin,0) and mean input . Firmata specifically does this.

Seems easy enough to match that behavior before Spark has too much legacy code.
