### PR TITLE
[Photon / P1] Fixes MAC address info not being available in listening mode

### DIFF
--- a/system/src/system_network_compat.cpp
+++ b/system/src/system_network_compat.cpp
@@ -101,6 +101,7 @@ void HAL_NET_notify_dhcp(bool dhcp)
 
 const void* network_config(network_handle_t network, uint32_t param, void* reserved)
 {
+    nif(network).update_config(true);
     return nif(network).config();
 }
 


### PR DESCRIPTION
### Problem

#1781

This is an artifact of Gen 2 / Gen 3 merge where we've changed the behavior of listening mode: it's no longer blocking and is a part of the system loop. This causes network config to be zeroed out by `manage_ip_config()` -> [`update_config()`](https://github.com/particle-iot/device-os/blob/develop/system/src/system_network_internal.h#L786).

### Solution

A simplest fix is probably just force-filling the configuration in the API `network_config()` call.

### Steps to Test

Put your Photon into listening mode, call `particle serial mac`. The MAC address should be available.

### Example App

N/A

### References

- Closes #1781

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)

---

- [bugfix] [Photon/P1] Fixes MAC address info not being available in listening mode [#1783](https://github.com/particle-iot/device-os/pull/1783)