### PR TITLE
[ci] disables shallow submodule checkouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ script:
 
 git:
   depth: 1
-  submodules_depth: 1
 
 env:
   matrix:


### PR DESCRIPTION
### Problem

We've introduced a change to .travis.yml recently to shallowly checkout the submodules with depth=1 to optimize build times, which doesn't really work if the submodule master branch is updated and the reference update is not in `develop` yet.

### Solution

This PR Removes `submodule_depth: 1` option from .travis.yml. This does not affect build times that much, they are still at around 15 mins.

### Steps to Test

N/A

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
