### PR TITLE
	add in description for device id printout

### DIFF
--- a/wiring/src/wifi_credentials_reader.cpp
+++ b/wiring/src/wifi_credentials_reader.cpp
@@ -27,6 +27,8 @@
 #include "delay_hal.h"
 #include "spark_utilities.h"
 
+using namespace spark;
+
 WiFiCredentialsReader::WiFiCredentialsReader(ConnectCallback connect_callback)
 {
   this->connect_callback = connect_callback;


### PR DESCRIPTION
Seems like this line was took out after the hal branch implementation:

https://github.com/spark/firmware/blob/master/src/wifi_credentials_reader.cpp#L80

Changed to "device" for future hardware and not only core.
