### PR TITLE
[Boron] Workaround for SARA R4 ppp session getting broken

### DIFF
--- a/hal/network/lwip/esp32/esp32ncpnetif.cpp
+++ b/hal/network/lwip/esp32/esp32ncpnetif.cpp
@@ -288,11 +288,6 @@ void Esp32NcpNetif::ncpDataHandlerCb(int id, const uint8_t* data, size_t size, v
 
 int Esp32NcpNetif::downImpl() {
     up_ = false;
-    auto r = wifiMan_->ncpClient()->on();
-    if (r) {
-        LOG(TRACE, "Failed to initialize ESP32 NCP client: %d", r);
-        return r;
-    }
     wifiMan_->ncpClient()->disconnect();
     LwipTcpIpCoreLock lk;
     netif_set_link_down(interface());

--- a/hal/network/lwip/ublox/pppncpnetif.cpp
+++ b/hal/network/lwip/ublox/pppncpnetif.cpp
@@ -55,7 +55,7 @@ enum class NetifEvent {
     PowerOn = 5
 };
 
-unsigned NCP_SARA_R410_MTU = 1300;
+unsigned NCP_SARA_R410_MTU = 1012;
 
 } // anonymous
 

--- a/hal/network/lwip/ublox/pppncpnetif.cpp
+++ b/hal/network/lwip/ublox/pppncpnetif.cpp
@@ -202,11 +202,6 @@ int PppNcpNetif::downImpl() {
     up_ = false;
     client_.notifyEvent(ppp::Client::EVENT_LOWER_DOWN);
     client_.disconnect();
-    auto r = celMan_->ncpClient()->on();
-    if (r) {
-        LOG(TRACE, "Failed to initialize ublox NCP client: %d", r);
-        return r;
-    }
     celMan_->ncpClient()->disconnect();
     return 0;
 }

--- a/hal/network/lwip/ublox/pppncpnetif.cpp
+++ b/hal/network/lwip/ublox/pppncpnetif.cpp
@@ -55,7 +55,7 @@ enum class NetifEvent {
     PowerOn = 5
 };
 
-unsigned NCP_SARA_R410_MTU = 1012;
+unsigned NCP_SARA_R410_MTU = 1000;
 
 } // anonymous
 

--- a/hal/src/boron/network/sara_ncp_client.h
+++ b/hal/src/boron/network/sara_ncp_client.h
@@ -108,7 +108,7 @@ private:
     int modemInit() const;
     int modemPowerOn() const;
     int modemPowerOff() const;
-    int modemHardReset() const;
+    int modemHardReset(bool powerOff = false) const;
     bool modemPowerState() const;
     int modemSetUartState(bool state) const;
 };

--- a/user/build.mk
+++ b/user/build.mk
@@ -71,7 +71,7 @@ endif
 INCLUDE_DIRS += $(MODULE_PATH)/libraries
 
 CFLAGS += -DSPARK_PLATFORM_NET=$(PLATFORM_NET)
-CPPFLAGS += -std=gnu++11
+CPPFLAGS += -std=gnu++14
 
 BUILTINS_EXCLUDE = malloc free realloc
 CFLAGS += $(addprefix -fno-builtin-,$(BUILTINS_EXCLUDE))

--- a/user/build.mk
+++ b/user/build.mk
@@ -71,7 +71,7 @@ endif
 INCLUDE_DIRS += $(MODULE_PATH)/libraries
 
 CFLAGS += -DSPARK_PLATFORM_NET=$(PLATFORM_NET)
-CPPFLAGS += -std=gnu++14
+CPPFLAGS += -std=gnu++11
 
 BUILTINS_EXCLUDE = malloc free realloc
 CFLAGS += $(addprefix -fno-builtin-,$(BUILTINS_EXCLUDE))

--- a/user/makefile
+++ b/user/makefile
@@ -5,6 +5,10 @@ BUILD_PATH_EXT = $(USER_BUILD_PATH_EXT)
 
 DEPENDENCIES = wiring system services communication hal
 
+ifdef TEST
+DEPENDENCIES += crypto
+endif
+
 include ../build/platform-id.mk
 
 ifeq ("","$(SPARK_NO_PLATFORM)")

