### PR TITLE
Reserve memory for system-part1 SRAM

### DIFF
--- a/modules/electron/system-part1/linker.ld
+++ b/modules/electron/system-part1/linker.ld
@@ -3,9 +3,9 @@ MEMORY
     APP_FLASH (rx)  : ORIGIN = 0x08060000, LENGTH = 128K
 /*
  SRAM is located immediately below system-part2, whcih has a base address
- of 0x20200000-10K. 
+ of 0x20200000-12K.
 */
-    SRAM      (rwx) : ORIGIN = 0x20020000-6K-10K, LENGTH = 6K
+    SRAM      (rwx) : ORIGIN = 0x20020000-12K-4K, LENGTH = 4K
 }
 
 INCLUDE module_system_part1_export.ld

--- a/modules/electron/system-part1/module_system_part3_export.ld
+++ b/modules/electron/system-part1/module_system_part3_export.ld
@@ -1,8 +1,8 @@
 
 system_part3_start = 0x8060000;
 
-system_part3_ram_end = 0x2001D800 - 2K /* 0x20200000-10K-1K */;
-system_part3_ram_start = 0x2001c000 - 2K /* end of SRAM - 16K */;
+system_part3_ram_end = 0x20020000 - 12K;
+system_part3_ram_start = 0x20020000 - 16K;
 
 system_part3_module_info_size = 24;
 

--- a/modules/electron/system-part2/module_system_part1_export.ld
+++ b/modules/electron/system-part2/module_system_part1_export.ld
@@ -5,6 +5,7 @@
  * 512-byte aligned.
  */
 system_part1_module_ram_end = 0x20000400;
+system_part1_module_ram_start = 0x20000000;
 
 INCLUDE "../../shared/stm32f2xx/part1_vtor_module.ld"
 

--- a/modules/electron/system-part3/module_system_part2_export.ld
+++ b/modules/electron/system-part3/module_system_part2_export.ld
@@ -42,7 +42,7 @@ min_heap_size = 16K;
  * Can be expanded or reduced as necessary. The heap dynamically expands from
  * it's static base to the heap top, which is the bottom of this module's static ram.
  */
-system_part2_ram_size = 8K;
+system_part2_ram_size = 8K; /* 12K - stack_size */
 
 /* Place system part2 static RAM immediately below stack. */
 system_part2_ram_start = ALIGN( stack_start - system_part2_ram_size, 512);

--- a/modules/electron/user-part/module_user_memory.ld
+++ b/modules/electron/user-part/module_user_memory.ld
@@ -3,6 +3,6 @@
 user_module_app_flash_origin = 0x08080000;
 user_module_app_flash_length = 128K;
 
-/* The SRAM Origin is system_part1_module_ram_end, and extends to system_static_ram_start */
+/* The SRAM Origin is system_part1_module_ram_end, and extends to system_part3_ram_start */
 user_module_sram_origin = 0x20000400;
-user_module_sram_length = 0x20000 - 0x400 - 16K - 2K;
+user_module_sram_length = 0x20000 - 0x400 - 12K - 4K;

--- a/modules/photon/system-part1/module_system_part1_export.ld
+++ b/modules/photon/system-part1/module_system_part1_export.ld
@@ -5,6 +5,7 @@
  * 512-byte aligned.
  */
 system_part1_module_ram_end = 0x20000300;
+system_part1_module_ram_start = 0x20000000;
 
 INCLUDE "../../shared/stm32f2xx/part1_vtor_module.ld"
 

--- a/modules/photon/system-part2/module_system_part2_export.ld
+++ b/modules/photon/system-part2/module_system_part2_export.ld
@@ -42,7 +42,7 @@ min_heap_size = 16K;
  * Can be expanded or reduced as necessary. The heap dynamically expands from
  * it's static base to the heap top, which is the bottom of this module's static ram.
  */
