### PR TITLE
[gen 2] adds Kore Vodafone SIM support & removes Twilio SIM support (…

### DIFF
--- a/hal/inc/cellular_hal_constants.h
+++ b/hal/inc/cellular_hal_constants.h
@@ -39,8 +39,8 @@ typedef void (*_CELLULAR_SMS_CB_MDM)(void* data, int index);
 
 #define DEFINE_NET_PROVIDER_DATA \
     DEFINE_NET_PROVIDER( CELLULAR_NETPROV_TELEFONICA, "spark.telefonica.com", (23*60), (5684) ),  \
-    DEFINE_NET_PROVIDER( CELLULAR_NETPROV_TWILIO, "wireless.twilio.com", (23*60), (4500) ),  \
-    DEFINE_NET_PROVIDER( CELLULAR_NETPROV_KORE, "", (23*60), (5684) ),  \
+    DEFINE_NET_PROVIDER( CELLULAR_NETPROV_KORE_VODAFONE, "vfd1.korem2m.com", (23*60), (5684) ),  \
+    DEFINE_NET_PROVIDER( CELLULAR_NETPROV_KORE_ATT, "10569.mcs", (23*60), (5684) ),  \
     DEFINE_NET_PROVIDER( CELLULAR_NETPROV_MAX, "", (0), (0) )
 
 #define DEFINE_NET_PROVIDER( idx, apn, keepalive, port )  idx

--- a/hal/src/electron/cellular_hal.cpp
+++ b/hal/src/electron/cellular_hal.cpp
@@ -35,7 +35,7 @@ const char* defaultOrUserApn(const CellularCredentials& cred)
             // Determine APN based on Modem Type
             const DevStatus* const status = electronMDM.getDevStatus();
             if (status->dev == DEV_SARA_R410) {
-                cellularNetProv = CELLULAR_NETPROV_KORE;
+                cellularNetProv = CELLULAR_NETPROV_KORE_ATT;
             }
         }
         return CELLULAR_NET_PROVIDER_DATA[cellularNetProv].apn;
