### PR TITLE
fixes hard fault when calling smart config with wifi off

### DIFF
--- a/src/spark_wlan.cpp
+++ b/src/spark_wlan.cpp
@@ -186,7 +186,11 @@ void Start_Smart_Config(void)
 	LED_SetRGBColor(RGB_COLOR_BLUE);
 	LED_On(LED_RGB);
 
+	/* If WiFi module is connected, disconnect it */
 	WiFi.disconnect();
+
+	/* If WiFi module is powered off, turn it on */
+	WiFi.on();
 
 	/* Create new entry for AES encryption key */
 	nvmem_create_entry(NVMEM_AES128_KEY_FILEID,16);


### PR DESCRIPTION
In reference to this issue: https://github.com/spark/firmware/issues/310

Simply calling WiFi.on() after WiFi.disconnect() with `Start_Smart_Config()` ensures that calling `WiFi.listen()` (which effectively calls: `Start_Smart_Config()` ) always runs without failing (Hard Fault SOS) under the following test set:

Starting with the following 3 system modes:
SYSTEM_MODE(AUTOMATIC); // default behavior when no system mode is explicitly set
SYSTEM_MODE(MANUAL);
SYSTEM_MODE(SEMI_AUTOMATIC);

After calling:
`Spark.connect();`
`Spark.disconnect();`
`WiFi.connect();`
`WiFi.disconnect();`
`WiFi.on();`
`WiFi.off();`

We finally call:
`WiFi.listen();`

TEST APP

``` cpp
#include "application.h"

/* uncomment one of the following at a time */
//SYSTEM_MODE(AUTOMATIC); // default behavior when no system mode is explicitly set
//SYSTEM_MODE(MANUAL);
//SYSTEM_MODE(SEMI_AUTOMATIC);

void setup() {
  Serial.begin(9600);
}

void loop() {
  if (Serial.available()) {
    int c = Serial.read();
    switch (c) {
      case 'C': Spark.connect(); break;
      case 'c': Spark.disconnect(); break;
      case 'W': WiFi.connect(); break;
      case 'w': WiFi.disconnect(); break;
      case 'O': WiFi.on(); break;
      case 'o': WiFi.off(); break;
      case 'L': WiFi.listen(); break;
    }
  }
}
```
