### PR TITLE
expires a session after 3 unsuccessful attempts at connecting to the cloud

### DIFF
--- a/communication/src/dtls_message_channel.cpp
+++ b/communication/src/dtls_message_channel.cpp
@@ -48,12 +48,6 @@ uint32_t compute_checksum(uint32_t(*calculate_crc)(const uint8_t* data, uint32_t
 }
 
 
-
-void SessionPersist::save(save_fn_t saver)
-{
-	save_this_with(saver);
-}
-
 void SessionPersist::prepare_save(const uint8_t* random, uint32_t keys_checksum, mbedtls_ssl_context* context, message_id_t next_id)
 {
 	if (context->state == MBEDTLS_SSL_HANDSHAKE_OVER)
@@ -82,10 +76,9 @@ void SessionPersist::update(mbedtls_ssl_context* context, save_fn_t saver, messa
 	}
 }
 
-auto SessionPersist::restore(mbedtls_ssl_context* context, bool renegotiate, uint32_t keys_checksum, message_id_t* next_id, restore_fn_t restorer) -> RestoreStatus
+auto SessionPersist::restore(mbedtls_ssl_context* context, bool renegotiate, uint32_t keys_checksum, message_id_t* next_id, restore_fn_t restorer, save_fn_t saver) -> RestoreStatus
 {
 	if (!restore_this_from(restorer)) {
-
 		return NO_SESSION;
 	}
 
@@ -94,9 +87,19 @@ auto SessionPersist::restore(mbedtls_ssl_context* context, bool renegotiate, uin
 		return NO_SESSION;
 	}
 
+    increment_use_count();
+    save(saver);
+
+    LOG(WARN, "session has %d uses", use_count());
+	if (has_expired()) {
+	    LOG(WARN, "session has expired after %d uses", use_count());
+	    return NO_SESSION;
+	}
+
 	// assume invalid initially. With the ssl context being reset,
 	// we cannot return NO_SESSION from this point onwards.
 	size = 0;
+
 	mbedtls_ssl_session_reset(context);
 
 	context->handshake->resume = 1;
@@ -113,7 +116,6 @@ auto SessionPersist::restore(mbedtls_ssl_context* context, bool renegotiate, uin
 		context->in_epoch = in_epoch;
 		memcpy(context->out_ctr, &out_ctr, sizeof(out_ctr));
 		memcpy(context->handshake->randbytes, randbytes, sizeof(randbytes));
-
 		context->transform_negotiate->ciphersuite_info = mbedtls_ssl_ciphersuite_from_id(ciphersuite);
 		if (!context->transform_negotiate->ciphersuite_info)
 		{
@@ -344,7 +346,7 @@ ProtocolError DTLSMessageChannel::establish(uint32_t& flags, uint32_t app_state_
 	}
 	bool renegotiate = false;
 
-	SessionPersist::RestoreStatus restoreStatus = sessionPersist.restore(&ssl_context, renegotiate, keys_checksum, coap_state, callbacks.restore);
+	SessionPersist::RestoreStatus restoreStatus = sessionPersist.restore(&ssl_context, renegotiate, keys_checksum, coap_state, callbacks.restore, callbacks.save);
 	LOG(INFO,"(CMPL,RENEG,NO_SESS,ERR) restoreStatus=%d", restoreStatus);
 	if (restoreStatus==SessionPersist::COMPLETE)
 	{
@@ -410,7 +412,6 @@ ProtocolError DTLSMessageChannel::establish(uint32_t& flags, uint32_t app_state_
 ProtocolError DTLSMessageChannel::notify_established()
 {
 	sessionPersist.make_persistent();
-	sessionPersist.save(callbacks.save);
 	return NO_ERROR;
 }
 
@@ -458,6 +459,18 @@ ProtocolError DTLSMessageChannel::receive(Message& message)
 #endif
 	}
 	return NO_ERROR;
+}
+
+/**
+ * Once data has been successfully received we can stop
+ * sending move-session messages.
+ * This is also used to reset the expiration counter.
+ */
+void DTLSMessageChannel::cancel_move_session()
+{
+    move_session = false;
+    sessionPersist.clear_use_count();
+    command(SAVE_SESSION);
 }
 
 ProtocolError DTLSMessageChannel::send(Message& message)

--- a/communication/src/dtls_message_channel.h
+++ b/communication/src/dtls_message_channel.h
@@ -116,7 +116,7 @@ private:
 
 	ProtocolError setup_context();
 
-	void cancel_move_session() { move_session = false; }
+	void cancel_move_session();
 
 	void reset_session();
 

--- a/communication/src/dtls_protocol.cpp
+++ b/communication/src/dtls_protocol.cpp
@@ -21,7 +21,7 @@ void DTLSProtocol::init(const char *id,
 	channelCallbacks.receive = callbacks.receive;
 	channelCallbacks.send = callbacks.send;
 	channelCallbacks.calculate_crc = callbacks.calculate_crc;
-	if (callbacks.size>=52) {
+	if (callbacks.size>=52) {   // todo - get rid of this magic number and define it by the size of some struct.
 		channelCallbacks.save = callbacks.save;
 		channelCallbacks.restore = callbacks.restore;
 	}

--- a/communication/src/dtls_session_persist.h
+++ b/communication/src/dtls_session_persist.h
@@ -117,9 +117,9 @@ public:
 	void increment_use_count() { use_counter++; }
 	void clear_use_count() { use_counter = 0; }
 	int use_count() { return use_counter; }
-	bool has_expired() { return use_counter >= maximumSessionUses; }
+	bool has_expired() { return use_counter >= MAXIMUM_SESSION_USES; }
 
-	static const int maximumSessionUses = 3;
+	static const int MAXIMUM_SESSION_USES = 3;
 };
 
 

--- a/communication/src/dtls_session_persist.h
+++ b/communication/src/dtls_session_persist.h
@@ -62,7 +62,7 @@ struct __attribute__((packed)) SessionPersistData
 	 */
 	uint8_t persistent;
 
-	uint8_t reserved;	// padding - use for something if needed.
+	uint8_t use_counter;	    // the number of times this session has been retrieved without being successfully used.
 
 	// do not add more members here - the offset of the public connection data should be
 	// constant. Add more members at the end of the struct.
@@ -114,6 +114,12 @@ public:
 
 	void invalidate() { size = 0; }
 
+	void increment_use_count() { use_counter++; }
+	void clear_use_count() { use_counter = 0; }
+	int use_count() { return use_counter; }
+	bool has_expired() { return use_counter >= maximumSessionUses; }
+
+	static const int maximumSessionUses = 3;
 };
 
 
@@ -204,7 +210,7 @@ public:
 	/**
 	 * Persist information in this context .
 	 */
-	void save(save_fn_t saver);
+	void save(save_fn_t saver) { save_this_with(saver); };
 	void restore(restore_fn_t restore) { restore_this_from(restore); }
 
 	/**
@@ -240,7 +246,7 @@ public:
 	/**
 	 * Restores the state from this context. The persistence flag is not changed.
 	 */
-	RestoreStatus restore(mbedtls_ssl_context* context, bool renegotiate, uint32_t keys_checksum, message_id_t* message, restore_fn_t restorer);
+	RestoreStatus restore(mbedtls_ssl_context* context, bool renegotiate, uint32_t keys_checksum, message_id_t* message, restore_fn_t restorer, save_fn_t saver);
 
 	uint32_t application_state_checksum(uint32_t (*calc_crc)(const uint8_t* data, uint32_t len));
 


### PR DESCRIPTION
### Problem

The device and cloud may get out of sync when reusing a session. For instance, session data may become corrupted on the device, or session caches on the cloud expired. 

When this occurs the device presently retries indefinitely to use the current session. 

### Solution

The number of times the session is used is counted - each time the session is restored as part of the main handshake, the use count is incremented.  When the use count reaches the expiration count (presently 3), the session is considered invalid, forcing it to be discarded and performing a full handshake. 

The use count is reset after successfully decrypting a message from the cloud. This validates the session data.

### Steps to Test

* Apply the randbytes hack, but rather than invert, we increment the data (or the session becomes valid every 2nd attempt.)
* Allow the device to connect to the cloud and then reset. Every 3rd try the device does a full handshake.


### References

* [ch32368](https://app.clubhouse.io/particle/story/32368/devices-can-expire-a-session-after-a-number-of-unsuccessful-connection-attempts)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
