### PR TITLE
[Gen 3] Fixes USB descriptors

### DIFF
--- a/hal/src/argon/app_usbd_string_config.h
+++ b/hal/src/argon/app_usbd_string_config.h
@@ -132,13 +132,13 @@
 #if PLATFORM_ID == 12 // Argon
 #define APP_USBD_STRINGS_USER \
     X(APP_USER_1, , APP_USBD_STRING_DESC('S', 'e', 'r', 'i', 'a', 'l')) \
-    X(USBD_WCID_STRING_IDX, = 0xee, APP_USBD_STRING_DESC('M', 'S', 'F', 'T', '1', '0', '0', 0xee)) \
-    X(USBD_CONTROL_STRING_IDX, , APP_USBD_STRING_DESC('A', 'r', 'g', 'o', 'n', ' ', 'C', 'o', 'n', 't', 'r', 'o', 'l', ' ', 'I', 'n', 't', 'e', 'r', 'f', 'a', 'c', 'e'))
+    X(USBD_CONTROL_STRING_IDX, , APP_USBD_STRING_DESC('A', 'r', 'g', 'o', 'n', ' ', 'C', 'o', 'n', 't', 'r', 'o', 'l', ' ', 'I', 'n', 't', 'e', 'r', 'f', 'a', 'c', 'e')) \
+    X(USBD_WCID_STRING_IDX, = 0xee, APP_USBD_STRING_DESC('M', 'S', 'F', 'T', '1', '0', '0', 0xee))
 #else
 #define APP_USBD_STRINGS_USER \
     X(APP_USER_1, , APP_USBD_STRING_DESC('S', 'e', 'r', 'i', 'a', 'l')) \
-    X(USBD_WCID_STRING_IDX, = 0xee, APP_USBD_STRING_DESC('M', 'S', 'F', 'T', '1', '0', '0', 0xee)) \
-    X(USBD_CONTROL_STRING_IDX, , APP_USBD_STRING_DESC('A', 'r', 'g', 'o', 'n', ' ', 'S', 'o', 'M', ' ', 'C', 'o', 'n', 't', 'r', 'o', 'l', ' ', 'I', 'n', 't', 'e', 'r', 'f', 'a', 'c', 'e'))
+    X(USBD_CONTROL_STRING_IDX, , APP_USBD_STRING_DESC('A', 'r', 'g', 'o', 'n', ' ', 'S', 'o', 'M', ' ', 'C', 'o', 'n', 't', 'r', 'o', 'l', ' ', 'I', 'n', 't', 'e', 'r', 'f', 'a', 'c', 'e')) \
+    X(USBD_WCID_STRING_IDX, = 0xee, APP_USBD_STRING_DESC('M', 'S', 'F', 'T', '1', '0', '0', 0xee))
 #endif
 
 /** @} */

--- a/hal/src/argon/app_usbd_string_config.h
+++ b/hal/src/argon/app_usbd_string_config.h
@@ -1,30 +1,30 @@
 /**
  * Copyright (c) 2016 - 2018, Nordic Semiconductor ASA
- * 
+ *
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this
  *    list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form, except as embedded into a Nordic
  *    Semiconductor ASA integrated circuit in a product or a software update for
  *    such product, must reproduce the above copyright notice, this list of
  *    conditions and the following disclaimer in the documentation and/or other
  *    materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
  *    contributors may be used to endorse or promote products derived from this
  *    software without specific prior written permission.
- * 
+ *
  * 4. This software, with or without modification, must only be used with a
  *    Nordic Semiconductor ASA integrated circuit.
- * 
+ *
  * 5. Any software provided in binary form under this license must not be reverse
  *    engineered, decompiled, modified and/or disassembled.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
  * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
  * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -35,7 +35,7 @@
  * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
  * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  */
 #ifndef APP_USBD_STRING_CONFIG_H
 #define APP_USBD_STRING_CONFIG_H
@@ -55,7 +55,7 @@
  * Comma separated list of supported languages.
  */
 #define APP_USBD_STRINGS_LANGIDS \
