### PR TITLE
fix gcc6 build

### DIFF
--- a/hal/src/stm32/concurrent_hal_impl.h
+++ b/hal/src/stm32/concurrent_hal_impl.h
@@ -49,6 +49,8 @@ int __gthread_cond_timedwait (__gthread_cond_t *cond,
 
 int __gthread_mutex_timedlock (__gthread_mutex_t* mutex, const __gthread_time_t* timeout);
 
+int __gthread_recursive_mutex_timedlock (__gthread_mutex_t* mutex, const __gthread_time_t* timeout);
+
 #ifdef	__cplusplus
 }
 #endif

--- a/hal/src/stm32/concurrent_hal_impl.h
+++ b/hal/src/stm32/concurrent_hal_impl.h
@@ -49,7 +49,7 @@ int __gthread_cond_timedwait (__gthread_cond_t *cond,
 
 int __gthread_mutex_timedlock (__gthread_mutex_t* mutex, const __gthread_time_t* timeout);
 
-int __gthread_recursive_mutex_timedlock (__gthread_mutex_t* mutex, const __gthread_time_t* timeout);
+int __gthread_recursive_mutex_timedlock (__gthread_recursive_mutex_t* mutex, const __gthread_time_t* timeout);
 
 #ifdef	__cplusplus
 }

--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/src/system_stm32f2xx.c
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/src/system_stm32f2xx.c
@@ -391,7 +391,7 @@ static void SetSysClock(void)
     RCC->CFGR |= RCC_CFGR_SW_PLL;
 
     /* Wait till the main PLL is used as system clock source */
-    while ((RCC->CFGR & (uint32_t)RCC_CFGR_SWS ) != RCC_CFGR_SWS_PLL);
+    while ((RCC->CFGR & (uint32_t)RCC_CFGR_SWS ) != RCC_CFGR_SWS_PLL)
     {
     }
   }


### PR DESCRIPTION
**Summary of Commits:**
Fix build with gcc6
 - fix misleading indentation
 - add __gthread_recursive_mutex_timedlock signature to concurrent_hal_impl

**Problem:** 
Firmware does not build with gcc6
* in gcc6 -Werror=misleading-indentation is enabled by default and existing code  failed to build 
fixed
* c++ std library using __gthread_recursive_mutex_timedlock function which is not defined in firmware code

**Solution:** 

* remove redundand semicolon
* added __gthread_recursive_mutex_timedlock signature

---

Doneness:

- [x] Contributor has signed CLA
- [X] Problem and Solution clearly stated
- [ ] Code peer reviewed
- [x] API tests compiled
- [ ] Run unit/integration/application tests on device
- [x] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)