### PR TITLE
[Gen 3] Always check ongoing RX DMA transaction when reporting number of bytes available in RX buffer

### DIFF
--- a/hal/src/nRF52840/usart_hal.cpp
+++ b/hal/src/nRF52840/usart_hal.cpp
@@ -266,13 +266,13 @@ public:
         CHECK_TRUE(isEnabled(), SYSTEM_ERROR_INVALID_STATE);
         RxLock lk(uarte_);
         ssize_t d = rxBuffer_.data();
-        if (d == 0 && receiving_) {
+        if (receiving_) {
             const ssize_t toConsume = timerValue() - rxConsumed_;
             if (toConsume > 0) {
                 rxBuffer_.acquireCommit(toConsume);
                 rxConsumed_ += toConsume;
+                d += toConsume;
             }
-            d += toConsume;
         }
         return d;
     }

--- a/user/tests/wiring/serial_loopback2/README.md
+++ b/user/tests/wiring/serial_loopback2/README.md
@@ -1,0 +1,12 @@
+## Serial testing hardware requirements
+
+Connect a jumper to TX and RX pins i.e. TX-RX lines should be shorted.
+```
+TX <-------> RX
+```
+
+## Flashing the wiring/serial_loopback2 test application
+
+```
+modules $ make TEST=wiring/serial_loopback2 PLATFORM=<platform> clean all program-dfu
+```

--- a/user/tests/wiring/serial_loopback2/application.cpp
+++ b/user/tests/wiring/serial_loopback2/application.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2019 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+SYSTEM_MODE(MANUAL);
+
+UNIT_TEST_APP();

--- a/user/tests/wiring/serial_loopback2/loopback.cpp
+++ b/user/tests/wiring/serial_loopback2/loopback.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2019 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "application.h"
+#include "unit-test/unit-test.h"
+#include "random.h"
+
+test(SERIAL_00_LoopbackNoDataLossAndAvailableIsCorrect) {
+    const size_t TEST_BUFFER_SIZE_MIN = 8;
+    const size_t TEST_BUFFER_SIZE_MAX = SERIAL_BUFFER_SIZE / 2;
+    const unsigned ITERATIONS = 10000;
+    const unsigned BAUD_RATE = 115200;
+
+    particle::Random rand;
+
+    Serial1.end();
+    Serial1.begin(BAUD_RATE);
+
+    for (unsigned i = 0; i < ITERATIONS; ++i) {
+        size_t bufferSize = random(TEST_BUFFER_SIZE_MIN, TEST_BUFFER_SIZE_MAX);
+        // Generate random data
+        char txBuf[bufferSize + 1] = {};
+        rand.genBase32(txBuf, bufferSize);
+
+        Serial1.write(txBuf);
+        Serial1.flush();
+
+        size_t pos = 0;
+        char rxBuf[bufferSize] = {};
+        do {
+            size_t available = bufferSize - pos;
+            assertEqual(available, Serial1.available());
+            if (available) {
+                rxBuf[pos] = (char)Serial1.read();
+            }
+        } while (++pos <= bufferSize);
+
+        assertTrue(!strncmp(txBuf, rxBuf, bufferSize));
+    }
+}


### PR DESCRIPTION
### Problem

`SerialX.available()` may report smaller number of bytes available in RX buffer than actually received, until the data is read out. There is no data loss though.

This is a "bug" in how we handle partial DMA transfers. We commit pending DMA data only if the RX buffer is empty, so you would see a smaller number in `available()` that wouldn't change until read out and then partially completed DMA transfer would be commited.

Originally issue was reported in https://community.particle.io/t/error-serial1-available-argon/48380/4

### Solution

Always check ongoing RX DMA transaction when reporting number of bytes available in RX buffer.

### Steps to Test

Run the `wiring/serial_loopback2` test.

### Example App

N/A

### References

- https://community.particle.io/t/error-serial1-available-argon/48380/4
- [CH31890]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
