### PR TITLE
[Internal] Fix `brew install gcc-arm-none-eabi-53` formula

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -24,7 +24,7 @@ message if the version is older than this.
 - `brew update`
 - copy/paste this in Terminal and press ENTER to create the proper Brew formula
 ```
-echo -e "gcc-arm-none-eabi-53.rb
+echo -e "
 require 'formula'
 
 class GccArmNoneEabi53 < Formula
@@ -35,7 +35,7 @@ class GccArmNoneEabi53 < Formula
 
   def install
     ohai 'Copying binaries...'
-    system 'cp', '-rv', 'arm-none-eabi', 'bin', 'lib', 'share', "#{prefix}/"
+    system 'cp', '-rv', 'arm-none-eabi', 'bin', 'lib', 'share', \"#{prefix}/\"
   end
 end" > /usr/local/Homebrew/Library/Taps/px4/homebrew-px4/gcc-arm-none-eabi-53.rb
 ```


### PR DESCRIPTION
### Problem

On MacOS High Sierra 10.13.3:

running the `brew install gcc-arm-none-eabi-53` step fails:

```Error: gcc-arm-none-eabi-53: /usr/local/Homebrew/Library/Taps/px4/homebrew-px4/gcc-arm-none-eabi-53.rb:13: syntax error, unexpected keyword_end```

Adding quotes on line 13 around the prefix command fixes the problem.  they need to be escaped in the echo command.

Running again we see the following problem:

```undefined local variable or method `gcc' for Formulary::FormulaNamespace400315692c1c92e387b328263702f935:Module```

removing gcc-arm-none-eabi-53.rb from the first line of the ruby file allows for successful installation. 


### Solution

copy and paste of the new text allows brew install to succeed without errors:

```
brew install gcc-arm-none-eabi-53
==> Installing gcc-arm-none-eabi-53 from px4/px4
Warning: A newer Command Line Tools release is available.
Update them from Software Update in the App Store.

==> Downloading https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q1-update/+download/gcc-arm-none-eabi-5_3-2016q1-20160330-mac.tar.bz2
==> Downloading from https://launchpadlibrarian.net/251687676/gcc-arm-none-eabi-5_3-2016q1-20160330-mac.tar.bz2
######################################################################## 100.0%
==> Copying binaries...
==> cp -rv arm-none-eabi bin lib share /usr/local/Cellar/gcc-arm-none-eabi-53/20160307/
🍺  /usr/local/Cellar/gcc-arm-none-eabi-53/20160307: 5,496 files, 443.7MB, built in 2 minutes 46 seconds
```

### Steps to Test

Run the steps in the document.
---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)

---

- [Internal] Fix `brew install gcc-arm-none-eabi-53` formula [#1708](https://github.com/particle-iot/device-os/pull/1708)