### PR TITLE
call Spark.process() when OTA_FLASH has started, regardless of mode. 

### DIFF
--- a/src/spark_wlan.cpp
+++ b/src/spark_wlan.cpp
@@ -568,7 +568,7 @@ void SPARK_WLAN_Loop(void)
       }
     }
 
-    if(System.mode() != MANUAL)
+    if(SPARK_FLASH_UPDATE || System.mode() != MANUAL)
     {
       Spark.process();
     }


### PR DESCRIPTION
Tested:
- Flashed via usb a modified tinker app with mode MANUAL, and Spark.connect() in setup, Spark.process() in loop, and this fix in place. 
- Loaded the same app into the inline IDE. Successfully performed OTA flash (verifying the fix)
- Attempted to flash again (now that the firmware in the core is build in the cloud without the fix), get the stuck magenta followed by reset few seconds later.
