### PR TITLE
Use I2C Polling mode by default & DMA mode optional via enableDMAMode()

### DIFF
--- a/inc/spark_wiring_i2c.h
+++ b/inc/spark_wiring_i2c.h
@@ -41,6 +41,7 @@ private:
   static I2C_InitTypeDef I2C_InitStructure;
 
   static uint32_t I2C_ClockSpeed;
+  static bool I2C_EnableDMAMode;
   static bool I2C_SetAsSlave;
   static bool I2C_Enabled;
 
@@ -59,6 +60,7 @@ private:
 public:
   TwoWire();
   void setSpeed(uint32_t);
+  void enableDMAMode(bool);
   void stretchClock(bool);
   void begin();
   void begin(uint8_t);


### PR DESCRIPTION
Fixes issue: Wire functionality broken as per V0.3.3 #321
