### PR TITLE
[Gen 3] STOP sleep mode support

### DIFF
--- a/hal/inc/core_hal.h
+++ b/hal/inc/core_hal.h
@@ -145,7 +145,7 @@ void HAL_Core_Enter_Safe_Mode(void* reserved);
 bool HAL_Core_Enter_Safe_Mode_Requested(void);
 void HAL_Core_Enter_Bootloader(bool persist);
 void HAL_Core_Enter_Stop_Mode(uint16_t wakeUpPin, uint16_t edgeTriggerMode, long seconds);
-int32_t HAL_Core_Enter_Stop_Mode_Ext(const uint16_t* pins, size_t pins_count, const InterruptMode* mode, size_t mode_count, long seconds, void* reserved);
+int HAL_Core_Enter_Stop_Mode_Ext(const uint16_t* pins, size_t pins_count, const InterruptMode* mode, size_t mode_count, long seconds, void* reserved);
 void HAL_Core_Execute_Stop_Mode(void);
 int HAL_Core_Enter_Standby_Mode(uint32_t seconds, uint32_t flags);
 void HAL_Core_Execute_Standby_Mode(void);

--- a/hal/inc/exflash_hal.h
+++ b/hal/inc/exflash_hal.h
@@ -36,6 +36,7 @@ typedef enum {
 } hal_exflash_command_t;
 
 int hal_exflash_init(void);
+int hal_exflash_uninit(void);
 int hal_exflash_write(uintptr_t addr, const uint8_t* data_buf, size_t data_size);
 int hal_exflash_erase_sector(uintptr_t addr, size_t num_sectors);
 int hal_exflash_erase_block(uintptr_t addr, size_t num_blocks);

--- a/hal/inc/hal_dynalib_core.h
+++ b/hal/inc/hal_dynalib_core.h
@@ -76,7 +76,7 @@ DYNALIB_FN(30, hal_core, HAL_Core_Led_Mirror_Pin, void(uint8_t, pin_t, uint32_t,
 DYNALIB_FN(31, hal_core, HAL_Core_Led_Mirror_Pin_Disable, void(uint8_t, uint8_t, void*))
 
 DYNALIB_FN(32, hal_core, HAL_Set_Event_Callback, void(HAL_Event_Callback, void*))
-DYNALIB_FN(33, hal_core, HAL_Core_Enter_Stop_Mode_Ext, int32_t(const uint16_t*, size_t, const InterruptMode*, size_t, long, void*))
+DYNALIB_FN(33, hal_core, HAL_Core_Enter_Stop_Mode_Ext, int(const uint16_t*, size_t, const InterruptMode*, size_t, long, void*))
 DYNALIB_FN(34, hal_core, HAL_Core_Execute_Standby_Mode_Ext, int(uint32_t, void*))
 
 DYNALIB_END(hal_core)

--- a/hal/inc/timer_hal.h
+++ b/hal/inc/timer_hal.h
@@ -1,26 +1,18 @@
-/**
- ******************************************************************************
- * @file    timer_hal.h
- * @authors Satish Nair, Brett Walach
- * @version V1.0.0
- * @date    12-Sept-2014
- * @brief
- ******************************************************************************
-  Copyright (c) 2013-2015 Particle Industries, Inc.  All rights reserved.
-
-  This library is free software; you can redistribute it and/or
-  modify it under the terms of the GNU Lesser General Public
-  License as published by the Free Software Foundation, either
-  version 3 of the License, or (at your option) any later version.
-
-  This library is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  Lesser General Public License for more details.
-
-  You should have received a copy of the GNU Lesser General Public
-  License along with this library; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
+/*
+ * Copyright (c) 2019 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
@@ -61,6 +53,8 @@ uint64_t hal_timer_millis(void* reserved);
 uint64_t hal_timer_micros(void* reserved);
 
 typedef struct {
+    uint16_t size;
+    uint16_t version;
     uint64_t base_clock_offset;
 } hal_timer_init_config_t;
 

--- a/hal/inc/timer_hal.h
+++ b/hal/inc/timer_hal.h
@@ -60,14 +60,27 @@ uint64_t hal_timer_millis(void* reserved);
  */
 uint64_t hal_timer_micros(void* reserved);
 
+typedef struct {
+    uint64_t base_clock_offset;
+} hal_timer_init_config_t;
+
 /**
  * @brief      Initializes timer HAL
+ *
+ * @param      conf  (optional) Configuration
+ *
+ * @return     0 in case of success, any other value in case of an error
+ */
+int hal_timer_init(const hal_timer_init_config_t* conf);
+
+/**
+ * @brief      Deinitializes timer HAL
  *
  * @param      reserved  Reserved argument
  *
  * @return     0 in case of success, any other value in case of an error
  */
-int hal_timer_init(void* reserved);
+int hal_timer_deinit(void* reserved);
 
 #ifdef __cplusplus
 }

--- a/hal/src/core/core_hal.c
+++ b/hal/src/core/core_hal.c
@@ -278,7 +278,7 @@ void HAL_Core_Enter_Bootloader(bool persist)
     HAL_Core_System_Reset();
 }
 
