### PR TITLE
Basic implementation for cellular command

### DIFF
--- a/hal/src/boron/cellular_hal.cpp
+++ b/hal/src/boron/cellular_hal.cpp
@@ -28,7 +28,14 @@
 #include "endian_util.h"
 #include "check.h"
 
+#include "at_parser.h"
+#include "at_command.h"
+#include "at_response.h"
+#include "modem/enums_hal.h"
+
 #include <limits>
+
+#define MAX_RESP_SIZE        1024
 
 namespace {
 
@@ -274,8 +281,150 @@ int cellular_signal(CellularSignalHal* signal, cellular_signal_t* signalExt) {
     return 0;
 }
 
+static int parse_match(char *buf, uint16_t size, const char* sta, const char* end) {
+    int o = 0;
+    if (sta) {
+        while (*sta) {
+            if (++o > size)                 return WAIT;
+            char ch = *buf++;
+            if (*sta++ != ch)               return NOT_FOUND;
+        }
+    }
+    if (!end)                               return o; // no termination
+    // at least any char
+    if (++o > size)                         return WAIT;
+    buf++;
+    // check the end
+    int x = 0;
+    while (end[x]) {
+        if (++o > size)                     return WAIT;
+        char ch = *buf++;
+        x = (end[x] == ch) ? x + 1 :
+            (end[0] == ch) ? 1 : 0;
+    }
+    return o;
+}
+
+static int get_mdm_type(char *buf, int size) {
+    static struct {
+            const char* sta;          const char* end;    int type;
+    } lut[] = {
+        { "RING",               NULL,               TYPE_RING       },
+        { "CONNECT",            NULL,               TYPE_CONNECT    },
+        { "+",                  NULL,               TYPE_PLUS       },
+        { "@",                  NULL,               TYPE_PROMPT     }, // Sockets
+        { ">",                  NULL,               TYPE_PROMPT     }, // SMS
+        { "ABORTED",            NULL,               TYPE_ABORTED    }, // Current command aborted
+    };
+
+    for (int i = 0; i < (int)(sizeof(lut)/sizeof(*lut)); i++) {
+        int ln = parse_match(buf, size, lut[i].sta, lut[i].end);
+        if (ln > 0) {
+            // LOG_DEBUG(TRACE, "get_mdm_type, src: %s, size: %d, type: 0x%x", buf, size, (uint32_t)lut[i].type);
+            return lut[i].type;
+        } else if (ln == WAIT) {
+            // LOG_DEBUG(TRACE, "get_mdm_type, WAIT");
+            return WAIT;
+        }
+    }
+    // LOG_DEBUG(TRACE, "get_mdm_type, UNKNOWN");
+    return TYPE_UNKNOWN;
+}
+
 int cellular_command(_CALLBACKPTR_MDM cb, void* param, system_tick_t timeout_ms, const char* format, ...) {
-    return SYSTEM_ERROR_NOT_SUPPORTED;
+    auto mgr = cellularNetworkManager();
+    CHECK_TRUE(mgr, SYSTEM_ERROR_UNKNOWN);
+    auto client = mgr->ncpClient();
+    CHECK_TRUE(client, SYSTEM_ERROR_UNKNOWN);
+    auto parser = client->atParser();
+    CHECK_TRUE(parser, SYSTEM_ERROR_UNKNOWN);
+
+    client->lock();
+
+    va_list args;
+    va_start(args, format);
+
+    // WORKAROUND: cut "\r\n", it has been resolved in AT Parser
+    auto * fmt = (char *)malloc(strlen(format) + 1);
+    if (!fmt) {
+        client->unlock();
+        return SYSTEM_ERROR_NO_MEMORY;
+    }
+    memcpy(fmt, format, strlen(format) + 1);
+    if (fmt[strlen(format) - 1] == '\n' && fmt[strlen(format) - 2] == '\r') {
+        fmt[strlen(format) - 1] = '\0';
+        fmt[strlen(format) - 2] = '\0';
+    }
+
+    auto resp = parser->command().vprintf(fmt, args).timeout(timeout_ms).send();
+
+    const size_t size = MAX_RESP_SIZE + 64; /* add some more space for framing */
+    auto * buf = (char *)malloc(size);
+    if (!buf) {
+        free(fmt);
+        client->unlock();
+        return SYSTEM_ERROR_NO_MEMORY;
+    }
+    memset(buf, 0, size);
+
+    int mdm_type = TYPE_OK;
+    while (resp.hasNextLine()) {
+        int n = resp.readLine(buf, size);
+        if (n > 0) {
+            if (cb) {
+                mdm_type = get_mdm_type(buf, n);
+                // WORKAROUND: Add "\r\n" for compatibility
+                // LOG_DEBUG(TRACE, "size: %d, read: %s", n, buf);
+                buf[n++] = '\r';
+                buf[n++] = '\n';
+                buf[n++] = '\0';
+                int cb_ret = cb(mdm_type, buf, n, param);
+                if (cb_ret != WAIT) {
+                    break;
+                }
+            }
+        } else {
+            LOG_DEBUG(WARN, "readLine err: %d", n);
+        }
+    };
+
+    int result = resp.readResult();
+    LOG_DEBUG(TRACE, "response result: %d, code: %d", result, resp.resultErrorCode());
+    if (result < 0) {
+        free(fmt);
+        free(buf);
+        client->unlock();
+        return SYSTEM_ERROR_UNKNOWN;
+    }
+
+    const char * mdm_str = NULL;
+    switch (result) {
+        case AtResponse::OK:          mdm_type = TYPE_OK;         mdm_str = "\r\nOK\r\n";           break;
+        case AtResponse::BUSY:        mdm_type = TYPE_BUSY;       mdm_str = "\r\nBUSY\r\n";         break;
+        case AtResponse::ERROR:       mdm_type = TYPE_ERROR;      mdm_str = "\r\nERROR\r\n";        break;
+        case AtResponse::CME_ERROR:   mdm_type = TYPE_ERROR;      mdm_str = "\r\n+CME ERROR\r\n";   break;
+        case AtResponse::CMS_ERROR:   mdm_type = TYPE_ERROR;      mdm_str = "\r\n+CMS ERROR\r\n";   break;
+        case AtResponse::NO_DIALTONE: mdm_type = TYPE_NODIALTONE; mdm_str = "\r\nNO DIALTONE\r\n";  break;
+        case AtResponse::NO_ANSWER:   mdm_type = TYPE_NOANSWER;   mdm_str = "\r\nNO ANSWER\r\n";    break;
+        case AtResponse::NO_CARRIER:  mdm_type = TYPE_NOCARRIER;  mdm_str = "\r\nNO CARRIER\r\n";   break;
+    }
+
+    if (cb) {
+        char cme_cms_error[50] = {0};
+        if (result == AtResponse::CME_ERROR || result == AtResponse::CMS_ERROR) {
+            sprintf(cme_cms_error, "%s, code: %d", mdm_str, resp.resultErrorCode());
+            cb(mdm_type, cme_cms_error, strlen(cme_cms_error)+1, param);
+        } else if (result >= 0) {
+            cb(mdm_type, mdm_str, strlen(mdm_str)+1, param);
+        }
+    }
+
+    va_end(args);
+    free(fmt);
+    free(buf);
+    client->unlock();
+
+    return SYSTEM_ERROR_NONE;
 }
 
 int cellular_data_usage_set(CellularDataHal* data, void* reserved) {

--- a/user/tests/hal/cellular/application.cpp
+++ b/user/tests/hal/cellular/application.cpp
@@ -1,0 +1,4 @@
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+UNIT_TEST_APP();

--- a/user/tests/hal/cellular/test_cellular_command.cpp
+++ b/user/tests/hal/cellular/test_cellular_command.cpp
@@ -84,7 +84,7 @@ test(AT_CMD_01_set_and_read_command) {
         at_resp_info_print(type, buf, len, lines);
         assertEqualBlock(type, (int)TYPE_OK);
         return WAIT;
-    }, &lines, 5000, "AT+CMEE=2\r\n"), (int)SYSTEM_ERROR_NONE);
+    }, &lines, 5000, "AT+CMEE=2\r\n"), (int)RESP_OK);
 
     lines = 0;
     assertEqualBlock(send_cellular_command([](int type, const char* buf, int len, int* curr_line) -> int {
@@ -99,7 +99,7 @@ test(AT_CMD_01_set_and_read_command) {
         }
         (*curr_line)++;
         return WAIT;
-    }, &lines, 5000, "AT+CMEE?\r\n"), (int)SYSTEM_ERROR_NONE);
+    }, &lines, 5000, "AT+CMEE?\r\n"), (int)RESP_OK);
 }
 
 test(AT_CMD_02_plus) {
@@ -116,7 +116,7 @@ test(AT_CMD_02_plus) {
         }
         (*lines)++;
         return WAIT;
-    }, &lines, 5000, "AT+CCID?\r\n"), (int)SYSTEM_ERROR_NONE);
+    }, &lines, 5000, "AT+CCID?\r\n"), (int)RESP_OK);
 
     lines = 0;
     assertEqualBlock(send_cellular_command([](int type, const char* buf, int len, int* lines) -> int {
@@ -129,7 +129,7 @@ test(AT_CMD_02_plus) {
         }
         (*lines)++;
         return WAIT;
-    }, &lines, 5000, "AT+CPIN?\r\n"), (int)SYSTEM_ERROR_NONE);
+    }, &lines, 5000, "AT+CPIN?\r\n"), (int)RESP_OK);
 }
 
 test(AT_CMD_03_unknown) {
@@ -146,7 +146,7 @@ test(AT_CMD_03_unknown) {
         }
         (*lines)++;
         return WAIT;
-    }, &lines, 5000, "AT+GSN\r\n"), (int)SYSTEM_ERROR_NONE);
+    }, &lines, 5000, "AT+GSN\r\n"), (int)RESP_OK);
 
     lines = 0;
     assertEqualBlock(send_cellular_command([](int type, const char* buf, int len, int* lines) -> int {
@@ -159,7 +159,7 @@ test(AT_CMD_03_unknown) {
         }
         (*lines)++;
         return WAIT;
-    }, &lines, 5000, "AT+CGMR\r\n"), (int)SYSTEM_ERROR_NONE);
+    }, &lines, 5000, "AT+CGMR\r\n"), (int)RESP_OK);
 }
 
 test(AT_CMD_04_error_test) {
@@ -176,7 +176,7 @@ test(AT_CMD_04_error_test) {
         }
         (*lines)++;
         return WAIT;
-    }, &lines, 5000, "AT+USOCL=7\r\n"), (int)SYSTEM_ERROR_NONE);
+    }, &lines, 5000, "AT+USOCL=7\r\n"), (int)RESP_ERROR);
 
     // +CMS ERROR: invalid memory index
     lines = 0;
