### PR TITLE
Do not fail the build if PARTICLE_DEVELOP is not defined

### DIFF
--- a/build/checks.mk
+++ b/build/checks.mk
@@ -1,11 +1,5 @@
-ifneq (, $(shell command -v git;))
-    git_branch := $(shell git rev-parse --abbrev-ref HEAD)
-    ifeq ("$(git_branch)","develop")
-        ifndef PARTICLE_DEVELOP
-            $(error Please note the develop branch contains untested, unreleased code. \
-            We recommend using the 'release/stable' branch which contains the latest released firmware code. \
-            To build the develop branch, please see the the build documentation at \
-            https://github.com/spark/firmware/blob/develop/docs/build.md#building-the-develop-branch)
-        endif
-    endif
-endif
+# Add environment checks here
+
+#ifeq (,$(shell command -v git;))
+#  $(error Git is not installed)
+#endif

--- a/docs/build.md
+++ b/docs/build.md
@@ -488,19 +488,13 @@ Before the 0.4.0 firmware was released, we recommended the develop branch for ea
 
 Pre-releases are available in `release/vx.x.x-rc.x` branches.  Default released firmware is available as `release/vx.x.x`, which is also then duplicated to `release/stable` and `master` branches.
 
-To build the develop branch, follow these guidelines:
-
-1. export the environment variable PARTICLE_DEVELOP=1
-2. after pulling from the develop branch, be sure to build and flash the system firmware
-
 
 ## Recipes and Tips
 
 - The variables passed to make can also be provided as environment variables,
 so you avoid having to type them out for each build. The environment variable value can be overridden
 by passing the variable on the command line.
- - `PARTICLE_DEVELOP` can be set in the environment when building from the `develop` branch. (Caveats apply that this is bleeding edge!)
- - `PLATFORM` set in the environment if you mainly build for one platform, e.g. the Photon.
+- `PLATFORM` set in the environment if you mainly build for one platform, e.g. the Photon.
 
 ### Photon
 


### PR DESCRIPTION
The `PARTICLE_DEVELOP` check still generates a lot of noise during compilation: https://community.particle.io/t/issue-fatal-not-a-git-repository-or-any-of-the-parent-directories-git/48744.

After a discussion with @monkbroc we decided to remove that check entirely.
