### PR TITLE
Parameter check for SPI slave mode with HAL_SPI_INTERFACE1

### DIFF
--- a/hal/src/nRF52840/spi_hal.cpp
+++ b/hal/src/nRF52840/spi_hal.cpp
@@ -280,6 +280,11 @@ void HAL_SPI_Begin(HAL_SPI_Interface spi, uint16_t pin) {
 }
 
 void HAL_SPI_Begin_Ext(HAL_SPI_Interface spi, SPI_Mode mode, uint16_t pin, void* reserved) {
+    if (spi == HAL_SPI_INTERFACE1 && mode == SPI_MODE_SLAVE) {
+        // HAL_SPI_INTERFACE1 does not support slave mode
+        return;
+    }
+
     if (m_spi_map[spi].enabled) {
         spi_uninit(spi);
     }


### PR DESCRIPTION
### Problem

 We use high-speed SPI as default SPI, however, it doesn't support SPI slave. This PR adds a parameter check in case users use the wrong mode and cause a failure.

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)

---

- [Enhancement] [Gen 3] Parameter check for SPI slave mode with HAL_SPI_INTERFACE1 [#1731](https://github.com/particle-iot/device-os/pull/1731)