### PR TITLE
Add support for accessing the SPI flash LittleFS from user-level

### DIFF
--- a/modules/argon/system-part1/module_system_part1_export.ld
+++ b/modules/argon/system-part1/module_system_part1_export.ld
@@ -41,3 +41,4 @@ PROVIDE ( dynalib_location_hal_netdb = system_part1_module_table + 80 );
 PROVIDE ( dynalib_location_hal_ifapi = system_part1_module_table + 84 );
 PROVIDE ( dynalib_location_hal_resolvapi = system_part1_module_table + 88 );
 PROVIDE ( dynalib_location_hal_wlan = system_part1_module_table + 92 );
+PROVIDE ( dynalib_location_custom = system_part1_module_table + 96 );

--- a/modules/boron/system-part1/module_system_part1_export.ld
+++ b/modules/boron/system-part1/module_system_part1_export.ld
@@ -41,3 +41,4 @@ PROVIDE ( dynalib_location_hal_netdb = system_part1_module_table + 80 );
 PROVIDE ( dynalib_location_hal_ifapi = system_part1_module_table + 84 );
 PROVIDE ( dynalib_location_hal_resolvapi = system_part1_module_table + 88 );
 PROVIDE ( dynalib_location_hal_cellular = system_part1_module_table + 92 );
+PROVIDE ( dynalib_location_custom = system_part1_module_table + 96 );

--- a/modules/shared/nRF52840/src/system-part1/module_system_part1.cpp
+++ b/modules/shared/nRF52840/src/system-part1/module_system_part1.cpp
@@ -40,6 +40,7 @@ DYNALIB_TABLE_EXTERN(hal_cellular);
 #if HAL_PLATFORM_WIFI
 DYNALIB_TABLE_EXTERN(hal_wlan);
 #endif // HAL_PLATFORM_WIFI
+DYNALIB_TABLE_EXTERN(custom);
 
 // strange that this is needed given that the entire block is scoped extern "C"
 // without it, the section name doesn't match *.system_part2_module as expected in the linker script
@@ -79,6 +80,7 @@ extern "C" __attribute__((externally_visible)) const void* const system_part1_mo
 #if HAL_PLATFORM_WIFI
     , DYNALIB_TABLE_NAME(hal_wlan)
 #endif // HAL_PLATFORM_WIFI
+    , DYNALIB_TABLE_NAME(custom)
 };
 
 #include "system_part1_loader.c"

--- a/modules/xenon/system-part1/module_system_part1_export.ld
+++ b/modules/xenon/system-part1/module_system_part1_export.ld
@@ -40,3 +40,4 @@ PROVIDE ( dynalib_location_hal_inet = system_part1_module_table + 76 );
 PROVIDE ( dynalib_location_hal_netdb = system_part1_module_table + 80 );
 PROVIDE ( dynalib_location_hal_ifapi = system_part1_module_table + 84 );
 PROVIDE ( dynalib_location_hal_resolvapi = system_part1_module_table + 88 );
+PROVIDE ( dynalib_location_custom = system_part1_module_table + 92 );

--- a/services-dynalib/src/custom_dynalib.c
+++ b/services-dynalib/src/custom_dynalib.c
@@ -1,0 +1,3 @@
+// Custom dynamic library
+#define DYNALIB_IMPORT
+#include "custom_dynalib.h"

