### PR TITLE
Enable workbench to recognize `uint32_t`

### DIFF
--- a/user/inc/Particle.h
+++ b/user/inc/Particle.h
@@ -2,7 +2,8 @@
 #ifndef PARTICLE_H
 #define	PARTICLE_H
 
+#include <stdint.h>
+
 #include "application.h"
 
 #endif	/* PARTICLE_H */
-


### PR DESCRIPTION
Maintain parity with Arduino IDE

### Problem

Workbench does not recognize `uint32_t`, but it does _NOT_ result in a compile error

### Solution

`#include <stdint.h>` in `Particle.h` to ensure `stdint.h` is in workbench's include path.

### Steps to Test

Create an app in workbench and specify `unit32_t` type

### Example App

```c
uint32_t var;

void setup() {}
void loop() {}
```

### References

https://community.particle.io/t/issue-uint32-t-is-not-a-type-name-when-configured-for-mesh/47359

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)