### PR TITLE
Fix/gen3 spi ss pin occupied

### DIFF
--- a/hal/network/lwip/wiznet/wiznetif.cpp
+++ b/hal/network/lwip/wiznet/wiznetif.cpp
@@ -86,10 +86,8 @@ namespace {
 void spi_ensure_configured(HAL_SPI_Interface spi, uint8_t clockdiv, uint8_t order, uint8_t mode) {
     hal_spi_info_t info = {.version = HAL_SPI_INFO_VERSION_2};
     HAL_SPI_Info(spi, &info, nullptr);
-    if (!info.enabled || info.ss_pin != 0xff || info.mode != SPI_MODE_MASTER) {
-        // 0xff is for PIN_INVALID, so that user takes control of the CS pin.
-        // While 0xffff is for SPI_DEFAULT_SS, in which case the SPI HAL driver will use the default CS pin.
-        HAL_SPI_Begin_Ext(spi, SPI_MODE_MASTER, 0xff, nullptr);
+    if (!info.enabled || info.ss_pin != PIN_INVALID || info.mode != SPI_MODE_MASTER) {
+        HAL_SPI_Begin_Ext(spi, SPI_MODE_MASTER, PIN_INVALID, nullptr);
     }
 
     if (info.mode != SPI_MODE_MASTER ||

--- a/hal/src/nRF52840/spi_hal.cpp
+++ b/hal/src/nRF52840/spi_hal.cpp
@@ -68,8 +68,8 @@ static const nrfx_spim_t m_spim3 = NRFX_SPIM_INSTANCE(3);
 static const nrfx_spis_t m_spis2 = NRFX_SPIS_INSTANCE(2);
 
 static nrf5x_spi_info_t m_spi_map[TOTAL_SPI] = {
-    {&m_spim3, NULL, APP_IRQ_PRIORITY_HIGH, NRFX_SPIM_PIN_NOT_USED, SCK, MOSI, MISO}, // TODO: SPI3 doesn't support SPI slave mode
-    {&m_spim2, &m_spis2, APP_IRQ_PRIORITY_HIGH, NRFX_SPIM_PIN_NOT_USED, D2, D3, D4},  // TODO: Change pin number
+    {&m_spim3, NULL, APP_IRQ_PRIORITY_HIGH, PIN_INVALID, SCK, MOSI, MISO}, // TODO: SPI3 doesn't support SPI slave mode
+    {&m_spim2, &m_spis2, APP_IRQ_PRIORITY_HIGH, PIN_INVALID, D2, D3, D4},  // TODO: Change pin number
 };
 
 static void spi_master_event_handler(nrfx_spim_evt_t const * p_event, void * p_context) {


### PR DESCRIPTION

### Problem
Pin A5 stays high when using Ethernet feather wing on Xenon. 

**ISSUE LINK:**
https://community.particle.io/t/pin-a5-stays-high-when-using-ethernet-feather-wing-on-xenon/47646

### Solution
Ethernet driver wants to control the SPI SS pin itself, it passes 0xffff to SPI driver, but 0xffff means SPI_DEFAULT_SS, here we use PIN_INVALID(0xff).

### Steps to Test
1. Connect a LED to A5 pin
2. Flash the example app
3. Regular blink should be observed

### Example App

```c
void setup() {
    pinMode(A5, OUTPUT);
}

void loop() {
    delay(100);
    digitalWrite(A5, HIGH);
    delay(100);
    digitalWrite(A5, LOW);
}
```

### References

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
