### PR TITLE
[Gen 3] NCP state reset

### DIFF
--- a/hal/src/argon/network/esp32_ncp_client.cpp
+++ b/hal/src/argon/network/esp32_ncp_client.cpp
@@ -467,17 +467,29 @@ int Esp32NcpClient::waitReady() {
             HAL_Delay_Milliseconds(1000);
         }
     }
-    if (!ready_) {
+
+    if (ready_) {
+        skipAll(serial_.get(), 1000);
+        parser_.reset();
+        parserError_ = 0;
+        LOG(TRACE, "NCP ready to accept AT commands");
+
+        auto r = initReady();
+        if (r != SYSTEM_ERROR_NONE) {
+            LOG(ERROR, "Failed to perform early initialization");
+            ready_ = false;
+        }
+    } else {
         LOG(ERROR, "No response from NCP");
+    }
+
+    if (!ready_) {
         espOff();
         ncpState(NcpState::OFF);
         return SYSTEM_ERROR_INVALID_STATE;
     }
-    skipAll(serial_.get(), 1000);
-    parser_.reset();
-    parserError_ = 0;
-    LOG(TRACE, "NCP ready to accept AT commands");
-    return initReady();
+
+    return 0;
 }
 
 int Esp32NcpClient::initReady() {


### PR DESCRIPTION
### Problem

NCP client may end up in a half-initialized state if early initialization in `initReady()` fails. Unless the calling code catches this and manually resets the state via `client->off()`, the NCP client will be left in a broken state.

### Solution

Catch `initReady()` failure in `waitReady()` and reset NCP state.

### Steps to Test

1. Set `setup_done` flag to `0xff` (unset)
2. Configure Boron to use external SIM, don't plug it in
3. Reset the device, it should end up in listening mode, open its serial port and run `i` command
4. ICCID and IMEI should be empty
5. Plug SIM card in
6. Run `i` command two more times, the second time IMEI and ICCID should be printed normally

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
