### PR TITLE
Feature/immediate updates

### DIFF
--- a/ci/unit_tests.sh
+++ b/ci/unit_tests.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 #
 # Top-level script for running unit tests.
+# for manual testing run
+# . install_boost.sh
+# ./unit_tests.sh
+
 ci_dir=$(dirname $BASH_SOURCE)
 cd $ci_dir
 
@@ -41,9 +45,15 @@ cd obj || die "cannot find obj dir"
 
 set -x -e
 
+# Run Communication Catch Tests
+cd $ci_dir/../communication/tests/catch
+make test PARTICLE_DEVELOP=1
+
 # Run CMake-based unit tests
 cd $unit_test_dir
 rm -rf .build
 mkdir .build && cd .build
 cmake ..
 make && make test
+
+

--- a/communication/src/chunked_transfer.cpp
+++ b/communication/src/chunked_transfer.cpp
@@ -66,8 +66,9 @@ ProtocolError ChunkedTransfer::handle_update_begin(
     }
     Message response;
     channel.response(message, response, 16);
-    size_t size = Messages::coded_ack(response.buf(),
-            success ? 0x00 : RESPONSE_CODE(4, 00), 0, 0);
+    size_t size = success ?
+    		Messages::empty_ack(response.buf(), 0, 0) :
+			Messages::coded_ack(response.buf(), token, RESPONSE_CODE(5, 03), 0, 0);
     response.set_length(size);
     response.set_id(msg_id);
     ProtocolError error = channel.send(response);

--- a/communication/src/chunked_transfer.cpp
+++ b/communication/src/chunked_transfer.cpp
@@ -20,6 +20,7 @@
 #include "chunked_transfer.h"
 #include "service_debug.h"
 #include "coap.h"