-system_part2_ram_size = 42K;
+system_part2_ram_size = 42K; /* 46K - stack_size */
 
 /* Place system part2 static RAM immediately below stack. */
 system_part2_ram_start = ALIGN( stack_start - system_part2_ram_size, 512);

--- a/modules/shared/stm32f2xx/inc/system_part1_loader.c
+++ b/modules/shared/stm32f2xx/inc/system_part1_loader.c
@@ -16,6 +16,7 @@ typedef void  (*constructor_ptr_t)(void);
  */
 extern void* dynamic_reset_handler_location;
 extern char stack_end;
+extern char system_part1_module_ram_start;
 
 /**
  * No register saving needed.
@@ -62,7 +63,7 @@ void* module_system_part1_pre_init()
 
     memset(&link_bss_location, 0, link_bss_size );
 
-    return link_end_of_static_ram;
+    return &system_part1_module_ram_start;
 }
 
 

--- a/modules/shared/stm32f2xx/inc/system_part2_loader.c
+++ b/modules/shared/stm32f2xx/inc/system_part2_loader.c
@@ -64,7 +64,7 @@ void system_part2_pre_init() {
 
     // The code below reserves memory for the static RAM of system-part1, which is going to be
     // relocated in 1.2.0 (see also part2.ld)
-#ifndef SYSTEM_VERSION_120
+#ifndef SYSTEM_VERSION_120RC1
     // Get the module version of system-part1
     const module_info_t* const part1 = FLASH_ModuleInfo(FLASH_INTERNAL, module_system_part1.start_address);
     // Adjust the end address of the heap if system-part1 is newer than system-part2

--- a/modules/shared/stm32f2xx/inc/system_part2_loader.c
+++ b/modules/shared/stm32f2xx/inc/system_part2_loader.c
@@ -5,7 +5,7 @@
 
 #include <string.h>
 
-#define MODULE_VERSION_V1_3_0 1300
+#define MODULE_VERSION_V1_3_0 1320
 
 extern void malloc_enable(uint8_t);
 extern void malloc_set_heap_start(void*);

--- a/modules/shared/stm32f2xx/inc/system_part3_loader.c
+++ b/modules/shared/stm32f2xx/inc/system_part3_loader.c
@@ -11,6 +11,7 @@ typedef void  (*constructor_ptr_t)(void);
  */
 extern void* dynamic_reset_handler_location;
 extern char stack_end;
+extern char system_part3_ram_start;
 
 void* module_system_part3_pre_init();
 
@@ -37,7 +38,7 @@ void* module_system_part3_pre_init()
 
     memset(&link_bss_location, 0, link_bss_size );
 
-    return link_end_of_static_ram;
+    return &system_part3_ram_start;
 }
 
 

--- a/modules/shared/stm32f2xx/part2.ld
+++ b/modules/shared/stm32f2xx/part2.ld
@@ -74,6 +74,12 @@ SECTIONS
     link_heap_location = ALIGN(system_part1_module_ram_end, 4);
     link_heap_location_end = system_heap_end;
 
+    /* The static RAM of system-part1 is going to be relocated in 1.2.0. This variable holds the new
+     * end address of the heap and is used by the system to reserve memory for the relocated region
+     * in the intermediate 1.1.0 release (see system_part2_loader.c)
+     */
+    link_heap_location_end_v1_2_0 = link_heap_location_end - 1536;
+
     padding_length = ALIGN(system_part2_ram_start - ORIGIN(SRAM), 512);
 
     .padding : /* 512 byte aligned offset in SRAM */