-int32_t HAL_Core_Enter_Stop_Mode_Ext(const uint16_t* pins, size_t pins_count, const InterruptMode* mode, size_t mode_count, long seconds, void* reserved)
+int HAL_Core_Enter_Stop_Mode_Ext(const uint16_t* pins, size_t pins_count, const InterruptMode* mode, size_t mode_count, long seconds, void* reserved)
 {
     HAL_Core_Enter_Stop_Mode(pins != NULL && pins_count > 0 ? *pins : TOTAL_PINS, mode != NULL && mode_count > 0 ? (uint16_t)(*mode) : 0xffff, seconds);
     return -1;

--- a/hal/src/gcc/core_hal.cpp
+++ b/hal/src/gcc/core_hal.cpp
@@ -239,7 +239,7 @@ void HAL_Core_Execute_Stop_Mode(void)
     MSG("Stop mode not implemented.");
 }
 
-int32_t HAL_Core_Enter_Stop_Mode_Ext(const uint16_t* pins, size_t pins_count, const InterruptMode* mode, size_t mode_count, long seconds, void* reserved)
+int HAL_Core_Enter_Stop_Mode_Ext(const uint16_t* pins, size_t pins_count, const InterruptMode* mode, size_t mode_count, long seconds, void* reserved)
 {
     MSG("Stop mode not implemented.");
     return -1;

--- a/hal/src/mesh-virtual/core_hal.cpp
+++ b/hal/src/mesh-virtual/core_hal.cpp
@@ -254,7 +254,7 @@ void HAL_Core_Execute_Stop_Mode(void)
     MSG("Stop mode not implemented.");
 }
 
