### PR TITLE
[Boron] Ensure that the modem is on before trying to retrieve IMEI and ICCID

### DIFF
--- a/hal/src/boron/cellular_hal.cpp
+++ b/hal/src/boron/cellular_hal.cpp
@@ -136,6 +136,10 @@ int cellular_device_info(CellularDevice* info, void* reserved) {
     CHECK_TRUE(mgr, SYSTEM_ERROR_UNKNOWN);
     const auto client = mgr->ncpClient();
     CHECK_TRUE(client, SYSTEM_ERROR_UNKNOWN);
+
+    const NcpClientLock lock(client);
+    // Ensure the modem is powered on
+    CHECK(client->on());
     CHECK(client->getIccid(info->iccid, sizeof(info->iccid)));
     CHECK(client->getImei(info->imei, sizeof(info->imei)));
     return 0;


### PR DESCRIPTION
### Problem

Boron in Listening Mode does not show IMEI and ICCID.
```console
i
Device ID: XXXXXXXXXXXXXXXXXXXXXX
Device Secret: XXXXXXXXXXXXXX
Serial Number: XXXXXXXXXXXXXX
IMEI:
ICCID:

v
system firmware version: 0.8.0-rc.26
```

### Solution

Ensure that the modem is on before trying to retrieve IMEI and ICCID in `cellular_device_info()`.

### Steps to Test

Put the Boron into listening mode, open its serial port, send 'i', it should correctly output IMEI and ICCID.

### Example App

N/A

### References

- [CH26968]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
