### PR TITLE
ch32350/error codes - Create AT specific errors

### DIFF
--- a/services/inc/system_error.h
+++ b/services/inc/system_error.h
@@ -49,7 +49,9 @@
         (OUT_OF_RANGE, "Out of range", -290), \
         (COAP, "CoAP error", -1000), /* -1199 ... -1000: CoAP errors */ \
         (COAP_4XX, "CoAP: 4xx", -1100), \
-        (COAP_5XX, "CoAP: 5xx", -1132)
+        (COAP_5XX, "CoAP: 5xx", -1132), \
+        (AT_NOT_OK, "AT command failure", -1200), /* -1399 ... -1200: AT command errors */ \
+        (AT_RESPONSE_UNEXPECTED, "Failed to parse AT response", -1210)
 
 // Expands to enum values for all errors
 #define SYSTEM_ERROR_ENUM_VALUES(prefix) \


### PR DESCRIPTION
Update `SYSTEM_ERROR_UNKNOWN` to `SYSTEM_ERROR_AT_NOT_OK` and `SYSTEM_ERROR_AT_RESPONSE_UNEXPECTED` to provide context to error messages for the sake of debugging.

ch32350 - Update error codes in Gen3 parser to facilitate debugging efforts and provide context to system errors