### PR TITLE
system event on isr

### DIFF
--- a/services/inc/panic_codes.h
+++ b/services/inc/panic_codes.h
@@ -9,21 +9,23 @@
 // followed by 300 blinks of the value of code
 /// ...---...    code   ...---...
 
-def_panic_codes(Faults,RGB_COLOR_RED,HardFault)
-def_panic_codes(Faults,RGB_COLOR_RED,NMIFault)
-def_panic_codes(Faults,RGB_COLOR_RED,MemManage)
-def_panic_codes(Faults,RGB_COLOR_RED,BusFault)
-def_panic_codes(Faults,RGB_COLOR_RED,UsageFault)
+def_panic_codes(Faults,RGB_COLOR_RED,HardFault)		// 1
+def_panic_codes(Faults,RGB_COLOR_RED,NMIFault)		// 2
+def_panic_codes(Faults,RGB_COLOR_RED,MemManage)		// 3
+def_panic_codes(Faults,RGB_COLOR_RED,BusFault)		// 4
+def_panic_codes(Faults,RGB_COLOR_RED,UsageFault)	// 5
 
-def_panic_codes(Cloud,RGB_COLOR_RED,InvalidLenth)
+def_panic_codes(Cloud,RGB_COLOR_RED,InvalidLenth)	// 6
 
-def_panic_codes(System,RGB_COLOR_RED,Exit)
-def_panic_codes(System,RGB_COLOR_RED,OutOfHeap)
+def_panic_codes(System,RGB_COLOR_RED,Exit)			// 7
+def_panic_codes(System,RGB_COLOR_RED,OutOfHeap)		// 8
 
-def_panic_codes(System,RGB_COLOR_RED,SPIOverRun)
+def_panic_codes(System,RGB_COLOR_RED,SPIOverRun)	// 9
 
-def_panic_codes(Software,RGB_COLOR_RED,AssertionFailure)
-def_panic_codes(Software,RGB_COLOR_RED,InvalidCase)
-def_panic_codes(Software,RGB_COLOR_RED,PureVirtualCall)
+def_panic_codes(Software,RGB_COLOR_RED,AssertionFailure)	// 10
+def_panic_codes(Software,RGB_COLOR_RED,InvalidCase)			// 11
+def_panic_codes(Software,RGB_COLOR_RED,PureVirtualCall)		// 12
 
-def_panic_codes(System,RGB_COLOR_RED,StackOverflow)
+def_panic_codes(System,RGB_COLOR_RED,StackOverflow)			// 13
+
+def_panic_codes(System,RGB_COLOR_RED,SemaphoreLockTimeout)	// 14

--- a/system/inc/system_event.h
+++ b/system/inc/system_event.h
@@ -122,9 +122,14 @@ void system_notify_time_changed(uint32_t data, void* reserved, void* reserved1);
 
 
 /**
- * Notifies all subscribers about an event.
+ * Notifies all subscribers about an event. The calling context must not be from an ISR.
  * @param event
  * @param data
  * @param pointer
  */
 void system_notify_event(system_event_t event, uint32_t data=0, void* pointer=nullptr, void (*fn)(void* data)=nullptr, void* fndata=nullptr);
+
+/**
+ * Notifies all subscribers about an event. When the notification is in the context of an ISR, it is marshaled to the system thread.
+ */
+void system_notify_event_isr(system_event_t event, uint32_t data=0, void* pointer=nullptr, void (*fn)(void* data)=nullptr, void* fndata=nullptr);

--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -276,7 +276,7 @@ void reset_button_click()
     button_current_clicks = 0;
     CLR_BUTTON_TIMEOUT();
     if (clicks > 0) {
-        system_notify_event(button_final_click, clicks);
+        system_notify_event_isr(button_final_click, clicks);
         button_final_clicks = clicks;
 #if Wiring_SetupButtonUX
         // Certain numbers of clicks can be processed directly in ISR
@@ -298,7 +298,7 @@ void handle_button_click(uint16_t depressed_duration)
             ARM_BUTTON_TIMEOUT(1000);
             reset = false;
         }
