### PR TITLE
[Electron/LTE] Make sure that the RAT information is actual before calculating signal strength (RSSI) and quality

### DIFF
--- a/hal/src/electron/modem/enums_hal.h
+++ b/hal/src/electron/modem/enums_hal.h
@@ -84,6 +84,20 @@ typedef enum {
     ACT_LTE_CAT_M1  = 6,
     ACT_LTE_CAT_NB1 = 7
 } AcT;
+//! Ublox-specific RAT
+typedef enum {
+    UBLOX_SARA_RAT_NONE              = -1,
+    UBLOX_SARA_RAT_GSM               = 0,
+    UBLOX_SARA_RAT_GSM_COMPACT       = 1,
+    UBLOX_SARA_RAT_UTRAN             = 2,
+    UBLOX_SARA_RAT_GSM_EDGE          = 3,
+    UBLOX_SARA_RAT_UTRAN_HSDPA       = 4,
+    UBLOX_SARA_RAT_UTRAN_HSUPA       = 5,
+    UBLOX_SARA_RAT_UTRAN_HSDPA_HSUPA = 6,
+    UBLOX_SARA_RAT_LTE               = 7,
+    UBLOX_SARA_RAT_EC_GSM_IOT        = 8,
+    UBLOX_SARA_RAT_E_UTRAN           = 9
+} UbloxSaraCellularAccessTechnology;
 //! Network Status
 typedef struct {
     Reg csd;        //!< CSD Registration Status (Circuit Switched Data)

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1277,6 +1277,12 @@ bool MDMParser::getSignalStrength(NetStatus &status)
     if (_init && _pwr) {
         MDM_INFO("\r\n[ Modem::getSignalStrength ] = = = = = = = = = =");
 
+        // Reformat the operator string to be numeric
+        // (allows the capture of `mcc` and `mnc`)
+        sendFormated("AT+COPS=3,2\r\n");
+        if (RESP_OK != waitFinalResp(nullptr, nullptr, COPS_TIMEOUT))
+            goto cleanup;
+
         // We do receive RAT changes asynchronously via CREG URCs, but
         // just in case we'll update it here explicitly.
         sendFormated("AT+COPS?\r\n");

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -120,8 +120,8 @@ inline void CLR_GPRS_TIMEOUT() {
 
 namespace {
 
-AcT toCellularAccessTechnology(int v) {
-    switch (v) {
+AcT toCellularAccessTechnology(int rat) {
+    switch (rat) {
         case 0: // GSM
         case 1: // GSM COMPACT
             return ACT_GSM;
@@ -1281,7 +1281,7 @@ bool MDMParser::getSignalStrength(NetStatus &status)
         // just in case we'll update it here explicitly.
         sendFormated("AT+COPS?\r\n");
         if (RESP_OK != waitFinalResp(_cbCOPS, &_net, COPS_TIMEOUT)) {
-            return ok;
+            goto cleanup;
         }
 
         sendFormated("AT+CSQ\r\n");
@@ -1290,6 +1290,8 @@ bool MDMParser::getSignalStrength(NetStatus &status)
             status = _net;
         }
     }
+
+cleanup:
     UNLOCK();
     return ok;
 }

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -121,23 +121,23 @@ inline void CLR_GPRS_TIMEOUT() {
 namespace {
 
 AcT toCellularAccessTechnology(int rat) {
-    switch (rat) {
-        case 0: // GSM
-        case 1: // GSM COMPACT
+    switch (static_cast<UbloxSaraCellularAccessTechnology>(rat)) {
+        case UBLOX_SARA_RAT_GSM:
+        case UBLOX_SARA_RAT_GSM_COMPACT:
             return ACT_GSM;
-        case 2: // UTRAN
+        case UBLOX_SARA_RAT_UTRAN:
             return ACT_UTRAN;
-        case 3: // GSM with EDGE availability
+        case UBLOX_SARA_RAT_GSM_EDGE:
             return ACT_EDGE;
-        case 4: // UTRAN with HSDPA availability
-        case 5: // UTRAN with HSUPA availability
-        case 6: // UTRAN with HSDPA and HSUPA availability
+        case UBLOX_SARA_RAT_UTRAN_HSDPA:
+        case UBLOX_SARA_RAT_UTRAN_HSUPA:
+        case UBLOX_SARA_RAT_UTRAN_HSDPA_HSUPA:
             return ACT_UTRAN;
-        case 7: // LTE
+        case UBLOX_SARA_RAT_LTE:
             return ACT_LTE;
-        case 8: // LTE Cat M1
+        case UBLOX_SARA_RAT_EC_GSM_IOT:
             return ACT_LTE_CAT_M1;
-        case 9: // LTE Cat NB1
+        case UBLOX_SARA_RAT_E_UTRAN:
             return ACT_LTE_CAT_NB1;
         default:
             return ACT_UNKNOWN;


### PR DESCRIPTION
### Problem

Invalid RAT information causes signal strength/quality information to be unavailable. This is caused by `AT+COPS?` in `checkNetStatus()` which invalidates the RAT set by URC handlers as it only handles `GSM` and `UTRAN` for some reason: https://github.com/particle-iot/device-os/blob/develop/hal/src/electron/modem/mdm_hal.cpp#L1380

### Solution

1. Fix `AT+COPS?` handler to correctly parse all RATs
2. Adds explicit `AT+COPS?` call to `getSignalStrength()`

### Steps to Test

N/A

### Example App

N/A

### References

- [CH32382]
- #1759 

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)

---

- [bugfix] [Electron/LTE] Make sure that the RAT information is actual before calculating signal strength (RSSI) and quality [#1779](https://github.com/particle-iot/device-os/pull/1779)