--- a/user/tests/wiring/no_fixture_long_running/network.cpp
+++ b/user/tests/wiring/no_fixture_long_running/network.cpp
@@ -88,7 +88,7 @@ test(NETWORK_01_LargePacketsDontCauseIssues_ResolveMtu) {
     const size_t IPV4_HEADER_LENGTH = 20;
     const size_t UDP_HEADER_LENGTH = 8;
     const size_t IPV4_PLUS_UDP_HEADER_LENGTH = IPV4_HEADER_LENGTH + UDP_HEADER_LENGTH;
-    const size_t MAX_MTU = 1500;
+    const size_t MAX_MTU = 1000;
     const size_t MIN_MTU = IPV4_PLUS_UDP_HEADER_LENGTH;
     const system_tick_t UDP_ECHO_REPLY_WAIT_TIME = 5000;
     const unsigned UDP_ECHO_RETRIES = 5;
@@ -145,4 +145,9 @@ test(NETWORK_01_LargePacketsDontCauseIssues_ResolveMtu) {
     assertFalse((bool)state.disconnected);
 
     assertTrue((mtu - IPV4_PLUS_UDP_HEADER_LENGTH) >= MBEDTLS_SSL_MAX_CONTENT_LEN);
+
+    SCOPE_GUARD({
+        Network.disconnect();
+        Network.off();
+    });
 }

--- a/user/tests/wiring/no_fixture_long_running/network.cpp
+++ b/user/tests/wiring/no_fixture_long_running/network.cpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2019 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "application.h"
+#include "unit-test/unit-test.h"
+#include "scope_guard.h"
+#include "random.h"
+#include <memory>
+#include "mbedtls_config.h"
+
+namespace {
+
+template <typename T, typename DT>
+T divRoundClosest(T n, DT d) {
+    return ((n + (d / 2)) / d);
+}
+
+template <typename T>
+T bisect(T value, T& min, T& max, bool forward) {
+    if (forward) {
+        size_t halfInterval = divRoundClosest(max - value, 2);
+        min = value;
+        return value + halfInterval;
+    } else {
+        size_t halfInterval = divRoundClosest(value - min, 2);
+        max = value;
+        return value - halfInterval;
+    }
+}
+
+bool udpEchoTest(UDP* udp, const IPAddress& ip, uint16_t port, const uint8_t* sendBuf, size_t len, unsigned retries, system_tick_t timeout) {
+    while (retries-- > 0) {
+        auto snd = udp->sendPacket(sendBuf, len, ip, port);
+        if (snd == (int)len) {
+            auto recvd = udp->parsePacket(timeout);
+            if (recvd == (int)len) {
+                return !memcmp(udp->buffer(), sendBuf, len);
+            }
+            // Failed to receive reply, retry
+        } else {
+            // Failed to send, abort immediately
+            break;
+        }
+    }
+
+    return false;
+}
+
+} // anonymous
+
+test(NETWORK_01_LargePacketsDontCauseIssues_ResolveMtu) {
+    Network.on();
+    Network.connect();
+    waitFor(Network.ready, 60000);
+    assertTrue(Network.ready());
+
+    struct State {
+        volatile bool disconnected;
+    };
+    State state = {};
+
+    auto evHandler = [](system_event_t event, int param, void* ctx) {
+        State* state = static_cast<State*>(ctx);
+        if (event == network_status && param == network_status_disconnected) {
+            state->disconnected = true;
+        }
+    };
+
+    System.on(network_status, evHandler);
+    SCOPE_GUARD({
+        System.off(network_status, evHandler);
+    });
+
+    const size_t IPV4_HEADER_LENGTH = 20;
+    const size_t UDP_HEADER_LENGTH = 8;
+    const size_t IPV4_PLUS_UDP_HEADER_LENGTH = IPV4_HEADER_LENGTH + UDP_HEADER_LENGTH;
+    const size_t MAX_MTU = 1500;
+    const size_t MIN_MTU = IPV4_PLUS_UDP_HEADER_LENGTH;
+    const system_tick_t UDP_ECHO_REPLY_WAIT_TIME = 5000;
+    const unsigned UDP_ECHO_RETRIES = 5;
+    const system_tick_t MINIMUM_TEST_TIME = 60000;
+
+    // FIXME: Hosted by @avtolstoy, should be changed to something else
+    const char UDP_ECHO_SERVER[] = "particle-udp-echo.rltm.org";
+    uint16_t UDP_ECHO_PORT = 40000;
+
+    // Resolve UDP echo server hostname to ip address, so that DNS resolutions
+    // no longer affect us after this point
+    const auto udpEchoIp = Network.resolve(UDP_ECHO_SERVER);
+    assertTrue(udpEchoIp);
+
+    // Create UDP client
+    auto udp = std::make_unique<UDP>();
+    assertTrue((bool)udp);
+
+    auto sendBuffer = std::make_unique<uint8_t[]>(MAX_MTU);
+    assertTrue((bool)sendBuffer);
+    auto recvBuffer = std::make_unique<uint8_t[]>(MAX_MTU);
+    assertTrue((bool)recvBuffer);
+
+    udp->setBuffer(MAX_MTU, recvBuffer.get());
+
+    particle::Random rand;
+
+    system_tick_t start = millis();
+
+    udp->begin(UDP_ECHO_PORT);
+    size_t mtu = MAX_MTU;
+    size_t minMtu = MIN_MTU;
+    size_t maxMtu = MAX_MTU;
+    while (mtu > IPV4_PLUS_UDP_HEADER_LENGTH) {
+        Serial.printlnf("Test MTU: %lu", mtu);
+        // Fille send buffer with random data
+        const size_t payloadSize = mtu - IPV4_PLUS_UDP_HEADER_LENGTH;
+        rand.gen((char*)sendBuffer.get(), payloadSize);
+        auto res = udpEchoTest(udp.get(), udpEchoIp, UDP_ECHO_PORT, sendBuffer.get(), payloadSize, UDP_ECHO_RETRIES, UDP_ECHO_REPLY_WAIT_TIME);
+        size_t newMtu = bisect(mtu, minMtu, maxMtu, res);
+        Serial.printlnf("New MTU: %lu", newMtu);
+        if (std::abs((int)newMtu - (int)mtu) <= 1) {
+            // Converged
+            break;
+        }
+        mtu = newMtu;
+    }
+
+    Serial.printlnf("Resolved MTU: %lu", mtu);
+    assertTrue((mtu - IPV4_PLUS_UDP_HEADER_LENGTH) >= MBEDTLS_SSL_MAX_CONTENT_LEN);
+
+    // The test should be running for at least a minute, just in case
+    if (millis() - start < MINIMUM_TEST_TIME) {
+        delay(millis() - start);
+    }
+    assertFalse((bool)state.disconnected);
+}

--- a/user/tests/wiring/no_fixture_long_running/network.cpp
+++ b/user/tests/wiring/no_fixture_long_running/network.cpp
@@ -104,12 +104,12 @@ test(NETWORK_01_LargePacketsDontCauseIssues_ResolveMtu) {
     assertTrue(udpEchoIp);
 
     // Create UDP client
-    auto udp = std::make_unique<UDP>();
+    std::unique_ptr<UDP> udp(new UDP());
     assertTrue((bool)udp);
 
-    auto sendBuffer = std::make_unique<uint8_t[]>(MAX_MTU);
+    std::unique_ptr<uint8_t[]> sendBuffer(new uint8_t[MAX_MTU]);
     assertTrue((bool)sendBuffer);
-    auto recvBuffer = std::make_unique<uint8_t[]>(MAX_MTU);
+    std::unique_ptr<uint8_t[]> recvBuffer(new uint8_t[MAX_MTU]);
     assertTrue((bool)recvBuffer);
 
     udp->setBuffer(MAX_MTU, recvBuffer.get());

--- a/user/tests/wiring/no_fixture_long_running/ticks.cpp
+++ b/user/tests/wiring/no_fixture_long_running/ticks.cpp
@@ -145,7 +145,7 @@ test(TICKS_01_millis_and_micros_rollover)
 
 test(TICKS_02_millis_and_micros_along_with_high_priority_interrupts)
 {
-    #define TWO_MINUTES 2*60*1000
+    static const system_tick_t TWO_MINUTES = 2 * 60 * 1000;
     system_tick_t start = millis();
     assert_micros_millis_interrupts(TWO_MINUTES);
     assertMoreOrEqual(millis()-start,TWO_MINUTES);
@@ -153,7 +153,7 @@ test(TICKS_02_millis_and_micros_along_with_high_priority_interrupts)
 
 test(TICKS_03_millis_and_micros_monotonically_increases)
 {
-    #define TWO_MINUTES 2*60*1000
+    static const system_tick_t TWO_MINUTES = 2 * 60 * 1000;
     system_tick_t start = millis();
     assert_micros_millis(TWO_MINUTES);
     assertMoreOrEqual(millis()-start,TWO_MINUTES);

--- a/wiring/src/spark_wiring_udp_posix.cpp
+++ b/wiring/src/spark_wiring_udp_posix.cpp
@@ -268,7 +268,7 @@ int UDP::parsePacket(system_tick_t timeout) {
 
     flush_buffer();         // start a new read - discard the old data
     if (_buffer && _buffer_size) {
-        int result = receivePacket(_buffer, _buffer_size);
+        int result = receivePacket(_buffer, _buffer_size, timeout);
         if (result > 0) {
             _total = result;
         }


### PR DESCRIPTION
### Problem

1. PPP link gets broken on LTE Borons and SoMs when sending larget packets:
```
0000040423 [lwip] TRACE: pppos_netif_output[3]: proto=0x21, len = 40
0000040426 [hal] TRACE: Outputing 1320 bytes
0000040433 [lwip] TRACE: pppos_netif_output[3]: proto=0x21, len = 1316
0000042175 [hal] TRACE: Outputing 16 bytes
0000042175 [lwip] TRACE: pppos_write[3]: len=12
0000042360 [hal] TRACE: Outputing 22 bytes
0000042360 [lwip] TRACE: pppos_write[3]: len=18
0000043426 [hal] TRACE: Outputing 1321 bytes
0000043427 [lwip] TRACE: pppos_netif_output[3]: proto=0x21, len = 1316
0000047176 [hal] TRACE: Outputing 16 bytes
0000047176 [lwip] TRACE: pppos_write[3]: len=12
0000048361 [hal] TRACE: Outputing 22 bytes
0000048361 [lwip] TRACE: pppos_write[3]: len=18
0000049429 [hal] TRACE: Outputing 1321 bytes
0000049430 [lwip] TRACE: pppos_netif_output[3]: proto=0x21, len = 1316
0000052177 [hal] TRACE: Outputing 16 bytes
0000052177 [lwip] TRACE: pppos_write[3]: len=12
0000054362 [hal] TRACE: Outputing 22 bytes
0000054362 [lwip] TRACE: pppos_write[3]: len=18
0000057178 [hal] TRACE: Outputing 16 bytes
0000057178 [lwip] TRACE: pppos_write[3]: len=12
0000060363 [hal] TRACE: Outputing 22 bytes
0000060363 [lwip] TRACE: pppos_write[3]: len=18
0000061432 [hal] TRACE: Outputing 1321 bytes
0000061433 [lwip] TRACE: pppos_netif_output[3]: proto=0x21, len = 1316
0000062179 [hal] TRACE: Outputing 16 bytes
0000062179 [lwip] TRACE: pppos_write[3]: len=12
0000066364 [hal] TRACE: Outputing 22 bytes
0000066364 [lwip] TRACE: pppos_write[3]: len=18
0000067180 [hal] TRACE: Outputing 16 bytes
0000067180 [lwip] TRACE: pppos_write[3]: len=12
0000072181 [hal] TRACE: Outputing 16 bytes
0000072181 [lwip] TRACE: pppos_write[3]: len=12
0000072365 [lwip] TRACE: IPV6CP: timeout sending Config-Requests
0000077182 [hal] TRACE: Outputing 16 bytes
0000077182 [lwip] TRACE: pppos_write[3]: len=12
0000082183 [hal] TRACE: Outputing 16 bytes
0000082183 [lwip] TRACE: pppos_write[3]: len=12
0000085436 [hal] TRACE: Outputing 1321 bytes
0000085437 [lwip] TRACE: pppos_netif_output[3]: proto=0x21, len = 1316
0000087184 [hal] TRACE: Outputing 16 bytes
0000087184 [lwip] TRACE: pppos_write[3]: len=12
0000092185 [lwip] TRACE: No response to 10 echo-requests
0000092185 [lwip] TRACE: Serial link appears to be disconnected.
0000092186 [lwip] TRACE: ppp phase changed[3]: phase=11
```

### Solution

1. Decrease MTU on LTE Borons and SoMs to a lower value (`NCP_SARA_R410_MTU`) **TODO: for now it's at 1300, should be changed to the one that actually works after the testing**

### Steps to Test

1. Can be tested with `MDM_01_socket_writes_with_length_more_than_1023_work_correctly`

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)

---

- [Bugfix] [Boron] Workaround for SARA R4 ppp session getting broken and system power manager fix [#1726](https://github.com/particle-iot/device-os/pull/1726)
- [Bugfix] Fixes system power manager re-enabling charging every 1s with a battery connected (now every 60s) [#1726](https://github.com/particle-iot/device-os/pull/1726)