-        system_notify_event(button_click, button_current_clicks);
+        system_notify_event_isr(button_click, button_current_clicks);
     }
     if (reset) {
         reset_button_click();
@@ -316,11 +316,11 @@ void HAL_Notify_Button_State(uint8_t button, uint8_t pressed)
     {
         if (pressed)
         {
-            wasListeningOnButtonPress = network_listening(0, 0, 0);
-            pressed_time = HAL_Timer_Get_Milli_Seconds();
+        	pressed_time = HAL_Timer_Get_Milli_Seconds();
+        	wasListeningOnButtonPress = network_listening(0, 0, 0);
             if (!wasListeningOnButtonPress)             // start of button press
             {
-                system_notify_event(button_status, 0);
+                system_notify_event_isr(button_status, 0);
             }
             button_cleared_credentials = false;
         }
@@ -330,7 +330,7 @@ void HAL_Notify_Button_State(uint8_t button, uint8_t pressed)
             uint16_t depressed_duration = release_time - pressed_time;
 
             if (!network_listening(0, 0, 0)) {
-                system_notify_event(button_status, depressed_duration);
+                system_notify_event_isr(button_status, depressed_duration);
                 handle_button_click(depressed_duration);
             }
             pressed_time = 0;

--- a/system/src/system_event.cpp
+++ b/system/src/system_event.cpp
@@ -19,6 +19,8 @@
 
 #include "system_event.h"
 #include "system_threading.h"
+#include "interrupts_hal.h"
+#include "system_task.h"
 #include <stdint.h>
 #include <vector>
 
@@ -98,6 +100,56 @@ void system_notify_event(system_event_t event, uint32_t data, void* pointer, voi
     }
     if (fn)
         fn(fndata);
+}
+
+class SystemEventTask : public ISRTaskQueue::Task {
+	system_event_t event_;
+	uint32_t data_;
+	void* pointer_;
+	void (*fn_)(void* data);
+	void* fndata_;
+
+	/**
+	 * @param task	The task to execute. It is an instance of SystemEventTask.
+	 */
+	static void execute(Task* task) {
+		auto that = reinterpret_cast<SystemEventTask*>(task);
+		that->notify();
+	}
+
+	/**
+	 * Notify the system event encoded in this class.
+	 */
+	void notify() {
+		system_notify_event(event_, data_, pointer_, fn_, fndata_);
+		system_pool_free(this, nullptr);
+	}
+
+public:
+
+	SystemEventTask(system_event_t event, uint32_t data, void* pointer, void (*fn)(void* data), void* fndata) {
+		event_ = event;
+		data_ = data;
+		pointer_ = pointer;
+		fn_ = fn;
+		fndata_ = fndata;
+		func = execute;
+	}
+
+};
+
+void system_notify_event_isr(system_event_t event, uint32_t data, void* pointer, void (*fn)(void* data), void* fndata)
+{
+	if (HAL_IsISR()) {
+		void* space = (system_pool_alloc(sizeof(SystemEventTask), nullptr));
+	    if (space) {
+			auto task = new (space) SystemEventTask(event, data, pointer, fn, fndata);
+			SystemISRTaskQueue.enqueue(task);
+	    };
+	}
+	else {
+		system_notify_event(event, data, pointer, fn, fndata);
+	}
 }
 
 void system_notify_time_changed(uint32_t data, void* reserved, void* reserved1) {


### PR DESCRIPTION
### Problem

The malloc implementation in release 0.8.0-rc.11 includes an explicit check to ensure malloc is not called from an ISR. 

The button events are sometimes handled from an ISR, and consequently when the system event is marshaled to the application thread (using malloc) the assertion fails and the system enters a SOS. 

### Solution

The button handlers use a new function `system_notify_event_isr` instead of `system_notify_event`.  The new ISR-aware function checks if the call is actually from an ISR - if not, it simply delegates to the original `system_notify_event`.  Otherwise, the event parameters are stored in a Task that is enqueued on the System ISR queue and the system event then later notified from the system thread.  This ensures that malloc is not called from the button handler ISR. 

### Steps to Test

[CH24165](https://app.clubhouse.io/particle/story/24165) contains test applications to trigger the issue.  After applying this PR the SOS no longer occurs. 

The example app below demonstrates that button clicks are still correctly handled on the application thread.  Note that the delay in the application thread means the button handlers sometimes take some time to execute.  

### Example App

```c

SYSTEM_THREAD(ENABLED);
SYSTEM_MODE(SEMI_AUTOMATIC);

void setup()
{
  Particle.connect();
  System.on(button_click, []() {
	 RGB.control(true);
	 RGB.color(255,128, 0);
	 delay(500);
	 RGB.control(false);
  });
}

void loop()
{
	delay(1000);
}

```

### References

- [CH24165](https://app.clubhouse.io/particle/story/24165)
---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
