### PR TITLE
Introduce safety checks on heap usage from ISRs

### DIFF
--- a/hal/src/electron/core_hal.c
+++ b/hal/src/electron/core_hal.c
@@ -203,10 +203,9 @@ static void init_malloc_mutex(void)
 
 void __malloc_lock(void* ptr)
 {
-    SPARK_ASSERT(!HAL_IsISR());
     if (malloc_mutex) {
         if (!xSemaphoreTakeRecursive(malloc_mutex, MALLOC_LOCK_TIMEOUT_MS)) {
-            PANIC(SemaphoreLockTimeout,"Semaphore Lock Timeout");
+            PANIC(HeapError, "Semaphore Lock Timeout");
             while (1);
         }
     }
@@ -214,7 +213,6 @@ void __malloc_lock(void* ptr)
 
 void __malloc_unlock(void* ptr)
 {
-    SPARK_ASSERT(!HAL_IsISR());
     if (malloc_mutex) {
         xSemaphoreGiveRecursive(malloc_mutex);
     }

--- a/newlib_nano/makefile
+++ b/newlib_nano/makefile
@@ -6,6 +6,6 @@ NEWLIBNANO_MODULE_PATH=.
 TARGET_TYPE = a
 BUILD_PATH_EXT = $(NEWLIBNANO_BUILD_PATH_EXT)
 
-DEPENDENCIES = hal
+DEPENDENCIES = hal services platform
 
 include ../build/arm-tlm.mk

--- a/newlib_nano/src/malloc.c
+++ b/newlib_nano/src/malloc.c
@@ -15,17 +15,22 @@ extern size_t xPortGetBlockSize( void* ptr );
 extern void __malloc_lock(struct _reent *ptr);
 extern void __malloc_unlock(struct _reent *ptr);
 
+static void panic_if_in_isr() {
+    if (HAL_IsISR()) {
+        PANIC(HeapError, "Heap usage from an ISR");
+        while (1);
+    }
+}
+
 void* _malloc_r(struct _reent *r, size_t s) {
     (void)r;
-    // should not be used in ISRs
-    SPARK_ASSERT(!HAL_IsISR());
+    panic_if_in_isr();
     void* ptr = pvPortMalloc((size_t)s);
     return ptr;
 }
 
 void _free_r(struct _reent* r, void* ptr) {
-    // should not be used in ISRs
-    SPARK_ASSERT(!HAL_IsISR());
+    panic_if_in_isr();
     // Hack of the century. We cannot free reent->_current_locale, because it's in
     // .text section on most of our platforms in flash and is simply a constant "C"
     if (r && ptr == r->_current_locale) {
@@ -49,8 +54,7 @@ void* _calloc_r(struct _reent* r, size_t n, size_t elem) {
 void* _realloc_r(struct _reent* r, void *ptr, size_t newsize) {
     (void)r;
 
-    // should not be used in ISRs
-    SPARK_ASSERT(!HAL_IsISR());
+    panic_if_in_isr();
 
     if (newsize == 0) {
         vPortFree(ptr);
@@ -70,8 +74,7 @@ void* _realloc_r(struct _reent* r, void *ptr, size_t newsize) {
 static struct mallinfo current_mallinfo = {0};
 
 struct mallinfo _mallinfo_r(struct _reent* r) {
-    // should not be used in ISRs
-    SPARK_ASSERT(!HAL_IsISR());
+    panic_if_in_isr();
     __malloc_lock(r);
 
     current_mallinfo.arena = xPortGetHeapSize();
@@ -90,8 +93,7 @@ void _malloc_stats_r(struct _reent* r) {
 size_t _malloc_usable_size_r(struct _reent* r, void* ptr) {
     (void)r;
 
-    // should not be used in ISRs
-    SPARK_ASSERT(!HAL_IsISR());
+    panic_if_in_isr();
 
     return xPortGetBlockSize(ptr);
 }

--- a/services/inc/panic_codes.h
+++ b/services/inc/panic_codes.h
@@ -28,4 +28,4 @@ def_panic_codes(Software,RGB_COLOR_RED,PureVirtualCall)		// 12
 
 def_panic_codes(System,RGB_COLOR_RED,StackOverflow)			// 13
 
-def_panic_codes(System,RGB_COLOR_RED,SemaphoreLockTimeout)	// 14
+def_panic_codes(System,RGB_COLOR_RED,HeapError)	    // 14


### PR DESCRIPTION
### Problem

Apparently we don't have checks on whether `malloc()`/`free()` etc functions are being called from an ISR, which should not be possible due to the usage of a semaphore for thread-safety.

We did have assertions for this previously but only for Electron.

### Solution

This PR renames `SemaphoreLockTimeout` panic code into a generic `HeapError` and adds `HAL_IsISR()` checks to `malloc()`, `free()`, `realloc()`, `mallinfo()`, and `malloc_usable_size()` functions (instead of `__malloc_lock()/unlock()` which are implemented separately for each platform and defined in WICED for Photons and P1 for example).

### Steps to Test

Run the example app, the device should panic once D0 is deasserted.

### Example App

```cpp
void setup() {
    pinMode(D0, INPUT_PULLUP);
    attachInterrupt(D0, (wiring_interrupt_handler_t)[](void) -> void {
        void* ptr = malloc(1024);
    }, FALLING);
}
```

### References

- [CH31998]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