@@ -233,3 +239,5 @@ ASSERT ( ORIGIN(SRAM) == system_part2_ram_start, "ORIGIN of SRAM should be equal
 ASSERT ( LENGTH(SRAM) == ( system_part2_ram_size + stack_size ), "LENGTH of SRAM should be equal to system_static_ram_size plus stack_size. Adjust by hand to obtain the correct address and length. ");
 
 ASSERT ( (link_bss_end - link_global_data_start) <= system_part2_ram_size, "Insufficient room for .data and .bss sections" )
+
+ASSERT ( link_end_of_static_ram <= system_part2_ram_end, "static RAM use exceeds allocated space" );

--- a/modules/shared/stm32f2xx/part2.ld
+++ b/modules/shared/stm32f2xx/part2.ld
@@ -74,12 +74,6 @@ SECTIONS
     link_heap_location = ALIGN(system_part1_module_ram_end, 4);
     link_heap_location_end = system_heap_end;
 
-    /* The static RAM of system-part1 is going to be relocated in 1.2.0. This variable holds the new
-     * end address of the heap and is used by the system to reserve memory for the relocated region
-     * in the intermediate 1.1.0 release (see system_part2_loader.c)
-     */
-    link_heap_location_end_v1_2_0 = link_heap_location_end - 1536;
-
     padding_length = ALIGN(system_part2_ram_start - ORIGIN(SRAM), 512);
 
     .padding : /* 512 byte aligned offset in SRAM */


### PR DESCRIPTION
### Problem

On the Photon, the size of the static RAM (SRAM) allocated for system-part1 is only 768 bytes, which is not enough to build Device OS with newer versions of GCC (5.4.x – 8.2.x): https://github.com/particle-iot/device-os/pull/1159#issuecomment-262969953.

The user part's SRAM is located immediately after the system-part1 SRAM, so the size of the latter region cannot be increased without breaking the backward compatibility:
```
Photon                                  Electron
+-------------------+ 0x20000000        +-------------------+ 0x20000000
| system-part1 SRAM |                   | system-part1 SRAM |
+-------------------+ 0x20000300        +-------------------+ 0x20000400
| user-part SRAM    |                   | user-part SRAM    |
+~~~~~~~~~~~~~~~~~~~+                   +~~~~~~~~~~~~~~~~~~~+
|                   |                   |                   |
|                   |                   | Heap              |
| Heap              |                   |                   |
|                   |                   +-------------------+ 0x2001c000
|                   |                   | system-part3 SRAM |
+-------------------+ 0x20014800        +-------------------+ 0x2001d000
| system-part2 SRAM |                   | system-part2 SRAM |
+-------------------+ 0x2001f000        +-------------------+ 0x2001f000
| Initial stack     |                   | Initial stack     |
+-------------------+ 0x20020000        +-------------------+ 0x20020000
```

### Solution

The only viable option we have is to move the system-part1 SRAM to another location. This should be done in two steps:
1. Make necessary changes in Device OS 1.2.0 to allow for relocation of the system-part1 SRAM in a later release.

2. Relocate the system-part1 SRAM in Device OS 1.3.0, increase its size and make 1.2.0 a mandatory intermediate release (this can be done via our regular module dependencies mechanism).
<br>On the Electron, we'd also like to relocate the system-part3 SRAM and put it immediately below the relocated system-part1 SRAM in Device OS 1.3.0. This would allow us to resize SRAM regions as necessary in the scope of a single OTA update in future releases.

This PR implements the first step of the process by making `module_system_part3_pre_init()` on Electron and `module_system_part1_pre_init()` on Photon return start addresses of the corresponding SRAM regions. If the system detects that the module version of system-part3 on Electron or system-part1 on Photon is greater than or equal to 1320 it will use the start address of the corresponding SRAM region as the end address of the heap.

As a result, the memory map in Device OS 1.3.0 will look as follows:

```
Photon                                  Electron
+-------------------+ 0x20000000        +-------------------+ 0x20000000
| user-part SRAM    |                   | user-part SRAM    |
+~~~~~~~~~~~~~~~~~~~+                   +~~~~~~~~~~~~~~~~~~~+
|                   |                   |                   |
|                   |                   | Heap              |
| Heap              |                   |                   |
|                   |                   +-------------------+ 0x2001ba00
|                   |                   | system-part3 SRAM |
+-------------------+ 0x20014200        +-------------------+ 0x2001ca00
| system-part1 SRAM |                   | system-part1 SRAM |
+-------------------+ 0x20014800        +-------------------+ 0x2001d000
| system-part2 SRAM |                   | system-part2 SRAM |
+-------------------+ 0x2001f000        +-------------------+ 0x2001f000
| Initial stack     |                   | Initial stack     |
+-------------------+ 0x20020000        +-------------------+ 0x20020000
```

### Steps to Test

**Note:** The steps below use our internal system part numbering scheme.

1. Build and flash this PR along with the following app to a Photon and an Electron:
```cpp
#include "application.h"

SYSTEM_MODE(SEMI_AUTOMATIC)

namespace {

const Serial1LogHandler logHandler(115200, LOG_LEVEL_WARN, {
    { "app", LOG_LEVEL_ALL }
});

} // namespace

void setup() {
    LOG(INFO, "Free memory: %u", (unsigned)System.freeMemory());
}

void loop() {
}
```

2. **Electron, Photon:** Run the app and take a note of the reported free heap memory.

3. **Electron, Photon:** Apply [this patch](https://github.com/particle-iot/device-os/files/3179311/patch.txt) (`git am < patch.txt`) and rebuild the firmware. The patch bumps the module versions and relocates the SRAM regions as shown on the diagram in the previous section.

4. **Electron:** flash system-part3 via DFU and reset the device. Verify that the amount of free memory has decreased by exactly 1.5K. At this point, the memory map looks as follows:
```
Electron
+-------------------+ 0x20000000
| system-part1 SRAM |
+-------------------+ 0x20000400
| user-part SRAM    |
+~~~~~~~~~~~~~~~~~~~+
|                   |
| Heap              |
|                   |
+-------------------+ 0x2001ba00
| system-part3 SRAM |
+-------------------+ 0x2001ca00
| Unused            |
+-------------------+ 0x2001d000
| system-part2 SRAM |
+-------------------+ 0x2001f000
| Initial stack     |
+-------------------+ 0x20020000
```

5. **Electron, Photon:** flash system-part1 via DFU and reset the device. **Photon:** Verify that the amount of free memory has decreased by exactly 1.5K. At this point, the memory map looks as follows:
```
Photon                                  Electron
+-------------------+ 0x20000000        +-------------------+ 0x20000000
| Unused            |                   | Unused            |
+-------------------+ 0x20000300        +-------------------+ 0x20000400
| user-part SRAM    |                   | user-part SRAM    |
+~~~~~~~~~~~~~~~~~~~+                   +~~~~~~~~~~~~~~~~~~~+
|                   |                   |                   |
|                   |                   | Heap              |
| Heap              |                   |                   |
|                   |                   +-------------------+ 0x2001ba00
|                   |                   | system-part3 SRAM |
+-------------------+ 0x20014200        +-------------------+ 0x2001ca00
| system-part1 SRAM |                   | system-part1 SRAM |
+-------------------+ 0x20014800        +-------------------+ 0x2001d000
| system-part2 SRAM |                   | system-part2 SRAM |
+-------------------+ 0x2001f000        +-------------------+ 0x2001f000
| Initial stack     |                   | Initial stack     |
+-------------------+ 0x20020000        +-------------------+ 0x20020000
```

6. **Electron, Photon:** Flash system-part2 and user-part via DFU. Verify that the application reclaimed the unused space shown on the above diagram (1K on Electron and 768 bytes on Photon).

7. **Electron, Photon:** Revert the patch, rebuild the firmware and flash it to the device along with the tinker application. Perform an OTA update to the patched firmware. Verify the results with `particle serial inspect` (the reported module versions should all be 1300).

8. **Electron, Photon:** Downgrade to the original firmware OTA, flashing the modules in the reverse order. Verify the results with `particle serial inspect`.

### References

- [ch30182]

---

- [enhancement] Reserve memory for system-part1 SRAM [#1742](https://github.com/particle-iot/device-os/pull/1742)