### PR TITLE
communication: cleans up CoAP timeout/parameters/retransmission stuff

### DIFF
--- a/communication/src/coap_channel.cpp
+++ b/communication/src/coap_channel.cpp
@@ -48,6 +48,7 @@ bool CoAPMessageStore::retransmit(CoAPMessage* msg, Channel& channel, system_tic
 
 void CoAPMessageStore::message_timeout(CoAPMessage& msg, Channel& channel)
 {
+	LOG(TRACE, "timeout waiting for ACK for message id=%x", msg.get_id());
 	g_unacknowledgedMessageCounter++;
 	msg.notify_timeout();
 	if (msg.is_request())
@@ -99,7 +100,7 @@ ProtocolError CoAPMessageStore::send(Message& msg, system_tick_t time)
 		if (coapType==CoAPType::CON)
 			coapmsg->prepare_retransmit(time);
 		else
-			coapmsg->set_expiration(time+CoAPMessage::MAX_TRANSMIT_SPAN);
+			coapmsg->set_expiration(time + CoAPMessage::EXCHANGE_LIFETIME);
 		add(*coapmsg);
 	}
 	return NO_ERROR;
@@ -150,7 +151,7 @@ ProtocolError CoAPMessageStore::receive(Message& msg, Channel& channel, system_t
 				return INSUFFICIENT_STORAGE;
 			// the timeout here is ideally purely academic since the application will respond immediately with an ACK/RESET
 			// which will be stored in place of this message, with it's own timeout.
-			coapmsg->set_expiration(time+CoAPMessage::MAX_TRANSMIT_SPAN);
+			coapmsg->set_expiration(time + CoAPMessage::EXCHANGE_LIFETIME);
 			add(*coapmsg);
 		}
 	}

--- a/communication/src/dtls_protocol.cpp
+++ b/communication/src/dtls_protocol.cpp
@@ -13,8 +13,13 @@ void DTLSProtocol::init(const char *id,
 {
 	set_protocol_flags(0);
 	memcpy(device_id, id, sizeof(device_id));
-	// send a ping once every 23 minutes
-	initialize_ping(23*60*1000,30000);
+	// Sets ping interval by default to 23 minutes. This is Electron-specific default
+	// value, however all the other platforms will override this currently depending
+	// on various conditions.
+	// IMPORTANT: the second argument is the timeout waiting for the ping
+	// acknowledgment. This SHOULD be set to MAX_TRANSMIT_WAIT, which is 93s
+	// for default transmission parameters defined in RFC7252. If required we might lower it.
+	initialize_ping(23 * 60 * 1000, CoAPMessage::MAX_TRANSMIT_WAIT);
 	DTLSMessageChannel::Callbacks channelCallbacks = {0};
 	channelCallbacks.millis = callbacks.millis;
 	channelCallbacks.handle_seed = handle_seed;


### PR DESCRIPTION
## POC. DO NOT MERGE AS-IS

### Description

This is something I made some time ago while investigating CoAP issues for Gen 3 devices, so putting it here so it's not lost in time.

This PR:
1. Cleans up (IMHO) CoAP parameter calculations
2. Fixes retransmission logic to exactly follow RFC (random part is calculated only once), additional logging
3. `MAX_TRANSMIT_SPAN` -> `EXCHANGE_LIFETIME` again to follow the RFC
4. Makes `PING` ACK timeout based on `MAX_TRANSMIT_SPAN` instead of arbitrary `30s`