### PR TITLE
Enable chrono string literals for time units

### DIFF
--- a/user/inc/application.h
+++ b/user/inc/application.h
@@ -30,6 +30,8 @@
 #define PARTICLE_WIRING_ARDUINO_COMPATIBILTY 0
 #endif
 
+#include <chrono>
+
 #include "system_version.h"
 
 #ifdef SPARK_PLATFORM
@@ -88,6 +90,7 @@
 
 using namespace spark;
 using namespace particle;
+using namespace std::literals::chrono_literals;
 
 #include "spark_wiring_arduino.h"
 

--- a/user/tests/app/chrono_literals/chrono_literals.cpp
+++ b/user/tests/app/chrono_literals/chrono_literals.cpp
@@ -1,0 +1,23 @@
+#include <Particle.h>
+
+/*
+ * Project: chrono_literals
+ * Description: Test chrono literal timing in `delay` API
+ * Author: Zachary J. Fields
+ * Date: 3 SEP 2019
+ */
+
+// setup() runs once, when the device is first turned on.
+void setup() {
+  // Put initialization like pinMode and begin functions here.
+  pinMode(D7, OUTPUT);
+}
+
+// loop() runs over and over again, as quickly as it can execute.
+void loop() {
+  // The core of your code will likely live here.
+  digitalWrite(D7, HIGH);
+  delay(3000);
+  digitalWrite(D7, LOW);
+  delay(3s);
+}

--- a/user/tests/wiring/api/cellular.cpp
+++ b/user/tests/wiring/api/cellular.cpp
@@ -61,6 +61,7 @@ test (api_cellular_listen)
     API_COMPILE(Cellular.listen(false));
     API_COMPILE(result = Cellular.listening());
     API_COMPILE(Cellular.setListenTimeout(10));
+    API_COMPILE(Cellular.setListenTimeout(10s));
     API_COMPILE(val = Cellular.getListenTimeout());
     (void)result; // avoid unused warning
     (void)val;    //   |

--- a/user/tests/wiring/api/cloud.cpp
+++ b/user/tests/wiring/api/cloud.cpp
@@ -129,6 +129,7 @@ test(api_spark_publish_vitals) {
     API_COMPILE(Particle.publishVitals(particle::NOW)); // publish vitals immediately
     API_COMPILE(Particle.publishVitals(0)); // disable periodic publishing
     API_COMPILE(Particle.publishVitals(5)); // publish vitals at 5 second intervals
+    API_COMPILE(Particle.publishVitals(5s)); // publish vitals at 5 second intervals
 }
 
 test(api_spark_subscribe) {
@@ -188,6 +189,7 @@ test(api_spark_connection) {
 
 #if HAL_PLATFORM_CLOUD_UDP
     API_COMPILE(Particle.keepAlive(20 * 60));
+    API_COMPILE(Particle.keepAlive(20min));
 #endif
 }
 

--- a/user/tests/wiring/api/cloud.cpp
+++ b/user/tests/wiring/api/cloud.cpp
@@ -188,7 +188,10 @@ test(api_spark_connection) {
     API_COMPILE(Particle.process());
 
 #if HAL_PLATFORM_CLOUD_UDP
+    int s = (20 * 60);
     API_COMPILE(Particle.keepAlive(20 * 60));
+    API_COMPILE(Particle.keepAlive(s));
+    API_COMPILE(Particle.keepAlive(1200s));
     API_COMPILE(Particle.keepAlive(20min));
 #endif
 }

--- a/user/tests/wiring/api/system.cpp
+++ b/user/tests/wiring/api/system.cpp
@@ -38,6 +38,7 @@ test(system_api) {
     API_COMPILE(System.resetReasonData());
 
     API_COMPILE(System.sleep(60));
+    API_COMPILE(System.sleep(60s));
 
 }
 
@@ -46,10 +47,13 @@ test(system_sleep)
 
     // All sleep methods should return System.sleep()
     API_COMPILE({ SleepResult r = System.sleep(60); (void)r; });
+    API_COMPILE({ SleepResult r = System.sleep(60s); (void)r; });
 
     API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_WLAN, 60); (void)r; });
+    API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_WLAN, 60s); (void)r; });
 
     API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, 60); (void)r; });
+    API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, 60s); (void)r; });
 
     API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP); (void)r; });
 
@@ -57,12 +61,16 @@ test(system_sleep)
     API_COMPILE({ SleepResult r = System.sleep(A0, RISING); (void)r; });
     API_COMPILE({ SleepResult r = System.sleep(A0, FALLING); (void)r; });
     API_COMPILE({ SleepResult r = System.sleep(A0, FALLING, 20); (void)r; });
+    API_COMPILE({ SleepResult r = System.sleep(A0, FALLING, 20s); (void)r; });
 
     // with network flags
     API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_WLAN, 60, SLEEP_NETWORK_STANDBY); (void)r; });
+    API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_WLAN, 60s, SLEEP_NETWORK_STANDBY); (void)r; });
 
     API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, 60, SLEEP_NETWORK_STANDBY); (void)r; });
+    API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, 60s, SLEEP_NETWORK_STANDBY); (void)r; });
     API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, SLEEP_NETWORK_STANDBY, 60); (void)r; });
