### PR TITLE
[LTE/Electron] Fixes software Timer()'s halting after millis() overflows (every 49.7 days)

### DIFF
--- a/hal/src/electron/rtos/FreeRTOSv8.2.2/FreeRTOS/Source/timers.c
+++ b/hal/src/electron/rtos/FreeRTOSv8.2.2/FreeRTOS/Source/timers.c
@@ -233,7 +233,7 @@ static TickType_t prvGetNextExpireTime( BaseType_t * const pxListWasEmpty ) PRIV
  * If a timer has expired, process it.  Otherwise, block the timer service task
  * until either a timer does expire or a command is received.
  */
-static void prvProcessTimerOrBlockTask( const TickType_t xNextExpireTime, const BaseType_t xListWasEmpty ) PRIVILEGED_FUNCTION;
+static void prvProcessTimerOrBlockTask( const TickType_t xNextExpireTime, BaseType_t xListWasEmpty ) PRIVILEGED_FUNCTION;
 
 /*-----------------------------------------------------------*/
 
@@ -439,7 +439,7 @@ BaseType_t xListWasEmpty;
 }
 /*-----------------------------------------------------------*/
 
-static void prvProcessTimerOrBlockTask( const TickType_t xNextExpireTime, const BaseType_t xListWasEmpty )
+static void prvProcessTimerOrBlockTask( const TickType_t xNextExpireTime, BaseType_t xListWasEmpty )
 {
 TickType_t xTimeNow;
 BaseType_t xTimerListsWereSwitched;
@@ -468,6 +468,13 @@ BaseType_t xTimerListsWereSwitched;
 				received - whichever comes first.  The following line cannot
 				be reached unless xNextExpireTime > xTimeNow, except in the
 				case when the current timer list is empty. */
+				if( xListWasEmpty != pdFALSE )
+				{
+					/* The current timer list is empty - is the overflow list
+					also empty? */
+					xListWasEmpty = listLIST_IS_EMPTY( pxOverflowTimerList );
+				}
+
 				vQueueWaitForMessageRestricted( xTimerQueue, ( xNextExpireTime - xTimeNow ), xListWasEmpty );
 
 				if( xTaskResumeAll() == pdFALSE )


### PR DESCRIPTION
### Problem

The [Particle software timers aka `Timer`](https://docs.particle.io/reference/device-os/firmware/photon/#software-timers) use the FreeRTOS timer feature. FreeRTOS version 8.2.2 used on the Electron introduced a bug where timers stop triggering after an overflow of the tick count, which happens after ~49 days.

### Solution

Rather than upgrade the whole FreeRTOS this PR backports the bugfix from https://github.com/cjlano/freertos/commit/f780d64f5244431c609696f7ca1c3e06ea268a76#diff-ed9ddddbc8c65ef44735bc5950056ef7R474

### Steps to Test

Steps to validate the issue and fix:
1. Modify https://github.com/particle-iot/device-os/blob/0b83dbf09fb9c98d910c91ac39d0a75c983fecad/hal/src/electron/rtos/FreeRTOSv8.2.2/FreeRTOS/Source/tasks.c#L1593 to trigger the timer overflow soon after boot

```
		xTickCount = ( TickType_t ) 0xFFFFD000U;
```
1. Add the example application below as `~Downloads/timer/timer.cpp`
1. Compile and flash with `modules$ make clean all -s COMPILE_LTO=n PLATFORM=electron DEBUG_BUILD=y APPDIR=~/Downloads/timer program-dfu`
1. Connect to the USB serial port and see the printed numbers go from 1 to 11 then stop.
1. Apply the changes in this PR
1. Recompile (clean build important!) and flash
1. Connect to the USB serial port and see the printed numbers go from 1 upwards without stopping.

### Example App

```c
#include "Particle.h"

SYSTEM_THREAD(ENABLED);

void print_every_second()
{
    static int count = 0;
    Serial.println(count++);
}

Timer timer(1000, print_every_second);

void setup()
{
    Serial.begin(9600);
    timer.start();
}
```

### Completeness

- [x] User is totes amazing for contributing!
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] (N/A) Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