@@ -184,7 +184,7 @@ test(AT_CMD_04_error_test) {
         at_resp_info_print(type, buf, len, lines);
         assertEqualBlock(type, (int)TYPE_ERROR);
         return WAIT;
-    }, &lines, 5000, "AT+CMSS=1000\r\n"), (int)SYSTEM_ERROR_NONE);
+    }, &lines, 5000, "AT+CMSS=1000\r\n"), (int)RESP_ERROR);
 }
 
 test(AT_CMD_05_no_carrier) {
@@ -194,6 +194,6 @@ test(AT_CMD_05_no_carrier) {
         at_resp_info_print(type, buf, len, lines);
         assertEqualBlock(type, (int)TYPE_NOCARRIER);
         return WAIT;
-    }, &lines, 5000, "atd1234567890\r\n"), (int)SYSTEM_ERROR_NONE);
+    }, &lines, 5000, "atd1234567890\r\n"), (int)RESP_ERROR);
 }
 

--- a/user/tests/hal/cellular/test_cellular_command.cpp
+++ b/user/tests/hal/cellular/test_cellular_command.cpp
@@ -177,4 +177,23 @@ test(AT_CMD_04_error_test) {
         (*lines)++;
         return WAIT;
     }, &lines, 5000, "AT+USOCL=7\r\n"), (int)SYSTEM_ERROR_NONE);
