### PR TITLE
Add BLE bare HAL APIs

### DIFF
--- a/hal/inc/ble_hal_api.h
+++ b/hal/inc/ble_hal_api.h
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2018 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef BLE_HAL_API_H
+#define BLE_HAL_API_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+/* BLE device address type */
+typedef enum {
+    BLE_ADDR_TYPE_PUBLIC = 0x00, /**< Public (identity) address.*/
+    BLE_ADDR_TYPE_RANDOM_STATIC = 0x01, /**< Random static (identity) address. */
+    BLE_ADDR_TYPE_RANDOM_PRIVATE_RESOLVABLE = 0x02, /**< Random private resolvable address. */
+    BLE_ADDR_TYPE_RANDOM_PRIVATE_NON_RESOLVABLE = 0x03, /**< Random private non-resolvable address. */
+    BLE_ADDR_TYPE_ANONYMOUS = 0x7F /**< An advertiser may advertise without its address. This type of advertising is called anonymous. */
+} ble_address_type_t;
+
+/* BLE device address */
+typedef struct {
+    ble_address_type_t type;
+    uint8_t            data[6];
+} ble_address_t;
+
+/* BLE advertising parameters */
+typedef struct {
+    uint8_t  type;
+    uint8_t  filter_policy;
+    uint16_t interval;
+    uint16_t duration;
+    uint8_t  inc_tx_power;
+} ble_adv_params_t;
+
+/* BLE scanning parameters */
+typedef struct {
+    uint8_t  active;
+    uint8_t  filter_policy;
+    uint16_t interval;
+    uint16_t window;
+    uint16_t timeout;
+} ble_scan_params_t;
+
+/* BLE connection parameters */
+typedef struct {
+    uint16_t min_conn_interval;         /**< Minimum Connection Interval in 1.25 ms units.*/
+    uint16_t max_conn_interval;         /**< Maximum Connection Interval in 1.25 ms units.*/
+    uint16_t slave_latency;             /**< Slave Latency in number of connection events.*/
+    uint16_t conn_sup_timeout;          /**< Connection Supervision Timeout in 10 ms units.*/
+} ble_conn_params_t;
+
+/* BLE connection status changed event */
+typedef struct {
+    uint16_t conn_handle;
+    uint8_t  status;
+    uint8_t  reason;
+} ble_connection_event_t;
+
+/* BLE scan result event */
+typedef struct {
+    uint8_t       type;
+    ble_address_t peer_addr;
+    ble_address_t direct_addr;
+    int8_t        tx_power;
+    int8_t        rssi;
+    uint8_t*      data;
+    uint16_t      data_len;
+} ble_scan_result_event_t;
+
+typedef void *ble_connection_callback_t(ble_connection_event_t* event);
+typedef void *ble_scan_result_callback_t(ble_scan_result_event_t* event);
+
+/* Callbacks on GAP events */
+typedef struct {
+    ble_connection_callback_t  conn_callback;
+    ble_scan_result_callback_t scan_callback;
+} ble_gap_event_callbacks_t;
+
+/* BLE service and characteristic discovery events */
+typedef struct {
+    uint16_t status;
+    uint16_t conn_handle;
+    uint16_t service_handle;
+    uint16_t char_handle;
+    uint16_t cccd_handle;
+    union {
+        uint16_t uuid16;
+        uint8_t  uuid128[16];
+    };
+} ble_discovery_event_t;
+
+/* GATT Client data transmission events */
+typedef struct {
+    uint16_t status;
+    uint16_t conn_handle;
+    uint16_t char_handle;
+    uint8_t* data;
+    uint16_t data_len;
+} ble_gattc_data_event_t;
+
+typedef void *ble_discovery_callback_t(ble_discovery_event_t* event);
+typedef void *ble_gattc_data_callback_t(ble_gattc_data_event_t* event);
+
+/* Callbacks on GATT Client events */
+typedef struct {
+    ble_discovery_callback_t  discovery_callback;
+    ble_gattc_data_callback_t data_callback;
+} ble_gattc_event_callbacks_t;
+
+/* GATT Server data transmission events */
+typedef struct {
+    uint16_t status;
+    uint16_t conn_handle;
+    uint16_t char_handle;
+    uint8_t* data;
+    uint16_t data_len;
+} ble_gatts_data_event_t;
+
+typedef void *ble_gatts_data_callback_t(ble_gatts_data_event_t* event);
+
+/* Callbacks on GATT Server events */
+typedef struct {
+    ble_gatts_data_callback_t data_callback;
+} ble_gatts_event_callbacks_t;
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Generic BLE functions */
+int hal_ble_init(void* reserved);
+int hal_ble_on_gap_event_callbacks(ble_gap_event_callbacks_t* callbacks);
+int hal_ble_on_gattc_event_callbacks(ble_gattc_event_callbacks_t* callback);
+int hal_ble_on_gatts_event_callbacks(ble_gatts_event_callbacks_t* callback);
+int hal_ble_set_device_address(ble_address_t addr);
+int hal_ble_get_device_address(ble_address_t* addr);
+int hal_ble_set_device_name(const char* device_name);
+int hal_ble_get_device_name(uint8_t* device_name, uint16_t* len);
+
+/* Functions for BLE Broadcaster */
+int hal_ble_set_tx_power(int8_t value);
+int hal_ble_get_tx_power(int8_t* value);
+int hal_ble_set_advertising_params(ble_adv_params_t* adv_params);
+int hal_ble_set_advertising_interval(uint16_t interval);
+int hal_ble_set_advertising_duration(uint16_t duration);
+int hal_ble_set_advertising_type(uint8_t type);
+int hal_ble_set_advertising_data(uint8_t* data, uint8_t len);
+int hal_ble_set_scan_response_data(uint8_t* data, uint8_t len);
+int hal_ble_start_advertising(void);
+int hal_ble_stop_advertising(void);
+bool hal_ble_is_advertising(void);
+
+/* Functions for BLE Observer */
+int hal_ble_set_scanning_params(ble_scan_params_t* scan_params);
+int hal_ble_start_scanning(void);
+int hal_ble_stop_scanning(void);
+
+/* Functions for BLE Central and Peripheral */
+int hal_ble_connect(ble_address_t* addr);
+int hal_ble_disconnect(uint16_t conn_handle);
+int hal_ble_update_connection_params(uint16_t conn_handle, ble_conn_params_t* conn_params);
+int hal_ble_set_ppcp(uint16_t conn_handle, ble_conn_params_t* conn_params);
+int hal_ble_get_rssi(uint16_t conn_handle);
+
+/* Functions for GATT Client */
+int hal_ble_discovery_services(uint16_t conn_handle);
+int hal_ble_discovery_characteristics(uint16_t conn_handle, uint16_t service_handle);
+int hal_ble_discovery_descriptors(uint16_t conn_handle, uint16_t char_handle);
+int hal_ble_subscribe(uint16_t conn_handle, uint8_t char_handle);
+int hal_ble_unsubscribe(uint16_t conn_handle, uint8_t char_handle);
+int hal_ble_write_with_response(uint16_t conn_handle, uint8_t char_handle, uint8_t* data, uint16_t len);
+int hal_ble_write_without_response(uint16_t conn_handle, uint8_t char_handle, uint8_t* data, uint16_t len);
+int hal_ble_read(uint16_t conn_handle, uint8_t char_handle, uint8_t* data, uint16_t* len);
+
+/* Functions for GATT Server */
+int hal_ble_add_service(uint16_t *service_handle);
+int hal_ble_add_characteristic(uint16_t service_handle, uint16_t *char_handle);
+int hal_ble_publish(uint16_t conn_handle, uint8_t char_handle, uint8_t* data, uint16_t len);
+int hal_ble_set_characteristic_value(uint8_t char_handle, uint8_t* data, uint16_t len);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* BLE_HAL_API_H */

