### PR TITLE
Bypass git dependency in build

### DIFF
--- a/build/checks.mk
+++ b/build/checks.mk
@@ -1,10 +1,11 @@
-
-git_branch := $(shell git rev-parse --abbrev-ref HEAD)
-ifeq ("$(git_branch)","develop")
-    ifndef PARTICLE_DEVELOP
-       $(error Please note the develop branch contains untested, unreleased code. \
-        We recommend using the 'release/stable' branch which contains the latest released firmware code. \
-        To build the develop branch, please see the the build documentation at \
-        https://github.com/spark/firmware/blob/develop/docs/build.md#building-the-develop-branch)
+ifneq (, $(shell /bin/bash -c "command -v git"))
+    git_branch := $(shell git rev-parse --abbrev-ref HEAD)
+    ifeq ("$(git_branch)","develop")
+        ifndef PARTICLE_DEVELOP
+            $(error Please note the develop branch contains untested, unreleased code. \
+            We recommend using the 'release/stable' branch which contains the latest released firmware code. \
+            To build the develop branch, please see the the build documentation at \
+            https://github.com/spark/firmware/blob/develop/docs/build.md#building-the-develop-branch)
+        endif
     endif
 endif

--- a/build/checks.mk
+++ b/build/checks.mk
@@ -1,4 +1,4 @@
-ifneq (, $(shell sh -c "command -v git"))
+ifneq (, $(shell command -v git;))
     git_branch := $(shell git rev-parse --abbrev-ref HEAD)
     ifeq ("$(git_branch)","develop")
         ifndef PARTICLE_DEVELOP

--- a/build/checks.mk
+++ b/build/checks.mk
@@ -1,4 +1,4 @@
-ifneq (, $(shell /bin/bash -c "command -v git"))
+ifneq (, $(shell sh -c "command -v git"))
     git_branch := $(shell git rev-parse --abbrev-ref HEAD)
     ifeq ("$(git_branch)","develop")
         ifndef PARTICLE_DEVELOP


### PR DESCRIPTION
### Problem

`git` should not be a build dependency.

It is possible for the firmware to build correctly without having `git` installed. Currently, `git` is used to test which branch is being built and offer a warning message if you are working on the `develop` branch, without the having specified the `PARTICLE_DEVELOP` environment variable.

The branch check forces a dependency on Git and spews error messages in its absence. The false positive error messages obfuscate true errors and warnings, which make it harder for a developer to monitor and catch warnings and errors.

### Solution

Gate the logic in `checks.mk` behind a check to see if `git` is installed

### Steps to Test

Build the firmware

### References

N/A

--------

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
