### PR TITLE
[LTE/Electron] bug fixes and enhancements

### DIFF
--- a/hal/src/electron/modem/electronserialpipe_hal.h
+++ b/hal/src/electron/modem/electronserialpipe_hal.h
@@ -106,6 +106,14 @@ public:
     */
     void rxPause();
 
+    /** returns size of TX pipe
+    */
+    int txSize();
+
+    /** returns size of RX pipe
+    */
+    int rxSize();
+
 protected:
     //! start transmission helper
     void txStart(void);

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -62,12 +62,25 @@ std::recursive_mutex mdm_mutex;
 // data read from a socket if the data contains a null byte
 // #define SOCKET_HEX_MODE
 
-// Timeouts for various AT commands
-#define USOWR_TIMEOUT   (120 * 1000) /* 120 for R4, 1 for U2/G3 */
-#define USORD_TIMEOUT   ( 1 * 1000)
-#define USOST_TIMEOUT   (10 * 1000)  /*  10 for R4, 1 for U2/G3 */
-#define USORF_TIMEOUT   ( 1 * 1000)
-#define COPS_TIMEOUT    ( 3 * 60 * 1000)
+// Timeouts for various AT commands based on R4 & U2/G3 AT command manual as of Jan 2019
+#define AT_TIMEOUT      (  1 * 1000)
+#define USOCL_TIMEOUT   ( 10 * 1000) /* 120s for R4 (TCP only, optimizing for UDP with 10s), 1s for U2/G3 */
+#define USOCO_TIMEOUT   ( 10 * 1000) /* 120s for R4 (TCP only, optimizing for UDP with 10s), 1s for U2/G3 */
+#define USOCR_TIMEOUT   (  1 * 1000)
+#define USOCTL_TIMEOUT  (  1 * 1000)
+#define USOWR_TIMEOUT   ( 10 * 1000) /* 120s for R4 (optimizing for non-blocking behavior with 10s), 1s for U2/G3 */
+#define USORD_TIMEOUT   ( 10 * 1000) /* FIXME: 1s for R4/U2/G3, but longer timeouts required in deployments */
+#define USOST_TIMEOUT   ( 10 * 1000) /*  10s for R4, 1s for U2/G3 */
+#define USORF_TIMEOUT   ( 10 * 1000) /* FIXME: 1s for R4/U2/G3, but longer timeouts required in deployments */
+#define CEER_TIMEOUT    (  1 * 1000)
+#define CEREG_TIMEOUT   (  1 * 1000)
+#define CGDCONT_TIMEOUT (  1 * 1000)
+#define CGREG_TIMEOUT   (  1 * 1000)
+#define COPS_TIMEOUT    (180 * 1000)
+#define CPWROFF_TIMEOUT ( 40 * 1000)
+#define CREG_TIMEOUT    (  1 * 1000)
+#define CSQ_TIMEOUT     (  1 * 1000)
+#define URAT_TIMEOUT    (  1 * 1000)
 
 // num sockets
 #define NUMSOCKETS      ((int)(sizeof(_sockets)/sizeof(*_sockets)))
@@ -268,6 +281,12 @@ int MDMParser::sendFormattedWithArgs(const char* format, va_list args) {
     return n;
 }
 
+bool MDMParser::_atOk(void)
+{
+    sendFormated("AT\r\n");
+    return (RESP_OK == waitFinalResp(nullptr, nullptr, AT_TIMEOUT));
+}
+
 int MDMParser::waitFinalResp(_CALLBACKPTR cb /* = NULL*/,
                              void* param /* = NULL*/,
                              system_tick_t timeout_ms /*= 5000*/)
@@ -431,7 +450,7 @@ int MDMParser::waitFinalResp(_CALLBACKPTR cb /* = NULL*/,
                 return RESP_ABORTED; // This means the current command was ABORTED, so retry your command if critical.
         }
         // relax a bit
-        HAL_Delay_Milliseconds(10);
+        HAL_Delay_Milliseconds(1);
     }
     while (!TIMEOUT(start, timeout_ms) && !_cancel_all_operations);
 
@@ -567,6 +586,13 @@ bool MDMParser::_powerOn(void)
     HAL_Pin_Mode(LVLOE_UC, OUTPUT);
     HAL_GPIO_Write(LVLOE_UC, 0);
 
+    // This connects to V_INT on the cellular modem. Monitoring V_INT can provide more
+    // fine-grained detail on when the modem is powered-on (HIGH) or has completed a
+    // power-off sequence and currently powered-off (LOW).
+    // NOTE: Modem isn't necessarily ready to communicate on its AT interface when V_INT
+    // first goes HIGH.
+    HAL_Pin_Mode(RI_UC, INPUT_PULLDOWN);
+
     if (!_init) {
         MDM_INFO("[ ElectronSerialPipe::begin ] = = = = = = = =");
 
@@ -605,9 +631,7 @@ bool MDMParser::_powerOn(void)
         }
 
         // check interface
