### PR TITLE
fix for #261 - setting brightness doesn't change the LED brightness immediately

### DIFF
--- a/inc/spark_utilities.h
+++ b/inc/spark_utilities.h
@@ -98,7 +98,7 @@ public:
 	static bool controlled(void);
 	static void control(bool);
 	static void color(int, int, int);
-  static void brightness(uint8_t);
+        static void brightness(uint8_t, bool update=true);
 };
 
 class SparkClass {

--- a/src/spark_utilities.cpp
+++ b/src/spark_utilities.cpp
@@ -183,13 +183,12 @@ void RGBClass::color(int red, int green, int blue)
 #endif
 }
 
-void RGBClass::brightness(uint8_t brightness)
+void RGBClass::brightness(uint8_t brightness, bool update)
 {
-#if !defined (RGB_NOTIFICATIONS_ON)
-	if (true != _control)
-		return;
-
+#if !defined (RGB_NOTIFICATIONS_ON)	
 	LED_SetBrightness(brightness);
+    if (_control && update)
+        LED_On(LED_RGB);
 #endif
 }
 


### PR DESCRIPTION
The code now changes the brightness immediately by default. If there are cases when this isn't desirable, an extra optional flag "update" has been added which can be set to `false` to postpone the LED update.
