### PR TITLE
[photon/p1] crypto: re-enables MD5 for TLS (WPA Enterprise)

### DIFF
--- a/crypto/inc/crypto_dynalib.h
+++ b/crypto/inc/crypto_dynalib.h
@@ -195,6 +195,13 @@ DYNALIB_FN(117, crypto, mbedtls_sha512_starts, void(mbedtls_sha512_context*, int
 DYNALIB_FN(118, crypto, mbedtls_sha512_update, void(mbedtls_sha512_context*, const unsigned char*, size_t))
 DYNALIB_FN(119, crypto, mbedtls_sha512_finish, void(mbedtls_sha512_context*, unsigned char output[64]))
 DYNALIB_FN(120, crypto, mbedtls_sha512_process, void(mbedtls_sha512_context*, const unsigned char data[128]))
+
+// MD5 with return value
+DYNALIB_FN(121, crypto, mbedtls_md5_starts_ret, int(mbedtls_md5_context*))
+DYNALIB_FN(122, crypto, mbedtls_md5_update_ret, int(mbedtls_md5_context*, const unsigned char*, size_t))
+DYNALIB_FN(123, crypto, mbedtls_md5_finish_ret, int(mbedtls_md5_context*, unsigned char[16]))
+DYNALIB_FN(124, crypto, mbedtls_internal_md5_process, int(mbedtls_md5_context*, const unsigned char[64]))
+
 #endif // PLATFORM_ID == 6 || PLATFORM_ID == 8
 DYNALIB_END(crypto)
 

--- a/crypto/inc/mbedtls_config_photon.h
+++ b/crypto/inc/mbedtls_config_photon.h
@@ -1938,7 +1938,7 @@
  * This module is required for SSL/TLS and X.509.
  * PEM_PARSE uses MD5 for decrypting encrypted keys.
  */
-// #define MBEDTLS_MD5_C
+#define MBEDTLS_MD5_C
 
 /**
  * \def MBEDTLS_MEMORY_BUFFER_ALLOC_C

--- a/crypto/inc/mbedtls_weaken.h
+++ b/crypto/inc/mbedtls_weaken.h
@@ -151,6 +151,12 @@
 #pragma weak mbedtls_sha512_finish
 #pragma weak mbedtls_sha512_process
 
+// MD5 with return value
+#pragma weak mbedtls_md5_starts_ret
+#pragma weak mbedtls_md5_update_ret
+#pragma weak mbedtls_md5_finish_ret
+#pragma weak mbedtls_internal_md5_process
+
 #endif
 
 #endif // MBEDTLS_WEAKEN


### PR DESCRIPTION
### Problem

MD5 got erroneously disabled for Photon and P1, which prevents WPA Enterprise authentication not working correctly.

### Solution

Bring it back!

### Steps to Test

Connect to WPA Enterprise AP with PEAP. Your device shouldn't crash.

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
