### PR TITLE
Remove the message "External flash is not supported" from Gen 3 builds

### DIFF
--- a/system/src/control/storage.cpp
+++ b/system/src/control/storage.cpp
@@ -59,9 +59,6 @@
 #endif
 
 // TODO: Add support for external flash (available if HAS_SERIAL_FLASH macro is defined)
-#ifdef USE_SERIAL_FLASH
-#pragma message("External flash is not supported")
-#endif
 
 #define PB(_name) particle_ctrl_##_name
 


### PR DESCRIPTION
### Problem

```
device-os/modules$ make PLATFORM=argon -s
  /home/monkbroc/Programming/firmware/modules/argon/system-part1/makefile /home/monkbroc/Programming/firmware/modules/argon/user-part/makefile
src/control/storage.cpp:63:50: note: #pragma message: External flash is not supported
 #pragma message("External flash is not supported")
                                                  ^
   text	   data	    bss	    dec	    hex	filename
 649424	   2156	  65792	 717372	  af23c	../../../build/target/system-part1/platform-12-m/system-part1.elf
Creating ../../../build/target/user-part/platform-12-m/module_user_memory.ld ...
Creating ../../../build/target/user-part/platform-12-m/module_user_memory.ld ...
   text	   data	    bss	    dec	    hex	filename
   4764	    104	    780	   5648	   1610	../../../build/target/user-part/platform-12-m/user-part.elf
```

This message shows up in all Gen 3 Device OS builds, including quiet builds. It is not an actionable message for end users. If we need to implement additional support for external flash in Device OS, let's plan for that instead of showing a message in the build output.

### Solution

Remove the message