### PR TITLE
[Gen 3] Fixes various issues caused by the gateway reset

### DIFF
--- a/hal/network/lwip/openthread/lwip_openthreadif.h
+++ b/hal/network/lwip/openthread/lwip_openthreadif.h
@@ -60,8 +60,10 @@ private:
 
     void input(otMessage* message);
     void stateChanged(uint32_t flags);
+    static void debugLogOtStateChange(uint32_t flags);
 
     void refreshIpAddresses();
+    void syncIpState();
 
     int up();
     int down();

--- a/hal/network/openthread/border_router_manager.cpp
+++ b/hal/network/openthread/border_router_manager.cpp
@@ -256,8 +256,10 @@ int BorderRouterManager::enable() {
         }
     }
 
+#ifdef DEBUG_BUILD
     int netDataVersion = otNetDataGetVersion(ot_get_instance());
     LOG_DEBUG(TRACE, "Network data version %d", netDataVersion);
+#endif // DEBUG_BUILD
 
     // We want to make sure that the leader network data changes, so we temporarily flip mPreferred flag
     // and settle on mPreferred = true once the network data propagates through the network. This is less

--- a/hal/network/openthread/border_router_manager.cpp
+++ b/hal/network/openthread/border_router_manager.cpp
@@ -37,6 +37,16 @@ using namespace particle;
 using namespace particle::net;
 using namespace particle::net::nat;
 
