### PR TITLE
[wiring] Make sure that `Serial` and `SerialX` methods are in sync with the documentation and don't return unexpected values

### DIFF
--- a/wiring/src/spark_wiring_usartserial.cpp
+++ b/wiring/src/spark_wiring_usartserial.cpp
@@ -67,22 +67,22 @@ void USARTSerial::blockOnOverrun(bool block)
 
 int USARTSerial::availableForWrite(void)
 {
-  return HAL_USART_Available_Data_For_Write(_serial);
+  return std::max(0, (int)HAL_USART_Available_Data_For_Write(_serial));
 }
 
 int USARTSerial::available(void)
 {
-  return HAL_USART_Available_Data(_serial);
+  return std::max(0, (int)HAL_USART_Available_Data(_serial));
 }
 
 int USARTSerial::peek(void)
 {
-  return HAL_USART_Peek_Data(_serial);
+  return std::max(-1, (int)HAL_USART_Peek_Data(_serial));
 }
 
 int USARTSerial::read(void)
 {
-  return HAL_USART_Read_Data(_serial);
+  return std::max(-1, (int)HAL_USART_Read_Data(_serial));
 }
 
 void USARTSerial::flush()

--- a/wiring/src/spark_wiring_usbserial.cpp
+++ b/wiring/src/spark_wiring_usbserial.cpp
@@ -65,24 +65,23 @@ void USBSerial::end()
 // Read data from buffer
 int USBSerial::read()
 {
-	return HAL_USB_USART_Receive_Data(_serial, false);
+	return std::max(-1, (int)HAL_USB_USART_Receive_Data(_serial, false));
 }
 
 int USBSerial::availableForWrite()
 {
-  return HAL_USB_USART_Available_Data_For_Write(_serial);
+  return std::max(0, (int)HAL_USB_USART_Available_Data_For_Write(_serial));
 }
 
 int USBSerial::available()
 {
-	return HAL_USB_USART_Available_Data(_serial);
+	return std::max(0, (int)HAL_USB_USART_Available_Data(_serial));
 }
 
 size_t USBSerial::write(uint8_t byte)
 {
   if (HAL_USB_USART_Available_Data_For_Write(_serial) > 0 || _blocking) {
-    HAL_USB_USART_Send_Data(_serial, byte);
-    return 1;
+    return std::max(0, (int)HAL_USB_USART_Send_Data(_serial, byte));
   }
   return 0;
 }
@@ -99,7 +98,7 @@ void USBSerial::blockOnOverrun(bool block)
 
 int USBSerial::peek()
 {
-	return HAL_USB_USART_Receive_Data(_serial, true);
+	return std::max(0, (int)HAL_USB_USART_Receive_Data(_serial, true));
 }
 
 USBSerial::operator bool() {

--- a/wiring/src/spark_wiring_usbserial.cpp
+++ b/wiring/src/spark_wiring_usbserial.cpp
@@ -98,7 +98,7 @@ void USBSerial::blockOnOverrun(bool block)
 
 int USBSerial::peek()
 {
-	return std::max(0, (int)HAL_USB_USART_Receive_Data(_serial, true));
+	return std::max(-1, (int)HAL_USB_USART_Receive_Data(_serial, true));
 }
 
 USBSerial::operator bool() {


### PR DESCRIPTION
### Problem

#1737

### Solution

Make sure that `available()`, `availableForWrite()`, `peek()` and `read()` don't forward the errors from HAL and only return 0 or -1 in case of errors appropriately.

### Steps to Test

N/A

### Example App

N/A

### References

- Closes #1737
- [CH32372]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)

---

- [wiring] Make sure that `Serial` and `SerialX` methods are in sync with the documentation and don't return unexpected values [#1782](https://github.com/particle-iot/device-os/pull/1782)