@@ -155,7 +155,6 @@ cellular_result_t cellular_connect(void* reserved)
 {
     const CellularCredentials& cred = cellularCredentials;
     const char* apn = cred.apn;
-    // TODO: Look for an APN based on IMSI for LTE providers as well
     apn = defaultOrUserApn(cred);
     CHECK_SUCCESS(electronMDM.connect(apn, cred.username, cred.password));
     return 0;

--- a/hal/src/electron/cellular_internal.cpp
+++ b/hal/src/electron/cellular_internal.cpp
@@ -10,19 +10,23 @@
 #include "net_hal.h"
 
 namespace detail {
+
+const int MCC_MNC_MIN_SIZE = 5;
+
 CellularNetProv _cellular_imsi_to_network_provider(const char* imsi) {
-    if (imsi && strlen(imsi) > 0) {
-        // convert to unsigned long long (imsi can be 15 digits)
-        unsigned long long imsi64 = strtoull(imsi, NULL, 10);
-        // LOG(INFO,"IMSI: %s %lu%lu", imsi, (uint32_t)(imsi64/100000000), (uint32_t)(imsi64-310260800000000));
-        // set network provider based on IMSI range
-        if (imsi64 >= 310260859000000 && imsi64 <= 310260859999999) {
-            return CELLULAR_NETPROV_TWILIO;
-        }
-        else {
+    if (imsi && strlen(imsi) >= MCC_MNC_MIN_SIZE) {
+        if (strncmp(imsi, "21407", 5) == 0) {
+            // LOG(INFO, "CELLULAR_NETPROV_TELEFONICA");
             return CELLULAR_NETPROV_TELEFONICA;
+        } else if (strncmp(imsi, "310410", 6) == 0) {
+            // LOG(INFO, "CELLULAR_NETPROV_KORE_ATT");
+            return CELLULAR_NETPROV_KORE_ATT;
+        } else if (strncmp(imsi, "20404", 5) == 0) {
+            // LOG(INFO, "CELLULAR_NETPROV_KORE_VODAFONE");
+            return CELLULAR_NETPROV_KORE_VODAFONE;
         }
     }
+    // LOG(INFO, "DEFAULT CELLULAR_NETPROV_TELEFONICA");
     return CELLULAR_NETPROV_TELEFONICA; // default to telefonica
 }
 

--- a/user/tests/unit/cellular.cpp
+++ b/user/tests/unit/cellular.cpp
@@ -31,14 +31,32 @@ using namespace detail;
 
 SCENARIO("IMSI range should default to Telefonica as Network Provider", "[cellular]") {
     REQUIRE(_cellular_imsi_to_network_provider(NULL) == CELLULAR_NETPROV_TELEFONICA);
-    REQUIRE(_cellular_imsi_to_network_provider("") == CELLULAR_NETPROV_TELEFONICA);
+    REQUIRE(_cellular_imsi_to_network_provider("")   == CELLULAR_NETPROV_TELEFONICA);
     REQUIRE(_cellular_imsi_to_network_provider("123456789012345") == CELLULAR_NETPROV_TELEFONICA);
+    REQUIRE(_cellular_imsi_to_network_provider("2040")  == CELLULAR_NETPROV_TELEFONICA);
+    REQUIRE(_cellular_imsi_to_network_provider("31041") == CELLULAR_NETPROV_TELEFONICA);
+    REQUIRE(_cellular_imsi_to_network_provider("2140")  == CELLULAR_NETPROV_TELEFONICA);
+    REQUIRE(_cellular_imsi_to_network_provider("0404")  == CELLULAR_NETPROV_TELEFONICA);
+    REQUIRE(_cellular_imsi_to_network_provider("10410") == CELLULAR_NETPROV_TELEFONICA);
+    REQUIRE(_cellular_imsi_to_network_provider("1407")  == CELLULAR_NETPROV_TELEFONICA);
 }
 
-SCENARIO("IMSI range should set Twilio as Network Provider", "[cellular]") {
-    REQUIRE(_cellular_imsi_to_network_provider("310260859000000") == CELLULAR_NETPROV_TWILIO);
-    REQUIRE(_cellular_imsi_to_network_provider("310260859500000") == CELLULAR_NETPROV_TWILIO);
-    REQUIRE(_cellular_imsi_to_network_provider("310260859999999") == CELLULAR_NETPROV_TWILIO);
+SCENARIO("IMSI range should set Kore Vodafone as Network Provider", "[cellular]") {
+    REQUIRE(_cellular_imsi_to_network_provider("204040000000000") == CELLULAR_NETPROV_KORE_VODAFONE);
+    REQUIRE(_cellular_imsi_to_network_provider("204045555555555") == CELLULAR_NETPROV_KORE_VODAFONE);
+    REQUIRE(_cellular_imsi_to_network_provider("204049999999999") == CELLULAR_NETPROV_KORE_VODAFONE);
+}
+
+SCENARIO("IMSI range should set Kore AT&T as Network Provider", "[cellular]") {
+    REQUIRE(_cellular_imsi_to_network_provider("310410000000000") == CELLULAR_NETPROV_KORE_ATT);
+    REQUIRE(_cellular_imsi_to_network_provider("310410555555555") == CELLULAR_NETPROV_KORE_ATT);
+    REQUIRE(_cellular_imsi_to_network_provider("310410999999999") == CELLULAR_NETPROV_KORE_ATT);
+}
+
+SCENARIO("IMSI range should set Telefonica as Network Provider", "[cellular]") {
+    REQUIRE(_cellular_imsi_to_network_provider("214070000000000") == CELLULAR_NETPROV_TELEFONICA);
+    REQUIRE(_cellular_imsi_to_network_provider("214075555555555") == CELLULAR_NETPROV_TELEFONICA);
+    REQUIRE(_cellular_imsi_to_network_provider("214079999999999") == CELLULAR_NETPROV_TELEFONICA);
 }
 
 TEST_CASE("cellular_signal()") {


### PR DESCRIPTION
…still supported through 3rd party API) [ch31955]

### Problem

- Kore Vodafone SIM not supported in system firmware for Gen 2 devices
- 3rd Party Twilio SIM users were having issues with system firmware taking over and using port 4500

### Solution

- Add Kore Vodafone SIM support via IMSI lookup & matching
- Remove Twilio SIM support (still supported through 3rd party API)

### Steps to Test

- ✅ Run unit tests
- ✅ Run included test app on:
    - ✅ E Series U201 with Kore Vodafone embedded SIM 
    - ✅ Electron U260 with Kore Vodafone 4FF Nano SIM 
    - ✅ Electron G350 with Kore Vodafone 4FF Nano SIM 
    - ✅ E Series R410 with Kore AT&T embedded SIM 
    - ✅ Electron U260 with Kore Telefonica 4FF Nano SIM 
    - ✅ Electron U260 with Kore Telefonica 4FF Nano SIM and 3rd party API
    - ✅ Electron U260 with Twilio 4FF Nano SIM and 3rd party API
- ✅ Tested Particle.keepAlive() worked up to 29 minutes with Kore Vodafone without UDP NAT timeout (might go further) 

### Example App

```c
#include "Particle.h"

SYSTEM_MODE(SEMI_AUTOMATIC)

// STARTUP(cellular_credentials_set("10569.mcs", "", "", NULL)); // KORE - AT&T
// STARTUP(cellular_credentials_set("vfd1.korem2m.com", "", "", NULL)); // KORE - vodaphone
// STARTUP(cellular_credentials_set("spark.telefonica.com", "", "", NULL)); // telefonica
// STARTUP(cellular_credentials_set("wireless.twilio.com", "", "", NULL)); // twilio

SerialLogHandler logHandler(115200, LOG_LEVEL_TRACE);

String variableString;
bool publishNow = false;

int setString(String data)
{
    variableString = data;
    publishNow = true;
    return variableString.length();
}

void setup() {
    while (!Serial.isConnected()) Particle.process();
    Particle.keepAlive(29*60);
    variableString.reserve(622);
    Particle.variable("string", variableString);
    Particle.function("set", setString);
    Particle.connect();
}

void loop() {
    if (Particle.connected() && publishNow) {
        publishNow = false;
        Log.info("========= PUBLISHING =========");
        Particle.publish("string", variableString, PRIVATE, WITH_ACK);
    }
}
```

### References

Closes [ch31955]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] N/A Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)

---

- [enhancement] [gen 2] adds Kore Vodafone SIM support & removes Twilio SIM support (still supported through 3rd party API) [ch31955] [#1780](https://github.com/particle-iot/device-os/pull/1780)