### PR TITLE
implements `make includes` to generate a list of include directories.

### DIFF
--- a/bootloader/makefile
+++ b/bootloader/makefile
@@ -12,6 +12,8 @@ LIB_DIRS += $(dir $(LIB_DEPS))
 
 export COMPILE_LTO=y
 
+# propagate this through the transient dependencies so they know that it is the bootloader being built.
+# perhaps propagating the top level module name would be more flexible.
 export BOOTLOADER_MODULE=1
 
 include ../build/platform-id.mk

--- a/build/build.md
+++ b/build/build.md
@@ -34,5 +34,33 @@ flavors are:
 Having separate flavors (to distinct build targets) ensures that they are
 consistently rebuilt when needed which would not be the case otherwise.
 
+## Module Variables
+
+### Target file variables that don't need to be set
+
+- `TARGET`: the target file(s) being constructed by a given module. Default is `$(TARGET_BASE).$(TARGET_TYPE)`. This is set by 
+   the modules that build the final binary to the list of pseudo-targets to be built, (e.g. elf lst size). It is incorporated into the `all` goal so that the target(s) are built. 
+- `TARGET_BASE`: the target file without the extension
+- `TARGET_NAME`: the final target filename (minus the extension). Default is `$(TARGET_FILE_PREFIX)$(TARGET_FILE_NAME)`
+- `TARGET_FILE_PREFIX`: Empty by default. Used to add a prefix to the target. This is used to add a `lib` prefix to library output files. 
+- `TARGET_PATH`: the output directory for the target file. Default is `(BUILD_PATH)/$(call sanitize,$(TARGET_DIR_NAME))` 
+- `BUILD_PATH`: the build path for this module
+- `MODULAR_EXT`: adds an extension to the platform variant in the output path so that monolithic and modular builds go to separate output directories.
+- `LTO_EXT`: adds an extension to the platform variant in the output path so that LTO and regular builds go to separate output directories.
+`BUILD_PATH_EXT`: the directory inside the `build/target/<module>` folder that contains subdirectories for this given build platform (and variant), e.g. `platform-14-m-lto` for platform 14, modular build with LTO.
 
 
+## Recursion and Module Dependencies
+
+There are two types of dependency:
+
+- *file system dependencies* are dependencies (other modules) that are needed to build the current module. It is typically the public interface of the dependency module. The `import.mk` of these dependencies are loaded and are used to set flags, set include directories. These modules are not built since it is assumed everything needed is already present in the filesystem.
+
+- *built dependencies* are modules that are recursively invoked with `make` and the same targets. This is used to build artefacts that the calling module needs, such as a library.
+
+The `DEPENDENCIES` variable lists the file system dependencies, while the `MAKE_DEPENDENCIES` file lists the built dependencies. It's quite typical that all `MAKE_DEPENDENCIES` also feature as `DEPENDENCIES` since the public interface (such as headers) is needed to consume the built artefacts of the module.
+
+The goals of the module are not passed down to submodules. This is a bit of a hack, most likely
+to avoid top-level goals such as `porgram-dfu` being passed down to submodules where they make no sense. The hack works since typically submodules have only one primary goal which is invoked as if `all` were invoked.
+
+However, this is unlikely to remain the case, so goals that make no sense to submodules should be filtered out rather than remove all goals. 

--- a/build/common-tools.mk
+++ b/build/common-tools.mk
@@ -19,6 +19,8 @@ DFUSUFFIX = dfu-suffix
 CURL = curl
 CRC = crc32
 XXD = xxd
+SORT = sort
+UNIQ = uniq
 SERIAL_SWITCHER = $(COMMON_BUILD)/serial_switcher.py
 
 crc32_path := $(shell which $(CRC))

--- a/build/recurse.mk
+++ b/build/recurse.mk
@@ -4,6 +4,9 @@
 CLEAN_DEPENDENCIES=$(patsubst %,clean_%,$(MAKE_DEPENDENCIES))
 
 # these variables are defined internally and passed to submakes
+RECURSIVE_VARIABLES?=GLOBAL_DEFINES MODULAR_FIRMWARE
+export $(RECURSIVE_VARIABLES)
+
 export GLOBAL_DEFINES
 export MODULAR_FIRMWARE
 


### PR DESCRIPTION
### Problem

Tools need to know the include directories and source files for system and application firmware.  

### Solution

The build system knows where the include directories and sources files are for the system and application firmware and so can generate a list.

Tasks:

- [ ] implement `make includes`
- [ ] implement `make sources`
- [ ] add prerequisite checks for the command line tools used (`uniq`, `sort`) 
- [ ] test on windows
- [ ] implement tests in the CI build to validate the new functionality

### Steps to Test

- run `make includes` and inspect the file that is the name of the target base `.includes.txt` added.  Can be run from `bootloader` and `main`. 

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
