### PR TITLE
Wait for confirmable messages when entering the deep sleep mode

### DIFF
--- a/communication/src/dtls_protocol.cpp
+++ b/communication/src/dtls_protocol.cpp
@@ -76,6 +76,12 @@ int DTLSProtocol::wait_confirmable(uint32_t timeout)
 		channel.client_messages().has_messages() ? "no" : "yes",
 		channel.server_messages().has_unacknowledged_requests() ? "no" : "yes");
 
+	if (err == ProtocolError::NO_ERROR && channel.has_unacknowledged_requests())
+	{
+		err = ProtocolError::MESSAGE_TIMEOUT;
+		LOG(WARN, "Timeout while waiting for confirmable messages to be processed");
+	}
+
 	return (int)err;
 }
 

--- a/communication/src/dtls_protocol.h
+++ b/communication/src/dtls_protocol.h
@@ -79,10 +79,6 @@ public:
 		{
 		case ProtocolCommands::SLEEP:
 			result = wait_confirmable();
-			// Discard the session on an event loop error
-			if (result != ProtocolError::NO_ERROR) {
-				channel.command(MessageChannel::CLOSE);
-			}
 			break;
 		case ProtocolCommands::DISCONNECT:
 			result = wait_confirmable();

--- a/communication/src/dtls_protocol.h
+++ b/communication/src/dtls_protocol.h
@@ -79,6 +79,10 @@ public:
 		{
 		case ProtocolCommands::SLEEP:
 			result = wait_confirmable();
+			// Discard the session on an event loop error
+			if (result != ProtocolError::NO_ERROR) {
+				channel.command(MessageChannel::CLOSE);
+			}
 			break;
 		case ProtocolCommands::DISCONNECT:
 			result = wait_confirmable();

--- a/system/inc/system_sleep.h
+++ b/system/inc/system_sleep.h
@@ -33,12 +33,13 @@ typedef enum
     SLEEP_MODE_WLAN = 0, SLEEP_MODE_DEEP = 1, SLEEP_MODE_SOFTPOWEROFF = 2
 } Spark_Sleep_TypeDef;
 
-enum class SystemSleepOption
+typedef enum System_Sleep_Flag
 {
-    NetworkOff = 0x00,
-    NetworkStandby = 0x01,
-    DisableWkpPin = 0x02
-};
+    SYSTEM_SLEEP_FLAG_NETWORK_OFF = 0x00,
+    SYSTEM_SLEEP_FLAG_NETWORK_STANDBY = 0x01,
+    SYSTEM_SLEEP_FLAG_DISABLE_WKP_PIN = 0x02,
+    SYSTEM_SLEEP_FLAG_NO_WAIT = 0x04
+} System_Sleep_Flag;
 
 /**
  * @param param A SystemSleepNetwork enum cast as an integer.

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -116,6 +116,10 @@ int system_sleep_impl(Spark_Sleep_TypeDef sleepMode, long seconds, uint32_t para
     //---- #2
     // SLEEP_NETWORK_STANDBY can keep the modem on during DEEP sleep
     // System.sleep(10) always powers down the network, even if SLEEP_NETWORK_STANDBY flag is used.
+
+    // Make sure all confirmable UDP messages are sent and acknowledged before sleeping
+    Spark_Sleep();
+
     if (network_sleep_flag(param) || SLEEP_MODE_WLAN == sleepMode) {
         network_suspend();
     }
@@ -158,11 +162,9 @@ int system_sleep_impl(Spark_Sleep_TypeDef sleepMode, long seconds, uint32_t para
 int system_sleep_pin_impl(const uint16_t* pins, size_t pins_count, const InterruptMode* modes, size_t modes_count, long seconds, uint32_t param, void* reserved)
 {
     SYSTEM_THREAD_CONTEXT_SYNC(system_sleep_pin_impl(pins, pins_count, modes, modes_count, seconds, param, reserved));
-    // If we're connected to the cloud, make sure all
-    // confirmable UDP messages are sent before sleeping
-    if (spark_cloud_flag_connected()) {
-        Spark_Sleep();
-    }
+
+    // Make sure all confirmable UDP messages are sent and acknowledged before sleeping
+    Spark_Sleep();
 
     bool network_sleep = network_sleep_flag(param);
     if (network_sleep)

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -94,7 +94,7 @@ void sleep_fuel_gauge()
 
 bool network_sleep_flag(uint32_t flags)
 {
-    return (flags & SLEEP_NETWORK_STANDBY.value()) == 0;
+    return (flags & SYSTEM_SLEEP_FLAG_NETWORK_STANDBY) == 0;
 }
 
 int system_sleep_impl(Spark_Sleep_TypeDef sleepMode, long seconds, uint32_t param, void* reserved)
@@ -118,7 +118,9 @@ int system_sleep_impl(Spark_Sleep_TypeDef sleepMode, long seconds, uint32_t para
     // System.sleep(10) always powers down the network, even if SLEEP_NETWORK_STANDBY flag is used.
 
     // Make sure all confirmable UDP messages are sent and acknowledged before sleeping
-    Spark_Sleep();
+    if (!(param & SYSTEM_SLEEP_FLAG_NO_WAIT)) {
+        Spark_Sleep();
+    }
 
     if (network_sleep_flag(param) || SLEEP_MODE_WLAN == sleepMode) {
         network_suspend();
@@ -164,7 +166,9 @@ int system_sleep_pin_impl(const uint16_t* pins, size_t pins_count, const Interru
     SYSTEM_THREAD_CONTEXT_SYNC(system_sleep_pin_impl(pins, pins_count, modes, modes_count, seconds, param, reserved));
 
     // Make sure all confirmable UDP messages are sent and acknowledged before sleeping
-    Spark_Sleep();
+    if (!(param & SYSTEM_SLEEP_FLAG_NO_WAIT)) {
+        Spark_Sleep();
+    }
 
     bool network_sleep = network_sleep_flag(param);
     if (network_sleep)

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -118,7 +118,7 @@ int system_sleep_impl(Spark_Sleep_TypeDef sleepMode, long seconds, uint32_t para
     // System.sleep(10) always powers down the network, even if SLEEP_NETWORK_STANDBY flag is used.
 
     // Make sure all confirmable UDP messages are sent and acknowledged before sleeping
-    if (!(param & SYSTEM_SLEEP_FLAG_NO_WAIT)) {
+    if (spark_cloud_flag_connected() && !(param & SYSTEM_SLEEP_FLAG_NO_WAIT)) {
         Spark_Sleep();
     }
 
@@ -166,7 +166,7 @@ int system_sleep_pin_impl(const uint16_t* pins, size_t pins_count, const Interru
     SYSTEM_THREAD_CONTEXT_SYNC(system_sleep_pin_impl(pins, pins_count, modes, modes_count, seconds, param, reserved));
 
     // Make sure all confirmable UDP messages are sent and acknowledged before sleeping
-    if (!(param & SYSTEM_SLEEP_FLAG_NO_WAIT)) {
+    if (spark_cloud_flag_connected() && !(param & SYSTEM_SLEEP_FLAG_NO_WAIT)) {
         Spark_Sleep();
     }
 

--- a/user/tests/wiring/api/system.cpp
+++ b/user/tests/wiring/api/system.cpp
@@ -65,6 +65,7 @@ test(system_sleep)
     API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, SLEEP_NETWORK_STANDBY, 60); (void)r; });
 
     API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, SLEEP_NETWORK_STANDBY); (void)r; });
+    API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, SLEEP_NETWORK_STANDBY | SLEEP_NO_WAIT); (void)r; });
 
     API_COMPILE({ SleepResult r = System.sleep(A0, CHANGE, SLEEP_NETWORK_STANDBY); (void)r; });
     API_COMPILE({ SleepResult r = System.sleep(A0, RISING, SLEEP_NETWORK_STANDBY); (void)r; });

--- a/wiring/inc/spark_wiring_system.h
+++ b/wiring/inc/spark_wiring_system.h
@@ -56,9 +56,10 @@ struct SleepOptionFlagType; // Tag type for System.sleep() flags
 typedef particle::Flags<SleepOptionFlagType, uint32_t> SleepOptionFlags;
 typedef SleepOptionFlags::FlagType SleepOptionFlag;
 
-const SleepOptionFlag SLEEP_NETWORK_OFF(static_cast<uint32_t>(SystemSleepOption::NetworkOff));
-const SleepOptionFlag SLEEP_NETWORK_STANDBY(static_cast<uint32_t>(SystemSleepOption::NetworkStandby));
-const SleepOptionFlag SLEEP_DISABLE_WKP_PIN(static_cast<uint32_t>(SystemSleepOption::DisableWkpPin));
+const SleepOptionFlag SLEEP_NETWORK_OFF(System_Sleep_Flag::SYSTEM_SLEEP_FLAG_NETWORK_OFF);
+const SleepOptionFlag SLEEP_NETWORK_STANDBY(System_Sleep_Flag::SYSTEM_SLEEP_FLAG_NETWORK_STANDBY);
+const SleepOptionFlag SLEEP_DISABLE_WKP_PIN(System_Sleep_Flag::SYSTEM_SLEEP_FLAG_DISABLE_WKP_PIN);
+const SleepOptionFlag SLEEP_NO_WAIT(System_Sleep_Flag::SYSTEM_SLEEP_FLAG_NO_WAIT);
 
 #if Wiring_LogConfig
 enum LoggingFeature {


### PR DESCRIPTION
### Problem

`System.sleep(SLEEP_MODE_DEEP, ...)` doesn't wait for confirmable messages to be processed before entering the deep sleep mode. If the current session data became invalid for some reason, this may put a sleepy device into an endless loop, where it wakes up, restores the session, publishes an event and goes back to sleep without ever noticing that there's no established connection with the cloud.

### Solution

By default, the system should wait for all confirmable messages to be processed before entering a sleep mode. This PR also introduces a flag that allows overriding the default behavior (`SLEEP_NO_WAIT`).

### Steps to Test

1. Flash the following application to an Electron:
```cpp
#include "application.h"

// SYSTEM_THREAD(ENABLED)

namespace {

const Serial1LogHandler logHandler(115200, LOG_LEVEL_WARN, {
    { "app", LOG_LEVEL_ALL }
});

} // namespace

void setup() {
    Log.info("setup()");
}

void loop() {
    Log.info("Particle.publish()");
    auto f = Particle.publish("my_event", PRIVATE | WITH_ACK);
    f.onSuccess([](bool) {
        Log.info("ACK received");
    }).onError([](Error) {
        Log.warn("Particle.publish() failed");
    });
    Log.info("System.sleep()");
    System.sleep(SLEEP_MODE_DEEP, 5);
}
```

Verify that the application gets notified about an ACK received for the published message before the device enters the deep sleep mode.

~2. Apply the following patch via `git apply`:~
```diff
diff --git a/communication/src/dtls_message_channel.cpp b/communication/src/dtls_message_channel.cpp
index dec29fb9d..be096f4c2 100644
--- a/communication/src/dtls_message_channel.cpp
+++ b/communication/src/dtls_message_channel.cpp
@@ -112,6 +112,7 @@ auto SessionPersist::restore(mbedtls_ssl_context* context, bool renegotiate, uin
 		context->state = MBEDTLS_SSL_HANDSHAKE_WRAPUP;
 		context->in_epoch = in_epoch;
 		memcpy(context->out_ctr, &out_ctr, sizeof(out_ctr));
+		context->out_ctr[0] = 'X'; // Invalidate the session data
 		memcpy(context->handshake->randbytes, randbytes, sizeof(randbytes));
 
 		context->transform_negotiate->ciphersuite_info = mbedtls_ssl_ciphersuite_from_id(ciphersuite);
```

~Verify that the device running the same application performs the full handshake on every second boot. When the system resumes the session using invalid data, it should take no longer than 1 minute for the communication layer to fail with a timeout error while waiting for ACKs and reset the session.~

**Edit:** A better solution for the second test case is implemented in https://github.com/particle-iot/device-os/pull/1776.

### References

- [ch32341]

---

- [bugfix] Wait for confirmable messages when entering the deep sleep mode [#1767](https://github.com/particle-iot/device-os/pull/1767)