### PR TITLE
[Boron/LTE] Enable Cat M1-only mode

### DIFF
--- a/hal/network/ncp/at_parser/at_response.h
+++ b/hal/network/ncp/at_parser/at_response.h
@@ -141,6 +141,8 @@ protected:
     int readLine(char* buf, size_t size, size_t offs);
     int error(int ret);
 
+    AtResponseReader& operator=(AtResponseReader&& reader);
+
     friend class detail::AtParserImpl;
 };
 
@@ -216,6 +218,10 @@ public:
      * Cancels the processing of the current AT command.
      */
     void reset();
+    /**
+     * Move-assigns `resp` to this response object.
+     */
+    AtResponse& operator=(AtResponse&& resp);
 
 private:
     int resultErrorCode_;

--- a/hal/src/boron/network/sara_ncp_client.cpp
+++ b/hal/src/boron/network/sara_ncp_client.cpp
@@ -716,12 +716,16 @@ int SaraNcpClient::initReady() {
             }
         }
         CHECK_PARSER_OK(resp.readResult());
+        int lastError = AtResponse::OK;
         for (unsigned act: acts) {
-            // A synthetic test shows that this command may fail for unknown reason. eDRX mode is a
-            // persistent setting and, eventually, it will get applied for each RAT during subsequent
-            // re-initialization attempts
-            CHECK_PARSER_OK(parser_.execCommand("AT+CEDRXS=3,%u", act)); // 3: Disable the use of eDRX
+            // This command may fail for unknown reason. eDRX mode is a persistent setting and, eventually,
+            // it will get applied for each RAT during subsequent re-initialization attempts
+            r = CHECK_PARSER(parser_.execCommand("AT+CEDRXS=3,%u", act)); // 3: Disable the use of eDRX
+            if (r != AtResponse::OK) {
+                lastError = r;
+            }
         }
+        CHECK_PARSER_OK(lastError);
         // Force Power Saving mode to be disabled for good measure
         CHECK_PARSER_OK(parser_.execCommand("AT+CPSMS=0"));
     } else {

--- a/hal/src/boron/network/sara_ncp_client.cpp
+++ b/hal/src/boron/network/sara_ncp_client.cpp
@@ -34,8 +34,10 @@
 
 #include "stream_util.h"
 
-#include <algorithm>
 #include "spark_wiring_interrupts.h"
+#include "spark_wiring_vector.h"
+
+#include <algorithm>
 
 #define CHECK_PARSER(_expr) \
         ({ \
@@ -693,22 +695,38 @@ int SaraNcpClient::initReady() {
     }
 
     if (ncpId() == MESH_NCP_SARA_R410) {
-        // Force eDRX mode to be disabled
-        // 18/23 hardware doesn't seem to be disabled by default
-        r = CHECK_PARSER(parser_.execCommand("AT+CEDRXS=0"));
-        CHECK_TRUE(r == AtResponse::OK, SYSTEM_ERROR_UNKNOWN);
+        // Force Cat M1-only mode
+        auto resp = parser_.sendCommand("AT+URAT?");
+        unsigned selectAct = 0, preferAct1 = 0, preferAct2 = 0;
+        r = CHECK_PARSER(resp.scanf("+URAT: %u,%u,%u", &selectAct, &preferAct1, &preferAct2));
+        CHECK_PARSER_OK(resp.readResult());
+        if (selectAct != 7 || (r >= 2 && preferAct1 != 7) || (r >= 3 && preferAct2 != 7)) { // 7: LTE Cat M1
+            // This is a persistent setting
+            CHECK_PARSER_OK(parser_.execCommand("AT+URAT=7"));
+        }
+        // Force eDRX mode to be disabled. AT+CEDRXS=0 doesn't seem disable eDRX completely, so
+        // so we're disabling it for each reported RAT individually
+        Vector<unsigned> acts;
+        resp = parser_.sendCommand("AT+CEDRXS?");
+        while (resp.hasNextLine()) {
+            unsigned act = 0;
+            r = resp.scanf("+CEDRXS: %u", &act);
+            if (r == 1) { // Ignore scanf() errors
+                CHECK_TRUE(acts.append(act), SYSTEM_ERROR_NO_MEMORY);
+            }
+        }
+        CHECK_PARSER_OK(resp.readResult());
+        for (unsigned act: acts) {
+            // A synthetic test shows that this command may fail for unknown reason. eDRX mode is a
+            // persistent setting and, eventually, it will get applied for each RAT during subsequent
+            // re-initialization attempts
+            CHECK_PARSER_OK(parser_.execCommand("AT+CEDRXS=3,%u", act)); // 3: Disable the use of eDRX
+        }
         // Force Power Saving mode to be disabled for good measure
-        r = CHECK_PARSER(parser_.execCommand("AT+CPSMS=0"));
-        CHECK_TRUE(r == AtResponse::OK, SYSTEM_ERROR_UNKNOWN);
-
-        r = CHECK_PARSER(parser_.execCommand("AT+CEDRXS?"));
-        CHECK_TRUE(r == AtResponse::OK, SYSTEM_ERROR_UNKNOWN);
-        r = CHECK_PARSER(parser_.execCommand("AT+CPSMS?"));
-        CHECK_TRUE(r == AtResponse::OK, SYSTEM_ERROR_UNKNOWN);
+        CHECK_PARSER_OK(parser_.execCommand("AT+CPSMS=0"));
     } else {
         // Power saving
-        r = CHECK_PARSER(parser_.execCommand("AT+UPSV=0"));
-        CHECK_TRUE(r == AtResponse::OK, SYSTEM_ERROR_UNKNOWN);
+        CHECK_PARSER_OK(parser_.execCommand("AT+UPSV=0"));
     }
 
     // Send AT+CMUX and initialize multiplexer

--- a/wiring/inc/spark_wiring_vector.h
+++ b/wiring/inc/spark_wiring_vector.h
@@ -246,7 +246,13 @@ private:
 template<typename T, typename AllocatorT>
 void swap(Vector<T, AllocatorT>& vector, Vector<T, AllocatorT>& vector2);
 
-} // namespace spark
+} // spark
+
+namespace particle {
+
+using ::spark::Vector;
+
+} // particle
 
 // spark::DefaultAllocator
 inline void* spark::DefaultAllocator::malloc(size_t size) {


### PR DESCRIPTION
### Problem

This PR sets the modem to the LTE Cat M1-only mode during the initialization, and also disables eDRX individually for each reported RAT (`AT+CEDRXS=0` doesn't seem to disable eDRX correctly).

### Steps to Test

1. Make sure the modem is set to the factory default settings, e.g. by using the following commands:
```
AT+URAT=7,8
AT+CEDRXS=1,2,"1001"
AT+CEDRXS=1,4,"1001"
AT+CEDRXS=1,5,"1001"
```
2. Make sure the NCP client overrides the default settings during the modem initialization.

### References

- [ch29791]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)

---

- [Enhancement] [Boron/LTE] Enable Cat M1-only mode and disable eDRX completely [#1723](https://github.com/particle-iot/device-os/pull/1723)