-    ((uint16_t)APP_USBD_LANG_ENGLISH | (uint16_t)APP_USBD_SUBLANG_ENGLISH_US)
+    (0x0409) // English (US) @avtolstoy: no idea why APP_USBD_XXX don't work correctly ((uint16_t)APP_USBD_LANG_ENGLISH | (uint16_t)APP_USBD_SUBLANG_ENGLISH_US)
 
 /**
  * @brief Manufacturer name string descriptor

--- a/hal/src/boron/app_usbd_string_config.h
+++ b/hal/src/boron/app_usbd_string_config.h
@@ -134,13 +134,13 @@
 #if PLATFORM_ID == 13 // Boron
 #define APP_USBD_STRINGS_USER \
     X(APP_USER_1, , APP_USBD_STRING_DESC('S', 'e', 'r', 'i', 'a', 'l')) \
-    X(USBD_WCID_STRING_IDX, = 0xee, APP_USBD_STRING_DESC('M', 'S', 'F', 'T', '1', '0', '0', 0xee)) \
-    X(USBD_CONTROL_STRING_IDX, , APP_USBD_STRING_DESC('B', 'o', 'r', 'o', 'n', ' ', 'C', 'o', 'n', 't', 'r', 'o', 'l', ' ', 'I', 'n', 't', 'e', 'r', 'f', 'a', 'c', 'e'))
+    X(USBD_CONTROL_STRING_IDX, , APP_USBD_STRING_DESC('B', 'o', 'r', 'o', 'n', ' ', 'C', 'o', 'n', 't', 'r', 'o', 'l', ' ', 'I', 'n', 't', 'e', 'r', 'f', 'a', 'c', 'e')) \
+    X(USBD_WCID_STRING_IDX, = 0xee, APP_USBD_STRING_DESC('M', 'S', 'F', 'T', '1', '0', '0', 0xee))
 #else
 #define APP_USBD_STRINGS_USER \
     X(APP_USER_1, , APP_USBD_STRING_DESC('S', 'e', 'r', 'i', 'a', 'l')) \
-    X(USBD_WCID_STRING_IDX, = 0xee, APP_USBD_STRING_DESC('M', 'S', 'F', 'T', '1', '0', '0', 0xee)) \
-    X(USBD_CONTROL_STRING_IDX, , APP_USBD_STRING_DESC('B', 'o', 'r', 'o', 'n', ' ', 'S', 'o', 'M', ' ', 'C', 'o', 'n', 't', 'r', 'o', 'l', ' ', 'I', 'n', 't', 'e', 'r', 'f', 'a', 'c', 'e'))
+    X(USBD_CONTROL_STRING_IDX, , APP_USBD_STRING_DESC('B', 'o', 'r', 'o', 'n', ' ', 'S', 'o', 'M', ' ', 'C', 'o', 'n', 't', 'r', 'o', 'l', ' ', 'I', 'n', 't', 'e', 'r', 'f', 'a', 'c', 'e')) \
+    X(USBD_WCID_STRING_IDX, = 0xee, APP_USBD_STRING_DESC('M', 'S', 'F', 'T', '1', '0', '0', 0xee))
 #endif
 
 /** @} */

--- a/hal/src/boron/app_usbd_string_config.h
+++ b/hal/src/boron/app_usbd_string_config.h
@@ -1,30 +1,30 @@
 /**
  * Copyright (c) 2016 - 2018, Nordic Semiconductor ASA
- * 
+ *
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this
  *    list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form, except as embedded into a Nordic
  *    Semiconductor ASA integrated circuit in a product or a software update for
  *    such product, must reproduce the above copyright notice, this list of
  *    conditions and the following disclaimer in the documentation and/or other
  *    materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
  *    contributors may be used to endorse or promote products derived from this
  *    software without specific prior written permission.
- * 
+ *
  * 4. This software, with or without modification, must only be used with a
  *    Nordic Semiconductor ASA integrated circuit.
- * 
+ *
  * 5. Any software provided in binary form under this license must not be reverse
  *    engineered, decompiled, modified and/or disassembled.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
  * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
  * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -35,10 +35,12 @@
  * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
  * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  */
 #ifndef APP_USBD_STRING_CONFIG_H
 #define APP_USBD_STRING_CONFIG_H
