### PR TITLE
[Mesh] Fixes WCID in bootloader

### DIFF
--- a/bootloader/src/nRF52840/usbd_dfu.cpp
+++ b/bootloader/src/nRF52840/usbd_dfu.cpp
@@ -377,7 +377,7 @@ DfuMal* DfuClassDriver::currentMal() {
 }
 
 int DfuClassDriver::setup(SetupRequest* req) {
-  if ((req->bRequest == 0xee && req->bmRequestType == 0b11000001 && req->wIndex == 0x0005) ||
+  if ((req->bRequest == 0xee && req->bmRequestType == 0xc1 && req->wIndex == 0x0005) ||
       (req->bRequest == 0xee && req->bmRequestType == 0xc0 && req->wIndex == 0x0004)) {
     return handleMsftRequest(req);
   }
@@ -503,7 +503,7 @@ int DfuClassDriver::inDone(uint8_t ep, unsigned status) {
 }
 
 const uint8_t* DfuClassDriver::getConfigurationDescriptor(uint16_t* length) {
-  *length = *((uint16_t*)cfgDesc_ + 2);
+  *length = *((uint16_t*)(cfgDesc_ + 2));
   return cfgDesc_;
 }
 

--- a/bootloader/src/nRF52840/usbd_wcid.h
+++ b/bootloader/src/nRF52840/usbd_wcid.h
@@ -21,8 +21,6 @@
 #define USB_WCID_DATA(...) __VA_ARGS__
 
 #define USB_WCID_MS_OS_STRING_DESCRIPTOR(signature, code)                   \
-    0x12,                                          /* bLength */            \
-    0x03,                                          /* bDescriptorType */    \
     signature,                                     /* qwSignature */        \
     code,                                          /* MS_VendorCode */      \
     0x00                                           /* Padding */


### PR DESCRIPTION
### Problem

WinUSB driver is not being automagically attached to DFU interface on Windows.

### Solution

Fixes [WCID](https://github.com/pbatard/libwdi/wiki/WCID-Devices) handling in the bootloader.

### Steps to Test

Flash the bootloader, connect to a Windows machine, the device should automagically show up in Device Manager under USB devices with WinUSB driver. `dfu-util` should work without requiring to use Zadig or anything else.

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
