### PR TITLE
Power leakage from external flash

### DIFF
--- a/hal/src/nRF52840/core_hal.c
+++ b/hal/src/nRF52840/core_hal.c
@@ -939,10 +939,19 @@ int HAL_Core_Execute_Standby_Mode_Ext(uint32_t flags, void* reserved) {
         return SYSTEM_ERROR_NOT_SUPPORTED;
     }
 
+    // Make sure we acquire exflash lock BEFORE going into a critical section
+    hal_exflash_lock();
 
     // This will disable all but SoftDevice interrupts (by modifying NVIC->ICER)
     uint8_t st = 0;
     sd_nvic_critical_region_enter(&st);
+
+    // Disable SysTick
+    SysTick->CTRL &= ~SysTick_CTRL_ENABLE_Msk;
+
+    // Disable external flash
+    hal_exflash_uninit();
+    hal_exflash_unlock();
 
     // Uninit GPIOTE
     nrfx_gpiote_uninit();

--- a/hal/src/nRF52840/core_hal.c
+++ b/hal/src/nRF52840/core_hal.c
@@ -951,7 +951,6 @@ int HAL_Core_Execute_Standby_Mode_Ext(uint32_t flags, void* reserved) {
 
     // Disable external flash
     hal_exflash_uninit();
-    hal_exflash_unlock();
 
     // Uninit GPIOTE
     nrfx_gpiote_uninit();


### PR DESCRIPTION
### Problem

1. We don't send enter sleep command to external flash before uninitializing it
1. We don't uninitialize external flash before entering STANDBY mode.

### Steps to Test
Test the fix on Xenon-SoM, the power consumption decrease from 8uA to 1uA in STANDBY mode.

### Example App

```c
void setup() {
}
void loop() {
    System.sleep(SLEEP_MODE_DEEP, 0);
}
```

### References

[CH29844]
[CH29689]

---

### Completeness

- [Bugfix] [Gen 3] Fixes a deadlock in `system_power_manager` and `i2c_hal` when exiting the sleep mode  [1725](https://github.com/particle-iot/device-os/pull/1725)
- [Enhancement] [Gen 3] QSPI flash is put into sleep mode and is deinitialized when entering STANDBY or STOP sleep mode [1725](https://github.com/particle-iot/device-os/pull/1725)