+    API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, SLEEP_NETWORK_STANDBY, 60s); (void)r; });
 
     API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, SLEEP_NETWORK_STANDBY); (void)r; });
     API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, SLEEP_NETWORK_STANDBY | SLEEP_NO_WAIT); (void)r; });
@@ -71,7 +79,9 @@ test(system_sleep)
     API_COMPILE({ SleepResult r = System.sleep(A0, RISING, SLEEP_NETWORK_STANDBY); (void)r; });
     API_COMPILE({ SleepResult r = System.sleep(A0, FALLING, SLEEP_NETWORK_STANDBY); (void)r; });
     API_COMPILE({ SleepResult r = System.sleep(A0, FALLING, 20, SLEEP_NETWORK_STANDBY); (void)r; });
+    API_COMPILE({ SleepResult r = System.sleep(A0, FALLING, 20s, SLEEP_NETWORK_STANDBY); (void)r; });
     API_COMPILE({ SleepResult r = System.sleep(A0, FALLING, SLEEP_NETWORK_STANDBY, 20); (void)r; });
+    API_COMPILE({ SleepResult r = System.sleep(A0, FALLING, SLEEP_NETWORK_STANDBY, 20s); (void)r; });
 
     // Multi-pin variants
     {
@@ -96,9 +106,12 @@ test(system_sleep)
          */
         API_COMPILE({ SleepResult r = System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), RISING); (void)r; });
         API_COMPILE({ SleepResult r = System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), RISING, 20); (void)r; });
+        API_COMPILE({ SleepResult r = System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), RISING, 20s); (void)r; });
         API_COMPILE({ SleepResult r = System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), RISING, SLEEP_NETWORK_STANDBY); (void)r; });
         API_COMPILE({ SleepResult r = System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), RISING, 20, SLEEP_NETWORK_STANDBY); (void)r; });
+        API_COMPILE({ SleepResult r = System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), RISING, 20s, SLEEP_NETWORK_STANDBY); (void)r; });
         API_COMPILE({ SleepResult r = System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), RISING, SLEEP_NETWORK_STANDBY, 20); (void)r; });
+        API_COMPILE({ SleepResult r = System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), RISING, SLEEP_NETWORK_STANDBY, 20s); (void)r; });
 
         /*
          * wakeup pins: pin_t* + size_t
@@ -106,18 +119,25 @@ test(system_sleep)
          */
         API_COMPILE({ SleepResult r = System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), mode_array, sizeof(mode_array)/sizeof(*mode_array)); (void)r; });
         API_COMPILE({ SleepResult r = System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), mode_array, sizeof(mode_array)/sizeof(*mode_array), 20); (void)r; });
+        API_COMPILE({ SleepResult r = System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), mode_array, sizeof(mode_array)/sizeof(*mode_array), 20s); (void)r; });
         API_COMPILE({ SleepResult r = System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), mode_array, sizeof(mode_array)/sizeof(*mode_array), SLEEP_NETWORK_STANDBY); (void)r; });
         API_COMPILE({ SleepResult r = System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), mode_array, sizeof(mode_array)/sizeof(*mode_array), 20, SLEEP_NETWORK_STANDBY); (void)r; });
+        API_COMPILE({ SleepResult r = System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), mode_array, sizeof(mode_array)/sizeof(*mode_array), 20s, SLEEP_NETWORK_STANDBY); (void)r; });
         API_COMPILE({ SleepResult r = System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), mode_array, sizeof(mode_array)/sizeof(*mode_array), SLEEP_NETWORK_STANDBY, 20); (void)r; });
+        API_COMPILE({ SleepResult r = System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), mode_array, sizeof(mode_array)/sizeof(*mode_array), SLEEP_NETWORK_STANDBY, 20s); (void)r; });
 		// SLEEP_DISABLE_WKP_PIN
 		API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, SLEEP_DISABLE_WKP_PIN); (void)r;});
 		API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, SLEEP_DISABLE_WKP_PIN, 60); (void)r;});
+		API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, SLEEP_DISABLE_WKP_PIN, 60s); (void)r;});
 		API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, 60, SLEEP_DISABLE_WKP_PIN); (void)r;});
+		API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, 60s, SLEEP_DISABLE_WKP_PIN); (void)r;});
 
 		// Flags OR-ing
 		API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, SLEEP_DISABLE_WKP_PIN | SLEEP_NETWORK_STANDBY); (void)r;});
 		API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, SLEEP_DISABLE_WKP_PIN | SLEEP_NETWORK_STANDBY, 60); (void)r;});
+		API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, SLEEP_DISABLE_WKP_PIN | SLEEP_NETWORK_STANDBY, 60s); (void)r;});
 		API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, 60, SLEEP_DISABLE_WKP_PIN | SLEEP_NETWORK_STANDBY); (void)r;});
