### PR TITLE
[hal] Fixes USBSerial SOS issue when removing USB cable from battery …

### DIFF
--- a/hal/src/argon/network/esp32_ncp_client.cpp
+++ b/hal/src/argon/network/esp32_ncp_client.cpp
@@ -467,17 +467,29 @@ int Esp32NcpClient::waitReady() {
             HAL_Delay_Milliseconds(1000);
         }
     }
-    if (!ready_) {
+
+    if (ready_) {
+        skipAll(serial_.get(), 1000);
+        parser_.reset();
+        parserError_ = 0;
+        LOG(TRACE, "NCP ready to accept AT commands");
+
+        auto r = initReady();
+        if (r != SYSTEM_ERROR_NONE) {
+            LOG(ERROR, "Failed to perform early initialization");
+            ready_ = false;
+        }
+    } else {
         LOG(ERROR, "No response from NCP");
+    }
+
+    if (!ready_) {
         espOff();
         ncpState(NcpState::OFF);
         return SYSTEM_ERROR_INVALID_STATE;
     }
-    skipAll(serial_.get(), 1000);
-    parser_.reset();
-    parserError_ = 0;
-    LOG(TRACE, "NCP ready to accept AT commands");
-    return initReady();
+
+    return 0;
 }
 
 int Esp32NcpClient::initReady() {

--- a/hal/src/nRF52840/usb_hal_cdc.c
+++ b/hal/src/nRF52840/usb_hal_cdc.c
@@ -343,7 +343,7 @@ int usb_uart_init(uint8_t *rx_buf, uint16_t rx_buf_size, uint8_t *tx_buf, uint16
 }
 
 int usb_uart_send(uint8_t data[], uint16_t size) {
-    if (!m_usb_instance.com_opened) {
+    if (!m_usb_instance.com_opened || m_usb_instance.power_state != POWER_STATE_READY) {
         return -1;
     }
 
@@ -375,7 +375,6 @@ int usb_uart_send(uint8_t data[], uint16_t size) {
 
         m_usb_instance.transmitting = true; // app_usbd_cdc_acm_write() cause interrupt before return!
         ret = app_usbd_cdc_acm_write(&m_app_cdc_acm, m_tx_buffer, pre_send_size);
-        SPARK_ASSERT(ret == NRF_SUCCESS);
         if (ret != NRF_SUCCESS) {
             m_usb_instance.transmitting = false;
             pre_send_size = 0;


### PR DESCRIPTION

### Problem

Fixes USBSerial SOS issue when removing USB cable from battery powered device

### Solution

This issue is caused when sending data in an invalid state, the solution is to check the power state and allow the error return of USB sending API.

### Steps to Test
1. Flash the example application to a battery powered device
1. Disconnect and reconnect the USB cable
1. Observe the LED status, whether it will enter SOS mode

### Example App

```c
void setup() {
    Serial.begin();
}

void loop() {
    Serial.print("millis: ");
    Serial.println(millis());
    delay(1000);
}
```

### References

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
