### PR TITLE
Fix/gen3 fix no fixture unit test

### DIFF
--- a/hal/inc/pinmap_hal.h
+++ b/hal/inc/pinmap_hal.h
@@ -212,8 +212,6 @@ STM32_Pin_Info* HAL_Pin_Map(void);
 #define RGBG            22
 #define RGBB            23
 
-#define A7              A5   // FIXME: A7 is used in spark_wiring_wifitester.cpp
-
 #else // Mesh SoMs
 
 // button pin
@@ -230,7 +228,7 @@ STM32_Pin_Info* HAL_Pin_Map(void);
 #endif
 
 // WKP pin
-#define WKP             D8   // FIXME:
+#define WKP             D8
 
 #if PLATFORM_ID == PLATFORM_XENON // Xenon
 #define TOTAL_PINS      (31)

--- a/user/tests/wiring/no_fixture/gpio.cpp
+++ b/user/tests/wiring/no_fixture/gpio.cpp
@@ -92,10 +92,13 @@ test(GPIO_04_DigitalWriteOnPinResultsInCorrectDigitalRead) {
     //To Do : Add test for remaining pins if required
 }
 
-#if !HAL_PLATFORM_NRF52840 // TODO
-
 test(GPIO_05_pulseIn_Measures1000usHIGHWithin5Percent) {
+#if !HAL_PLATFORM_NRF52840
     pin_t pin = D1; // pin under test
+#else
+    pin_t pin = D2; // pin under test
+#endif
+
     uint32_t avgPulseHigh = 0;
     // when
     SINGLE_THREADED_BLOCK() {
@@ -114,7 +117,11 @@ test(GPIO_05_pulseIn_Measures1000usHIGHWithin5Percent) {
 }
 
 test(GPIO_06_pulseIn_Measures1000usLOWWithin5Percent) {
+#if !HAL_PLATFORM_NRF52840
     pin_t pin = D1; // pin under test
+#else
+    pin_t pin = D2; // pin under test
+#endif
 
     uint32_t avgPulseLow = 0;
     // when
@@ -132,8 +139,6 @@ test(GPIO_06_pulseIn_Measures1000usLOWWithin5Percent) {
     assertMoreOrEqual(avgPulseLow, 950);
     assertLessOrEqual(avgPulseLow, 1050);
 }
-
-#endif // !HAL_PLATFORM_NRF52840
 
 test(GPIO_07_pulseIn_TimesOutAfter3Seconds) {
     pin_t pin = D1; // pin under test
@@ -154,6 +159,8 @@ test(GPIO_07_pulseIn_TimesOutAfter3Seconds) {
     assertMoreOrEqual(millis()-startTime, 2850);
     assertLessOrEqual(millis()-startTime, 3150);
 }
+
+#if !HAL_PLATFORM_NRF52840
 
 test(GPIO_08_AnalogReadWorksMixedWithDigitalRead) {
     pin_t pin = A0;
@@ -179,3 +186,5 @@ test(GPIO_08_AnalogReadWorksMixedWithDigitalRead) {
     analogRead(pin);
     assertEqual(HAL_Get_Pin_Mode(pin), AN_INPUT);
 }
+
+#endif //  !HAL_PLATFORM_NRF52840

--- a/user/tests/wiring/no_fixture/led.cpp
+++ b/user/tests/wiring/no_fixture/led.cpp
@@ -233,11 +233,14 @@ test(LED_11_MirroringWorks) {
     RGB.control(true);
     RGB.brightness(255);
 
+#if !HAL_PLATFORM_NRF52840
     const pin_t pins[3] = {A4, A5, A7};
-
+#else
+    const pin_t pins[3] = {A4, A5, A3};
+#endif
     // Mirror to r=A4, g=A5, b=A7. Non-inverted (common cathode).
     // RGB led mirroring in bootloader is not enabled
-    RGB.mirrorTo(A4, A5, A7, false, false);
+    RGB.mirrorTo(pins[0], pins[1], pins[2], false, false);
 
     RGB.color(0, 0, 0);
     assertRgbLedMirrorPinsColor(pins, 0, 0, 0);

--- a/user/tests/wiring/no_fixture_long_running/pwm.cpp
+++ b/user/tests/wiring/no_fixture_long_running/pwm.cpp
@@ -14,11 +14,18 @@ static const uint32_t maxPulseSamples = 100;
 static const uint32_t minimumFrequency = 100;
 
 uint8_t pwm_pins[] = {
-
-#if defined(STM32F2XX)
-        D0, D1, D2, D3, A4, A5, WKP, RX, TX
-#else
+#if (PLATFORM_ID == 0) // Core
         A0, A1, A4, A5, A6, A7, D0, D1
+#elif (PLATFORM_ID == 6) // Photon
+        D0, D1, D2, D3, A4, A5, WKP, RX, TX
+#elif (PLATFORM_ID == 8) // P1
+        D0, D1, D2, D3, A4, A5, WKP, RX, TX, P1S0, P1S1, P1S6
+#elif (PLATFORM_ID == 10) // Electron
+        D0, D1, D2, D3, A4, A5, WKP, RX, TX, B0, B1, B2, B3, C4, C5
+#elif HAL_PLATFORM_NRF52840 // Xenon/Argon/Boron
+        D2, D3, D4, D5, D6, /* D7, */ D8, A0, A1, A2, A3, A4, A5 /* , RGBR, RGBG, RGBB */
+#else
+#error "Unsupported platform"
 #endif
 };
 
@@ -31,6 +38,13 @@ template <typename F> void for_all_pwm_pins(F callback)
         callback(pwm_pins[i]);
     }
 }
+
+#if (PLATFORM_ID == 8) // P1
+test(PWM_00_P1S6SetupForP1) {
+    // disable POWERSAVE_CLOCK on P1S6
+    System.disableFeature(FEATURE_WIFI_POWERSAVE_CLOCK);
+}
+#endif
 
 test(PWM_01_CompherensiveResolutionFrequency) {
     for_all_pwm_pins([&](uint16_t pin) {
@@ -136,4 +150,11 @@ test(PWM_01_CompherensiveResolutionFrequency) {
     });
 }
 
+#if (PLATFORM_ID == 8) // P1
+test(PWM_99_P1S6CleanupForP1) {
+    // enable POWERSAVE_CLOCK on P1S6
+    System.enableFeature(FEATURE_WIFI_POWERSAVE_CLOCK);
+}
 #endif
+
+#endif // PLATFORM_ID >= 3

--- a/user/tests/wiring/no_fixture_long_running/ticks.cpp
+++ b/user/tests/wiring/no_fixture_long_running/ticks.cpp
@@ -45,6 +45,7 @@ void assert_micros_millis(int duration, bool overflow = false)
 
 void assert_micros_millis_interrupts(int duration)
 {
+    // TODO: nRF52 platforms
 #if PLATFORM_ID==0 || (PLATFORM_ID>=6 && PLATFORM_ID<=10)
     // Enable some high priority interrupt to run interference
     pinMode(D0, OUTPUT);
@@ -127,7 +128,8 @@ test(TICKS_00_millis_micros_baseline_test)
     assertMoreOrEqual(micros() - startMicros, DELAY);
 }
 
-#if !defined(MODULAR_FIRMWARE) || !MODULAR_FIRMWARE
+// TODO: nRF52 platforms
+#if (!defined(MODULAR_FIRMWARE) || !MODULAR_FIRMWARE) && !defined(HAL_PLATFORM_NRF52840)
 // the __advance_system1MsTick isn't dynamically linked so we build this as a monolithic app
 #include "hw_ticks.h"
 test(TICKS_01_millis_and_micros_rollover)

--- a/wiring/src/spark_wiring_wifitester.cpp
+++ b/wiring/src/spark_wiring_wifitester.cpp
@@ -398,8 +398,13 @@ void WiFiTester::checkWifiSerial(char c) {
             }
             if (ok) {
                 if (!strcmp("ALL", parts[1])) {
+#if HAL_PLATFORM_NRF52840
+                    setPinOutputRange(A0, A5, pinValue);
+                    setPinOutputRange(D0, D8, pinValue);
+#else
                     setPinOutputRange(A0, A7, pinValue);
                     setPinOutputRange(D0, D7, pinValue);
+#endif
                 }
                 else if (parts[1][0]=='D' && is_digit(parts[1][1]) && !parts[1][2]) {
                     setPinOutput(D0 + (parts[1][1]-'0'), pinValue);


### PR DESCRIPTION
### Problem

This PR is additional fixes for some issue in [[Gen 3] Fix on-device unit tests](https://github.com/particle-iot/device-os/pull/1663)

> `GPIO_05`, `GPIO_06` take too long and eventually fail.

This is because PWM function is not available on D1 pin, use D2 instead

> `GPIO_08` expects `HAL_ADC_Read()` to change the pin mode to `AN_INPUT`.

`AN_INPUT` is only for Gen2 device

> `LED_11` fails to validate the state of the RGB LED (possibly, due to `HAL_Led_Rgb_Get_Max_Value()` returning a value that doesn't work well with the test logic).

A7 is not available on Gen3 device and `HAL_Led_Rgb_Get_Max_Value()` is fixed in [mirror button and led](https://github.com/particle-iot/device-os/pull/1590)

### Solution

N/A

### Steps to Test
`user/tests/wiring/no_fixture`

wait until  [mirror button and led](https://github.com/particle-iot/device-os/pull/1590) merged

### References

[CH28410]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
