### PR TITLE
allow branches for both dependent repos to be specified

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 before_install:
   - sudo apt-get update
 install:
-  - cd .. && $TRAVIS_BUILD_DIR/ci/clone_repos.sh $TRAVIS_BRANCH && cd $TRAVIS_BUILD_DIR
+  - cd .. && $TRAVIS_BUILD_DIR/ci/clone_repos.sh $TRAVIS_BRANCH $TRAVIS_BRANCH && cd $TRAVIS_BUILD_DIR
   - npm install -g spark-cli
   - ./ci/install_arm_gcc.sh && ./ci/install_gcc.sh
   - ./ci/create_spark_cli_json.sh

--- a/ci/clone_repos.sh
+++ b/ci/clone_repos.sh
@@ -1,6 +1,7 @@
 #$/bin/bash
 
-# $1 - branch name to clone
+# $1 - branch name to in core-common-lib
+# $2 - branch name to clone in core-communication-lib
 
-git clone --depth 50 --branch=master git://github.com/spark/core-common-lib.git
-git clone --depth 50 --branch=master git://github.com/spark/core-communication-lib.git
+git clone --depth 50 --branch=$1 git://github.com/spark/core-common-lib.git
+git clone --depth 50 --branch=$2 git://github.com/spark/core-communication-lib.git


### PR DESCRIPTION
Branches may not want to build against the same branch name across core-firmware, core-common-lib and core-comms-lib. This change allows each branch to specify in the travis.yml which branches are required.

The default is to use the same branch as the one in core-firmware, but this can be changed per branch.