+namespace {
+
+void generateRandomPrefix(otIp6Prefix& prefix, size_t length) {
+    prefix.mPrefix.mFields.m8[0] = 0xfd;
+    Random rand;
+    rand.gen((char*)prefix.mPrefix.mFields.m8 + 1, length);
+}
+
+} // anonymous
+
 BorderRouterManager::BorderRouterManager()
         : started_(false),
           enabled_(false) {
@@ -182,6 +192,12 @@ int BorderRouterManager::stopServices() {
 }
 
 int BorderRouterManager::enable() {
+    enabled_ = true;
+
+    if (!isIfUp()) {
+        return 0;
+    }
+
     particle::net::ot::ThreadLock lk;
 
     otNetworkDataIterator iterator = OT_NETWORK_DATA_ITERATOR_INIT;
@@ -214,40 +230,70 @@ int BorderRouterManager::enable() {
             if (ot_get_border_router_prefix(ot_get_instance(), 0, &config_.mPrefix) ||
                     config_.mPrefix.mLength != 64) {
                 // Failed to retrieve from persistent storage
-                // Generate new prefix
-                config_.mPrefix.mPrefix.mFields.m8[0] = 0xfd;
-                Random rand;
-                rand.gen((char*)config_.mPrefix.mPrefix.mFields.m8 + 1, 5); // Generate global ID
+                // Generate new prefix, five random bytes (global id)
+                generateRandomPrefix(config_.mPrefix, 5);
                 config_.mPrefix.mLength = 64;
                 ot_set_border_router_prefix(ot_get_instance(), 0, &config_.mPrefix);
             }
         }
-
-        LOG(TRACE, "Adding prefix into local network data");
-        CHECK(otBorderRouterAddOnMeshPrefix(ot_get_instance(), &config_));
     }
 
     iterator = OT_NETWORK_DATA_ITERATOR_INIT;
     bool presentLeader = false;
+    bool leaderPreferred = false;
+    bool leaderNeedsUpdate = false;
     while (otNetDataGetNextOnMeshPrefix(ot_get_instance(), &iterator, &config) == OT_ERROR_NONE) {
-        if (config.mRloc16 == otThreadGetRloc16(ot_get_instance())) {
+        // IMPORTANT: ignore RLOC16 if we are still a child!
+        if (config.mRloc16 == otThreadGetRloc16(ot_get_instance()) || otThreadGetDeviceRole(ot_get_instance()) == OT_DEVICE_ROLE_CHILD) {
             if (config_.mPrefix.mLength == config.mPrefix.mLength && otIp6PrefixMatch(&config.mPrefix.mPrefix, &config_.mPrefix.mPrefix) >= config_.mPrefix.mLength) {
                 presentLeader = true;
+                leaderPreferred = config.mPreferred;
+
+                config_.mRloc16 = config.mRloc16;
+                leaderNeedsUpdate = memcmp(&config_, &config, sizeof(otBorderRouterConfig));
                 break;
             }
         }
     }
 
-    if (isIfUp() && !presentLeader) {
-        LOG(TRACE, "Trying to synchronize local netdata with leader");
-        if (otThreadGetDeviceRole(ot_get_instance()) == OT_DEVICE_ROLE_CHILD) {
-            otThreadBecomeRouter(ot_get_instance());
-        }
-        otBorderRouterRegister(ot_get_instance());
+    int netDataVersion = otNetDataGetVersion(ot_get_instance());
+    LOG_DEBUG(TRACE, "Network data version %d", netDataVersion);
+
+    // We want to make sure that the leader network data changes, so we temporarily flip mPreferred flag
+    // and settle on mPreferred = true once the network data propagates through the network. This is less
+    // disruptive than simply clearing our prefixes from the leader.
+    if (!presentLocal) {
+        config_.mPreferred = !leaderPreferred;
+        LOG(TRACE, "Adding prefix into local network data preferred (%d, %d)", config_.mPreferred, leaderPreferred);
+        CHECK(otBorderRouterAddOnMeshPrefix(ot_get_instance(), &config_));
+    } else if (!config_.mPreferred && presentLeader && !leaderPreferred) {
+        config_.mPreferred = true;
+        LOG(TRACE, "Adding prefix into local network data preferred (%d, %d)", config_.mPreferred, leaderPreferred);
+        CHECK(otBorderRouterAddOnMeshPrefix(ot_get_instance(), &config_));
+        leaderNeedsUpdate = true;
     }
 
-    enabled_ = true;
+    LOG_DEBUG(TRACE, "Netdata state (%d, %d, %d)", presentLocal, presentLeader, leaderNeedsUpdate);
 
+    if (!presentLocal || !presentLeader || leaderNeedsUpdate) {
+        return syncWithLeader();
+    }
+
+    return 0;
+}
+
+int BorderRouterManager::syncWithLeader() {
+    // Only send network data update when we are a child, in all the other cases OpenThread
+    // should be able to do it on its own.
+    if (otThreadGetDeviceRole(ot_get_instance()) == OT_DEVICE_ROLE_CHILD) {
+        // NOTE: we are using API here that is reserved for testing and demo purposes only.
+        // > Changing settings with this API will render a production application non-compliant
+        // > with the Thread Specification.
+        // This call was added to workaround REED -> Router promotion timeout, which is a random
+        // value between 0 and ROUTER_SELECTION_JITTER (120s by default).
+        otThreadBecomeRouter(ot_get_instance());
+        return ot_system_error(otBorderRouterRegister(ot_get_instance()));
+    }
     return 0;
 }
 
@@ -258,6 +304,8 @@ int BorderRouterManager::disable() {
         LOG(TRACE, "Disabling border routing");
         otBorderRouterRemoveOnMeshPrefix(ot_get_instance(), &config_.mPrefix);
         otBorderRouterRegister(ot_get_instance());
+        // Invalidate config
+        config_.mOnMesh = 0;
     }
 
     enabled_ = false;
@@ -288,7 +336,7 @@ void BorderRouterManager::otStateChanged(uint32_t flags) {
     }
 
     /* link state */
-    if (flags & (OT_CHANGED_THREAD_ROLE | OT_CHANGED_THREAD_NETDATA)) {
+    if (flags & (OT_CHANGED_THREAD_ROLE | OT_CHANGED_THREAD_NETDATA | OT_CHANGED_THREAD_PARTITION_ID)) {
         switch (otThreadGetDeviceRole(ot_get_instance())) {
             /* We will only disable border routing when Thread interface is downed */
             case OT_DEVICE_ROLE_DISABLED:

--- a/hal/network/openthread/border_router_manager.h
+++ b/hal/network/openthread/border_router_manager.h
@@ -61,6 +61,7 @@ private:
 
     int enable();
     int disable();
+    int syncWithLeader();
 
     bool isIfUp() const;
 

--- a/hal/src/nRF52840/openthread/openthread-config-project.h
+++ b/hal/src/nRF52840/openthread/openthread-config-project.h
@@ -73,6 +73,14 @@
 #define OPENTHREAD_CONFIG_PLATFORM_INFO                         "Xenon"
 
 /**
+ * @def OPENTHREAD_CONFIG_ENABLE_SLAAC
+ *
+ * Define as 1 to enable support for adding of auto-configured SLAAC addresses by OpenThread.
+ *
+ */
+#define OPENTHREAD_CONFIG_ENABLE_SLAAC                          0
+
+/**
  * @def OPENTHREAD_CONFIG_MAX_CHILDREN
  *
  * The maximum number of children.

--- a/system/src/system_network_manager.cpp
+++ b/system/src/system_network_manager.cpp
@@ -849,8 +849,10 @@ void NetworkManager::resolvEventHandlerCb(void* arg, const void* data) {
 }
 
 void NetworkManager::resolvEventHandler(const void* data) {
-    /* FIXME */
     refreshIpState();
+    // NOTE: we could potentially force a cloud ping on DNS change, but
+    // this seems excessive, and it's better to rely on IP state only instead
+    // forceCloudPingIfConnected();
 }
 
 const char* NetworkManager::stateToName(State state) const {


### PR DESCRIPTION
### Problem

Mesh devices may be unable to connect to the cloud or appear to be connected but can neither send nor receive data to/from the cloud under certain conditions.

### Solution

1. OpenThread version we've upgraded to in the end of January moved SLAAC functionality into its core and enabled it by default, which interfered with our own SLAAC logic. A PR was submitted later to the OpenThread repo to make this configurable, so for now we are simply pulling in that PR and disable SLAAC: https://github.com/particle-iot/openthread/commit/ea382ea6002ce41af4151bac64e26b36a1e3cb49
2. Under certain conditions (see 'Steps to Test' to replicate) mesh devices don't notice that the gateway has been reset. This is resolved by artificially publishing a prefix with `preferred` flag set to 0 (which means that the addresses generated from this prefix should be 'DEPRECATED' but may still be used for communications), waiting for this change to propagate through the network and then re-publishing with proper `preferred` set to 1, so that the device can receive events from OpenThread about a potential change in upstream connection availability and explicitly check their cloud connection state by issuing a ping.
3. When changing the state of IP addresses on OpenThread interface, make sure that events are being fired, so that system level subscribers may understand that there is a potential change in connection availability.
4. Make sure that `Pref::1/PrefLen` address is always generated (instead of a random one) from the prefix announced by the gateway itself no matter the current role (child or router).

### Steps to Test

The easiest way to test this is to create a mesh network of 3 devices.

1. Power down all devices
2. Power up non-gateway devices
3. Make sure that one of them becomes the leader (for now take a look at the logs for that)
4. Power on the gateway device
5. Wait until all three are connected to the cloud and are breathing cyan
6. Power off the gateway device for about a minute or so. The other two devices should stay breathing cyan (occasionally you might see some blinks due to ping timeouts and session resumption)
7. Power the gateway back on BEFORE the other devices start blinking green
8. All three should connect to the cloud. The non-gateway devices should not go through blinking green state.
9. Make sure you may reach your non-gateway devices from the cloud (e.g. `particle nyan`)
10. Wait for some minutes, you should still be able to reach your non-gateway devices and they should be breathing cyan

Steps 9 - 10 should fail on `develop` and should work correctly with this PR.

### Example App

N/A

### References

- [CH29981]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)

---

- [bugfix] [gen 3] Fixes various issues caused by the gateway reset [#1778](https://github.com/particle-iot/device-os/pull/1778)