### PR TITLE
[bootloader] SysTick needs to be disabled in Reset_System() on Gen 2 platforms

### DIFF
--- a/platform/MCU/STM32F1xx/SPARK_Firmware_Driver/inc/hw_config.h
+++ b/platform/MCU/STM32F1xx/SPARK_Firmware_Driver/inc/hw_config.h
@@ -127,6 +127,7 @@ typedef enum
 
 /* Exported functions ------------------------------------------------------- */
 void Set_System(void);
+void Reset_System(void);
 void NVIC_Configuration(void);
 void SysTick_Configuration(void);
 
@@ -209,9 +210,6 @@ void Finish_Update(void);
 
 uint16_t Bootloader_Get_Version(void);
 void Bootloader_Update_Version(uint16_t bootloaderVersion);
-
-inline void Reset_System(void) {
-}
 
 /* External variables --------------------------------------------------------*/
 extern uint8_t USE_SYSTEM_FLAGS;

--- a/platform/MCU/STM32F1xx/SPARK_Firmware_Driver/src/hw_config.c
+++ b/platform/MCU/STM32F1xx/SPARK_Firmware_Driver/src/hw_config.c
@@ -163,6 +163,11 @@ void Set_System(void)
     FLASH_ClearFlags();
 }
 
+void Reset_System(void)
+{
+    SysTick_Disable();
+}
+
 /*******************************************************************************
  * Function Name  : NVIC_Configuration
  * Description    : Configures Vector Table base location.

--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/src/hw_config.c
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/src/hw_config.c
@@ -211,6 +211,7 @@ void Set_System(void)
 
 void Reset_System(void)
 {
+    SysTick_Disable();
 }
 
 /*******************************************************************************


### PR DESCRIPTION
### Problem

Bootloader on Gen 2 platforms built out of `develop` currently fails to boot correctly into system parts. This is an artifact of Gen2/3 merge, where the preparatory logic for deinitializing things in the bootloader before jumping into the application was moved out of the common bootloader code into platform-specific `Reset_System()` function.

### Solution

Disable `SysTick` in `Reset_System()` on Gen 2 platforms and core.

### Steps to Test

Build bootloader out of this branch, flash it, it should correctly jump into system parts.

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
