### PR TITLE
Fix/argon netif deadlock

### DIFF
--- a/hal/network/lwip/esp32/esp32ncpnetif.cpp
+++ b/hal/network/lwip/esp32/esp32ncpnetif.cpp
@@ -181,6 +181,7 @@ void Esp32NcpNetif::loop(void* arg) {
             if (self->up_) {
                 LwipTcpIpCoreLock lk;
                 if (!netif_is_link_up(self->interface())) {
+                    lk.unlock();
                     if (self->upImpl()) {
                         self->wifiMan_->ncpClient()->off();
                     }

--- a/hal/network/lwip/esp32/esp32ncpnetif.cpp
+++ b/hal/network/lwip/esp32/esp32ncpnetif.cpp
@@ -181,6 +181,7 @@ void Esp32NcpNetif::loop(void* arg) {
             if (self->up_) {
                 LwipTcpIpCoreLock lk;
                 if (!netif_is_link_up(self->interface())) {
+                    // If we don't unlock the mutex here, we can easily cause a deadlock
                     lk.unlock();
                     if (self->upImpl()) {
                         self->wifiMan_->ncpClient()->off();


### PR DESCRIPTION
### Problem

In certain cases Argon may deadlock when reinitializing its NCP client.

### Solution

Ensure that LwIP lock is unlocked before executing NCP client-specific functions in `esp32ncpnetif`.

### Steps to Test

N/A

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