+
+    // +CMS ERROR: invalid memory index
+    lines = 0;
+    assertEqualBlock(send_cellular_command([](int type, const char* buf, int len, int* lines) -> int {
+        at_resp_info_print(type, buf, len, lines);
+        assertEqualBlock(type, (int)TYPE_ERROR);
+        return WAIT;
+    }, &lines, 5000, "AT+CMSS=1000\r\n"), (int)SYSTEM_ERROR_NONE);
 }
+
+test(AT_CMD_05_no_carrier) {
+    int lines = 0;
+
+    assertEqualBlock(send_cellular_command([](int type, const char* buf, int len, int* lines) -> int {
+        at_resp_info_print(type, buf, len, lines);
+        assertEqualBlock(type, (int)TYPE_NOCARRIER);
+        return WAIT;
+    }, &lines, 5000, "atd1234567890\r\n"), (int)SYSTEM_ERROR_NONE);
+}
+

--- a/user/tests/hal/cellular/test_cellular_command.cpp
+++ b/user/tests/hal/cellular/test_cellular_command.cpp
@@ -2,8 +2,8 @@
 #include "unit-test/unit-test.h"
 
 SYSTEM_MODE(MANUAL);
-STARTUP(cellular_credentials_set("", "", "", NULL));
-STARTUP(Cellular.setActiveSim(EXTERNAL_SIM));
+//STARTUP(cellular_credentials_set("", "", "", NULL));
+//STARTUP(Cellular.setActiveSim(EXTERNAL_SIM));
 
 #define assertBlock(arg1,op,op_name,arg2) if (!Test::assertion<typeof(arg2)>(F(__FILE__),__LINE__,F(#arg1),(arg1),F(op_name),op,F(#arg2),(arg2))) while(1);
 #define assertEqualBlock(arg1,arg2)       assertBlock(arg1,isEqual,"==",arg2)

