### PR TITLE
[Electron/LTE] disables all eDRX AcT types [ch32051]

### DIFF
--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -480,6 +480,23 @@ void MDMParser::unlock()
     mdm_mutex.unlock();
 }
 
+int MDMParser::_cbCEDRXS(int type, const char* buf, int len, EdrxActs* edrxActs)
+{
+    if (((type == TYPE_PLUS) || (type == TYPE_UNKNOWN)) && edrxActs) {
+        // if response is "\r\n+CEDRXS:\r\n", all AcT's disabled, do nothing
+        if (strncmp(buf, "\r\n+CEDRXS:\r\n", len) != 0) {
+            int a;
+            if (sscanf(buf, "\r\n+CEDRXS: %1d[2-5]", &a) == 1 ||
+                sscanf(buf, "+CEDRXS: %1d[2-5]", &a) == 1) {
+                if (edrxActs->count < MDM_R410_EDRX_ACTS_MAX) {
+                    edrxActs->act[edrxActs->count++] = a;
+                }
+            }
+        }
+    }
+    return WAIT;
+}
+
 int MDMParser::_cbString(int type, const char* buf, int len, char* str)
 {
     if (str && (type == TYPE_UNKNOWN)) {
@@ -807,33 +824,6 @@ bool MDMParser::init(DevStatus* status)
     sendFormated("AT+CCID\r\n");
     if (RESP_OK != waitFinalResp(_cbCCID, _dev.ccid))
         goto failure;
-    // enable power saving
-    if (_dev.lpm != LPM_DISABLED) {
-        // enable power saving (requires flow control, cts at least)
-        sendFormated("AT+UPSV=%d\r\n", _power_mode);
-        if (RESP_OK != waitFinalResp())
-            goto failure;
-        if (_power_mode != 0) {
-            _dev.lpm = LPM_ACTIVE;
-        }
-    }
-    if (_dev.dev == DEV_SARA_R410) {
-        // Force eDRX mode to be disabled
-        // 18/23 hardware doesn't seem to be disabled by default
-        sendFormated("AT+CEDRXS=3,2\r\n");
-        if (RESP_OK != waitFinalResp())
-            goto failure;
-        sendFormated("AT+CEDRXS?\r\n");
-        if (RESP_OK != waitFinalResp())
-            goto failure;
-        // Force Power Saving mode to be disabled for good measure
-        sendFormated("AT+CPSMS=0\r\n");
-        if (RESP_OK != waitFinalResp())
-            goto failure;
-        sendFormated("AT+CPSMS?\r\n");
-        if (RESP_OK != waitFinalResp())
-            goto failure;
-    }
     // Setup SMS in text mode
     sendFormated("AT+CMGF=1\r\n");
     if (RESP_OK != waitFinalResp())
@@ -857,14 +847,73 @@ bool MDMParser::init(DevStatus* status)
     if (waitFinalResp() != RESP_OK) {
         goto failure;
     }
-#endif
-    if (status)
+#endif // SOCKET_HEX_MODE
+    // enable power saving
+    if (_dev.lpm != LPM_DISABLED) {
+        // enable power saving (requires flow control, cts at least)
+        sendFormated("AT+UPSV=%d\r\n", _power_mode);
+        if (RESP_OK != waitFinalResp())
+            goto failure;
+        if (_power_mode != 0) {
+            _dev.lpm = LPM_ACTIVE;
+        }
+    }
+    // All _dev items collected without error, populate status.
+    if (status) {
         memcpy(status, &_dev, sizeof(DevStatus));
+    }
+    if (_dev.dev == DEV_SARA_R410) {
+        // Force Power Saving mode to be disabled for good measure
+        sendFormated("AT+CPSMS=0\r\n");
+        if (RESP_OK != waitFinalResp())
+            goto failure;
+        sendFormated("AT+CPSMS?\r\n");
+        if (RESP_OK != waitFinalResp())
+            goto failure;
+        // Force eDRX mode to be disabled
+        // 18/23 hardware doesn't seem to be disabled by default
+        sendFormated("AT+CEDRXS?\r\n");
+        // Reset the detected count each time we check for eDRX AcTs enabled
+        EdrxActs _edrxActs;
+        if (RESP_ERROR == waitFinalResp(_cbCEDRXS, &_edrxActs)) {
+            goto reset_failure;
+        }
+        bool resetNeeded = false;
+        for (int i = 0; i < _edrxActs.count; i++) {
+            sendFormated("AT+CEDRXS=3,%d\r\n", _edrxActs.act[i]);
+            waitFinalResp(); // Not checking for error since we will reset either way
+            resetNeeded = true;
+        }
+        if (resetNeeded) {
+            goto reset_failure;
+        }
+    } // if (_dev.dev == DEV_SARA_R410)
     UNLOCK();
     return true;
+
 failure:
     UNLOCK();
+    return false;
 
+reset_failure:
+    // Don't get stuck in a reset-retry loop
+    static int resetFailureAttempts = 0;
+    if (resetFailureAttempts++ < 3) {
+        sendFormated("AT+CFUN=15\r\n");
+        waitFinalResp();
+        _init = false; // invalidate init and prevent cellular registration
+        _pwr = false;  //   |
+        // When this exits false, ARM_WLAN_WD 1 will fire and timeout after 30s.
+        // MDMParser::powerOn and MDMParser::init will then be retried by the system.
+    } // else {
+        // stop resetting, and try to register.
+        // Preventing cellular registration gets us back to retrying init() faster,
+        // and the timeout of 3 attempts is arbitrary but allows us to register and
+        // connect even with an error, since that error is persisting and might just
+        // be a fluke or bug in the modem. Allowing to continue on eventually helps
+        // the device recover in odd situations we can't predict.
+    // }
+    UNLOCK();
     return false;
 }
 

--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -531,6 +531,18 @@ protected:
     static int _cbCPIN(int type, const char* buf, int len, Sim* sim);
     static int _cbCCID(int type, const char* buf, int len, char* ccid);
     // network
+    #define MDM_R410_EDRX_ACTS_MAX (4) //!< maximum number of AcTs for eDRX mode on SARA-R410M-02B
+    // eDRX AcTs
+    struct EdrxActs {
+        int act[MDM_R410_EDRX_ACTS_MAX];
+        int count;
+
+        EdrxActs()
+        {
+            memset(this, 0, sizeof(*this));
+        }
+    };
+    static int _cbCEDRXS(int type, const char* buf, int len, EdrxActs* edrxActs);
     static int _cbUGCNTRD(int type, const char* buf, int len, MDM_DataUsage* data);
     static int _cbBANDAVAIL(int type, const char* buf, int len, MDM_BandSelect* data);
     static int _cbBANDSEL(int type, const char* buf, int len, MDM_BandSelect* data);


### PR DESCRIPTION
### Problem

eDRX is enabled by default on production u-Blox modules, and it causes a variable lag in the network data transmissions.  We have previously disabled it, but not entirely.

### Solution

Scan for and disable each eDRX AcT type, and reset the modem if disabling is required or an error occurs.

>**Note:** When disabling eDRX mode, the modem needs to be reset to clear eDRX behavior in the cellular network.  This will cause a one time ~30s reconnection delay after OTA updating the new firmware.

>**Note:** When eDRX mode is enabled, TX on the device temporarily allows the network to RX faster.  For example, if the device published every 2 minutes and we asynchronous tried to read a Particle Variable every ~5 seconds, the device would up timing out 2-3 times in a row and succeeding 2-3 times in a row repeatedly.  This affects OTA updates as well.  An OTA update might never start until the device pings the Cloud and reduces the RX timing in the network.  Because of this, devices with this behavior that are remote in the field might need special care in updating them remotely, Ex. a script that repeatedly tries OTA updating every 30 seconds for 30 minutes.

### Steps to Test

🔗 [Electron/LTE firmware compiled for this PR-1762, v1.1.0-rc.2.  Tinker included but not required.](https://www.dropbox.com/s/gox036vwxp51iok/particle_device-os%401.1.0-rc.2-pr-1762.zip?dl=1)

Manual testing required:
1. Flash LTE device with this system firmware and tinker
2. Make a function call `particle call <device> digitalwrite D7,LOW`
3. It should return 1 if successful
4. Repeat every 30 seconds for 10 or more attempts

⚠️ Should you need to for testing purposes, you may enable eDRX mode with the following commands:

```c
sendFormated("AT+CEDRXS=2,2,\"1001\"\r\n"); waitFinalResp();
sendFormated("AT+CEDRXS=2,3,\"1001\"\r\n"); waitFinalResp();
sendFormated("AT+CEDRXS=2,4,\"1001\"\r\n"); waitFinalResp();
sendFormated("AT+CEDRXS=2,5,\"1001\"\r\n"); waitFinalResp();
```

### References

#1567 
Closes [ch32051]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] [n/a] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)

---

- [bugfix] [Electron/LTE] disables all eDRX AcT types [ch32051] [#1762](https://github.com/particle-iot/device-os/pull/1762)