--- a/services/inc/custom_dynalib.h
+++ b/services/inc/custom_dynalib.h
@@ -1,0 +1,36 @@
+#ifndef CUSTOM_DYNALIB_H
+#define CUSTOM_DYNALIB_H
+
+#include "dynalib.h"
+
+#ifdef DYNALIB_EXPORT
+#include <stdint.h>
+#endif // defined(DYNALIB_EXPORT)
+
+DYNALIB_BEGIN(custom)
+
+// LittleFS file functions.
+DYNALIB_FN(0, custom, file_remove, int(const char*))
+DYNALIB_FN(1, custom, file_rename, int(const char*, const char*))
+DYNALIB_FN(2, custom, file_stat, int(const char*, struct lfs_info*))
+DYNALIB_FN(3, custom, file_open, int(lfs_file_t*, const char*, unsigned int))
+DYNALIB_FN(4, custom, file_close, int(lfs_file_t*))
+//DYNALIB_FN(5, custom, file_sync, int(lfs_file_t*))
+//DYNALIB_FN(6, custom, file_read, int32_t(lfs_file_t*, void *, uint32_t))
+//DYNALIB_FN(7, custom, file_write, int32_t(lfs_file_t*, void *, uint32_t))
+//DYNALIB_FN(8, custom, file_seek, int32_t(lfs_file_t*, int32_t, int))
+//DYNALIB_FN(9, custom, file_truncate, int(lfs_file_t*, uint32_t))
+//DYNALIB_FN(10, custom, file_tell, int32_t(lfs_file_t*))
+//DYNALIB_FN(11, custom, file_rewind, int(lfs_file_t*))
+//DYNALIB_FN(12, custom, file_size, int32_t(lfs_file_t*))
+// LittleFS directory functions.
+DYNALIB_FN(5, custom, dir_open, int(lfs_dir_t*, const char*))
+DYNALIB_FN(6, custom, dir_close, int(lfs_dir_t*))
+DYNALIB_FN(7, custom, dir_read, int(lfs_dir_t*, struct lfs_info*))
+//DYNALIB_FN(16, custom, dir_seek, int(lfs_dir_t*, uint32_t))
+//DYNALIB_FN(17, custom, dir_tell, int32_t(lfs_dir_t*))
+//DYNALIB_FN(18, custom, dir_rewind, int(lfs_dir_t*))
+
+DYNALIB_END(custom)
+
+#endif  /* CUSTOM_DYNALIB_H */

--- a/services/inc/filesys.h
+++ b/services/inc/filesys.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2019 Thorsten von Eicken.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "filesystem.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// The following functions are straight adaptations from littlefs.
+// The lfs_ prefix is dropped from the name (except for remove/rename/stat) and the first
+// argument (lfs_t*) is omitted.
+// All this is done for two reasons: this way we don't need to export the lfs_t filesystem to
+// user-level and, mor importantly, it avoids name clashes at user-level because the littlefs
+// library is linked into user-level (bad idea, seems like an expediency in order not to have to
+// disentangle some dependencies in the platform stuff).
+
+int file_remove(const char *path);
+int file_rename(const char *oldpath, const char *newpath);
+int file_stat(const char *path, struct lfs_info *info);
+int file_open(lfs_file_t *file, const char* path, unsigned flags);
+int file_close(lfs_file_t *file);
+int dir_open(lfs_dir_t *dir, const char *path);
+int dir_close(lfs_dir_t *dir);
+int dir_read(lfs_dir_t *dir, struct lfs_info *info);
+
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/services/src/custom_dynalib.c
+++ b/services/src/custom_dynalib.c
@@ -1,0 +1,26 @@
+/**
+ ******************************************************************************
+ * @file    custom-dynalib.c
+ * @author  Thorsten von Eicken
+ ******************************************************************************
+  Copyright (c) 2019 Thorsten von Eicken.  All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation, either
+  version 3 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************
+ */
+
+#define DYNALIB_EXPORT
+
+#include "filesys.h"
+#include "custom_dynalib.h"