+		API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, 60s, SLEEP_DISABLE_WKP_PIN | SLEEP_NETWORK_STANDBY); (void)r;});
     }
     API_COMPILE({
         SleepResult r;

--- a/user/tests/wiring/api/timedelay.cpp
+++ b/user/tests/wiring/api/timedelay.cpp
@@ -26,7 +26,9 @@
 test(delay) {
 
     API_COMPILE(delay(100));
+    API_COMPILE(delay(100ms));
     API_COMPILE(delayMicroseconds(100));
+    API_COMPILE(delayMicroseconds(100us));
 }
 
 test(ticks) {

--- a/user/tests/wiring/api/wifi.cpp
+++ b/user/tests/wiring/api/wifi.cpp
@@ -61,6 +61,7 @@ test (wifi_api_listen)
     API_COMPILE(WiFi.listen(false));
     API_COMPILE(result = WiFi.listening());
     API_COMPILE(WiFi.setListenTimeout(10));
+    API_COMPILE(WiFi.setListenTimeout(10s));
     API_COMPILE(val = WiFi.getListenTimeout());
     (void)result; // avoid unused warning
     (void)val;    //   |

--- a/wiring/inc/spark_wiring_cellular.h
+++ b/wiring/inc/spark_wiring_cellular.h
@@ -20,6 +20,8 @@
 #ifndef SPARK_WIRING_CELLULAR_H
 #define	SPARK_WIRING_CELLULAR_H
 
+#include <chrono>
+
 #include "spark_wiring_platform.h"
 #include "spark_wiring_network.h"
 #include "system_network.h"
@@ -80,9 +82,11 @@ public:
         network_listen(*this, begin ? 0 : 1, NULL);
     }
 
-    void setListenTimeout(uint16_t timeout) {
+    inline void setListenTimeout(uint16_t timeout) {
         network_set_listen_timeout(*this, timeout, NULL);
     }
+
+    inline void setListenTimeout(std::chrono::seconds s) { setListenTimeout(s.count()); }
 
     uint16_t getListenTimeout(void) {
         return network_get_listen_timeout(*this, 0, NULL);

--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include <chrono>
+
 #include "spark_wiring_string.h"
 #include "events.h"
 #include "system_cloud.h"
@@ -263,6 +265,7 @@ class CloudClass {
      * @note The periodic functionality is not available for the Spark Core.
      */
     int publishVitals(system_tick_t period_s = particle::NOW);
+    inline int publishVitals(std::chrono::seconds s = std::chrono::seconds(particle::NOW)) { return publishVitals(s.count()); }
 
     inline bool subscribe(const char *eventName, EventHandler handler, Spark_Subscription_Scope_TypeDef scope)
     {
@@ -359,7 +362,7 @@ class CloudClass {
     static String deviceID(void) { return SystemClass::deviceID(); }
 
 #if HAL_PLATFORM_CLOUD_UDP
-    static void keepAlive(unsigned sec)
+    inline static void keepAlive(unsigned sec)
     {
         particle::protocol::connection_properties_t conn_prop = {0};
         conn_prop.size = sizeof(conn_prop);
@@ -368,6 +371,8 @@ class CloudClass {
                                                sec * 1000, &conn_prop, nullptr),
                  (void)0);
     }
+
+    inline static void keepAlive(std::chrono::seconds s) { keepAlive(s.count()); }
 #endif
 
 private:

--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -265,7 +265,7 @@ class CloudClass {
      * @note The periodic functionality is not available for the Spark Core.
      */
     int publishVitals(system_tick_t period_s = particle::NOW);
-    inline int publishVitals(std::chrono::seconds s = std::chrono::seconds(particle::NOW)) { return publishVitals(s.count()); }
+    inline int publishVitals(std::chrono::seconds s) { return publishVitals(s.count()); }
 
     inline bool subscribe(const char *eventName, EventHandler handler, Spark_Subscription_Scope_TypeDef scope)
     {

--- a/wiring/inc/spark_wiring_system.h
+++ b/wiring/inc/spark_wiring_system.h
@@ -22,6 +22,7 @@
 
 #ifndef SPARK_WIRING_SYSTEM_H
 #define SPARK_WIRING_SYSTEM_H
+
 #include "spark_wiring_ticks.h"
 #include "spark_wiring_string.h"
 #include "spark_wiring_platform.h"
@@ -37,6 +38,7 @@
 #include "system_user.h"
 #include "system_version.h"
 #include "spark_wiring_flags.h"
+#include <chrono>
 #include <limits>
 #include <mutex>
 
@@ -146,19 +148,18 @@ public:
     }
 #endif
 
-
     static SleepResult sleep(Spark_Sleep_TypeDef sleepMode, long seconds=0, SleepOptionFlags flag=SLEEP_NETWORK_OFF);
-    inline static SleepResult sleep(Spark_Sleep_TypeDef sleepMode, SleepOptionFlags flag, long seconds=0) {
-        return sleep(sleepMode, seconds, flag);
-    }
+
+    inline static SleepResult sleep(Spark_Sleep_TypeDef sleepMode, SleepOptionFlags flag, long seconds=0) { return sleep(sleepMode, seconds, flag); }
+    inline static SleepResult sleep(Spark_Sleep_TypeDef sleepMode, SleepOptionFlags flag, std::chrono::seconds s=std::chrono::seconds(0)) { return sleep(sleepMode, flag, s.count()); }
 
     inline static SleepResult sleep(long seconds) { return sleep(SLEEP_MODE_WLAN, seconds); }
-    inline static SleepResult sleep(uint16_t wakeUpPin, InterruptMode edgeTriggerMode, long seconds=0, SleepOptionFlags flag=SLEEP_NETWORK_OFF) {
-        return sleepPinImpl(&wakeUpPin, 1, &edgeTriggerMode, 1, seconds, flag);
-    }
-    inline static SleepResult sleep(uint16_t wakeUpPin, InterruptMode edgeTriggerMode, SleepOptionFlags flag, long seconds=0) {
-        return sleep(wakeUpPin, edgeTriggerMode, seconds, flag);
-    }
+    inline static SleepResult sleep(std::chrono::seconds s) { return sleep(s.count()); }
+
+    inline static SleepResult sleep(uint16_t wakeUpPin, InterruptMode edgeTriggerMode, long seconds=0, SleepOptionFlags flag=SLEEP_NETWORK_OFF) { return sleepPinImpl(&wakeUpPin, 1, &edgeTriggerMode, 1, seconds, flag); }
+    inline static SleepResult sleep(uint16_t wakeUpPin, InterruptMode edgeTriggerMode, std::chrono::seconds s=std::chrono::seconds(0), SleepOptionFlags flag=SLEEP_NETWORK_OFF) { return sleep(wakeUpPin, edgeTriggerMode, s.count(), flag); }
+    inline static SleepResult sleep(uint16_t wakeUpPin, InterruptMode edgeTriggerMode, SleepOptionFlags flag, long seconds=0) { return sleep(wakeUpPin, edgeTriggerMode, seconds, flag); }
+    inline static SleepResult sleep(uint16_t wakeUpPin, InterruptMode edgeTriggerMode, SleepOptionFlags flag, std::chrono::seconds s=std::chrono::seconds(0)) { return sleep(wakeUpPin, edgeTriggerMode, flag, s.count()); }
 
     /*
      * wakeup pins: std::initializer_list<pin_t>
@@ -169,9 +170,9 @@ public:
         // static_assert(pins.size() > 0, "Provided pin list is empty");
         return sleepPinImpl(pins.begin(), pins.size(), &edgeTriggerMode, 1, seconds, flag);
     }
-    inline static SleepResult sleep(std::initializer_list<pin_t> pins, InterruptMode edgeTriggerMode, SleepOptionFlags flag, long seconds = 0) {
-        return sleep(pins, edgeTriggerMode, seconds, flag);
-    }
+    inline static SleepResult sleep(std::initializer_list<pin_t> pins, InterruptMode edgeTriggerMode, std::chrono::seconds s = std::chrono::seconds(0), SleepOptionFlags flag = SLEEP_NETWORK_OFF) { return sleep(pins, edgeTriggerMode, s.count(), flag); }
+    inline static SleepResult sleep(std::initializer_list<pin_t> pins, InterruptMode edgeTriggerMode, SleepOptionFlags flag, long seconds = 0) { return sleep(pins, edgeTriggerMode, seconds, flag); }
+    inline static SleepResult sleep(std::initializer_list<pin_t> pins, InterruptMode edgeTriggerMode, SleepOptionFlags flag, std::chrono::seconds s = std::chrono::seconds(0)) { return sleep(pins, edgeTriggerMode, flag, s.count()); }
     /*
      * wakeup pins: std::initializer_list<pin_t>
      * trigger mode: std::initializer_list<InterruptMode>
@@ -182,31 +183,27 @@ public:
         // static_assert(edgeTriggerMode.size() > 0, "Provided InterruptMode list is empty");
         return sleepPinImpl(pins.begin(), pins.size(), edgeTriggerMode.begin(), edgeTriggerMode.size(), seconds, flag);
     }
-    inline static SleepResult sleep(std::initializer_list<pin_t> pins, std::initializer_list<InterruptMode> edgeTriggerMode, SleepOptionFlags flag, long seconds = 0) {
-        return sleep(pins, edgeTriggerMode, seconds, flag);
-    }
+    inline static SleepResult sleep(std::initializer_list<pin_t> pins, std::initializer_list<InterruptMode> edgeTriggerMode, std::chrono::seconds s = std::chrono::seconds(0), SleepOptionFlags flag = SLEEP_NETWORK_OFF) { return sleep(pins, edgeTriggerMode, s.count(), flag); }
+    inline static SleepResult sleep(std::initializer_list<pin_t> pins, std::initializer_list<InterruptMode> edgeTriggerMode, SleepOptionFlags flag, long seconds = 0) { return sleep(pins, edgeTriggerMode, seconds, flag); }
+    inline static SleepResult sleep(std::initializer_list<pin_t> pins, std::initializer_list<InterruptMode> edgeTriggerMode, SleepOptionFlags flag, std::chrono::seconds s = std::chrono::seconds(0)) { return sleep(pins, edgeTriggerMode, flag, s.count()); }
 
     /*
      * wakeup pins: pin_t* + size_t
      * trigger mode: single InterruptMode
      */
-    inline static SleepResult sleep(const pin_t* pins, size_t pinsSize, InterruptMode edgeTriggerMode, long seconds = 0, SleepOptionFlags flag = SLEEP_NETWORK_OFF) {
-        return sleepPinImpl(pins, pinsSize, &edgeTriggerMode, 1, seconds, flag);
-    }
-    inline static SleepResult sleep(const pin_t* pins, size_t pinsSize, InterruptMode edgeTriggerMode, SleepOptionFlags flag, long seconds = 0) {
-        return sleep(pins, pinsSize, edgeTriggerMode, seconds, flag);
-    }
+    inline static SleepResult sleep(const pin_t* pins, size_t pinsSize, InterruptMode edgeTriggerMode, long seconds = 0, SleepOptionFlags flag = SLEEP_NETWORK_OFF) { return sleepPinImpl(pins, pinsSize, &edgeTriggerMode, 1, seconds, flag); }
+    inline static SleepResult sleep(const pin_t* pins, size_t pinsSize, InterruptMode edgeTriggerMode, std::chrono::seconds s = std::chrono::seconds(0), SleepOptionFlags flag = SLEEP_NETWORK_OFF) { return sleep(pins, pinsSize, edgeTriggerMode, s.count(), flag); }
+    inline static SleepResult sleep(const pin_t* pins, size_t pinsSize, InterruptMode edgeTriggerMode, SleepOptionFlags flag, long seconds = 0) { return sleep(pins, pinsSize, edgeTriggerMode, seconds, flag); }
+    inline static SleepResult sleep(const pin_t* pins, size_t pinsSize, InterruptMode edgeTriggerMode, SleepOptionFlags flag, std::chrono::seconds s = std::chrono::seconds(0)) { return sleep(pins, pinsSize, edgeTriggerMode, flag, s.count()); }
 
     /*
      * wakeup pins: pin_t* + size_t
      * trigger mode: InterruptMode* + size_t
      */
-    inline static SleepResult sleep(const pin_t* pins, size_t pinsSize, const InterruptMode* edgeTriggerMode, size_t edgeTriggerModeSize, long seconds = 0, SleepOptionFlags flag = SLEEP_NETWORK_OFF) {
-        return sleepPinImpl(pins, pinsSize, edgeTriggerMode, edgeTriggerModeSize, seconds, flag);
-    }
-    inline static SleepResult sleep(const pin_t* pins, size_t pinsSize, const InterruptMode* edgeTriggerMode, size_t edgeTriggerModeSize, SleepOptionFlags flag, long seconds = 0) {
-        return sleep(pins, pinsSize, edgeTriggerMode, edgeTriggerModeSize, seconds, flag);
-    }
+    inline static SleepResult sleep(const pin_t* pins, size_t pinsSize, const InterruptMode* edgeTriggerMode, size_t edgeTriggerModeSize, long seconds = 0, SleepOptionFlags flag = SLEEP_NETWORK_OFF) { return sleepPinImpl(pins, pinsSize, edgeTriggerMode, edgeTriggerModeSize, seconds, flag); }
+    inline static SleepResult sleep(const pin_t* pins, size_t pinsSize, const InterruptMode* edgeTriggerMode, size_t edgeTriggerModeSize, std::chrono::seconds s = std::chrono::seconds(0), SleepOptionFlags flag = SLEEP_NETWORK_OFF) { return sleep(pins, pinsSize, edgeTriggerMode, edgeTriggerModeSize, s.count(), flag); }
+    inline static SleepResult sleep(const pin_t* pins, size_t pinsSize, const InterruptMode* edgeTriggerMode, size_t edgeTriggerModeSize, SleepOptionFlags flag, long seconds = 0) { return sleep(pins, pinsSize, edgeTriggerMode, edgeTriggerModeSize, seconds, flag); }
+    inline static SleepResult sleep(const pin_t* pins, size_t pinsSize, const InterruptMode* edgeTriggerMode, size_t edgeTriggerModeSize, SleepOptionFlags flag, std::chrono::seconds s = std::chrono::seconds(0)) { return sleep(pins, pinsSize, edgeTriggerMode, edgeTriggerModeSize, flag, s.count()); }
 
     static String deviceID(void) { return spark_deviceID(); }
 

--- a/wiring/inc/spark_wiring_system.h
+++ b/wiring/inc/spark_wiring_system.h
@@ -149,17 +149,18 @@ public:
 #endif
 
     static SleepResult sleep(Spark_Sleep_TypeDef sleepMode, long seconds=0, SleepOptionFlags flag=SLEEP_NETWORK_OFF);
+    inline static SleepResult sleep(Spark_Sleep_TypeDef sleepMode, std::chrono::seconds s, SleepOptionFlags flag=SLEEP_NETWORK_OFF) { return sleep(sleepMode, s.count(), flag); }
 
     inline static SleepResult sleep(Spark_Sleep_TypeDef sleepMode, SleepOptionFlags flag, long seconds=0) { return sleep(sleepMode, seconds, flag); }
-    inline static SleepResult sleep(Spark_Sleep_TypeDef sleepMode, SleepOptionFlags flag, std::chrono::seconds s=std::chrono::seconds(0)) { return sleep(sleepMode, flag, s.count()); }
+    inline static SleepResult sleep(Spark_Sleep_TypeDef sleepMode, SleepOptionFlags flag, std::chrono::seconds s) { return sleep(sleepMode, flag, s.count()); }
 
     inline static SleepResult sleep(long seconds) { return sleep(SLEEP_MODE_WLAN, seconds); }
     inline static SleepResult sleep(std::chrono::seconds s) { return sleep(s.count()); }
 
     inline static SleepResult sleep(uint16_t wakeUpPin, InterruptMode edgeTriggerMode, long seconds=0, SleepOptionFlags flag=SLEEP_NETWORK_OFF) { return sleepPinImpl(&wakeUpPin, 1, &edgeTriggerMode, 1, seconds, flag); }
-    inline static SleepResult sleep(uint16_t wakeUpPin, InterruptMode edgeTriggerMode, std::chrono::seconds s=std::chrono::seconds(0), SleepOptionFlags flag=SLEEP_NETWORK_OFF) { return sleep(wakeUpPin, edgeTriggerMode, s.count(), flag); }
+    inline static SleepResult sleep(uint16_t wakeUpPin, InterruptMode edgeTriggerMode, std::chrono::seconds s, SleepOptionFlags flag=SLEEP_NETWORK_OFF) { return sleep(wakeUpPin, edgeTriggerMode, s.count(), flag); }
     inline static SleepResult sleep(uint16_t wakeUpPin, InterruptMode edgeTriggerMode, SleepOptionFlags flag, long seconds=0) { return sleep(wakeUpPin, edgeTriggerMode, seconds, flag); }
-    inline static SleepResult sleep(uint16_t wakeUpPin, InterruptMode edgeTriggerMode, SleepOptionFlags flag, std::chrono::seconds s=std::chrono::seconds(0)) { return sleep(wakeUpPin, edgeTriggerMode, flag, s.count()); }
+    inline static SleepResult sleep(uint16_t wakeUpPin, InterruptMode edgeTriggerMode, SleepOptionFlags flag, std::chrono::seconds s) { return sleep(wakeUpPin, edgeTriggerMode, flag, s.count()); }
 
     /*
      * wakeup pins: std::initializer_list<pin_t>
@@ -170,9 +171,9 @@ public:
         // static_assert(pins.size() > 0, "Provided pin list is empty");
         return sleepPinImpl(pins.begin(), pins.size(), &edgeTriggerMode, 1, seconds, flag);
     }
-    inline static SleepResult sleep(std::initializer_list<pin_t> pins, InterruptMode edgeTriggerMode, std::chrono::seconds s = std::chrono::seconds(0), SleepOptionFlags flag = SLEEP_NETWORK_OFF) { return sleep(pins, edgeTriggerMode, s.count(), flag); }
+    inline static SleepResult sleep(std::initializer_list<pin_t> pins, InterruptMode edgeTriggerMode, std::chrono::seconds s, SleepOptionFlags flag = SLEEP_NETWORK_OFF) { return sleep(pins, edgeTriggerMode, s.count(), flag); }
     inline static SleepResult sleep(std::initializer_list<pin_t> pins, InterruptMode edgeTriggerMode, SleepOptionFlags flag, long seconds = 0) { return sleep(pins, edgeTriggerMode, seconds, flag); }
-    inline static SleepResult sleep(std::initializer_list<pin_t> pins, InterruptMode edgeTriggerMode, SleepOptionFlags flag, std::chrono::seconds s = std::chrono::seconds(0)) { return sleep(pins, edgeTriggerMode, flag, s.count()); }
+    inline static SleepResult sleep(std::initializer_list<pin_t> pins, InterruptMode edgeTriggerMode, SleepOptionFlags flag, std::chrono::seconds s) { return sleep(pins, edgeTriggerMode, flag, s.count()); }
     /*
      * wakeup pins: std::initializer_list<pin_t>
      * trigger mode: std::initializer_list<InterruptMode>
@@ -183,27 +184,27 @@ public:
         // static_assert(edgeTriggerMode.size() > 0, "Provided InterruptMode list is empty");
         return sleepPinImpl(pins.begin(), pins.size(), edgeTriggerMode.begin(), edgeTriggerMode.size(), seconds, flag);
     }
-    inline static SleepResult sleep(std::initializer_list<pin_t> pins, std::initializer_list<InterruptMode> edgeTriggerMode, std::chrono::seconds s = std::chrono::seconds(0), SleepOptionFlags flag = SLEEP_NETWORK_OFF) { return sleep(pins, edgeTriggerMode, s.count(), flag); }
+    inline static SleepResult sleep(std::initializer_list<pin_t> pins, std::initializer_list<InterruptMode> edgeTriggerMode, std::chrono::seconds s, SleepOptionFlags flag = SLEEP_NETWORK_OFF) { return sleep(pins, edgeTriggerMode, s.count(), flag); }
     inline static SleepResult sleep(std::initializer_list<pin_t> pins, std::initializer_list<InterruptMode> edgeTriggerMode, SleepOptionFlags flag, long seconds = 0) { return sleep(pins, edgeTriggerMode, seconds, flag); }
-    inline static SleepResult sleep(std::initializer_list<pin_t> pins, std::initializer_list<InterruptMode> edgeTriggerMode, SleepOptionFlags flag, std::chrono::seconds s = std::chrono::seconds(0)) { return sleep(pins, edgeTriggerMode, flag, s.count()); }
+    inline static SleepResult sleep(std::initializer_list<pin_t> pins, std::initializer_list<InterruptMode> edgeTriggerMode, SleepOptionFlags flag, std::chrono::seconds s) { return sleep(pins, edgeTriggerMode, flag, s.count()); }
 
     /*
      * wakeup pins: pin_t* + size_t
      * trigger mode: single InterruptMode
      */
     inline static SleepResult sleep(const pin_t* pins, size_t pinsSize, InterruptMode edgeTriggerMode, long seconds = 0, SleepOptionFlags flag = SLEEP_NETWORK_OFF) { return sleepPinImpl(pins, pinsSize, &edgeTriggerMode, 1, seconds, flag); }
-    inline static SleepResult sleep(const pin_t* pins, size_t pinsSize, InterruptMode edgeTriggerMode, std::chrono::seconds s = std::chrono::seconds(0), SleepOptionFlags flag = SLEEP_NETWORK_OFF) { return sleep(pins, pinsSize, edgeTriggerMode, s.count(), flag); }
+    inline static SleepResult sleep(const pin_t* pins, size_t pinsSize, InterruptMode edgeTriggerMode, std::chrono::seconds s, SleepOptionFlags flag = SLEEP_NETWORK_OFF) { return sleep(pins, pinsSize, edgeTriggerMode, s.count(), flag); }
     inline static SleepResult sleep(const pin_t* pins, size_t pinsSize, InterruptMode edgeTriggerMode, SleepOptionFlags flag, long seconds = 0) { return sleep(pins, pinsSize, edgeTriggerMode, seconds, flag); }
-    inline static SleepResult sleep(const pin_t* pins, size_t pinsSize, InterruptMode edgeTriggerMode, SleepOptionFlags flag, std::chrono::seconds s = std::chrono::seconds(0)) { return sleep(pins, pinsSize, edgeTriggerMode, flag, s.count()); }
+    inline static SleepResult sleep(const pin_t* pins, size_t pinsSize, InterruptMode edgeTriggerMode, SleepOptionFlags flag, std::chrono::seconds s) { return sleep(pins, pinsSize, edgeTriggerMode, flag, s.count()); }
 
     /*
      * wakeup pins: pin_t* + size_t
      * trigger mode: InterruptMode* + size_t
      */
     inline static SleepResult sleep(const pin_t* pins, size_t pinsSize, const InterruptMode* edgeTriggerMode, size_t edgeTriggerModeSize, long seconds = 0, SleepOptionFlags flag = SLEEP_NETWORK_OFF) { return sleepPinImpl(pins, pinsSize, edgeTriggerMode, edgeTriggerModeSize, seconds, flag); }
-    inline static SleepResult sleep(const pin_t* pins, size_t pinsSize, const InterruptMode* edgeTriggerMode, size_t edgeTriggerModeSize, std::chrono::seconds s = std::chrono::seconds(0), SleepOptionFlags flag = SLEEP_NETWORK_OFF) { return sleep(pins, pinsSize, edgeTriggerMode, edgeTriggerModeSize, s.count(), flag); }
+    inline static SleepResult sleep(const pin_t* pins, size_t pinsSize, const InterruptMode* edgeTriggerMode, size_t edgeTriggerModeSize, std::chrono::seconds s, SleepOptionFlags flag = SLEEP_NETWORK_OFF) { return sleep(pins, pinsSize, edgeTriggerMode, edgeTriggerModeSize, s.count(), flag); }
     inline static SleepResult sleep(const pin_t* pins, size_t pinsSize, const InterruptMode* edgeTriggerMode, size_t edgeTriggerModeSize, SleepOptionFlags flag, long seconds = 0) { return sleep(pins, pinsSize, edgeTriggerMode, edgeTriggerModeSize, seconds, flag); }
-    inline static SleepResult sleep(const pin_t* pins, size_t pinsSize, const InterruptMode* edgeTriggerMode, size_t edgeTriggerModeSize, SleepOptionFlags flag, std::chrono::seconds s = std::chrono::seconds(0)) { return sleep(pins, pinsSize, edgeTriggerMode, edgeTriggerModeSize, flag, s.count()); }
+    inline static SleepResult sleep(const pin_t* pins, size_t pinsSize, const InterruptMode* edgeTriggerMode, size_t edgeTriggerModeSize, SleepOptionFlags flag, std::chrono::seconds s) { return sleep(pins, pinsSize, edgeTriggerMode, edgeTriggerModeSize, flag, s.count()); }
 
     static String deviceID(void) { return spark_deviceID(); }
 

--- a/wiring/inc/spark_wiring_ticks.h
+++ b/wiring/inc/spark_wiring_ticks.h
@@ -26,12 +26,14 @@
 #ifndef SPARK_WIRING_TICKS_H
 #define	SPARK_WIRING_TICKS_H
 
+#include <chrono>
+
+#include "delay_hal.h"
+#include "timer_hal.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "timer_hal.h"
-#include "delay_hal.h"
 
 inline system_tick_t millis(void) { return HAL_Timer_Get_Milli_Seconds(); }
 inline unsigned long micros(void) { return HAL_Timer_Get_Micro_Seconds(); }
@@ -42,6 +44,7 @@ inline void delayMicroseconds(unsigned int us) { HAL_Delay_Microseconds(us); }
 }
 #endif
 
+static inline void delay(std::chrono::milliseconds ms) { ::delay(ms.count()); }
+static inline void delayMicroseconds(std::chrono::microseconds us) { ::delayMicroseconds(us.count()); }
 
 #endif	/* SPARK_WIRING_TICKS_H */
-

--- a/wiring/inc/spark_wiring_timer.h
+++ b/wiring/inc/spark_wiring_timer.h
@@ -19,12 +19,14 @@
 
 #pragma once
 
+#include <chrono>
+#include <functional>
+
 #if PLATFORM_ID!=3
+
 #include "stddef.h"
 #include "concurrent_hal.h"
 #include "spark_wiring_thread.h"
-#include <chrono>
-#include <functional>
 
 class Timer
 {

--- a/wiring/inc/spark_wiring_timer.h
+++ b/wiring/inc/spark_wiring_timer.h
@@ -23,6 +23,7 @@
 #include "stddef.h"
 #include "concurrent_hal.h"
 #include "spark_wiring_thread.h"
+#include <chrono>
 #include <functional>
 
 class Timer
@@ -50,6 +51,7 @@ public:
     bool stopFromISR() { return _stop(0, true); }
     bool resetFromISR() { return _reset(0, true); }
     bool changePeriodFromISR(unsigned period) { return _changePeriod(period, 0, true); }
+    inline bool changePeriodFromISR(std::chrono::milliseconds ms) { return changePeriodFromISR(ms.count()); }
 
     static const unsigned default_wait = 0x7FFFFFFF;
 
@@ -57,6 +59,7 @@ public:
     bool stop(unsigned block=default_wait) { return _stop(block, false); }
     bool reset(unsigned block=default_wait) { return _reset(block, false); }
     bool changePeriod(unsigned period, unsigned block=default_wait) { return _changePeriod(period, block, false); }
+    inline bool changePeriod(std::chrono::milliseconds ms, unsigned block=default_wait) { return changePeriod(ms.count(), block); }
 
     bool isValid() const { return handle!=nullptr; }
     bool isActive() const { return isValid() && os_timer_is_active(handle, nullptr); }
@@ -81,6 +84,7 @@ public:
     {
          return handle ? !os_timer_change(handle, OS_TIMER_CHANGE_PERIOD, fromISR, period, block, nullptr) : false;
     }
+    bool _changePeriod(std::chrono::milliseconds ms, unsigned block, bool fromISR=false) { return _changePeriod(ms.count(), block, fromISR); }
 
     void dispose()
     {
@@ -155,6 +159,8 @@ public:
     {
         return true;
     }
+    inline static bool changePeriod(const std::chrono::milliseconds ms) { return changePeriod(ms.count()); }
+
     inline static void dispose(void)
     {
     }

--- a/wiring/inc/spark_wiring_watchdog.h
+++ b/wiring/inc/spark_wiring_watchdog.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <chrono>
+
 #include "spark_wiring_thread.h"
 #include "delay_hal.h"
 #include "timer_hal.h"
@@ -49,6 +51,7 @@ public:
 	{
 		checkin();
 	}
+	ApplicationWatchdog(std::chrono::milliseconds ms, std::function<void(void)> fn, unsigned stack_size=DEFAULT_STACK_SIZE) : ApplicationWatchdog(ms.count(), fn, stack_size) {}
 
     // This constuctor helps to resolve overloaded function types, such as System.reset(), which is not always
     // possible in case of std::function
@@ -56,6 +59,7 @@ public:
         ApplicationWatchdog(timeout_ms, std::function<void()>(fn), stack_size)
     {
     }
+    ApplicationWatchdog(std::chrono::milliseconds ms, void (*fn)(), unsigned stack_size=DEFAULT_STACK_SIZE) : ApplicationWatchdog(ms.count(), fn, stack_size) {}
 
 	bool isComplete()
 	{

--- a/wiring/inc/spark_wiring_wifi.h
+++ b/wiring/inc/spark_wiring_wifi.h
@@ -28,6 +28,8 @@
 
 #include "spark_wiring_platform.h"
 
+#include <chrono>
+
 #if Wiring_WiFi
 
 #include "spark_wiring_network.h"
@@ -162,6 +164,7 @@ public:
     void setListenTimeout(uint16_t timeout) {
         network_set_listen_timeout(*this, timeout, NULL);
     }
+    inline void setListenTimeout(std::chrono::seconds s) { setListenTimeout(s.count()); }
 
     uint16_t getListenTimeout(void) {
         return network_get_listen_timeout(*this, 0, NULL);


### PR DESCRIPTION
I wanted to follow the naming of the `stl` under the `particle` namespace, but had to make a compromise on the naming convention.

**`stl::literals::chrono_literals`**
- `ms`
- `s`
- `min`
- `h`

**`particle::literals::chrono_literals`**
- `_ms`
- `_s`
- `_min`
- `_h`

**Usage example:**

```
delay(3);      // delay 3 milliseconds
delay(3_ms);   // delay 3 milliseconds
delay(3_s);    // delay 3 seconds
delay(3_min);  // delay 3 minutes
delay(3_h);    // delay 3 hours
```

The compiler will _NOT_ allow, under any circumstance, disabling the warning generated when a user-defined string literal is not proceeded by an underscore.

The biggest difference is the fact the `stl` literals use a base storage of `uint64_t`, which would be slow to compute on our hardware, but the `particle` literals use a base storage of `system_tick_t`.

I have confirmed this syntax works as expected with the `delay()` function in a blinky sketch on the photon.

The build artifacts don't appear to change in size. Which actually makes me suspicious, but I deleted them switched branches and rebuilt them twice.

| module | size orig | size mod |
|:---------- |:-----------:|:------------:|
| bootloader | 15264 | 15264 |
| system-part1 | 239492 | 239492 |
| system-part2 | 252240 | 252240 |
| blinky | 4392 | 4392 |