### PR TITLE
Fix/hal/spi default config

### DIFF
--- a/hal/src/nRF52840/spi_hal.cpp
+++ b/hal/src/nRF52840/spi_hal.cpp
@@ -206,23 +206,14 @@ static void spi_init(HAL_SPI_Interface spi, SPI_Mode mode) {
 static void spi_uninit(HAL_SPI_Interface spi) {
     if (m_spi_map[spi].spi_mode == SPI_MODE_MASTER) {
         nrfx_spim_uninit(m_spi_map[spi].master);
-        HAL_Pin_Mode(m_spi_map[spi].ss_pin, PIN_MODE_NONE);
     } else {
         nrfx_spis_uninit(m_spi_map[spi].slave);
         HAL_Interrupts_Detach(m_spi_map[spi].ss_pin);
-        HAL_Pin_Mode(m_spi_map[spi].ss_pin, PIN_MODE_NONE);
     }
 
     HAL_Set_Pin_Function(m_spi_map[spi].sck_pin, PF_NONE);
     HAL_Set_Pin_Function(m_spi_map[spi].mosi_pin, PF_NONE);
     HAL_Set_Pin_Function(m_spi_map[spi].miso_pin, PF_NONE);
-}
-
-static void ss_pin_uninit(HAL_SPI_Interface spi) {
-    uint8_t nrf_pin = get_nrf_pin_num(m_spi_map[spi].ss_pin);
-    if (nrf_pin != NRFX_SPIM_PIN_NOT_USED) {
-        HAL_Pin_Mode(m_spi_map[spi].ss_pin, PIN_MODE_NONE);
-    }
 }
 
 static uint32_t spi_tx_rx(HAL_SPI_Interface spi, uint8_t *tx_buf, uint8_t *rx_buf, uint32_t size) {
@@ -289,10 +280,6 @@ void HAL_SPI_Begin(HAL_SPI_Interface spi, uint16_t pin) {
 }
 
 void HAL_SPI_Begin_Ext(HAL_SPI_Interface spi, SPI_Mode mode, uint16_t pin, void* reserved) {
-    if (m_spi_map[spi].ss_pin != PIN_INVALID) {
-        ss_pin_uninit(spi);
-    }
-
     if (m_spi_map[spi].enabled) {
         spi_uninit(spi);
     }

--- a/platform/MCU/nRF52840/inc/sdk_config_system.h
+++ b/platform/MCU/nRF52840/inc/sdk_config_system.h
@@ -125,3 +125,6 @@
 
 #define APP_USBD_VID                            USBD_VID_SPARK
 #define APP_USBD_PID                            USBD_PID_CDC
+
+#define NRFX_SPIM_MISO_PULL_CFG                 0  // MISO pin pull configuration. The default configuration is pull down,
+                                                   // change it to no pull <0=> NRF_GPIO_PIN_NOPULL.


### PR DESCRIPTION
### Problem

This PR includes two fixes:
1. Nordic SDK uses PULLDOWN configuration for MISO, which may affect some users' tricky usage.
2. When calling SPI.begin() to define a new CS pin, the SPI driver of Gen2 will keep the GPIO configuration of old CS pin while the SPI driver of Gen3 will reset old CS pin. I'm not sure whether this fix is a good choice, just for compatibility with Gen2 device.

I was puzzled why Gen2 SPI driver doesn't reset GPIO even if we call `HAL_SPI_End()`, that means once we use SPI driver it will make an unrecoverable configuration to a GPIO. 

#### Related Issue:
[issue-1671](https://github.com/particle-iot/device-os/issues/1671)

### Steps to Test

1. Flash example application
1. Press command `1` the LED will turn on, then press command `2`:
    1. Without the fix: LED will turn off
    1. With the fix: LED will keep on

### Example App

```c
void setup() {
    Serial.begin();
}

void loop() {
    while (Serial.available()) {
        char ch = Serial.read();
        Serial.write(ch);

        switch (ch) {
            case '1': {
                SPI.begin(7);
                break;
            }
            case '2': {
                SPI.begin(8);
                break;
            }
            case '3': {
                pinMode(7, INPUT);
                break;
            }
        }
    }
}
```

### References

[CH27213]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