--- a/user/tests/hal/cellular/test_cellular_command.cpp
+++ b/user/tests/hal/cellular/test_cellular_command.cpp
@@ -1,0 +1,180 @@
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+SYSTEM_MODE(MANUAL);
+STARTUP(cellular_credentials_set("", "", "", NULL));
+STARTUP(Cellular.setActiveSim(EXTERNAL_SIM));
+
+#define assertBlock(arg1,op,op_name,arg2) if (!Test::assertion<typeof(arg2)>(F(__FILE__),__LINE__,F(#arg1),(arg1),F(op_name),op,F(#arg2),(arg2))) while(1);
+#define assertEqualBlock(arg1,arg2)       assertBlock(arg1,isEqual,"==",arg2)
+#define assertNotEqualBlock(arg1,arg2)    assertBlock(arg1,isNotEqual,"!=",arg2)
+
+Serial1LogHandler logHandler(115200, LOG_LEVEL_ALL, { 
+                                {"ncp",     LOG_LEVEL_ALL},
+                                {"app",     LOG_LEVEL_ALL},
+                                {"lwip",    LOG_LEVEL_NONE},
+                                {"ot",      LOG_LEVEL_NONE},
+                                {"sys",     LOG_LEVEL_NONE},
+                                {"system",  LOG_LEVEL_NONE}
+                            });
+
+static int at_resp_info_print(int type, const char* buf, int len, int* lines) {
+    Serial.printlnf("┌-----------------------------------------------------┐");
+    switch (type) {
+        case NOT_FOUND:         Serial.printlnf("Type: UNKNOWN");           break;
+        case WAIT:              Serial.printlnf("Type: WAIT");              break;
+        case RESP_OK:           Serial.printlnf("Type: RESP_OK");           break;
+        case RESP_ERROR:        Serial.printlnf("Type: RESP_ERROR");        break;
+        case RESP_PROMPT:       Serial.printlnf("Type: RESP_PROMPT");       break;
+        case RESP_ABORTED:      Serial.printlnf("Type: RESP_ABORTED");      break;
+
+        case TYPE_OK:           Serial.printlnf("Type: TYPE_OK");           break;
+        case TYPE_ERROR:        Serial.printlnf("Type: TYPE_ERROR");        break;
+        case TYPE_CONNECT:      Serial.printlnf("Type: TYPE_CONNECT");      break;
+        case TYPE_NOCARRIER:    Serial.printlnf("Type: TYPE_NOCARRIER");    break;
+        case TYPE_NODIALTONE:   Serial.printlnf("Type: TYPE_NODIALTONE");   break;
+        case TYPE_BUSY:         Serial.printlnf("Type: TYPE_BUSY");         break;
+        case TYPE_NOANSWER:     Serial.printlnf("Type: TYPE_NOANSWER");     break;
+        case TYPE_PROMPT:       Serial.printlnf("Type: TYPE_PROMPT");       break;
+        case TYPE_PLUS:         Serial.printlnf("Type: TYPE_PLUS");         break;
+        case TYPE_TEXT:         Serial.printlnf("Type: TYPE_TEXT");         break;
+        case TYPE_ABORTED:      Serial.printlnf("Type: TYPE_ABORTED");      break;
+        case TYPE_DBLNEWLINE:   Serial.printlnf("Type: TYPE_DBLNEWLINE");   break;
+        default:
+            Serial.printlnf("Type: SHOULD ENTER THIS CASE!"); break;
+            break;
+    }
+    Serial.printf("len: %d, line: %d, hex data: ", len, *lines);
+    for (int i = 0; i < len; i++) {
+        Serial.printf("%02X ", buf[i]);
+    }
+    Serial.printlnf("");
+    Serial.printf("text: ");
+    for (int i = 0; i < len; i++) {
+        if (buf[i] == '\r') {
+            Serial.printf("\\r");
+        } else if (buf[i] == '\n') {
+            Serial.printf("\\n");
+
+        } else {
+            Serial.printf("%c", buf[i]);
+        }
+    }
+    Serial.printlnf("");
+
+    Serial.printlnf("└-----------------------------------------------------┘");
+
+    return WAIT;
+}
+
+template<typename... Targs>
+static int send_cellular_command(int (*cb)(int type, const char* buf, int len, int* lines),
+                                 int* lines, system_tick_t timeout_ms, const char* format, Targs... Fargs) 
+{
+    return Cellular.command(cb, lines, timeout_ms, format, Fargs...);
+}
+
+test(AT_CMD_01_set_and_read_command) {
+    int lines;
+
+    Cellular.on();
+
+    // CMEE=1: use error code mode
+    assertEqualBlock(send_cellular_command([](int type, const char* buf, int len, int* lines) -> int {
+        at_resp_info_print(type, buf, len, lines);
+        assertEqualBlock(type, (int)TYPE_OK);
+        return WAIT;
+    }, &lines, 5000, "AT+CMEE=2\r\n"), (int)SYSTEM_ERROR_NONE);
+
+    lines = 0;
+    assertEqualBlock(send_cellular_command([](int type, const char* buf, int len, int* curr_line) -> int {
+        at_resp_info_print(type, buf, len, curr_line);
+        if (*curr_line == 0) {
+            assertEqualBlock(type, (int)TYPE_PLUS);
+            char * dst = strstr(buf, "+CMEE: ");
+            assertEqualBlock(dst!=NULL, true);
+            assertEqualBlock(dst[strlen("+CMEE: ")]=='2', true);
+        } else {
+            assertEqualBlock(type, (int)TYPE_OK);
+        }
+        (*curr_line)++;
+        return WAIT;
+    }, &lines, 5000, "AT+CMEE?\r\n"), (int)SYSTEM_ERROR_NONE);
+}
+
+test(AT_CMD_02_plus) {
+    int lines;
+
+    lines = 0;
+    assertEqualBlock(send_cellular_command([](int type, const char* buf, int len, int* lines) -> int {
+        at_resp_info_print(type, buf, len, lines);
+        if (*lines == 0) {
+            assertEqualBlock(type, (int)TYPE_PLUS);
+            assertEqualBlock(strstr(buf, "+CCID:")!=NULL, true);
+        } else {
+            assertEqualBlock(type, (int)TYPE_OK);
+        }
+        (*lines)++;
+        return WAIT;
+    }, &lines, 5000, "AT+CCID?\r\n"), (int)SYSTEM_ERROR_NONE);
+
+    lines = 0;
+    assertEqualBlock(send_cellular_command([](int type, const char* buf, int len, int* lines) -> int {
+        at_resp_info_print(type, buf, len, lines);
+        if (*lines == 0) {
+            assertEqualBlock(type, (int)TYPE_PLUS);
+            assertEqualBlock(strstr(buf, "+CPIN:")!=NULL, true);
+        } else {
+            assertEqualBlock(type, (int)TYPE_OK);
+        }
+        (*lines)++;
+        return WAIT;
+    }, &lines, 5000, "AT+CPIN?\r\n"), (int)SYSTEM_ERROR_NONE);
+}
+
+test(AT_CMD_03_unknown) {
+    int lines;
+
+    lines = 0;
+    assertEqualBlock(send_cellular_command([](int type, const char* buf, int len, int* lines) -> int {
+        at_resp_info_print(type, buf, len, lines);
+        if (*lines == 0) {
+            // Get SN number, e.g. 352753090314178
+            assertEqualBlock(type, (int)TYPE_UNKNOWN);
+        } else {
+            assertEqualBlock(type, (int)TYPE_OK);
+        }
+        (*lines)++;
+        return WAIT;
+    }, &lines, 5000, "AT+GSN\r\n"), (int)SYSTEM_ERROR_NONE);
+
+    lines = 0;
+    assertEqualBlock(send_cellular_command([](int type, const char* buf, int len, int* lines) -> int {
+        at_resp_info_print(type, buf, len, lines);
+        if (*lines == 0) {
+            // Get ublox firmware version, e.g. 00.0.00.00.00 [Sep 07 2018 19:37:56]
+            assertEqualBlock(type, (int)TYPE_UNKNOWN);
+        } else {
+            assertEqualBlock(type, (int)TYPE_OK);
+        }
+        (*lines)++;
+        return WAIT;
+    }, &lines, 5000, "AT+CGMR\r\n"), (int)SYSTEM_ERROR_NONE);
+}
+
+test(AT_CMD_04_error_test) {
+    int lines;
+
+    lines = 0;
+    assertEqualBlock(send_cellular_command([](int type, const char* buf, int len, int* lines) -> int {
+        at_resp_info_print(type, buf, len, lines);
+        if (*lines == 0) {
+            // Get SN number, e.g. 352753090314178
+            assertEqualBlock(type, (int)TYPE_ERROR);
+        } else {
+            assertEqualBlock(type, (int)TYPE_OK);
+        }
+        (*lines)++;
+        return WAIT;
+    }, &lines, 5000, "AT+USOCL=7\r\n"), (int)SYSTEM_ERROR_NONE);
+}


### PR DESCRIPTION
### Problem

Providing Cellular command on Gen 3 Devices to allow testing customer AT commands.

### Solution

Given `AT Parser` has helped do some formatting work, for compatibility, we add some workarounds to make sure the behavior has the same result as it on Gen 2 devices.

#### TODO
**unsupported feature:**
 - Not support SMS, need to support `>` AT response int AT Parser
 - Not support Socket, need to support `@` AT response in AT Parser

### Steps to Test

1. Flash unit test application `user/tests/hal/cellular` to Electron and Boron

### Example App

`user/tests/hal/cellular/test_cellular_command.cpp`

### References

[CH26290]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
