### PR TITLE
[Electron] [G350] fixes Cellular.RSSI() issues due to unknown RAT

### DIFF
--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1165,6 +1165,12 @@ bool MDMParser::checkNetStatus(NetStatus* status /*= NULL*/)
         if (RESP_OK != waitFinalResp(_cbCSQ, &_net, CSQ_TIMEOUT)) {
             goto failure;
         }
+        // +CREG, +CGREG, +COPS does not contain <AcT> for G350 devices.
+        // After we are registered to CSD or PSD, populate _net.act with ACT_GSM to ensure
+        // Device Diagnostics and RSSI() API have a RAT for conversion lookup purposes.
+        if (_dev.dev == DEV_SARA_G350) {
+            _net.act = ACT_GSM;
+        }
     }
     if (status) {
         memcpy(status, &_net, sizeof(NetStatus));


### PR DESCRIPTION
### Problem

Cellular.RSSI() does not work on Electron G350 due to RAT (Radio Access Technology) being unknown, and subsequently conversion of values errors out.  This affects the Cellular.RSSI() API and also Device Diagnostics.

### Solution

During registration, default to RAT = ACT_GSM if device is Electron G350.

### Steps to Test

- Observe with v1.0.0 or v1.0.1 firmware and Tinker, Device Diagnostics contains no `device.network.signal.strength:` info.
- Compile with this PR and everything works as expected, assuming the device really has a signal.

### References

Examples of the issue here:
https://community.particle.io/t/no-signal-strength-information-for-electron-2g-on-device-os-1-0-0/47460/10?u=bdub

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] (N/A) Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)

---

- [Bugfix] [Electron] [G350] fixes Cellular.RSSI() issues due to unknown RAT [#1721](https://github.com/particle-iot/device-os/pull/1721)