--- a/services/src/filesys.cpp
+++ b/services/src/filesys.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2018 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "filesys.h"
+
+#include "scope_guard.h"
+#include "check.h"
+
+int file_remove(const char *path) { return -1; }
+
+int file_rename(const char *oldpath, const char *newpath) { return -1; }
+
+int file_stat(const char *path, struct lfs_info *info) { return -1; }
+
+int file_open(lfs_file_t *file, const char* path, unsigned flags) {
+    const auto fs = filesystem_get_instance(nullptr);
+    CHECK_TRUE(fs, SYSTEM_ERROR_FILE);
+    lfs_info info = {};
+    int r = lfs_stat(&fs->instance, path, &info);
+    if (r != LFS_ERR_OK) {
+        const auto p = strrchr(path, '/');
+        if (p && p != path) {
+            const auto dirPath = strndup(path, p - path);
+            CHECK_TRUE(dirPath, SYSTEM_ERROR_NO_MEMORY);
+            SCOPE_GUARD({
+                free(dirPath);
+            });
+            r = lfs_mkdir(&fs->instance, dirPath);
+            CHECK_TRUE(r == LFS_ERR_OK || r == LFS_ERR_EXIST, SYSTEM_ERROR_FILE);
+        }
+        flags |= LFS_O_CREAT;
+    } else if (info.type != LFS_TYPE_REG) {
+        return SYSTEM_ERROR_FILE;
+    }
+    r = lfs_file_open(&fs->instance, file, path, flags);
+    CHECK_TRUE(r == LFS_ERR_OK, SYSTEM_ERROR_FILE);
+    return 0;
+}
+
+int file_close(lfs_file_t *file) { return -1; }
+
+int dir_open(lfs_dir_t *dir, const char *path) {
+    //LOG(INFO, "dir_open(%s)", path);
+    const auto fs = filesystem_get_instance(nullptr);
+    CHECK_TRUE(fs, SYSTEM_ERROR_FILE);
+    return lfs_dir_open(&fs->instance, dir, path);
+}
+
+int dir_close(lfs_dir_t *dir) {
+    const auto fs = filesystem_get_instance(nullptr);
+    CHECK_TRUE(fs, SYSTEM_ERROR_FILE);
+    return lfs_dir_close(&fs->instance, dir);
+}
+
+int dir_read(lfs_dir_t *dir, struct lfs_info *info) {
+    const auto fs = filesystem_get_instance(nullptr);
+    CHECK_TRUE(fs, SYSTEM_ERROR_FILE);
+    return lfs_dir_read(&fs->instance, dir, info);
+}


### PR DESCRIPTION
**At this point this PR is for discussion purposes. It is clearly incomplete. Is this even going into an interesting direction at all?**

### Problem

The purpose of this PR is to provide user-level access to the LittleFS filesystem on the SPI flash chip.

### Solution

As a first step, this PR exposes all the LittleFS file and directory functions to user-level. It strips the `lfs_t` first parameter and inserts the filesystem of the SPI flash.
A second step would be to provide a "wiring" wrapper to the raw lfs function, perhaps a clone of https://github.com/espressif/arduino-esp32/blob/master/libraries/FS/src/FSImpl.h 

### Steps to Test

No tests yet.

### Example App

The following functions print the directory tree:

```c
void fs_print_dir(lfs_dir_t *d, const char *path, int level) {
    while (true) {
        lfs_info info;
        int err = dir_read(d, &info);
        if (err == 0) return;
        if (err < 0) {
            Log.warn("dir_read->%d", err);
            return;
        }
        if (strcmp(info.name, ".") == 0 || strcmp(info.name, "..") == 0) continue;
        for (int i=0; i<level; i++) Serial.print("  ");
        Serial.printf("%s (%d)\n", info.name, info.size);
        if (info.type == LFS_TYPE_DIR) {
            char child[strlen(path)+strlen(info.name)+2];
            sprintf(child, "%s/%s", path, info.name);
            lfs_dir_t c;
            err = dir_open(&c, child);
            if (err != 0) {
                Log.warn("dir_open(%s)->%d", child, err);
                return;
            }
            fs_print_dir(&c, child, level+1);
        }
    }
}

void fs_print_tree() {
    lfs_dir_t root;
    int err = dir_open(&root, "");
    if (err != 0) {
        Serial.printf("Error opening root: %d\n", err);
        return;
    }
    Serial.println("----- directory tree");
    fs_print_dir(&root, "", 0);
    Serial.println("-----");
}
```

Output:
```
----- directory tree
sys (0)
  dct.bin (8391)
  openthread.dat (16)
  cellular_config.bin (21)
-----
```

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
