### PR TITLE
Fixes incorrect sbi() and cbi() definitions (Arduino compatibility)

### DIFF
--- a/user/inc/Arduino.h
+++ b/user/inc/Arduino.h
@@ -137,10 +137,10 @@ inline void yield() {
 #endif
 
 #ifndef cbi
-#define cbi(sfr, bit) ((sfr) &= ~_BV(bit))
+#define cbi(sfr, bitmask) ((*(sfr)) &= ~(bitmask))
 #endif
 #ifndef sbi
-#define sbi(sfr, bit) ((sfr) |= _BV(bit))
+#define sbi(sfr, bitmask) ((*(sfr)) |= (bitmask))
 #endif
 
 // XXX

--- a/user/tests/wiring/no_fixture/arduino.cpp
+++ b/user/tests/wiring/no_fixture/arduino.cpp
@@ -1,0 +1,16 @@
+#include "Arduino.h"
+#include "unit-test/unit-test.h"
+
+test(ARDUINO_cbi_sbi_portOutputRegister_digitalPinToBitMask) {
+    pinMode(D7, OUTPUT);
+    auto port = digitalPinToPort(D7);
+    auto pinmask = digitalPinToBitMask(D7);
+    cbi(portOutputRegister(port), pinmask);
+    assertEqual(digitalRead(D7), (int32_t)LOW);
+    sbi(portOutputRegister(port), pinmask);
+    assertEqual(digitalRead(D7), (int32_t)HIGH);
+}
+
+test(ARDUINO_cbi_sbi_portOutputRegister_digitalPinToBitMask_deinit) {
+    pinMode(D7, INPUT);
+}


### PR DESCRIPTION
<details>
  <summary><i>submission notes</i></summary>

```
**Important:** Please sanitize/remove any confidential info like usernames, passwords, org names, product names/ids, access tokens, client ids/secrets, or anything else you don't wish to share.

Please Read and Sign the Contributor License Agreement ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md)).

You may also delete this submission notes header if you'd like. Thank you for contributing!
```
</details>

### Problem

See #1299 

### Solution

Fix `sbi()` and `cbi()` definitions :)

### Steps to Test

- `wiring/no_fixture`: `ARDUINO_cbi_sbi_portOutputRegister_digitalPinToBitMask`

### Example App

N/A

### References

- Close #1299
- [CH7829]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