-int32_t HAL_Core_Enter_Stop_Mode_Ext(const uint16_t* pins, size_t pins_count, const InterruptMode* mode, size_t mode_count, long seconds, void* reserved)
+int HAL_Core_Enter_Stop_Mode_Ext(const uint16_t* pins, size_t pins_count, const InterruptMode* mode, size_t mode_count, long seconds, void* reserved)
 {
     MSG("Stop mode not implemented.");
     return -1;

--- a/hal/src/nRF52840/core_hal.c
+++ b/hal/src/nRF52840/core_hal.c
@@ -972,6 +972,12 @@ int HAL_Core_Execute_Standby_Mode_Ext(uint32_t flags, void* reserved) {
     uint32_t nrf_pin = NRF_GPIO_PIN_MAP(PIN_MAP[WKP].gpio_port, PIN_MAP[WKP].gpio_pin);
     nrf_gpio_cfg_sense_input(nrf_pin, NRF_GPIO_PIN_PULLUP, NRF_GPIO_PIN_SENSE_LOW);
 
+    // Disable PWM
+    nrf_pwm_disable(NRF_PWM0);
+    nrf_pwm_disable(NRF_PWM1);
+    nrf_pwm_disable(NRF_PWM2);
+    nrf_pwm_disable(NRF_PWM3);
+
     // RAM retention is configured on early boot in Set_System()
 
     SPARK_ASSERT(sd_power_system_off() == NRF_SUCCESS);

--- a/hal/src/nRF52840/core_hal.c
+++ b/hal/src/nRF52840/core_hal.c
@@ -729,8 +729,6 @@ int HAL_Core_Enter_Stop_Mode_Ext(const uint16_t* pins, size_t pins_count, const 
 
     int reason = SYSTEM_ERROR_UNKNOWN;
 
-    // Ask SoftDevice to go into low power mode
-    sd_power_mode_set(NRF_POWER_MODE_LOWPWR);
     // Workaround for FPU anomaly
     fpu_sleep_prepare();
 
@@ -914,9 +912,6 @@ int HAL_Core_Enter_Stop_Mode_Ext(const uint16_t* pins, size_t pins_count, const 
 
     // Unmasks all non-softdevice interrupts
     HAL_enable_irq(hst);
-
-    // Restore softdevice power mode
-    sd_power_mode_set(NRF_POWER_MODE_CONSTLAT);
 
     // Release LFCLK
     nrf_drv_clock_lfclk_release();

--- a/hal/src/nRF52840/openthread/alarm.c
+++ b/hal/src/nRF52840/openthread/alarm.c
@@ -730,7 +730,7 @@ uint64_t hal_timer_micros(void* reserved) {
     // Volatile is most likely unnecessary here, leaving for now just in case
     volatile uint64_t curUs = GetCurrentTime(kUsTimer);
     volatile uint32_t lastOverflowTicks = sTickCountAtLastOverflow;
-    volatile uint32_t lastOverflowMicros = sTimerMicrosAtLastOverflow;
+    volatile uint64_t lastOverflowMicros = sTimerMicrosAtLastOverflow;
     volatile uint32_t curTicks = DWT->CYCCNT;
     nrf_rtc_int_enable(RTC_INSTANCE, NRF_RTC_INT_OVERFLOW_MASK);
 

--- a/hal/src/nRF52840/openthread/alarm.c
+++ b/hal/src/nRF52840/openthread/alarm.c
@@ -59,6 +59,9 @@
 
 #include <openthread/config.h>
 
+#include "hw_ticks.h"
+#include "timer_hal.h"
+
 // clang-format off
 #define RTC_FREQUENCY       NRF_802154_RTC_FREQUENCY
 
@@ -104,6 +107,9 @@ static volatile uint8_t  sMutex;           ///< Mutex for write access to @ref s
 static volatile uint64_t sTimeOffset = 0;  ///< Time overflowCounter to keep track of current time (in millisecond).
 static volatile bool     sEventPending;    ///< Timer fired and upper layer should be notified.
 static AlarmData         sTimerData[kNumTimers]; ///< Data of the timers.
+static volatile uint32_t sTickCountAtLastOverflow; ///< DWT->CYCCNT value at the time latest overflow occurred
+static volatile uint64_t sTimerMicrosAtLastOverflow; ///< microseconds at the time latest overflow occured
+static volatile uint64_t sTimerMicrosBaseOffset; ///< Base offset for Particle-specific microsecond counter
 
 static const AlarmChannelData sChannelData[kNumTimers] = //
     {                                                    //
@@ -433,6 +439,8 @@ void nrf5AlarmInit(void)
     sOverflowCounter = 0;
     sMutex           = 0;
     sTimeOffset      = 0;
+    sTickCountAtLastOverflow = 0;
+    sTimerMicrosAtLastOverflow = 0;
 
     // Setup low frequency clock.
     nrf_drv_clock_lfclk_request(NULL);
@@ -459,7 +467,11 @@ void nrf5AlarmInit(void)
         nrf_rtc_int_disable(RTC_INSTANCE, sChannelData[i].mCompareInt);
     }
 
+    int pri = __get_PRIMASK();
+    __disable_irq();
     nrf_rtc_task_trigger(RTC_INSTANCE, NRF_RTC_TASK_START);
+    DWT->CYCCNT = 0;
+    __set_PRIMASK(pri);
 }
 
 void nrf5AlarmDeinit(void)
@@ -664,6 +676,13 @@ void RTC_IRQ_HANDLER(void)
 
         // Handle OVERFLOW event by reading current value of overflow counter.
         (void)GetOverflowCounter();
+
+        // Store current DWT->CYCCNT and RTC counter value
+        int pri = __get_PRIMASK();
+        __disable_irq();
+        sTimerMicrosAtLastOverflow = GetCurrentTime(kUsTimer);
+        sTickCountAtLastOverflow = DWT->CYCCNT;
+        __set_PRIMASK(pri);
     }
 
     // Handle compare match.
@@ -690,15 +709,48 @@ uint16_t otPlatTimeGetXtalAccuracy(void)
 #endif // OPENTHREAD_CONFIG_ENABLE_TIME_SYNC
 
 // Particle-specific
-int hal_timer_init(void* reserved) {
+int hal_timer_init(const hal_timer_init_config_t* conf) {
+    if (conf) {
+        sTimerMicrosBaseOffset = conf->base_clock_offset;
+    }
     nrf5AlarmInit();
     return 0;
 }
 
+int hal_timer_deinit(void* reserved) {
+    nrf5AlarmDeinit();
+    return 0;
+}
+
 uint64_t hal_timer_micros(void* reserved) {
-    return GetCurrentTime(kUsTimer);
+    // Extends the resolution from 31us to about 5us using DWT->CYCCNT
+    // Make sure that sTickCountAtLastOverflow and current timer values are fetched atomically
+    nrf_rtc_int_disable(RTC_INSTANCE, NRF_RTC_INT_OVERFLOW_MASK);
+    __DMB();
+    // Volatile is most likely unnecessary here, leaving for now just in case
+    volatile uint64_t curUs = GetCurrentTime(kUsTimer);
+    volatile uint32_t lastOverflowTicks = sTickCountAtLastOverflow;
+    volatile uint32_t lastOverflowMicros = sTimerMicrosAtLastOverflow;
+    volatile uint32_t curTicks = DWT->CYCCNT;
+    nrf_rtc_int_enable(RTC_INSTANCE, NRF_RTC_INT_OVERFLOW_MASK);
+
+    int usTicks = SYSTEM_US_TICKS;
+
+    uint64_t elapsedUs = curUs - lastOverflowMicros;
+    uint64_t elapsedTicks = elapsedUs * usTicks;
+    uint32_t syncTicks = (uint32_t)((uint64_t)lastOverflowTicks + elapsedTicks);
+    uint32_t tickDiff = curTicks - syncTicks;
+    int64_t tickDiffFinal;
+    if (tickDiff > (US_PER_OVERFLOW / 10) * usTicks) {
+        tickDiff = 0xffffffff - tickDiff;
+        tickDiffFinal = -((int64_t)tickDiff);
+    } else {
+        tickDiffFinal = tickDiff;
+    }
+
+    return sTimerMicrosBaseOffset + ((int64_t)curUs + ((tickDiffFinal) / usTicks));
 }
 
 uint64_t hal_timer_millis(void* reserved) {
-    return GetCurrentTime(kUsTimer) / US_PER_MS;
+    return hal_timer_micros(NULL) / US_PER_MS;
 }

--- a/hal/src/stm32f2xx/core_hal_stm32f2xx.c
+++ b/hal/src/stm32f2xx/core_hal_stm32f2xx.c
@@ -600,7 +600,7 @@ void HAL_Core_Enter_Safe_Mode(void* reserved)
     HAL_Core_System_Reset_Ex(RESET_REASON_SAFE_MODE, 0, NULL);
 }
 
-int32_t HAL_Core_Enter_Stop_Mode_Ext(const uint16_t* pins, size_t pins_count, const InterruptMode* mode, size_t mode_count, long seconds, void* reserved)
+int HAL_Core_Enter_Stop_Mode_Ext(const uint16_t* pins, size_t pins_count, const InterruptMode* mode, size_t mode_count, long seconds, void* reserved)
 {
     // Initial sanity check
     if ((pins_count == 0 || mode_count == 0 || pins == NULL || mode == NULL) && seconds <= 0) {

--- a/hal/src/template/core_hal.cpp
+++ b/hal/src/template/core_hal.cpp
@@ -75,7 +75,7 @@ void HAL_Core_Enter_Stop_Mode(uint16_t wakeUpPin, uint16_t edgeTriggerMode)
 {
 }
 
-int32_t HAL_Core_Enter_Stop_Mode_Ext(const uint16_t* pins, size_t pins_count, const InterruptMode* mode, size_t mode_count, long seconds, void* reserved)
+int HAL_Core_Enter_Stop_Mode_Ext(const uint16_t* pins, size_t pins_count, const InterruptMode* mode, size_t mode_count, long seconds, void* reserved)
 {
     return -1;
 }

--- a/platform/MCU/nRF52840/inc/sdk_config_system.h
+++ b/platform/MCU/nRF52840/inc/sdk_config_system.h
@@ -131,3 +131,6 @@
 
 #define APP_USBD_DEVICE_VER_MAJOR               1
 #define APP_USBD_DEVICE_VER_MINOR               1
+
+#define NRFX_POWER_CONFIG_DEFAULT_DCDCEN        1
+

--- a/platform/MCU/nRF52840/src/hw_config.c
+++ b/platform/MCU/nRF52840/src/hw_config.c
@@ -184,6 +184,8 @@ void Reset_System(void) {
 
     BUTTON_Uninit();
 
+    hal_exflash_uninit();
+
     __DSB();
 }
 

--- a/system/src/system_network_manager_api.cpp
+++ b/system/src/system_network_manager_api.cpp
@@ -393,7 +393,7 @@ void manage_network_connection() {
         SPARK_WLAN_SLEEP = wasSleeping;
         cfod_count = 0;
     } else {
-        if (spark_cloud_flag_auto_connect() && !s_forcedDisconnect) {
+        if (spark_cloud_flag_auto_connect() && (!s_forcedDisconnect || !SPARK_WLAN_SLEEP)) {
             if (!NetworkManager::instance()->isConnectivityAvailable() && !NetworkManager::instance()->isEstablishingConnections()) {
                 network_connect(0, 0, 0, 0);
             }

--- a/user/tests/app/sleep_multiple_pins/application.cpp
+++ b/user/tests/app/sleep_multiple_pins/application.cpp
@@ -1,156 +1,29 @@
+/*
+ * Copyright (c) 2019 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHAN'TABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "application.h"
 
 SYSTEM_MODE(MANUAL);
 
-/* Pins by Source
- *
- * GPIO_PinSource0: A7 (WKP), P1S0, P1S2, B2, B4
- * GPIO_PinSource1: RGBR, P1S1, P1S5, B3, B5
- * GPIO_PinSource2: A2, RGBG, C0, PWR_UC
- * GPIO_PinSource3: D4, A1, RGBB
- * GPIO_PinSource4: D3, A6 (DAC/DAC1), P1S3, RESET_UC
- * GPIO_PinSource5: D2, A0, A3 (DAC2)
- * GPIO_PinSource6: D1, A4, B1
- * GPIO_PinSource7: D0, A5, SETUP_BUTTON
- * GPIO_PinSource8: B0, C5, PM_SCL_UC
- * GPIO_PinSource9: TX, C4, PM_SDA_UC
- * GPIO_PinSource10: RX, C3, TXD_UC
- * GPIO_PinSource11: C2, RXD_UC
- * GPIO_PinSource12: C1, RI_UC
- * GPIO_PinSource13: D7, P1S4, CTS_UC, LOW_BAT_UC
- * GPIO_PinSource14: D6, RTS_UC
- * GPIO_PinSource15: D5, LVLOE_UC
- */
-
-/* COMMON TO PHOTON, P1 and ELECTRON */
-/* D0            - 00  { GPIOB, GPIO_Pin_7, GPIO_PinSource7, NONE, NONE, TIM4, TIM_Channel_2, PIN_MODE_NONE, 0, 0 }, */
-/* D1            - 01  { GPIOB, GPIO_Pin_6, GPIO_PinSource6, NONE, NONE, TIM4, TIM_Channel_1, PIN_MODE_NONE, 0, 0 }, */
-/* D2            - 02  { GPIOB, GPIO_Pin_5, GPIO_PinSource5, NONE, NONE, TIM3, TIM_Channel_2, PIN_MODE_NONE, 0, 0 }, */
-/* D3            - 03  { GPIOB, GPIO_Pin_4, GPIO_PinSource4, NONE, NONE, TIM3, TIM_Channel_1, PIN_MODE_NONE, 0, 0 }, */
-/* D4            - 04  { GPIOB, GPIO_Pin_3, GPIO_PinSource3, NONE, NONE, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* D5            - 05  { GPIOA, GPIO_Pin_15, GPIO_PinSource15, NONE, NONE, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* D6            - 06  { GPIOA, GPIO_Pin_14, GPIO_PinSource14, NONE, NONE, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* D7            - 07  { GPIOA, GPIO_Pin_13, GPIO_PinSource13, NONE, NONE, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* NOT USED      - 08  { NULL, NONE, NONE, NONE, NONE, NULL, NONE, NONE, NONE, NONE }, */
-/* NOT USED      - 09  { NULL, NONE, NONE, NONE, NONE, NULL, NONE, NONE, NONE, NONE }, */
-/* A0            - 10  { GPIOC, GPIO_Pin_5, GPIO_PinSource5, ADC_Channel_15, NONE, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* A1            - 11  { GPIOC, GPIO_Pin_3, GPIO_PinSource3, ADC_Channel_13, NONE, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* A2            - 12  { GPIOC, GPIO_Pin_2, GPIO_PinSource2, ADC_Channel_12, NONE, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* DAC2, A3      - 13  { GPIOA, GPIO_Pin_5, GPIO_PinSource5, ADC_Channel_5, DAC_Channel_2, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* A4            - 14  { GPIOA, GPIO_Pin_6, GPIO_PinSource6, ADC_Channel_6, NONE, TIM3, TIM_Channel_1, PIN_MODE_NONE, 0, 0 }, */
-/* A5            - 15  { GPIOA, GPIO_Pin_7, GPIO_PinSource7, ADC_Channel_7, NONE, TIM3, TIM_Channel_2, PIN_MODE_NONE, 0, 0 }, */
-/* DAC, DAC1, A6 - 16  { GPIOA, GPIO_Pin_4, GPIO_PinSource4, ADC_Channel_4, DAC_Channel_1, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* WKP, A7       - 17  { GPIOA, GPIO_Pin_0, GPIO_PinSource0, ADC_Channel_0, NONE, TIM5, TIM_Channel_1, PIN_MODE_NONE, 0, 0 }, */
-/* RX            - 18  { GPIOA, GPIO_Pin_10, GPIO_PinSource10, NONE, NONE, TIM1, TIM_Channel_3, PIN_MODE_NONE, 0, 0 }, */
-/* TX            - 19  { GPIOA, GPIO_Pin_9, GPIO_PinSource9, NONE, NONE, TIM1, TIM_Channel_2, PIN_MODE_NONE, 0, 0 }, */
-/* SETUP BUTTON  - 20  { GPIOC, GPIO_Pin_7, GPIO_PinSource7, NONE, NONE, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* RGBR          - 21  { GPIOA, GPIO_Pin_1, GPIO_PinSource1, NONE, NONE, TIM2, TIM_Channel_2, PIN_MODE_NONE, 0, 0 }, */
-/* RGBG          - 22  { GPIOA, GPIO_Pin_2, GPIO_PinSource2, NONE, NONE, TIM2, TIM_Channel_3, PIN_MODE_NONE, 0, 0 }, */
-/* RGBB          - 23  { GPIOA, GPIO_Pin_3, GPIO_PinSource3, NONE, NONE, TIM2, TIM_Channel_4, PIN_MODE_NONE, 0, 0 } */
-#if PLATFORM_ID == 8 // P1
-/* P1S0          - 24 ,{ GPIOB, GPIO_Pin_0, GPIO_PinSource0, ADC_Channel_8, NONE, TIM3, TIM_Channel_3, PIN_MODE_NONE, 0, 0 }, */
-/* P1S1          - 25  { GPIOB, GPIO_Pin_1, GPIO_PinSource1, ADC_Channel_9, NONE, TIM3, TIM_Channel_4, PIN_MODE_NONE, 0, 0 }, */
-/* P1S2          - 26  { GPIOC, GPIO_Pin_0, GPIO_PinSource0, ADC_Channel_10, NONE, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* P1S3          - 27  { GPIOC, GPIO_Pin_4, GPIO_PinSource4, ADC_Channel_14, NONE, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* P1S4          - 28  { GPIOC, GPIO_Pin_13, GPIO_PinSource13, NONE, NONE, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* P1S5          - 29  { GPIOC, GPIO_Pin_1, GPIO_PinSource1, ADC_Channel_11, NONE, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* P1S6          - 30  { GPIOA, GPIO_Pin_8, GPIO_PinSource8, NONE, NONE, TIM1, TIM_Channel_1, PIN_MODE_NONE, 0, 0 }, */
-#endif
-
-#if PLATFORM_ID == 10 // Electron
-/* B0            - 24 ,{ GPIOC, GPIO_Pin_8, GPIO_PinSource8, NONE, NONE, TIM8, TIM_Channel_3, PIN_MODE_NONE, 0, 0 }, */
-/* B1            - 25  { GPIOC, GPIO_Pin_6, GPIO_PinSource6, NONE, NONE, TIM8, TIM_Channel_1, PIN_MODE_NONE, 0, 0 }, */
-/* B2            - 26  { GPIOB, GPIO_Pin_0, GPIO_PinSource0, ADC_Channel_8, NONE, TIM3, TIM_Channel_3, PIN_MODE_NONE, 0, 0 }, */
-/* B3            - 27  { GPIOB, GPIO_Pin_1, GPIO_PinSource1, ADC_Channel_9, NONE, TIM3, TIM_Channel_4, PIN_MODE_NONE, 0, 0 }, */
-/* B4            - 28  { GPIOC, GPIO_Pin_0, GPIO_PinSource0, ADC_Channel_10, NONE, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* B5            - 29  { GPIOC, GPIO_Pin_1, GPIO_PinSource1, ADC_Channel_11, NONE, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* C0            - 30  { GPIOD, GPIO_Pin_2, GPIO_PinSource2, NONE, NONE, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* C1            - 31  { GPIOC, GPIO_Pin_12, GPIO_PinSource12, NONE, NONE, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* C2            - 32  { GPIOC, GPIO_Pin_11, GPIO_PinSource11, NONE, NONE, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* C3            - 33  { GPIOC, GPIO_Pin_10, GPIO_PinSource10, NONE, NONE, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* C4            - 34  { GPIOB, GPIO_Pin_9, GPIO_PinSource9, NONE, NONE, TIM4, TIM_Channel_4, PIN_MODE_NONE, 0, 0 }, */
-/* C5            - 35  { GPIOB, GPIO_Pin_8, GPIO_PinSource8, NONE, NONE, TIM4, TIM_Channel_3, PIN_MODE_NONE, 0, 0 }, */
-/* TXD_UC        - 36  { GPIOB, GPIO_Pin_10, GPIO_PinSource10, NONE, NONE, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* RXD_UC        - 37  { GPIOB, GPIO_Pin_11, GPIO_PinSource11, NONE, NONE, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* RI_UC         - 38  { GPIOB, GPIO_Pin_12, GPIO_PinSource12, NONE, NONE, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* CTS_UC        - 39  { GPIOB, GPIO_Pin_13, GPIO_PinSource13, NONE, NONE, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* RTS_UC        - 40  { GPIOB, GPIO_Pin_14, GPIO_PinSource14, NONE, NONE, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* PWR_UC        - 41  { GPIOB, GPIO_Pin_2, GPIO_PinSource2, NONE, NONE, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* RESET_UC      - 42  { GPIOC, GPIO_Pin_4, GPIO_PinSource4, NONE, NONE, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* LVLOE_UC      - 43  { GPIOB, GPIO_Pin_15, GPIO_PinSource15, NONE, NONE, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* PM_SDA_UC     - 44  { GPIOC, GPIO_Pin_9, GPIO_PinSource9, NONE, NONE, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* PM_SCL_UC     - 45  { GPIOA, GPIO_Pin_8, GPIO_PinSource8, NONE, NONE, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-/* LOW_BAT_UC    - 46  { GPIOC, GPIO_Pin_13, GPIO_PinSource13, NONE, NONE, NULL, NONE, PIN_MODE_NONE, 0, 0 }, */
-#endif
-
-const pin_t pins[] = {
-    A7,
-#if PLATFORM_ID == 10
-    B3,
-#endif
-#if PLATFORM_ID == 8
-    P1S1,
-#endif
-    A2,
-    D4,
-    D3,
-    D2,
-    D1,
-    BTN,
-#if PLATFORM_ID == 10
-    B0,
-#endif
-    TX,
-    RX,
-#if PLATFORM_ID == 10
-    C2,
-    C1,
-#endif
-#if PLATFORM_ID == 8
-    P1S4,
-#endif
-    D6,
-    D5
-};
-
-const char* pin_names[] = {
-    "A7",
-#if PLATFORM_ID == 10
-    "B3",
-#endif
-#if PLATFORM_ID == 8
-    "P1S1",
-#endif
-    "A2",
-    "D4",
-    "D3",
-    "D2",
-    "D1",
-    "SETUP button",
-#if PLATFORM_ID == 10
-    "B0",
-#endif
-    "TX",
-    "RX",
-#if PLATFORM_ID == 10
-    "C2",
-    "C1",
-#endif
-#if PLATFORM_ID == 8
-    "P1S4"
-#endif
-    "D6",
-    "D5"
-};
-
-const size_t pinCount = sizeof(pins)/sizeof(*pins);
-
-InterruptMode mode[pinCount];
+extern const pin_t g_pins[];
+extern const char* g_pin_names[];
+extern const size_t g_pin_count;
 
 void setup() {
-    for (unsigned i = 0; i < sizeof(mode)/sizeof(*mode); i++) {
-        mode[i] = (pins[i] == BTN ? FALLING : (i % 2 == 0 ? RISING : FALLING));
-    }
 }
 
 void countdown(int c) {
@@ -166,15 +39,20 @@ void countdown(int c) {
 }
 
 const char* getPinName(pin_t pin) {
-    for (unsigned i = 0; i < pinCount; i++) {
-        if (pins[i] == pin) {
-            return pin_names[i];
+    for (unsigned i = 0; i < g_pin_count; i++) {
+        if (g_pins[i] == pin) {
+            return g_pin_names[i];
         }
     }
     return "UNKNOWN";
 }
 
 void loop() {
+    InterruptMode mode[g_pin_count];
+    for (unsigned i = 0; i < sizeof(mode)/sizeof(*mode); i++) {
+        mode[i] = (g_pins[i] == BTN ? FALLING : (i % 2 == 0 ? RISING : FALLING));
+    }
+
     waitUntil(Serial.isConnected);
     SleepResult r = System.sleepResult();
     if (r.wokenUpByPin()) {
@@ -184,8 +62,8 @@ void loop() {
     }
     Serial.println("Press any key to enter STOP mode");
     Serial.println("You should be able to wake up your device using any of these pins:");
-    for (unsigned i = 0; i < sizeof(pins)/sizeof(*pins); i++) {
-        Serial.printlnf("%s: %s", pin_names[i], mode[i] == RISING ? "RISING" : "FALLING");
+    for (unsigned i = 0; i < g_pin_count; i++) {
+        Serial.printlnf("%s: %s", g_pin_names[i], mode[i] == RISING ? "RISING" : "FALLING");
     }
     Serial.println();
     Serial.println("The device will also automatically wake up after 60 seconds");
@@ -196,5 +74,5 @@ void loop() {
         Serial.read();
     }
     countdown(3);
-    System.sleep(pins, pinCount, mode, pinCount, 60);
+    System.sleep(g_pins, g_pin_count, mode, g_pin_count, 60);
 }


### PR DESCRIPTION
### Problem

STOP mode is not implemented for Gen 3 devices.

### Solution

Well, implement it.

### Tests to run

- :heavy_check_mark: `app/sleep_multiple_pins`
- :heavy_check_mark: `wiring/sleep`

### References

- [CH26710]
- [CH27767]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