--- a/hal/inc/ble_hal_api.h
+++ b/hal/inc/ble_hal_api.h
@@ -21,6 +21,8 @@
 #include <stdint.h>
 #include <stddef.h>
 
+namespace particle { namespace ble {
+
 /* BLE device address type */
 typedef enum {
     BLE_ADDR_TYPE_PUBLIC = 0x00, /**< Public (identity) address.*/
@@ -35,6 +37,15 @@ typedef struct {
     ble_address_type_t type;
     uint8_t            data[6];
 } ble_address_t;
+
+/* BLE UUID */
+typedef struct {
+    uint8_t type;
+    union {
+        uint16_t uuid16;
+        uint8_t  uuid128[16];
+    };
+} ble_uuid_t;
 
 /* BLE advertising parameters */
 typedef struct {
@@ -91,16 +102,20 @@ typedef struct {
 
 /* BLE service and characteristic discovery events */
 typedef struct {
-    uint16_t status;
-    uint16_t conn_handle;
-    uint16_t service_handle;
-    uint16_t char_handle;
-    uint16_t cccd_handle;
-    union {
-        uint16_t uuid16;
-        uint8_t  uuid128[16];
-    };
+    uint16_t   status;
+    uint16_t   conn_handle;
+    uint16_t   service_handle;
+    uint16_t   char_handle;
+    uint16_t   cccd_handle;
+    ble_uuid_t uuid;
 } ble_discovery_event_t;
+
+/* BLE characteristic definition */
+typedef struct {
+    ble_uuid_t uuid;
+    uint8_t*   value;
+    uint8_t    properties;
+} ble_characteristic_t;
 
 /* GATT Client data transmission events */
 typedef struct {
@@ -150,6 +165,10 @@ int hal_ble_set_device_address(ble_address_t addr);
 int hal_ble_get_device_address(ble_address_t* addr);
 int hal_ble_set_device_name(const char* device_name);
 int hal_ble_get_device_name(uint8_t* device_name, uint16_t* len);
+int hal_ble_set_appearance(uint16_t appearance);
+int hal_ble_get_appearance(uint16_t* appearance);
+int hal_ble_add_to_whitelist(ble_address_t* addr);
+int hal_ble_remove_from_whitelist(ble_address_t* addr);
 
 /* Functions for BLE Broadcaster */
 int hal_ble_set_tx_power(int8_t value);
@@ -158,6 +177,7 @@ int hal_ble_set_advertising_params(ble_adv_params_t* adv_params);
 int hal_ble_set_advertising_interval(uint16_t interval);
 int hal_ble_set_advertising_duration(uint16_t duration);
 int hal_ble_set_advertising_type(uint8_t type);
+int hal_ble_enable_advertising_filter(bool enable);
 int hal_ble_set_advertising_data(uint8_t* data, uint8_t len);
 int hal_ble_set_scan_response_data(uint8_t* data, uint8_t len);
 int hal_ble_start_advertising(void);
@@ -166,14 +186,21 @@ bool hal_ble_is_advertising(void);
 
 /* Functions for BLE Observer */
 int hal_ble_set_scanning_params(ble_scan_params_t* scan_params);
+int hal_ble_set_scanning_interval(uint16_t interval);
+int hal_ble_set_scanning_window(uint16_t window);
+int hal_ble_set_scanning_timeout(uint16_t timeout);
+int hal_ble_enable_scanning_filter(bool enable);
+int hal_ble_set_scanning_policy(uint8_t value);
 int hal_ble_start_scanning(void);
 int hal_ble_stop_scanning(void);
 
 /* Functions for BLE Central and Peripheral */
 int hal_ble_connect(ble_address_t* addr);
+int hal_ble_connect_cancel(void);
 int hal_ble_disconnect(uint16_t conn_handle);
 int hal_ble_update_connection_params(uint16_t conn_handle, ble_conn_params_t* conn_params);
-int hal_ble_set_ppcp(uint16_t conn_handle, ble_conn_params_t* conn_params);
+int hal_ble_set_ppcp(ble_conn_params_t* conn_params);
+int hal_ble_get_ppcp(ble_conn_params_t* conn_params);
 int hal_ble_get_rssi(uint16_t conn_handle);
 
 /* Functions for GATT Client */
@@ -187,13 +214,16 @@ int hal_ble_write_without_response(uint16_t conn_handle, uint8_t char_handle, ui
 int hal_ble_read(uint16_t conn_handle, uint8_t char_handle, uint8_t* data, uint16_t* len);
 
 /* Functions for GATT Server */
-int hal_ble_add_service(uint16_t *service_handle);
-int hal_ble_add_characteristic(uint16_t service_handle, uint16_t *char_handle);
+int hal_ble_add_service(particle::ble::ble_uuid_t const* uuid, uint16_t* service_handle);
+int hal_ble_add_characteristic(uint16_t service_handle, ble_characteristic_t* characteristic, uint16_t *char_handle);
 int hal_ble_publish(uint16_t conn_handle, uint8_t char_handle, uint8_t* data, uint16_t len);
 int hal_ble_set_characteristic_value(uint8_t char_handle, uint8_t* data, uint16_t len);
+int hal_ble_get_characteristic_value(uint8_t char_handle, uint8_t* data, uint16_t* len);
 
 #ifdef __cplusplus
 } // extern "C"
 #endif
+
+} } /* particle::ble */
 
 #endif /* BLE_HAL_API_H */

--- a/hal/src/nRF52840/ble_hal_api.cpp
+++ b/hal/src/nRF52840/ble_hal_api.cpp
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) 2018 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Headers included from nRF5_SDK/components/softdevice/s140/headers */
+#include "ble.h"
+#include "ble_types.h"
+#include "ble_gap.h"
+#include "ble_gatt.h"
+#include "ble_gattc.h"
+#include "ble_gatts.h"
+/* Headers included from nRF5_SDK/components/softdevice/common */
+#include "nrf_sdh.h"
+#include "nrf_sdh_ble.h"
+#include "nrf_sdh_soc.h"
+
+#include "concurrent_hal.h"
+#include "static_recursive_mutex.h"
+#include <mutex>
+
+#include "ble_hal_api.h"
+#include "system_error.h"
+#include "logging.h"
+
+LOG_SOURCE_CATEGORY("hal.ble_api")
+
+
+#define BLE_CONN_CFG_TAG                1
+#define BLE_OBSERVER_PRIO               1
+
+
+StaticRecursiveMutex s_bleMutex;
+
+class bleLock {
+    static void lock() {
+        s_bleMutex.lock();
+    }
+
+    static void unlock() {
+        s_bleMutex.unlock();
+    }
+};
+
+static system_error_t sysError(uint32_t error) {
+    switch (error) {
+        case NRF_SUCCESS:             return SYSTEM_ERROR_NONE;
+        case NRF_ERROR_INVALID_STATE: return SYSTEM_ERROR_INVALID_STATE;
+        case NRF_ERROR_BUSY:          return SYSTEM_ERROR_BUSY;
+        case NRF_ERROR_NO_MEM:        return SYSTEM_ERROR_NO_MEMORY;
+        default:                      return SYSTEM_ERROR_UNKNOWN;
+    }
+}
+
+static void processBleEvent(const ble_evt_t* event, void* p_context) {
+    ret_code_t ret;
+
+    switch (event->header.evt_id) {
+        case BLE_GAP_EVT_CONNECTED: {
+            LOG_DEBUG(TRACE, "BLE connected, handle: 0x%04X", event->evt.gap_evt.conn_handle);
+            break;
+        }
+        case BLE_GAP_EVT_DISCONNECTED: {
+            LOG_DEBUG(TRACE, "BLE Disconnected, handle: 0x%04X, reason: %d",
+                      event->evt.gap_evt.conn_handle,
+                      event->evt.gap_evt.params.disconnected.reason);
+            break;
+        }
+        case BLE_GAP_EVT_PHY_UPDATE_REQUEST: {
+            LOG_DEBUG(TRACE, "PHY update request.");
+            ble_gap_phys_t phys = {};
+            phys.rx_phys = BLE_GAP_PHY_AUTO;
+            phys.tx_phys = BLE_GAP_PHY_AUTO;
+            ret = sd_ble_gap_phy_update(event->evt.gap_evt.conn_handle, &phys);
+            if (ret != NRF_SUCCESS) {
+                LOG(ERROR, "sd_ble_gap_phy_update() failed: %u", (unsigned)ret);
+            }
+            break;
+        }
+        default: {
+            LOG_DEBUG(TRACE, "Unhandled BLE event: %u", (unsigned)event->header.evt_id);
+            break;
+        }
+    }
+}
+
+int hal_ble_init(void* reserved) {
+    std::lock_guard<bleLock> lk(bleLock());
+
+    /* The SoftDevice has been enabled in core_hal.c */
+
+    // Configure the BLE stack using the default settings.
+    // Fetch the start address of the application RAM.
+    uint32_t ram_start = 0;
+    ret_code_t ret = nrf_sdh_ble_default_cfg_set(BLE_CONN_CFG_TAG, &ram_start);
+    if (ret != NRF_SUCCESS) {
+        LOG(ERROR, "nrf_sdh_ble_default_cfg_set() failed: %u", (unsigned)ret);
+        return sysError(ret);
+    }
+    LOG_DEBUG(TRACE, "RAM start: 0x%08x", (unsigned)ram_start);
+
+    // Enable the stack
+    ret = nrf_sdh_ble_enable(&ram_start);
+    if (ret != NRF_SUCCESS) {
+        LOG(ERROR, "nrf_sdh_ble_enable() failed: %u", (unsigned)ret);
+        return sysError(ret);
+    }
+
+    // Register a handler for BLE events.
+    NRF_SDH_BLE_OBSERVER(bleObserver, BLE_OBSERVER_PRIO, processBleEvent, nullptr);
+
+    return SYSTEM_ERROR_NONE;
+}
+
+int hal_ble_on_gap_event_callbacks(ble_gap_event_callbacks_t* callbacks) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_on_gattc_event_callbacks(ble_gattc_event_callbacks_t* callback) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_on_gatts_event_callbacks(ble_gatts_event_callbacks_t* callback) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_set_device_address(ble_address_t const* addr) {
+    std::lock_guard<bleLock> lk(bleLock());
+    ble_gap_addr_t local_addr;
+
+    local_addr.addr_id_peer = 0;
+    local_addr.addr_type    = addr->type;
+    memcpy(local_addr.addr, addr->data, BLE_GAP_ADDR_LEN);
+
+    ret_code_t ret = sd_ble_gap_addr_set(&local_addr);
+    if (ret != NRF_SUCCESS) {
+        LOG(ERROR, "sd_ble_gap_addr_set() failed: %u", (unsigned)ret);
+    }
+    return sysError(ret);
+}
+
+int hal_ble_get_device_address(ble_address_t* addr) {
+    std::lock_guard<bleLock> lk(bleLock());
+    ble_gap_addr_t local_addr;
+
+    ret_code_t ret = sd_ble_gap_addr_get(&local_addr);
+    if (ret == NRF_SUCCESS) {
+        addr->type = (ble_address_type_t)local_addr.addr_type;
+        memcpy(addr->data, local_addr.addr, BLE_GAP_ADDR_LEN);
+    }
+    else {
+        LOG(ERROR, "sd_ble_gap_addr_get() failed: %u", (unsigned)ret);
+    }
+    return sysError(ret);
+}
+
+int hal_ble_set_device_name(const char* device_name) {
+    std::lock_guard<bleLock> lk(bleLock());
+    ble_gap_conn_sec_mode_t sec_mode;
+
+    BLE_GAP_CONN_SEC_MODE_SET_OPEN(&sec_mode);
+
+    ret_code_t ret = sd_ble_gap_device_name_set(&sec_mode, (const uint8_t*)device_name, strlen(device_name));
+    if (ret != NRF_SUCCESS) {
+        LOG(ERROR, "sd_ble_gap_device_name_set() failed: %u", (unsigned)ret);
+    }
+    return sysError(ret);
+}
+
+int hal_ble_get_device_name(uint8_t* device_name, uint16_t* len) {
+    std::lock_guard<bleLock> lk(bleLock());
+
+    // non NULL-terminated string returned.
+    ret_code_t ret = sd_ble_gap_device_name_get(device_name, len);
+    if (ret != NRF_SUCCESS) {
+        LOG(ERROR, "sd_ble_gap_device_name_get() failed: %u", (unsigned)ret);
+    }
+    return sysError(ret);
+}
+
+int hal_ble_set_tx_power(int8_t value) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_get_tx_power(int8_t* value) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_set_advertising_params(ble_adv_params_t* adv_params) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_set_advertising_interval(uint16_t interval) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_set_advertising_duration(uint16_t duration) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_set_advertising_type(uint8_t type) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_set_advertising_data(uint8_t* data, uint8_t len) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_set_scan_response_data(uint8_t* data, uint8_t len) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_start_advertising(void) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_stop_advertising(void) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+bool hal_ble_is_advertising(void) {
+    return false;
+}
+
+int hal_ble_set_scanning_params(ble_scan_params_t* scan_params) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_start_scanning(void) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_stop_scanning(void) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_connect(ble_address_t* addr) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_disconnect(uint16_t conn_handle) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_update_connection_params(uint16_t conn_handle, ble_conn_params_t* conn_params) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_set_ppcp(uint16_t conn_handle, ble_conn_params_t* conn_params) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_get_rssi(uint16_t conn_handle) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_discovery_services(uint16_t conn_handle) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_discovery_characteristics(uint16_t conn_handle, uint16_t service_handle) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_discovery_descriptors(uint16_t conn_handle, uint16_t char_handle) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_add_service(uint16_t *service_handle) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_add_characteristic(uint16_t service_handle, uint16_t *char_handle) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_subscribe(uint16_t conn_handle, uint8_t char_handle) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_unsubscribe(uint16_t conn_handle, uint8_t char_handle) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_write_with_response(uint16_t conn_handle, uint8_t char_handle, uint8_t* data, uint16_t len) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_write_without_response(uint16_t conn_handle, uint8_t char_handle, uint8_t* data, uint16_t len) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_read(uint16_t conn_handle, uint8_t char_handle, uint8_t* data, uint16_t* len) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_publish(uint16_t conn_handle, uint8_t char_handle, uint8_t* data, uint16_t len) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_set_characteristic_value(uint8_t char_handle, uint8_t* data, uint16_t len) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+

--- a/hal/src/nRF52840/ble_hal_api.cpp
+++ b/hal/src/nRF52840/ble_hal_api.cpp
@@ -37,6 +37,7 @@
 
 LOG_SOURCE_CATEGORY("hal.ble_api")
 
+using namespace particle::ble;
 
 #define BLE_CONN_CFG_TAG                1
 #define BLE_OBSERVER_PRIO               1
@@ -96,6 +97,7 @@ static void processBleEvent(const ble_evt_t* event, void* p_context) {
     }
 }
 
+/* This function should be called previous to any other BLE APIs. */
 int hal_ble_init(void* reserved) {
     std::lock_guard<bleLock> lk(bleLock());
 
@@ -193,6 +195,26 @@ int hal_ble_get_device_name(uint8_t* device_name, uint16_t* len) {
     return sysError(ret);
 }
 
+int hal_ble_set_appearance(uint16_t appearance) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_get_appearance(uint16_t* appearance) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_add_to_whitelist(ble_address_t* addr) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_remove_from_whitelist(ble_address_t* addr) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
 int hal_ble_set_tx_power(int8_t value) {
     std::lock_guard<bleLock> lk(bleLock());
     return 0;
@@ -219,6 +241,11 @@ int hal_ble_set_advertising_duration(uint16_t duration) {
 }
 
 int hal_ble_set_advertising_type(uint8_t type) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_enable_advertising_filter(bool enable) {
     std::lock_guard<bleLock> lk(bleLock());
     return 0;
 }
@@ -252,6 +279,31 @@ int hal_ble_set_scanning_params(ble_scan_params_t* scan_params) {
     return 0;
 }
 
+int hal_ble_set_scanning_interval(uint16_t interval) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_set_scanning_window(uint16_t window) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_set_scanning_timeout(uint16_t timeout) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_enable_scanning_filter(bool enable) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_set_scanning_policy(uint8_t value) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
 int hal_ble_start_scanning(void) {
     std::lock_guard<bleLock> lk(bleLock());
     return 0;
@@ -267,6 +319,11 @@ int hal_ble_connect(ble_address_t* addr) {
     return 0;
 }
 
+int hal_ble_connect_cancel(void) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
 int hal_ble_disconnect(uint16_t conn_handle) {
     std::lock_guard<bleLock> lk(bleLock());
     return 0;
@@ -277,7 +334,12 @@ int hal_ble_update_connection_params(uint16_t conn_handle, ble_conn_params_t* co
     return 0;
 }
 
-int hal_ble_set_ppcp(uint16_t conn_handle, ble_conn_params_t* conn_params) {
+int hal_ble_set_ppcp(ble_conn_params_t* conn_params) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_get_ppcp(ble_conn_params_t* conn_params) {
     std::lock_guard<bleLock> lk(bleLock());
     return 0;
 }
@@ -302,12 +364,12 @@ int hal_ble_discovery_descriptors(uint16_t conn_handle, uint16_t char_handle) {
     return 0;
 }
 
-int hal_ble_add_service(uint16_t *service_handle) {
+int hal_ble_add_service(particle::ble::ble_uuid_t const* uuid, uint16_t* service_handle) {
     std::lock_guard<bleLock> lk(bleLock());
     return 0;
 }
 
-int hal_ble_add_characteristic(uint16_t service_handle, uint16_t *char_handle) {
+int hal_ble_add_characteristic(uint16_t service_handle, ble_characteristic_t* characteristic, uint16_t *char_handle) {
     std::lock_guard<bleLock> lk(bleLock());
     return 0;
 }
@@ -343,6 +405,11 @@ int hal_ble_publish(uint16_t conn_handle, uint8_t char_handle, uint8_t* data, ui
 }
 
 int hal_ble_set_characteristic_value(uint8_t char_handle, uint8_t* data, uint16_t len) {
+    std::lock_guard<bleLock> lk(bleLock());
+    return 0;
+}
+
+int hal_ble_get_characteristic_value(uint8_t char_handle, uint8_t* data, uint16_t* len) {
     std::lock_guard<bleLock> lk(bleLock());
     return 0;
 }


### PR DESCRIPTION
The file name and API name may be changed once we have finished the BLE HAL APIs set that can fully support the BLE control request in the listening mode. Just want to make the BLE control request work using the pre-existing BLE HAL APIs before that happens.