+#include <algorithm>
 
 namespace particle { namespace protocol {
 

--- a/communication/src/dtls_session_persist.h
+++ b/communication/src/dtls_session_persist.h
@@ -50,7 +50,7 @@ typedef struct __attribute__((packed)) SessionPersistDataOpaque
 namespace particle { namespace protocol {
 
 /**
- * A simple POD for the persisted session data.
+ * A simple PODO for the persisted session data.
  */
 struct __attribute__((packed)) SessionPersistData
 {

--- a/communication/src/dtls_session_persist.h
+++ b/communication/src/dtls_session_persist.h
@@ -50,7 +50,7 @@ typedef struct __attribute__((packed)) SessionPersistDataOpaque
 namespace particle { namespace protocol {
 
 /**
- * A simple PODO for the persisted session data.
+ * A simple POD for the persisted session data.
  */
 struct __attribute__((packed)) SessionPersistData
 {

--- a/communication/src/ping.h
+++ b/communication/src/ping.h
@@ -47,7 +47,10 @@ public:
 	}
 
 	/**
-	 * Handle ping messages
+	 * Handle ping messages. If a message is not received
+	 * within the timeout, the connection is considered unreliable.
+	 * @param millis_since_last_message Elapsed number of milliseconds since the last message was received.
+	 * @param callback a no-arg callable that is used to perform a ping to the cloud.
 	 */
 	template <typename Callback> ProtocolError process(system_tick_t millis_since_last_message, Callback ping)
 	{
@@ -61,6 +64,8 @@ public:
 		}
 		else
 		{
+			// ping interval set, so check if we need to send a ping
+			// The ping is sent based on the elapsed time since the last message
 			if (ping_interval && ping_interval < millis_since_last_message)
 			{
 				expecting_ping_ack = true;
@@ -72,6 +77,11 @@ public:
 
 	bool is_expecting_ping_ack() const { return expecting_ping_ack; }
 
+	/**
+	 * Notifies the Pinger that a message has been received
+	 * and that there is presently no need to resend a ping
+	 * until the ping interval has elapsed.
+	 */
 	void message_received() { expecting_ping_ack = false; }
 };
 

--- a/communication/src/protocol.cpp
+++ b/communication/src/protocol.cpp
@@ -338,6 +338,10 @@ int Protocol::begin()
 	return error;
 }
 
+const auto HELLO_FLAG_OTA_UPGRADE_SUCCESSFUL = 1;
+const auto HELLO_FLAG_DIAGNOSTICS_SUPPORT = 2;
+const auto HELLO_FLAG_IMMEDIATE_UPDATES_SUPPORT = 4;
+
 /**
  * Send the hello message over the channel.
  * @param was_ota_upgrade_successful {@code true} if the previous OTA update was successful.
@@ -347,8 +351,8 @@ ProtocolError Protocol::hello(bool was_ota_upgrade_successful)
 	Message message;
 	channel.create(message);
 
-	uint8_t flags = was_ota_upgrade_successful ? 1 : 0;
-	flags |= 2;		// diagnostics support
+	uint8_t flags = was_ota_upgrade_successful ? HELLO_FLAG_OTA_UPGRADE_SUCCESSFUL : 0;
+	flags |= HELLO_FLAG_DIAGNOSTICS_SUPPORT | HELLO_FLAG_IMMEDIATE_UPDATES_SUPPORT;
 	size_t len = build_hello(message, flags);
 	message.set_length(len);
 	message.set_confirm_received(true);

--- a/communication/src/protocol.h
+++ b/communication/src/protocol.h
@@ -37,7 +37,6 @@ class Protocol
 	 * todo - move this into the message channel?
 	 */
 	system_tick_t last_message_millis;
-	system_tick_t cloud_connected_millis;
 
 	/**
 	 * The product_id represented by this device. set_product_id()

--- a/communication/src/publisher.h
+++ b/communication/src/publisher.h
@@ -44,7 +44,7 @@ public:
 
 	inline bool is_system(const char* event_name)
 	{
-		return !strncmp(event_name, "spark", 5);
+		return !strncmp(event_name, "spark", 5) || !strncmp(event_name, "particle", 8);
 	}
 
 	bool is_rate_limited(bool is_system_event, system_tick_t millis)

--- a/communication/tests/catch/coap.cpp
+++ b/communication/tests/catch/coap.cpp
@@ -60,7 +60,7 @@ SCENARIO("CoAP::header")
 			int size = coap.header(buf, CoAPType::CON, CoAPCode::CONTINUE, 0, nullptr, message_id_t(0x1234));
 			THEN("The buffer is filled out correctly")
 			{
-				REQUIRE(buf[0]==0x43);
+				REQUIRE(buf[0]==0x40);	// version << 6 (0x40) + Type:CON=0 << 4 + tokenlen 0
 				REQUIRE(buf[1]==40);
 				REQUIRE(buf[2]==0x12);
 				REQUIRE(buf[3]==0x34);

--- a/communication/tests/catch/hal_stubs.cpp
+++ b/communication/tests/catch/hal_stubs.cpp
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include "logging.h"
+#include "diagnostics.h"
 
 extern "C" uint32_t HAL_RNG_GetRandomNumber()
 {
@@ -38,4 +39,8 @@ extern "C" void log_message(int level, const char *category, LogAttributes *attr
 
 extern "C" void log_write(int level, const char *category, const char *data, size_t size, void *reserved)
 {
+}
+
+extern "C" int diag_register_source(const diag_source* src, void* reserved) {
+	return 0;
 }

--- a/communication/tests/catch/makefile
+++ b/communication/tests/catch/makefile
@@ -22,6 +22,8 @@ DYNALIB=dynalib
 HAL=hal
 SERVICES=services
 WIRING=wiring
+CRYPTO=crypto
+MBEDTLS=third_party/mbedtls/mbedtls
 
 TARGETDIR=target
 TARGET=runner
@@ -39,12 +41,16 @@ target_files = $(patsubst $(SRC_ROOT)/%,%,$(call rwildcard,$(SRC_ROOT)/$1,$2))
 
 # sources are relative to the communications folder
 CPPSRC += $(call target_files,tests/catch,*.cpp)
-#CPPSRC += $(call target_files,src,*.cpp)
+
 CPPSRC += src/coap.cpp src/messages.cpp src/events.cpp src/protocol.cpp
 CPPSRC += src/chunked_transfer.cpp src/coap_channel.cpp src/eckeygen.cpp
-CPPSRC += src/dtls_message_channel.cpp src/dtls_protocol.cpp
+CPPSRC += src/dtls_message_channel.cpp src/dtls_protocol.cpp src/publisher.cpp
+CPPSRC += src/communication_diagnostic.cpp
 
-CSRC += $(call target_files,lib/mbedtls/library,*.c)
+CRYPTO_DIR = $(abspath $(PROJECT_ROOT)/$(CRYPTO))
+CRYPTO_CPPSRC += $(wildcard $(CRYPTO_DIR)/src/*.cpp)
+MBEDTLS_DIR = $(abspath $(PROJECT_ROOT)/$(MBEDTLS))
+MBEDTLS_CSRC = $(wildcard $(MBEDTLS_DIR)/library/*.c)
 
 include $(call rwildcard,$(PROJECT_ROOT)/$(COMMUNICATION)/,include.mk)
 include $(call rwildcard,$(PROJECT_ROOT)/$(COMMUNICATION)/lib/,build.mk)
@@ -57,6 +63,8 @@ INCLUDE_DIRS += $(PROJECT_ROOT)/$(COMMUNICATION)/src
 INCLUDE_DIRS += $(PROJECT_ROOT)/$(HAL)/shared $(PROJECT_ROOT)/$(HAL)/inc
 INCLUDE_DIRS += $(PROJECT_ROOT)/$(DYNALIB)/inc
 INCLUDE_DIRS += $(PROJECT_ROOT)/$(WIRING)/inc
+INCLUDE_DIRS += $(PROJECT_ROOT)/$(CRYPTO)/inc
+INCLUDE_DIRS += $(PROJECT_ROOT)/$(MBEDTLS)/include
 
 CFLAGS += $(patsubst %,-I%,$(INCLUDE_DIRS)) -I.
 CFLAGS += -ffunction-sections -fdata-sections -Wall
@@ -73,13 +81,20 @@ CFLGAS += fprofile-arcs -ftest-coverage
 
 CPPFLAGS += -std=gnu++11
 CPPFLAGS += -DCATCH_CONFIG_SFINAE
+CFLAGS += -DINTERRUPTS_HAL_EXCLUDE_PLATFORM_HEADERS
+CFLAGS += -DMBEDTLS_SSL_RAW_PUBLIC_KEY_SUPPORT
 
 # Collect all object and dep files
 ALLOBJ += $(addprefix $(BUILD_PATH)/, $(CSRC:.c=.o))
 ALLOBJ += $(addprefix $(BUILD_PATH)/, $(CPPSRC:.cpp=.o))
+ALLOBJ += $(subst $(MBEDTLS_DIR),$(BUILD_PATH)/mbedtls,$(MBEDTLS_CSRC:.c=.o))
+ALLOBJ += $(subst $(CRYPTO_DIR),$(BUILD_PATH)/crypto,$(CRYPTO_CPPSRC:.cpp=.o))
 
 ALLDEPS += $(addprefix $(BUILD_PATH)/, $(CSRC:.c=.o.d))
 ALLDEPS += $(addprefix $(BUILD_PATH)/, $(CPPSRC:.cpp=.o.d))
+ALLDEPS += $(subst $(MBEDTLS_DIR),$(BUILD_PATH)/mbedtls,$(MBEDTLS_CSRC:.c=.o.d))
+ALLDEPS += $(subst $(CRYPTO_DIR),$(BUILD_PATH)/crypto,$(CRYPTO_CPPSRC:.cpp=.o.d))
+
 
 all: runner
 
@@ -89,13 +104,28 @@ $(TARGETDIR)/$(TARGET) : $(BUILD_PATH) $(ALLOBJ)
 	@echo Building target: $@
 	@echo Invoking: GCC C++ Linker
 	$(MKDIR) $(dir $@)
-	$(LD) $(CFLAGS) $(ALLOBJ) $(LIBS) --output $@ $(LDFLAGS)
+	$(LD) -Darse5 $(CFLAGS) $(ALLOBJ) $(LIBS) --output $@ $(LDFLAGS)
 	@echo
 
 $(BUILD_PATH):
 	$(MKDIR) $(BUILD_PATH)
 
 # Tool invocations
+
+$(BUILD_PATH)/mbedtls/library/%.o : $(MBEDTLS_DIR)/library/%.c
+	@echo Building file: $<
+	@echo Invoking: GCC C Compiler
+	$(MKDIR) $(dir $@)
+	$(CCC) $(CCFLAGS) -c -o $@ $<
+	@echo
+
+$(BUILD_PATH)/crypto/%.o : $(CRYPTO_DIR)/%.cpp
+	@echo Building file: $<
+	@echo Invoking: GCC CPP Compiler
+	$(MKDIR) $(dir $@)
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
+	@echo
+
 
 # C compiler to build .o from .c in $(BUILD_DIR)
 $(BUILD_PATH)/%.o : $(SRC_ROOT)/%.c
@@ -111,14 +141,7 @@ $(BUILD_PATH)/%.o : $(SRC_ROOT)/%.cpp
 	@echo Building file: $<
 	@echo Invoking: GCC CPP Compiler
 	$(MKDIR) $(dir $@)
-	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c -o $@ $<
-	@echo
-
-$(BUILD_PATH)/lib/mbedtls/library/%.o : $(COMMUNICATION_MODULE_PATH)/lib/mbedtls/library/%.c
-	@echo Building file: $<
-	@echo Invoking: GCC CPP Compiler
-	$(MKDIR) $(dir $@)
-	$(CC) $(CXXFLAGS) $(CPPFLAGS) -c -o $@ $<
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
 	@echo
 
 # Other Targets

--- a/communication/tests/catch/ping.cpp
+++ b/communication/tests/catch/ping.cpp
@@ -130,10 +130,21 @@ SCENARIO("ping requests and responses are managed")
 
 		WHEN("Calling back before 10s")
 		{
-			THEN("The ping is considered anknowledged.")
+			THEN("The ping is not considered acknowledge")
+			{
+				// ping callback is not used
+				REQUIRE(pinger.process(10000, []{return IO_ERROR;})==NO_ERROR);
+				REQUIRE(pinger.is_expecting_ping_ack());
+			}
+
+			AND_WHEN("A message is received at the timeout interval")
 			{
 				REQUIRE(pinger.process(10000, []{return IO_ERROR;})==NO_ERROR);
-				REQUIRE(!pinger.is_expecting_ping_ack());
+				pinger.message_received();
+				THEN("the ping request is acknowledged")
+				{
+					REQUIRE(!pinger.is_expecting_ping_ack());
+				}
 			}
 		}
 

--- a/communication/tests/catch/publisher.cpp
+++ b/communication/tests/catch/publisher.cpp
@@ -1,0 +1,93 @@
+/**
+ ******************************************************************************
+  Copyright (c) 2013-2015 Particle Industries, Inc.  All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation, either
+  version 3 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************
+ */
+
+#include "publisher.h"
+
+#include "catch.hpp"
+
+using namespace particle::protocol;
+
+SCENARIO("publisher")
+{
+	GIVEN("a publisher")
+	{
+		Protocol* protocol = nullptr;
+		Publisher publisher(protocol);
+
+		WHEN("4 application events are sent within 1 second")
+		{
+			REQUIRE(publisher.is_rate_limited(false, 1000)==false);
+			REQUIRE(publisher.is_rate_limited(false, 1200)==false);
+			REQUIRE(publisher.is_rate_limited(false, 1400)==false);
+			REQUIRE(publisher.is_rate_limited(false, 1600)==false);
+
+			const system_tick_t next_app_event = 5000;  // 1000ms + 4s
+			THEN("application events until 4 seconds have elapsed are rate limited")
+			{
+				for (system_tick_t i=1600; i<next_app_event; i+=100) {
+					REQUIRE(publisher.is_rate_limited(false, i)==true);
+				}
+			}
+
+			THEN("an application event after 4 seconds have elapsed is not rate limited")
+			{
+				REQUIRE(publisher.is_rate_limited(false, next_app_event)==false);
+			}
+		}
+
+		WHEN("255 system events are sent in less than a minute")
+		{
+			for (int i=0; i<255; i++) {
+				INFO("The counter is " << i);
+				REQUIRE(publisher.is_rate_limited(true, i)==false);
+			}
+
+			THEN("all system events until the next minute begins are rate limited")
+			{
+				for (int i=1000; i<60*1000; i+=1000) {
+					INFO("The counter is " << i);
+					REQUIRE(publisher.is_rate_limited(true, i)==true);
+				}
+
+				// it's only approximately 1 minute, the cutoff is 64k milliseconds
+				for (int i=60000; i<65536; i+=8) {
+					INFO("The counter is " << i);
+					REQUIRE(publisher.is_rate_limited(true, i)==true);
+				}
+
+				AND_THEN("system events in the next minute are not rate limited")
+				{
+					for (int i=65536; i<65536+255; i++) {
+						INFO("The counter is " << i);
+						REQUIRE(publisher.is_rate_limited(true, i)==false);
+					}
+				}
+			}
+
+			THEN("application events are still rate limited after a burst of 4")
+			{
+				REQUIRE(publisher.is_rate_limited(false, 1000)==false);
+				REQUIRE(publisher.is_rate_limited(false, 1000)==false);
+				REQUIRE(publisher.is_rate_limited(false, 1000)==false);
+				REQUIRE(publisher.is_rate_limited(false, 1000)==false);
+				REQUIRE(publisher.is_rate_limited(false, 1000)==true);
+			}
+		}
+	}
+}

--- a/crypto/src/mbedtls_util.cpp
+++ b/crypto/src/mbedtls_util.cpp
@@ -56,10 +56,12 @@ __attribute__((weak)) mbedtls_callbacks_t* mbedtls_get_callbacks(void* reserved)
 }
 #endif // defined(CRYPTO_PART1_SIZE_OPTIMIZATIONS) || PLATFORM_ID == 0
 
+#if PLATFORM_ID!=3
 unsigned long mbedtls_timing_hardclock()
 {
     return HAL_Timer_Microseconds();
 }
+#endif
 
 int mbedtls_x509_crt_pem_to_der(const char* pem_crt, size_t pem_len, uint8_t** der_crt, size_t* der_len)
 {

--- a/hal/inc/interrupts_hal.h
+++ b/hal/inc/interrupts_hal.h
@@ -32,6 +32,7 @@
 #if defined(USE_STDPERIPH_DRIVER) || (!defined(SPARK_NO_PLATFORM) && !defined(INTERRUPTS_HAL_EXCLUDE_PLATFORM_HEADERS))
 #include "interrupts_irq.h"
 #else
+#include <stdint.h>
 typedef int32_t IRQn_Type;
 typedef int32_t hal_irq_t;
 #endif // SPARK_NO_PLATFORM

--- a/system/inc/system_event.h
+++ b/system/inc/system_event.h
@@ -50,9 +50,10 @@ enum SystemEvents {
     cloud_status = 1<<6,             // parameter is 0 for disconnected, 1 for connecting, 8 for connected, 9 for disconnecting. other values reserved.
     button_status = 1<<7,            // parameter is >0 for time pressed in ms (when released) or 0 for just pressed.
     firmware_update = 1<<8,          // parameter is 0 for begin, 1 for OTA complete, -1 for error.
-    firmware_update_pending = 1<<9,
+    firmware_update_pending = 1<<9,	// notifies the application that an OTA update is pending and will be delivered when updates are enabled
     reset_pending = 1<<10,          // notifies that the system would like to shutdown (System.resetPending() return true)
-    reset = 1<<11,                  // notifies that the system will now reset on return from this event.
+    // todo - rename to system_reset, or otherwise avoid common name clashes
+	reset = 1<<11,                  // notifies that the system will now reset on return from this event.
     button_click = 1<<12,           // generated for every click in series - data is number of clicks in the lower 4 bits.
     button_final_click = 1<<13,     // generated for last click in series - data is the number of clicks in the lower 4 bits.
     time_changed = 1<<14,

--- a/system/inc/system_update.h
+++ b/system/inc/system_update.h
@@ -153,6 +153,7 @@ void system_pending_shutdown();
 
 int system_set_flag(system_flag_t flag, uint8_t value, void* reserved);
 int system_get_flag(system_flag_t flag, uint8_t* value,void* reserved);
+int system_refresh_flag(system_flag_t flag);
 
 /**
  * Formats the diagnostic data using an appender function.

--- a/system/inc/system_update.h
+++ b/system/inc/system_update.h
@@ -136,13 +136,13 @@ typedef enum
     /**
      * Enable/Disable runtime power management peripheral detection
      */
-	SYSTEM_FLAG_PM_DETECTION,
+    SYSTEM_FLAG_PM_DETECTION,
 
 	/**
 	 * When 0, OTA updates are only applied when SYSTEM_FLAG_OTA_UPDATE_ENABLED is set.
 	 * When 1, OTA updates are applied irrespective of the value of SYSTEM_FLAG_OTA_UPDATE_ENABLED.
 	 */
-	SYSTEM_FLAG_OTA_UPDATE_FORCED,
+    SYSTEM_FLAG_OTA_UPDATE_FORCED,
 
     SYSTEM_FLAG_MAX
 

--- a/system/inc/system_update.h
+++ b/system/inc/system_update.h
@@ -136,7 +136,12 @@ typedef enum
     /**
      * Enable/Disable runtime power management peripheral detection
      */
-    SYSTEM_FLAG_PM_DETECTION,
+    SYSTEM_FLAG_PM_DETECTION, 
+	/**
+	 * When 0, OTA updates are only applied when SYSTEM_FLAG_OTA_UPDATE_ENABLED is set.
+	 * When 1, OTA updates are applied irrespective of the value of SYSTEM_FLAG_OTA_UPDATE_ENABLED.
+	 */
+	SYSTEM_FLAG_OTA_UPDATE_FORCED,
 
     SYSTEM_FLAG_MAX
 

--- a/system/inc/system_update.h
+++ b/system/inc/system_update.h
@@ -136,7 +136,8 @@ typedef enum
     /**
      * Enable/Disable runtime power management peripheral detection
      */
-    SYSTEM_FLAG_PM_DETECTION, 
+	SYSTEM_FLAG_PM_DETECTION,
+
 	/**
 	 * When 0, OTA updates are only applied when SYSTEM_FLAG_OTA_UPDATE_ENABLED is set.
 	 * When 1, OTA updates are applied irrespective of the value of SYSTEM_FLAG_OTA_UPDATE_ENABLED.

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -292,11 +292,17 @@ void invokeEventHandlerString(uint16_t handlerInfoSize, FilteringEventHandler* h
     invokeEventHandlerInternal(handlerInfoSize, handlerInfo, name.c_str(), data.c_str(), reserved);
 }
 
+void SystemEvents(const char* name, const char* data);
+
+bool is_system_handler(uint16_t handlerInfoSize, FilteringEventHandler* handlerInfo) {
+	// for now we hack this to recognize our own system handler
+	return handlerInfo->handler==SystemEvents;
+}
 
 void invokeEventHandler(uint16_t handlerInfoSize, FilteringEventHandler* handlerInfo,
                 const char* event_name, const char* event_data, void* reserved)
 {
-    if (system_thread_get_state(NULL)==spark::feature::DISABLED)
+    if (is_system_handler(handlerInfoSize, handlerInfo) || system_thread_get_state(NULL)==spark::feature::DISABLED)
     {
         invokeEventHandlerInternal(handlerInfoSize, handlerInfo, event_name, event_data, reserved);
     }

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -912,6 +912,16 @@ int Spark_Handshake(bool presence_announce)
             }
         }
 
+        if (!System.updatesEnabled()) {
+        	// force the event to be resent. The cloud assumes updates
+        	// are enabled by default.
+        	system_refresh_flag(SYSTEM_FLAG_OTA_UPDATE_ENABLED);
+        }
+
+        if (System.updatesForced()) {
+        	system_refresh_flag(SYSTEM_FLAG_OTA_UPDATE_FORCED);
+        }
+
         if (presence_announce) {
             Multicast_Presence_Announcement();
         }

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -901,6 +901,8 @@ int Send_Firmware_Update_Flags()
     if (System.updatesForced()) {
     	system_refresh_flag(SYSTEM_FLAG_OTA_UPDATE_FORCED);
     }
+
+    return 0;
 }
 
 int Spark_Handshake(bool presence_announce)

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -890,6 +890,19 @@ void Spark_Protocol_Init(void)
     }
 }
 
+int Send_Firmware_Update_Flags()
+{
+    if (!System.updatesEnabled()) {
+    	// force the event to be resent. The cloud assumes updates
+    	// are enabled by default.
+    	system_refresh_flag(SYSTEM_FLAG_OTA_UPDATE_ENABLED);
+    }
+
+    if (System.updatesForced()) {
+    	system_refresh_flag(SYSTEM_FLAG_OTA_UPDATE_FORCED);
+    }
+}
+
 int Spark_Handshake(bool presence_announce)
 {
     cloud_socket_aborted = false; // Clear cancellation flag for socket operations
@@ -949,15 +962,7 @@ int Spark_Handshake(bool presence_announce)
             }
         }
 
-        if (!System.updatesEnabled()) {
-        	// force the event to be resent. The cloud assumes updates
-        	// are enabled by default.
-        	system_refresh_flag(SYSTEM_FLAG_OTA_UPDATE_ENABLED);
-        }
-
-        if (System.updatesForced()) {
-        	system_refresh_flag(SYSTEM_FLAG_OTA_UPDATE_FORCED);
-        }
+        Send_Firmware_Update_Flags();
 
         if (presence_announce) {
             Multicast_Presence_Announcement();
@@ -976,6 +981,8 @@ int Spark_Handshake(bool presence_announce)
             spark_protocol_send_time_request(sp);
             Spark_Process_Events();
         }
+
+        Send_Firmware_Update_Flags();
     }
     if (particle_key_errors != NO_ERROR) {
         char buf[sizeof(unsigned long)*8+1];

--- a/system/src/system_update.cpp
+++ b/system/src/system_update.cpp
@@ -127,6 +127,14 @@ void system_flag_changed(system_flag_t flag, uint8_t oldValue, uint8_t newValue)
 	}
 }
 
+/**
+ * Refreshes the flag by performing the update action.
+ */
+int system_refresh_flag(system_flag_t flag) {
+	uint8_t value;
+	int result = system_get_flag(flag, &value, nullptr);
+	system_flag_changed(flag, value, value);
+	return result;
 }
 
 int system_set_flag(system_flag_t flag, uint8_t value, void*)

--- a/user/tests/app/immediate_updates/immediate_updates.cpp
+++ b/user/tests/app/immediate_updates/immediate_updates.cpp
@@ -1,0 +1,73 @@
+#include "Particle.h"
+
+#define VERSION 6
+PRODUCT_ID(2448);
+PRODUCT_VERSION(VERSION);
+SYSTEM_MODE(SEMI_AUTOMATIC);
+
+int version = VERSION;
+int updatesEnabled;
+int updatesForced;
+int updatesPending;
+int doReset;
+
+int handler(const char*  name, const char*  data) {
+        Serial.println(name);
+        digitalWrite(D7, !digitalRead(D7));
+        return 0;
+}
+
+int publish(const char* name) {
+   return Particle.publish(name, "data", 60, PRIVATE);
+}
+
+int systemReset(const char*) {
+   doReset = true;
+   return 0;
+}
+
+
+int enableUpdates(const char* name) {
+	bool enable = strcmp(name, "0");
+	if (enable) {
+		System.enableUpdates();
+	}
+	else {
+		System.disableUpdates();
+	}
+	return enable;
+}
+
+void setup() {
+   Serial.begin(9600);
+#if !USE_SWD_JTAG
+   pinMode(D7, OUTPUT);
+#endif
+   Particle.subscribe("test", handler, MY_DEVICES);
+   Particle.function("publish", publish);
+   Particle.function("reset", systemReset);
+   Particle.function("enableUpdates", enableUpdates);
+   Particle.variable("version", version);
+   Particle.variable("updatesEnabled", updatesEnabled);
+   Particle.variable("updatesForced", updatesForced);
+   Particle.variable("updatesPending", updatesPending);
+   System.disableUpdates();
+   Particle.connect();
+}
+
+void updateVariables() {
+	updatesEnabled = System.updatesEnabled();
+	updatesForced = System.updatesForced();
+	updatesPending = System.updatesPending();
+}
+
+void loop() {
+	updateVariables();
+	if (doReset) {
+		uint32_t now = millis();
+		while (millis()-now < 500) {
+			Particle.process();
+		}
+		System.reset();
+	}
+}

--- a/wiring/inc/spark_wiring_system.h
+++ b/wiring/inc/spark_wiring_system.h
@@ -324,6 +324,10 @@ public:
         return get_flag(SYSTEM_FLAG_OTA_UPDATE_ENABLED)!=0;
     }
 
+    inline uint8_t updatesForced()
+    {
+    	return get_flag(SYSTEM_FLAG_OTA_UPDATE_FORCED)!=0;
+    }
 
     inline void enableReset()
     {


### PR DESCRIPTION
### Problem

The original implementation of System.disableUpdates() did not operate in tandem with the cloud, and did not work in an intuitive manner as a consequence.

### Solution

System events from the cloud are used to notify the device that updates are pending and to force updates enabled when previously disabled in firmware. 

The device publishes system events in response to firmware updates being enabled or forced. 
The device listens to system events and updates the updates pending and forced flags accordingly.

The CoAP response when updates are disabled has been changed to 5.03 (Service Unavailable) and the response carried with a token, so the cloud reacts immediately. 

System events were previously being handled on the application thread. This has been changed to handle them on the system thread. 


### Steps to Test

The test application in user/tests/app/immediate_updates.  The SDD describes the manual test plan.


### References

- [CH24823] - Immediate firmware updates epic
- [CH27381]

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