+
+#include "app_usbd_langid.h"
 
 /**
  * @defgroup app_usbd_string_conf USBD string configuration
@@ -55,7 +57,7 @@
  * Comma separated list of supported languages.
  */
 #define APP_USBD_STRINGS_LANGIDS \
-    ((uint16_t)APP_USBD_LANG_ENGLISH | (uint16_t)APP_USBD_SUBLANG_ENGLISH_US)
+    (0x0409) // English (US) @avtolstoy: no idea why APP_USBD_XXX don't work correctly ((uint16_t)APP_USBD_LANG_ENGLISH | (uint16_t)APP_USBD_SUBLANG_ENGLISH_US)
 
 /**
  * @brief Manufacturer name string descriptor

--- a/hal/src/xenon/app_usbd_string_config.h
+++ b/hal/src/xenon/app_usbd_string_config.h
@@ -1,30 +1,30 @@
 /**
  * Copyright (c) 2016 - 2018, Nordic Semiconductor ASA
- * 
+ *
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this
  *    list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form, except as embedded into a Nordic
  *    Semiconductor ASA integrated circuit in a product or a software update for
  *    such product, must reproduce the above copyright notice, this list of
  *    conditions and the following disclaimer in the documentation and/or other
  *    materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
  *    contributors may be used to endorse or promote products derived from this
  *    software without specific prior written permission.
- * 
+ *
  * 4. This software, with or without modification, must only be used with a
  *    Nordic Semiconductor ASA integrated circuit.
- * 
+ *
  * 5. Any software provided in binary form under this license must not be reverse
  *    engineered, decompiled, modified and/or disassembled.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
  * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
  * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -35,7 +35,7 @@
  * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
  * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  */
 #ifndef APP_USBD_STRING_CONFIG_H
 #define APP_USBD_STRING_CONFIG_H
@@ -55,7 +55,7 @@
  * Comma separated list of supported languages.
  */
 #define APP_USBD_STRINGS_LANGIDS \
-    ((uint16_t)APP_USBD_LANG_ENGLISH | (uint16_t)APP_USBD_SUBLANG_ENGLISH_US)
+    (0x0409) // English (US) @avtolstoy: no idea why APP_USBD_XXX don't work correctly ((uint16_t)APP_USBD_LANG_ENGLISH | (uint16_t)APP_USBD_SUBLANG_ENGLISH_US)
 
 /**
  * @brief Manufacturer name string descriptor

--- a/hal/src/xenon/app_usbd_string_config.h
+++ b/hal/src/xenon/app_usbd_string_config.h
@@ -132,13 +132,13 @@
 #if PLATFORM_ID == 14 // Xenon
 #define APP_USBD_STRINGS_USER \
     X(APP_USER_1, , APP_USBD_STRING_DESC('S', 'e', 'r', 'i', 'a', 'l')) \
-    X(USBD_WCID_STRING_IDX, = 0xee, APP_USBD_STRING_DESC('M', 'S', 'F', 'T', '1', '0', '0', 0xee)) \
-    X(USBD_CONTROL_STRING_IDX, , APP_USBD_STRING_DESC('X', 'e', 'n', 'o', 'n', ' ', 'C', 'o', 'n', 't', 'r', 'o', 'l', ' ', 'I', 'n', 't', 'e', 'r', 'f', 'a', 'c', 'e'))
+    X(USBD_CONTROL_STRING_IDX, , APP_USBD_STRING_DESC('X', 'e', 'n', 'o', 'n', ' ', 'C', 'o', 'n', 't', 'r', 'o', 'l', ' ', 'I', 'n', 't', 'e', 'r', 'f', 'a', 'c', 'e')) \
+    X(USBD_WCID_STRING_IDX, = 0xee, APP_USBD_STRING_DESC('M', 'S', 'F', 'T', '1', '0', '0', 0xee))
 #else
 #define APP_USBD_STRINGS_USER \
     X(APP_USER_1, , APP_USBD_STRING_DESC('S', 'e', 'r', 'i', 'a', 'l')) \
-    X(USBD_WCID_STRING_IDX, = 0xee, APP_USBD_STRING_DESC('M', 'S', 'F', 'T', '1', '0', '0', 0xee)) \
-    X(USBD_CONTROL_STRING_IDX, , APP_USBD_STRING_DESC('X', 'e', 'n', 'o', 'n', ' ', 'S', 'o', 'M', ' ', 'C', 'o', 'n', 't', 'r', 'o', 'l', ' ', 'I', 'n', 't', 'e', 'r', 'f', 'a', 'c', 'e'))
+    X(USBD_CONTROL_STRING_IDX, , APP_USBD_STRING_DESC('X', 'e', 'n', 'o', 'n', ' ', 'S', 'o', 'M', ' ', 'C', 'o', 'n', 't', 'r', 'o', 'l', ' ', 'I', 'n', 't', 'e', 'r', 'f', 'a', 'c', 'e')) \
+    X(USBD_WCID_STRING_IDX, = 0xee, APP_USBD_STRING_DESC('M', 'S', 'F', 'T', '1', '0', '0', 0xee))
 #endif
 
 /** @} */

