### PR TITLE
fix mismatched types in arguments to std::min and std::max

### DIFF
--- a/communication/src/chunked_transfer.cpp
+++ b/communication/src/chunked_transfer.cpp
@@ -279,8 +279,8 @@ ProtocolError ChunkedTransfer::handle_update_done(token_t token, Message& messag
     {
         updating = 2;       // flag that we are sending missing chunks.
         DEBUG("update done - missing chunks starting at %d", index);
-        chunk_index_t increase = std::max(unsigned(chunk_count*0.2), MINIMUM_CHUNK_INCREASE);	// ensure always some growth
-        chunk_index_t resend_chunk_count = std::min(unsigned(chunk_count+increase), MISSED_CHUNKS_TO_SEND);
+        chunk_index_t increase = std::max(size_t(chunk_count*0.2), size_t(MINIMUM_CHUNK_INCREASE));	// ensure always some growth
+        chunk_index_t resend_chunk_count = std::min(size_t(chunk_count+increase), size_t(MISSED_CHUNKS_TO_SEND));
         chunk_count = 0;
 
         error = send_missing_chunks(channel, resend_chunk_count);


### PR DESCRIPTION
<details>
  <summary><i>fixes type mismatch in std::min and std::max</i></summary>
</details>

### Problem

A modern compiler doesn't accept mismatched arguments to std::min and std::max. I'm crosscompiling (PLATFORM_GCC) with gcc 8.
You should try it. Some interesting warnings pop up for device-os.

### Solution

Use size_t for both.

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