-        sendFormated("AT\r\n");
-        int r = waitFinalResp(NULL,NULL,1000);
-        if(RESP_OK == r) {
+        if(_atOk()) {
             _pwr = true;
             break;
         }
@@ -641,7 +665,7 @@ bool MDMParser::_powerOn(void)
     waitFinalResp(NULL,NULL,200);
 
     // echo off
-    sendFormated("AT E0\r\n");
+    sendFormated("ATE0\r\n");
     if(RESP_OK != waitFinalResp())
         goto failure;
     // enable verbose error messages
@@ -840,6 +864,7 @@ bool MDMParser::powerOff(void)
     LOCK();
     bool ok = false;
     bool continue_cancel = false;
+    bool check_ri = false;
     if (_init && _pwr) {
         MDM_INFO("\r\n[ Modem::powerOff ] = = = = = = = = = = = = = =");
         if (_cancel_all_operations) {
@@ -847,25 +872,51 @@ bool MDMParser::powerOff(void)
             resume(); // make sure we can use the AT parser
         }
         for (int i=0; i<3; i++) { // try 3 times
-            sendFormated("AT+CPWROFF\r\n");
-            int ret = waitFinalResp(NULL,NULL,40*1000);
-            if (RESP_OK == ret) {
-                _pwr = false;
-                // todo - add if these are automatically done on power down
-                //_activated = false;
-                //_attached = false;
-                // Give the modem some time to switch off cleanly
-                HAL_Delay_Milliseconds(1000);
-                ok = true;
+            if(!_atOk()) {
+                MDM_INFO("\r\n[ Modem::powerOff ] AT Failure, trying PWR_UC...");
+                HAL_GPIO_Write(PWR_UC, 0);
+                // >1.5 seconds on SARA R410M
+                // >1 second on SARA U2
+                // plus a little extra for good luck
+                HAL_Delay_Milliseconds(1600);
+                HAL_GPIO_Write(PWR_UC, 1);
+                if (_dev.dev == DEV_SARA_R410) {
+                    check_ri = true;
+                }
                 break;
-            }
-            else if (RESP_ABORTED == ret) {
-                MDM_INFO("\r\n[ Modem::powerOff ] found ABORTED, retrying...");
-            }
-            else {
-                MDM_INFO("\r\n[ Modem::powerOff ] timeout, retrying...");
+            } else {
+                sendFormated("AT+CPWROFF\r\n");
+                int ret = waitFinalResp(nullptr, nullptr, CPWROFF_TIMEOUT);
+                if (RESP_OK == ret) {
+                    _pwr = false;
+                    // todo - add if these are automatically done on power down
+                    //_activated = false;
+                    //_attached = false;
+                    ok = true;
+                    check_ri = true;
+                    break;
+                }
+                else if (RESP_ABORTED == ret) {
+                    MDM_INFO("\r\n[ Modem::powerOff ] found ABORTED, retrying...");
+                }
+                else {
+                    MDM_INFO("\r\n[ Modem::powerOff ] timeout, retrying...");
+                }
             }
         }
+    }
+
+    if (check_ri) {
+        system_tick_t t0 = HAL_Timer_Get_Milli_Seconds();
+        while (HAL_GPIO_Read(RI_UC) && !TIMEOUT(t0, 10000))
+        {
+            HAL_Delay_Milliseconds(1); // just wait
+        }
+        if(!HAL_GPIO_Read(RI_UC))
+        {
+            _pwr = false;
+        }
+        MDM_INFO("\r\n[ Modem::powerOff ] took %lu ms", HAL_Timer_Get_Milli_Seconds() - t0);
     }
 
     // Close serial connection
@@ -927,6 +978,21 @@ int MDMParser::_cbCCID(int type, const char* buf, int len, char* ccid)
     return WAIT;
 }
 
+bool MDMParser::_checkEpsReg(void) {
+    // On the SARA R410M check EPS registration
+    if (_dev.dev == DEV_SARA_R410) {
+        LOCK();
+        int r;
+        sendFormated("AT+CEREG?\r\n");
+        r = waitFinalResp(nullptr, nullptr, CEREG_TIMEOUT);
+        UNLOCK();
+        if (r != RESP_OK || !REG_OK(_net.eps)) {
+            return false;
+        }
+    }
+    return true;
+}
+
 bool MDMParser::registerNet(const char* apn, NetStatus* status /*= NULL*/, system_tick_t timeout_ms /*= 180000*/)
 {
     LOCK();
@@ -935,17 +1001,38 @@ bool MDMParser::registerNet(const char* apn, NetStatus* status /*= NULL*/, syste
         // Check to see if we are already connected. If so don't issue these
         // commands as they will knock us off the cellular network.
         bool ok = false;
+        // We may already be connected quickly on boot, or connect within the first
+        // call to checkNetStatus(), so these registration URCs need to be set up at
+        // least once to ensure they continue to work later on when using _checkEpsReg()
+        if (_dev.dev == DEV_SARA_R410) {
+            // Set up the EPS network registration URC
+            sendFormated("AT+CEREG=2\r\n");
+            if (RESP_OK != waitFinalResp(nullptr, nullptr, CEREG_TIMEOUT)) {
+                goto failure;
+            }
+        } else {
+            // Set up the GPRS network registration URC
+            sendFormated("AT+CGREG=2\r\n");
+            if (RESP_OK != waitFinalResp(nullptr, nullptr, CGREG_TIMEOUT)) {
+                goto failure;
+            }
+            // Set up the GSM network registration URC
+            sendFormated("AT+CREG=2\r\n");
+            if (RESP_OK != waitFinalResp(nullptr, nullptr, CREG_TIMEOUT)) {
+                goto failure;
+            }
+        }
         if (!(ok = checkNetStatus())) {
 #ifdef MDM_DEBUG
             // Show enabled RATs
             sendFormated("AT+URAT?\r\n");
-            waitFinalResp();
+            waitFinalResp(nullptr, nullptr, URAT_TIMEOUT);
 #endif // defined(MDM_DEBUG)
             if (_dev.dev == DEV_SARA_R410) {
                 // Get default context settings
                 sendFormated("AT+CGDCONT?\r\n");
                 CGDCONTparam ctx = {};
-                if (waitFinalResp(_cbCGDCONT, &ctx) != RESP_OK) {
+                if (waitFinalResp(_cbCGDCONT, &ctx, CGDCONT_TIMEOUT) != RESP_OK) {
                     goto failure;
                 }
                 // TODO: SARA-R410-01B modules come preconfigured with AT&T's APN ("broadband"), which may
@@ -955,55 +1042,43 @@ bool MDMParser::registerNet(const char* apn, NetStatus* status /*= NULL*/, syste
                 // the factory default settings. Ideally, setting of a default APN should be based on IMSI
                 if (strcmp(ctx.type, "IP") != 0 || strcmp(ctx.apn, apn ? apn : "") != 0) {
                     // Stop the network registration and update the context settings
+                    if (!_atOk()) {
+                        goto failure;
+                    }
                     sendFormated("AT+COPS=2\r\n");
                     if (waitFinalResp(nullptr, nullptr, COPS_TIMEOUT) != RESP_OK) {
                         goto failure;
                     }
                     sendFormated("AT+CGDCONT=%d,\"IP\",\"%s\"\r\n", PDP_CONTEXT, apn ? apn : "");
-                    if (waitFinalResp() != RESP_OK) {
+                    if (waitFinalResp(nullptr, nullptr, CGDCONT_TIMEOUT) != RESP_OK) {
                         goto failure;
                     }
                 }
                 // Make sure automatic network registration is enabled
+                if (!_atOk()) {
+                    goto failure;
+                }
                 sendFormated("AT+COPS=0\r\n");
                 if (waitFinalResp(nullptr, nullptr, COPS_TIMEOUT) != RESP_OK) {
                     goto failure;
                 }
-                // Set up the EPS network registration URC
-                sendFormated("AT+CEREG=2\r\n");
-                if (waitFinalResp() != RESP_OK) {
-                    goto failure;
-                }
-            } else {
-                // setup the GPRS network registration URC (Unsolicited Response Code)
-                // 0: (default value and factory-programmed value): network registration URC disabled
-                // 1: network registration URC enabled
-                // 2: network registration and location information URC enabled
-                sendFormated("AT+CGREG=2\r\n");
-                if (RESP_OK != waitFinalResp())
-                    goto failure;
-                // setup the network registration URC (Unsolicited Response Code)
-                // 0: (default value and factory-programmed value): network registration URC disabled
-                // 1: network registration URC enabled
-                // 2: network registration and location information URC enabled
-                sendFormated("AT+CREG=2\r\n");
-                if (RESP_OK != waitFinalResp())
-                    goto failure;
             }
-            // Now check every 15 seconds for 5 minutes to see if we're connected to the tower (GSM and GPRS)
+            // Now check every 15 seconds for 5 minutes to see if we're connected to the tower (GSM, GPRS and LTE)
             system_tick_t start = HAL_Timer_Get_Milli_Seconds();
             while (!(ok = checkNetStatus(status)) && !TIMEOUT(start, timeout_ms) && !_cancel_all_operations) {
                 system_tick_t start = HAL_Timer_Get_Milli_Seconds();
-                while ((HAL_Timer_Get_Milli_Seconds() - start < 15000UL) && !_cancel_all_operations); // just wait
-                //HAL_Delay_Milliseconds(15000);
+                while ((HAL_Timer_Get_Milli_Seconds() - start < 15000UL) && !_cancel_all_operations) {
+                    // Pump the URCs looking for +CREG/+CGREG/+CEREG connection events.
+                    // Busy wait 100ms, prevents super fast memory allocation/deallocation in waitFinalResponse.
+                    waitFinalResp(nullptr, nullptr, 100);
+                    if (REG_OK(_net.csd) || REG_OK(_net.psd) || REG_OK(_net.eps)) {
+                        break; // force another checkNetStatus() call
+                    }
+                }
             }
             if (_net.csd == REG_DENIED) MDM_ERROR("CSD Registration Denied\r\n");
             if (_net.psd == REG_DENIED) MDM_ERROR("PSD Registration Denied\r\n");
             if (_net.eps == REG_DENIED) MDM_ERROR("EPS Registration Denied\r\n");
-            // if (_net.csd == REG_DENIED || _net.psd == REG_DENIED) {
-            //     sendFormated("AT+CEER\r\n");
-            //     waitFinalResp();
-            // }
         }
         UNLOCK();
         return ok;
@@ -1017,31 +1092,36 @@ bool MDMParser::checkNetStatus(NetStatus* status /*= NULL*/)
 {
     bool ok = false;
     LOCK();
+    // TODO: optimize, add a param/variable to prevent clearing _net if
+    // arriving here after break() from inner while() in registerNet().
     memset(&_net, 0, sizeof(_net));
     _net.lac = 0xFFFF;
     _net.ci = 0xFFFFFFFF;
     if (_dev.dev == DEV_SARA_R410) {
-        // check EPS registration
+        // check EPS registration (LTE)
         sendFormated("AT+CEREG?\r\n");
-        waitFinalResp();
+        waitFinalResp(nullptr, nullptr, CEREG_TIMEOUT);
     } else {
-        // check registration
+        // check CSD registration (GSM)
         sendFormated("AT+CREG?\r\n");
-        waitFinalResp();     // don't fail as service could be not subscribed
+        waitFinalResp(nullptr, nullptr, CREG_TIMEOUT); // don't fail as service could be not subscribed
 
-        // check PSD registration
+        // check PSD registration (GPRS)
         sendFormated("AT+CGREG?\r\n");
-        waitFinalResp(); // don't fail as service could be not subscribed
+        waitFinalResp(nullptr, nullptr, CGREG_TIMEOUT); // don't fail as service could be not subscribed
     }
-    if (REG_OK(_net.csd) || REG_OK(_net.psd) || REG_OK(_net.eps))
-    {
+    if (REG_OK(_net.csd) || REG_OK(_net.psd) || REG_OK(_net.eps)) {
+        // get the current operator and radio access technology we are connected to
+        if (!_atOk()) {
+            goto failure;
+        }
         sendFormated("AT+COPS?\r\n");
-        if (RESP_OK != waitFinalResp(_cbCOPS, &_net)) {
+        if (RESP_OK != waitFinalResp(_cbCOPS, &_net, COPS_TIMEOUT)) {
             goto failure;
         }
         // get the signal strength indication
         sendFormated("AT+CSQ\r\n");
-        if (RESP_OK != waitFinalResp(_cbCSQ, &_net)) {
+        if (RESP_OK != waitFinalResp(_cbCSQ, &_net, CSQ_TIMEOUT)) {
             goto failure;
         }
     }
@@ -1068,7 +1148,7 @@ bool MDMParser::getSignalStrength(NetStatus &status)
     if (_init && _pwr) {
         MDM_INFO("\r\n[ Modem::getSignalStrength ] = = = = = = = = = =");
         sendFormated("AT+CSQ\r\n");
-        if (RESP_OK == waitFinalResp(_cbCSQ, &_net)) {
+        if (RESP_OK == waitFinalResp(_cbCSQ, &_net, CSQ_TIMEOUT)) {
             ok = true;
             status = _net;
         }
@@ -1679,10 +1759,12 @@ bool MDMParser::detach(void)
             // TODO: There's no GPRS service in LTE, although the GRPS detach command still disables
             // the PSD connection. For now let's unregister from the network entirely, since the
             // behavior of the detach command in relation to LTE is not documented
-            sendFormated("AT+COPS=2\r\n");
-            if (waitFinalResp(nullptr, nullptr, COPS_TIMEOUT) == RESP_OK) {
-                _activated = false;
-                ok = true;
+            if (_atOk()) {
+                sendFormated("AT+COPS=2\r\n");
+                if (waitFinalResp(nullptr, nullptr, COPS_TIMEOUT) == RESP_OK) {
+                    _activated = false;
+                    ok = true;
+                }
             }
         } else {
             // if (_ip != NOIP) {  // if we deactivate() first we won't have an IP
@@ -1775,14 +1857,14 @@ int MDMParser::_socketCloseHandleIfOpen(int socket_handle) {
     // +USOCTL: 0,1,0
     int handle = MDM_SOCKET_ERROR;
     sendFormated("AT+USOCTL=%d,1\r\n", socket_handle);
-    if ((RESP_OK == waitFinalResp(_cbUSOCTL, &handle)) &&
+    if ((RESP_OK == waitFinalResp(_cbUSOCTL, &handle, USOCTL_TIMEOUT)) &&
         (handle != MDM_SOCKET_ERROR)) {
         DEBUG_D("Socket handle %d was open, now closing...\r\n", handle);
         // Close it if it's open
         // AT+USOCL=0
         // OK
         sendFormated("AT+USOCL=%d\r\n", handle);
-        if (RESP_OK == waitFinalResp()) {
+        if (RESP_OK == waitFinalResp(nullptr, nullptr, USOCL_TIMEOUT)) {
             DEBUG_D("Socket handle %d was closed.\r\n", handle);
             ok = true;
         }
@@ -1808,7 +1890,7 @@ int MDMParser::_socketSocket(int socket, IpProtocol ipproto, int port)
         sendFormated("AT+USOCR=6\r\n");
     }
     int handle = MDM_SOCKET_ERROR;
-    if ((RESP_OK == waitFinalResp(_cbUSOCR, &handle)) &&
+    if ((RESP_OK == waitFinalResp(_cbUSOCR, &handle, USOCR_TIMEOUT)) &&
         (handle != MDM_SOCKET_ERROR)) {
         DEBUG_D("Socket %d: handle %d was created\r\n", socket, handle);
         _sockets[socket].handle     = handle;
@@ -1836,7 +1918,7 @@ int MDMParser::socketSocket(IpProtocol ipproto, int port)
         }
     }
 
-    if (_attached) {
+    if (_attached && _atOk()) {
         // Check for any stale handles that are open on the modem but not currently associated
         // with a socket. These may occur after power cycling the STM32 with modem connected
         // or if a previous socket was not closed cleanly. socketFree() will unconditionally
@@ -1875,9 +1957,15 @@ bool MDMParser::socketConnect(int socket, const MDM_IP& ip, int port)
     bool ok = false;
     LOCK();
     if (ISSOCKET(socket) && (!_sockets[socket].connected)) {
+        // On the SARA R410M check EPS registration prior due to an issue
+        // where the USOCO can lockup the modem if connection drops
+        if (!_checkEpsReg()) {
+            UNLOCK();
+            return false;
+        }
         DEBUG_D("socketConnect(%d,port:%d)\r\n", socket,port);
         sendFormated("AT+USOCO=%d,\"" IPSTR "\",%d\r\n", _sockets[socket].handle, IPNUM(ip), port);
-        if (RESP_OK == waitFinalResp(nullptr, nullptr, 120000)) { // SARA-U2: < 20s, SARA-R4: < 120s
+        if (RESP_OK == waitFinalResp(nullptr, nullptr, USOCO_TIMEOUT)) {
             ok = _sockets[socket].connected = true;
         }
     }
@@ -1915,11 +2003,18 @@ bool MDMParser::socketClose(int socket)
     if (ISSOCKET(socket)
         && (_sockets[socket].connected || _sockets[socket].open))
     {
+        // On the SARA R410M check EPS registration prior due to an issue
+        // where the USOCL can lockup the modem if connection drops and we
+        // are trying to close a TCP socket (without using the async option).
         DEBUG_D("socketClose(%d)\r\n", socket);
-        sendFormated("AT+USOCL=%d\r\n", _sockets[socket].handle);
-        if (RESP_ERROR == waitFinalResp()) {
-            sendFormated("AT+CEER\r\n"); // For logging visibility
-            waitFinalResp();
+        if (_checkEpsReg()) {
+            sendFormated("AT+USOCL=%d\r\n", _sockets[socket].handle);
+            if (RESP_ERROR == waitFinalResp(nullptr, nullptr, USOCL_TIMEOUT)) {
+                if (_dev.dev != DEV_SARA_R410) {
+                    sendFormated("AT+CEER\r\n"); // For logging visibility
+                    waitFinalResp(nullptr, nullptr, CEER_TIMEOUT);
+                }
+            }
         }
         // Assume RESP_OK in most situations, and assume closed
         // already if we couldn't close it, even though this can
@@ -1975,10 +2070,16 @@ int MDMParser::socketSend(int socket, const char * buf, int len)
                 uint8_t retry_num = 0;
                 int response = 0;
                 do {
+                    // On the SARA R410M check EPS registration prior due to an issue
+                    // where the USOWR can lockup the modem if connection drops
+                    if (!_checkEpsReg()) {
+                        UNLOCK();
+                        return MDM_SOCKET_ERROR;
+                    }
                     sendFormated("AT+USOWR=%d,%d\r\n",_sockets[socket].handle,blk);
                     response = waitFinalResp(nullptr, nullptr, USOWR_TIMEOUT);
                     if (response == RESP_PROMPT) {
-                        HAL_Delay_Milliseconds(50);
+                        // HAL_Delay_Milliseconds(50);
                         send(buf, blk);
                         response = waitFinalResp(nullptr, nullptr, USOWR_TIMEOUT);
                         if (response == RESP_OK) {
@@ -2044,10 +2145,13 @@ int MDMParser::socketSend(int socket, const char * buf, int len)
             chunkSize -= n;
         } while (chunkSize > 0);
         // Write command suffix
+        if (!_atOk()) {
+            goto error;
+        }
         if (send("\"\r\n", 3) != 3) {
             goto error;
         }
-        if (waitFinalResp(nullptr, nullptr, USOST_TIMEOUT) != RESP_OK) {
+        if (waitFinalResp(nullptr, nullptr, USOWR_TIMEOUT) != RESP_OK) {
             goto error;
         }
         UNLOCK();
@@ -2075,11 +2179,17 @@ int MDMParser::socketSendTo(int socket, MDM_IP ip, int port, const char * buf, i
             if (ISSOCKET(socket)) {
                 uint8_t retry_num = 0;
                 int response = 0;
+                // On the SARA R410M check EPS registration prior due to an issue
+                // where the USOST can lockup the modem if connection drops
+                if (!_checkEpsReg()) {
+                    UNLOCK();
+                    return MDM_SOCKET_ERROR;
+                }
                 do {
                     sendFormated("AT+USOST=%d,\"" IPSTR "\",%d,%d\r\n",_sockets[socket].handle,IPNUM(ip),port,blk);
                     response = waitFinalResp(nullptr, nullptr, USOST_TIMEOUT);
                     if (response == RESP_PROMPT) {
-                        HAL_Delay_Milliseconds(50);
+                        // HAL_Delay_Milliseconds(50);
                         send(buf, blk);
                         response = waitFinalResp(nullptr, nullptr, USOST_TIMEOUT);
                         if (response == RESP_OK) {
@@ -2166,9 +2276,12 @@ int MDMParser::socketReadable(int socket)
             return MDM_SOCKET_ERROR;
     LOCK();
     if (ISSOCKET(socket) && _sockets[socket].connected) {
-            //DEBUG_D("socketReadable(%d)\r\n", socket);
-        // allow to receive unsolicited commands
-        waitFinalResp(NULL, NULL, 0);
+        // DEBUG_D("socketReadable(%d)\r\n", socket);
+        // Allow to receive unsolicited commands.
+        // Set to 10ms timeout to mimic previous response when waitFinalResp()
+        // contained 10ms busy wait and we used a 0ms timeout value below.
+        // Slows fast malloc/free of RX large buffer, as we wait for incoming data.
+        waitFinalResp(nullptr, nullptr, 10);
         if (_sockets[socket].connected)
            pending = _sockets[socket].pending;
     }

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -594,7 +594,7 @@ bool MDMParser::_powerOn(void)
     HAL_Pin_Mode(RI_UC, INPUT_PULLDOWN);
 
     if (!_init) {
-        MDM_INFO("[ ElectronSerialPipe::begin ] = = = = = = = =");
+        MDM_INFO("[ ElectronSerialPipe::begin ] pipeTx=%d pipeRx=%d", electronMDM.txSize(), electronMDM.rxSize());
 
         // Here we initialize the UART with hardware flow control enabled, even though some of
         // the modems don't support it (SARA-R4 at the time of writing). It is assumed that the
@@ -922,6 +922,7 @@ bool MDMParser::powerOff(void)
     // Close serial connection
     electronMDM.end();
     _init = false;
+    MDM_INFO("[ ElectronSerialPipe::end ] pipeTx=%d pipeRx=%d", electronMDM.txSize(), electronMDM.rxSize());
 
     HAL_Pin_Mode(PWR_UC, INPUT);
     HAL_Pin_Mode(RESET_UC, INPUT);

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -792,7 +792,7 @@ bool MDMParser::init(DevStatus* status)
     if (_dev.dev == DEV_SARA_R410) {
         // Force eDRX mode to be disabled
         // 18/23 hardware doesn't seem to be disabled by default
-        sendFormated("AT+CEDRXS=0\r\n");
+        sendFormated("AT+CEDRXS=3,2\r\n");
         if (RESP_OK != waitFinalResp())
             goto failure;
         sendFormated("AT+CEDRXS?\r\n");

--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -530,6 +530,7 @@ protected:
     static int _cbCGPADDR(int type, const char* buf, int len, MDM_IP* ip);
     struct CGDCONTparam { char type[8]; char apn[32]; };
     static int _cbCGDCONT(int type, const char* buf, int len, CGDCONTparam* param);
+    static int _cbURAT(int type, const char *buf, int len, bool *matched_default);
     // sockets
     static int _cbCMIP(int type, const char* buf, int len, MDM_IP* ip);
     static int _cbUPSND(int type, const char* buf, int len, int* act);

--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -577,6 +577,8 @@ protected:
     bool _socketFree(int socket);
     bool _powerOn(void);
     void _setBandSelectString(MDM_BandSelect &data, char* bands, int index=0); // private helper to create bands strings
+    bool _atOk(void);
+    bool _checkEpsReg(void);
     static MDMParser* inst;
     bool _init;
     bool _pwr;

--- a/hal/src/electron/modem/pipe_hal.h
+++ b/hal/src/electron/modem/pipe_hal.h
@@ -23,6 +23,7 @@
 #include <stddef.h>
 
 #include "service_debug.h"
+#include "interrupts_hal.h"
 
 #ifdef putc
 #undef putc
@@ -48,6 +49,7 @@ public:
         _a = b ? NULL : n ? new T[n + 1] : NULL;
         _r = 0;
         _w = 0;
+        _o = 0;
         _b = b ? b : _a;
         _s = n + 1;
     }
@@ -249,6 +251,17 @@ public:
     void done(void)
     {
         _r = _o;
+    }
+
+    /** reset all indexes to empty the pipe
+    */
+    void reset()
+    {
+        auto prev = HAL_disable_irq();
+        _r = 0;
+        _w = 0;
+        _o = 0;
+        HAL_enable_irq(prev);
     }
 
 private:

--- a/user/tests/wiring/no_fixture/cellular.cpp
+++ b/user/tests/wiring/no_fixture/cellular.cpp
@@ -517,7 +517,8 @@ static int atCallback(int type, const char* buf, int len, int* lines) {
 
 test(MDM_02_at_commands_with_long_response_are_correctly_parsed_and_flow_controlled) {
     // TODO: Add back this test when SARA R410 supports HW Flow Control?
-    if (skip_r410) {
+    if (cellular_modem_type() == DEV_SARA_R410) {
+        skip_r410 = true;
         Serial.println("TODO: Add back this test when SARA R410 supports HW Flow Control?");
         skip();
         return;

--- a/user/tests/wiring/no_fixture/pwm.cpp
+++ b/user/tests/wiring/no_fixture/pwm.cpp
@@ -250,12 +250,14 @@ test(PWM_08_LowDCAnalogWriteOnPinResultsInCorrectPulseWidth) {
     // 8-bit resolution
     analogWriteResolution(pin, 8);
     assertEqual(analogWriteResolution(pin), 8);
+    // analogWrite(pin, 25); // 9.8% Duty Cycle at 500Hz = 196us HIGH, 1804us LOW.
+    // if (pin == D0) delay(5000);
     uint32_t avgPulseHigh = 0;
-    for(int i=0;i<100;i++) {
-        analogWrite(pin, 25); // 10% Duty Cycle at 500Hz = 200us HIGH, 1800us LOW.
+    for(int i=0; i<10; i++) {
+        analogWrite(pin, 25); // 9.8% Duty Cycle at 500Hz = 196us HIGH, 1804us LOW.
         avgPulseHigh += pulseIn(pin, HIGH);
     }
-    avgPulseHigh /= 100;
+    avgPulseHigh /= 10;
     analogWrite(pin, 0);
 
     // then
@@ -266,28 +268,32 @@ test(PWM_08_LowDCAnalogWriteOnPinResultsInCorrectPulseWidth) {
     // 4-bit resolution
     analogWriteResolution(pin, 4);
     assertEqual(analogWriteResolution(pin), 4);
+    // analogWrite(pin, 2); // 13.3% Duty Cycle at 500Hz = 266us HIGH, 1733us LOW.
+    // if (pin == D0) delay(5000);
     avgPulseHigh = 0;
-    for(int i=0;i<100;i++) {
-        analogWrite(pin, 2); // 10% Duty Cycle at 500Hz = 200us HIGH, 1800us LOW.
+    for(int i=0; i<10; i++) {
+        analogWrite(pin, 2); // 13.3% Duty Cycle at 500Hz = 266us HIGH, 1733us LOW.
         avgPulseHigh += pulseIn(pin, HIGH);
     }
-    avgPulseHigh /= 100;
+    avgPulseHigh /= 10;
     analogWrite(pin, 0);
 
     // then
-    // avgPulseHigh should equal 200 +/- 80
-    assertMoreOrEqual(avgPulseHigh, 120);
-    assertLessOrEqual(avgPulseHigh, 280);
+    // avgPulseHigh should equal 266 +/- 50
+    assertMoreOrEqual(avgPulseHigh, 216);
+    assertLessOrEqual(avgPulseHigh, 316);
 
     // 12-bit resolution
     analogWriteResolution(pin, 12);
     assertEqual(analogWriteResolution(pin), 12);
+    // analogWrite(pin, 409); // 10% Duty Cycle at 500Hz = 200us HIGH, 1800us LOW.
+    // if (pin == D0) delay(5000);
     avgPulseHigh = 0;
-    for(int i=0;i<100;i++) {
+    for(int i=0; i<10; i++) {
         analogWrite(pin, 409); // 10% Duty Cycle at 500Hz = 200us HIGH, 1800us LOW.
         avgPulseHigh += pulseIn(pin, HIGH);
     }
-    avgPulseHigh /= 100;
+    avgPulseHigh /= 10;
     analogWrite(pin, 0);
 
     // then
@@ -298,12 +304,14 @@ test(PWM_08_LowDCAnalogWriteOnPinResultsInCorrectPulseWidth) {
     // 15-bit resolution
     analogWriteResolution(pin, 15);
     assertEqual(analogWriteResolution(pin), 15);
+    // analogWrite(pin, 3277); // 10% Duty Cycle at 500Hz = 200us HIGH, 1800us LOW.
+    // if (pin == D0) delay(5000);
     avgPulseHigh = 0;
-    for(int i=0;i<100;i++) {
+    for(int i=0; i<10; i++) {
         analogWrite(pin, 3277); // 10% Duty Cycle at 500Hz = 200us HIGH, 1800us LOW.
         avgPulseHigh += pulseIn(pin, HIGH);
     }
-    avgPulseHigh /= 100;
+    avgPulseHigh /= 10;
     analogWrite(pin, 0);
 
     // then
@@ -323,58 +331,66 @@ test(PWM_09_LowFrequencyAnalogWriteOnPinResultsInCorrectPulseWidth) {
     // 8-bit resolution
     analogWriteResolution(pin, 8);
     assertEqual(analogWriteResolution(pin), 8);
+    // analogWrite(pin, 25, 10); // 9.8% Duty Cycle at 10Hz = 9800us HIGH, 90200us LOW.
+    // if (pin == D0) delay(5000);
     uint32_t avgPulseHigh = 0;
-    for(int i=0;i<5;i++) {
-        analogWrite(pin, 25, 10); // 10% Duty Cycle at 10Hz = 10000us HIGH, 90000us LOW.
+    for(int i=0; i<2; i++) {
+        analogWrite(pin, 25, 10); // 9.8% Duty Cycle at 10Hz = 9800us HIGH, 90200us LOW.
         avgPulseHigh += pulseIn(pin, HIGH);
     }
-    avgPulseHigh /= 5;
+    avgPulseHigh /= 2;
     // then
-    // avgPulseHigh should equal 10000 +/- 50
-    assertMoreOrEqual(avgPulseHigh, 9050);
-    assertLessOrEqual(avgPulseHigh, 10050);
+    // avgPulseHigh should equal 9800 +/- 100
+    assertMoreOrEqual(avgPulseHigh, 9700);
+    assertLessOrEqual(avgPulseHigh, 9900);
 
     // 4-bit resolution
     analogWriteResolution(pin, 4);
     assertEqual(analogWriteResolution(pin), 4);
+    // analogWrite(pin, 2, 10); // 13.3% Duty Cycle at 10Hz = 13333us HIGH, 86000us LOW.
+    // if (pin == D0) delay(5000);
     avgPulseHigh = 0;
-    for(int i=0;i<5;i++) {
-        analogWrite(pin, 2, 10); // 10% Duty Cycle at 10Hz = 10000us HIGH, 90000us LOW.
+    for(int i=0; i<2; i++) {
+        analogWrite(pin, 2, 10); // 13.3% Duty Cycle at 10Hz = 13333us HIGH, 90000us LOW.
         avgPulseHigh += pulseIn(pin, HIGH);
     }
-    avgPulseHigh /= 5;
+    avgPulseHigh /= 2;
     // then
-    // avgPulseHigh should equal 10000 +/- 4000
-    assertMoreOrEqual(avgPulseHigh, 6000);
-    assertLessOrEqual(avgPulseHigh, 14000);
+    // avgPulseHigh should equal 13333 +/- 1000
+    assertMoreOrEqual(avgPulseHigh, (13333 - 1000) );
+    assertLessOrEqual(avgPulseHigh, (13333 + 1000) );
 
     // 12-bit resolution
     analogWriteResolution(pin, 12);
     assertEqual(analogWriteResolution(pin), 12);
+    // analogWrite(pin, 409, 10); // 10% Duty Cycle at 10Hz = 10000us HIGH, 90000us LOW.
+    // if (pin == D0) delay(5000);
     avgPulseHigh = 0;
-    for(int i=0;i<5;i++) {
+    for(int i=0; i<2; i++) {
         analogWrite(pin, 409, 10); // 10% Duty Cycle at 10Hz = 10000us HIGH, 90000us LOW.
         avgPulseHigh += pulseIn(pin, HIGH);
     }
-    avgPulseHigh /= 5;
+    avgPulseHigh /= 2;
     // then
-    // avgPulseHigh should equal 10000 +/- 50
-    assertMoreOrEqual(avgPulseHigh, 9050);
-    assertLessOrEqual(avgPulseHigh, 10050);
+    // avgPulseHigh should equal 10000 +/- 100
+    assertMoreOrEqual(avgPulseHigh,  9900);
+    assertLessOrEqual(avgPulseHigh, 10100);
 
     // 15-bit resolution
     analogWriteResolution(pin, 15);
     assertEqual(analogWriteResolution(pin), 15);
+    // analogWrite(pin, 3277, 10); // 10% Duty Cycle at 10Hz = 10000us HIGH, 90000us LOW.
+    // if (pin == D0) delay(5000);
     avgPulseHigh = 0;
-    for(int i=0;i<5;i++) {
+    for(int i=0; i<2; i++) {
         analogWrite(pin, 3277, 10); // 10% Duty Cycle at 10Hz = 10000us HIGH, 90000us LOW.
         avgPulseHigh += pulseIn(pin, HIGH);
     }
-    avgPulseHigh /= 5;
+    avgPulseHigh /= 2;
     // then
-    // avgPulseHigh should equal 10000 +/- 50
-    assertMoreOrEqual(avgPulseHigh, 9050);
-    assertLessOrEqual(avgPulseHigh, 10050);
+    // avgPulseHigh should equal 10000 +/- 100
+    assertMoreOrEqual(avgPulseHigh,  9900);
+    assertLessOrEqual(avgPulseHigh, 10100);
 
     analogWrite(pin, 0, 10);
     pinMode(pin, INPUT);
@@ -390,12 +406,14 @@ test(PWM_10_HighFrequencyAnalogWriteOnPinResultsInCorrectPulseWidth) {
     // 8-bit resolution
     analogWriteResolution(pin, 8);
     assertEqual(analogWriteResolution(pin), 8);
+    // analogWrite(pin, 25, 10000); // 9.8% Duty Cycle at 10kHz = 9.8us HIGH, 90.2us LOW.
+    // if (pin == D0) delay(5000);
     uint32_t avgPulseHigh = 0;
-    for(int i=0;i<1000;i++) {
-        analogWrite(pin, 25, 10000); // 10% Duty Cycle at 10kHz = 10us HIGH, 90us LOW.
+    for(int i=0; i<10; i++) {
+        analogWrite(pin, 25, 10000); // 9.8% Duty Cycle at 10kHz = 9.8us HIGH, 90.2us LOW.
         avgPulseHigh += pulseIn(pin, HIGH);
     }
-    avgPulseHigh /= 1000;
+    avgPulseHigh /= 10;
     // then
     // avgPulseHigh should equal 10 +/- 5
     assertMoreOrEqual(avgPulseHigh, 5);
@@ -404,46 +422,52 @@ test(PWM_10_HighFrequencyAnalogWriteOnPinResultsInCorrectPulseWidth) {
     // 4-bit resolution
     analogWriteResolution(pin, 4);
     assertEqual(analogWriteResolution(pin), 4);
+    // analogWrite(pin, 2, 10000); // 13.3% Duty Cycle at 10kHz = 13.3us HIGH, 86.6us LOW.
+    // if (pin == D0) delay(5000);
     avgPulseHigh = 0;
-    for(int i=0;i<1000;i++) {
-        analogWrite(pin, 2, 10000); // 10% Duty Cycle at 10kHz = 10us HIGH, 90us LOW.
+    for(int i=0; i<10; i++) {
+        analogWrite(pin, 2, 10000); // 13.3% Duty Cycle at 10kHz = 13.3us HIGH, 86.6us LOW.
         avgPulseHigh += pulseIn(pin, HIGH);
     }
-    avgPulseHigh /= 1000;
+    avgPulseHigh /= 10;
     // then
-    // avgPulseHigh should equal 10 +/- 5
-    assertMoreOrEqual(avgPulseHigh, 5);
-    assertLessOrEqual(avgPulseHigh, 15);
+    // avgPulseHigh should equal 13 +/- 5
+    assertMoreOrEqual(avgPulseHigh, 8);
+    assertLessOrEqual(avgPulseHigh, 18);
 
     // 12-bit resolution
     analogWriteResolution(pin, 12);
     assertEqual(analogWriteResolution(pin), 12);
+    // analogWrite(pin, 409, 10000); // 10% Duty Cycle at 10kHz = 10us HIGH, 90us LOW.
+    // if (pin == D0) delay(5000);
     avgPulseHigh = 0;
-    for(int i=0;i<1000;i++) {
-        analogWrite(pin, 409, 1000); // 10% Duty Cycle at 1kHz = 100us HIGH, 900us LOW.
+    for(int i=0; i<10; i++) {
+        analogWrite(pin, 409, 10000); // 10% Duty Cycle at 10kHz = 10us HIGH, 90us LOW.
         avgPulseHigh += pulseIn(pin, HIGH);
     }
-    avgPulseHigh /= 1000;
+    avgPulseHigh /= 10;
     // then
-    // avgPulseHigh should equal 100 +/- 20
-    assertMoreOrEqual(avgPulseHigh, 80);
-    assertLessOrEqual(avgPulseHigh, 120);
+    // avgPulseHigh should equal 10 +/- 2
+    assertMoreOrEqual(avgPulseHigh, 8);
+    assertLessOrEqual(avgPulseHigh, 12);
 
     // 15-bit resolution
     analogWriteResolution(pin, 15);
     assertEqual(analogWriteResolution(pin), 15);
+    // analogWrite(pin, 3277, 10000); // 10% Duty Cycle at 10kHz = 10us HIGH, 90us LOW.
+    // if (pin == D0) delay(5000);
     avgPulseHigh = 0;
-    for(int i=0;i<1000;i++) {
-        analogWrite(pin, 3277, 1000); // 10% Duty Cycle at 1kHz = 100us HIGH, 900us LOW.
+    for(int i=0; i<10; i++) {
+        analogWrite(pin, 3277, 10000); // 10% Duty Cycle at 10kHz = 10us HIGH, 90us LOW.
         avgPulseHigh += pulseIn(pin, HIGH);
     }
-    avgPulseHigh /= 1000;
+    avgPulseHigh /= 10;
     // then
-    // avgPulseHigh should equal 100 +/- 20
-    assertMoreOrEqual(avgPulseHigh, 80);
-    assertLessOrEqual(avgPulseHigh, 120);
+    // avgPulseHigh should equal 10 +/- 2
+    assertMoreOrEqual(avgPulseHigh, 8);
+    assertLessOrEqual(avgPulseHigh, 12);
 
-    analogWrite(pin, 0, 1000);
+    analogWrite(pin, 0, 500);
     pinMode(pin, INPUT);
 	});
 }


### PR DESCRIPTION
### Problem

Several LTE bugs have been found that all revolve around socket AT commands being prone to various types of failure.  See below.

### Solution(s)

#### Fixes incorrect handling of socket send when lost signal recovers during 2nd try
    
- If signal was lost before socket send, first command would timeout, during retry if signal was restored the first command would send and return OK instead of the second command requiring a PROMPT.  We would return a socket error instead of signaling data was sent OK.  This caused a network teardown and reconnection unnecessarily.
- Also adjusts the timeouts for various commands used during socket send operations.

#### Changes eDRX mode command so that it fully indicates it is disabled
    
- Despite eDRX mode being disabled via CEDRXS=0, it would still indicate \r\n+CEDRXS: 2, ... \r\n
- Now with CEDRXS=3,2 it will respond as fully disabled \r\n+CEDRXS:\r\n

#### Fixes LTE AT command interface failing when sending data with no cell signal, and more... [ch26915]
    
- If signal was lost before data sent, the AT interface would hang until the modem was reset.  This process would take around 10 minutes.
- Added checks for network registration before certain commands: USOST, USOCO, USOWR, USOCL to prevent AT interface hanging.  Unfortunately it still takes 20-30s before network registration updates, so we can still stall on these commands at times.
- Timeouts were reduced as much as possible per AT command manuals to speed up recovery process when AT interface fails.  Some timeouts were optimized for UDP usage.
- Additional checks for AT interface being available were added before long timeout commands.
- Improvements to power off routine added by using the PWR_UC pin and checking for V_INT voltage to drop.
- 10ms delay changed to 1ms delay in main parsing loop to speed up processing of many commands.
- Removed 50ms delay in socket send functions (TCP & UDP) which should also speed up communication.
- CREG?/CGREG?/CEREG? polling sped up considerably from 15s delays between tries to 10ms (1500x faster in certain cases). Time to register now on 2G/3G/LTE can be <4s for a warm boot and <9s for a cold boot.

#### Fixes LTE devices remaining disconnected until reset when connecting with no signal [ch26919]
    
- If the modem starts up with the factory default URAT setting of 7,8 (Cat-M1 & Cat-NB1) and is not able to initially connect to a Cat-M1 network, it will start scanning for Cat-NB1 networks and not return to scanning for Cat-M1 networks. In this case, it will be unable to connect to a Cat-M1 network until the cellular modem is power cycled after 5 minutes.
- Solution is to disable Cat-NB1 RAT and only use Cat-M1 RAT by default.

#### Fixes LTE/Electron AT command replay issue [ch26922]
    
- If the AT interface fails, commands sent to the modem can be replayed when it is power cycled and reset due to the circular buffer not being cleared completely.
- This resolves the issue by resetting all indexes used in the circular buffer to 0 when the serial pipe is effectively closed.

#### Make UPSD/USPDA/USPND timeouts proper (UPSDA was being short changed in deactivate()

#### Fixes PWM tests calculations and speeds up PWM wiring/no_fixture test

### Steps to Test

- Run `wiring/no_fixture` tests
- Simulate no signal by removing the antenna
    - and sending data after 5 seconds, wait for AT commands to fail, replace antenna after 30 seconds, unit should recover after about 60 seconds from when data was sent.
    - and sending data after 5 seconds, wait for AT commands to fail, reset the device, unit should boot up again and try to register.  (failing case would get stuck in listening mode repeatedly due to the AT command replay issue)
    - and sending data after 40 seconds (unit should already be indicating no signal and no network connection), AT commands should not fail as all offending commands should be avoided with CEREG? checks, replace antenna, unit should recover in about 30 seconds from when data was sent.
    - and sending data immediately, and replace antenna after first USOST command observed, unit should recover without issue and keep communicating.
    - and sending data immediately, and replace antenna after second USOST command observed, unit should usually recover without issue and keep communicating.
    - and cold boot the unit, and observe it will now toggle between CEREG: 2,0 and CEREG: 2,2.  After replacing the antenna it will connect almost immediately.
- Ensure URAT? responds with +URAT: 7 instead of +URAT: 7,8
- Attempt to force URAT=7,8 to check again that system will fix this default situation
```c
SYSTEM_MODE(SEMI_AUTOMATIC);
SYSTEM_THREAD(ENABLED);
void setup() {
    cellular_on(NULL);
    cellular_command(NULL, NULL, 1000, "AT+URAT=7,8\r\n");
    Particle.connect();
}
```

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] (N/A) Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