--- a/platform/MCU/nRF52840/inc/sdk_config_system.h
+++ b/platform/MCU/nRF52840/inc/sdk_config_system.h
@@ -133,7 +133,7 @@
                                                    // change it to no pull <0=> NRF_GPIO_PIN_NOPULL.
 
 #define APP_USBD_DEVICE_VER_MAJOR               1
-#define APP_USBD_DEVICE_VER_MINOR               1
+#define APP_USBD_DEVICE_VER_MINOR               2
 
 #define NRFX_POWER_CONFIG_DEFAULT_DCDCEN        1
 

--- a/platform/MCU/nRF52840/inc/sdk_config_system.h
+++ b/platform/MCU/nRF52840/inc/sdk_config_system.h
@@ -125,6 +125,9 @@
 
 #define APP_USBD_VID                            USBD_VID_SPARK
 #define APP_USBD_PID                            USBD_PID_CDC
+#define APP_USBD_DEVICE_CLASS                   0xef
+#define APP_USBD_DEVICE_SUB_CLASS               0x02
+#define APP_USBD_DEVICE_PROTOCOL                0x01
 
 #define NRFX_SPIM_MISO_PULL_CFG                 0  // MISO pin pull configuration. The default configuration is pull down,
                                                    // change it to no pull <0=> NRF_GPIO_PIN_NOPULL.


### PR DESCRIPTION
### Problem

1. Particle CLI is unable to communicate with Gen 3 devices over USB Control Interface
2. Windows complains about USB strings

### Solution

1. particle-iot/nrf5_sdk#7 along with d3212bfb25276e97442780b0113bf4d4a64dab49 fix `bDeviceClass`, `bDeviceSubClass` and `bDeviceProtocol` in USB device descriptor
2. Hardcoding `0x0409` (English (US)) as the USB LangID. I wasn't able to figure out why `APP_USBD_LANG_ENGLISH` and `APP_USBD_SUBLANG_ENGLISH_US` weren't producing the correct result. The resulting LangID was `0x0009`.
3. particle-iot/nrf5_sdk#8 fixes interface-specific vendor request handling

### Steps to Test

1. Verify that Particle CLI works (assuming no interfering drivers are installed)
2. `usbview.exe` may be used to verify there are no complaints about the strings, see screenshot below

### usbview
![image](https://user-images.githubusercontent.com/388478/55086526-1d3b5b80-50db-11e9-976f-5455b5a58a03.png)

### References

- particle-iot/nrf5_sdk#7
- particle-iot/nrf5_sdk#8

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
