### PR TITLE
intelligent update flags synchronization

### DIFF
--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -886,13 +886,26 @@ void Spark_Protocol_Init(void)
 
 int Send_Firmware_Update_Flags()
 {
-    if (!System.updatesEnabled()) {
+    // short-circuiting the current state and always sending these flags
+    /*
+      Problem
+      The device previously only sends the value of these flags when they
+      have changed from the default. However, they are reset when the device
+      resets, yet the cloud is not informed of this change.
+
+      Solution
+      Send the state of these flags whenever connecting to the cloud, so the
+      cloud has the latest state. This will increase data usage marginally.
+      This feature will be reworked in a later release to allow
+      synchronization with less data use.
+     */
+    if (true || !System.updatesEnabled()) {
     	// force the event to be resent. The cloud assumes updates
     	// are enabled by default.
     	system_refresh_flag(SYSTEM_FLAG_OTA_UPDATE_ENABLED);
     }
 
-    if (System.updatesForced()) {
+    if (true || System.updatesForced()) {
     	system_refresh_flag(SYSTEM_FLAG_OTA_UPDATE_FORCED);
     }
 


### PR DESCRIPTION


### Problem

The device previously only sends the value of these flags when they have changed from the default. However, they are reset when the device resets, yet the cloud is not informed of this change. 

### Solution

Send the state of these flags whenever connecting to the cloud, so the cloud has the latest state.  This will increase data usage marginally.  This feature will be reworked in a later release to allow synchronization with less data use. 

### Steps to Test

- Load the intelligent updates test app to a device
- View the device in the Console
- Call the function enableUpdates with value 0.  Confirm that updates are disabled.
- Reset the device
- The console will automatically detect that updates are now enabled. 

### References

- [[CH30507]](https://app.clubhouse.io/particle/story/30507/synchronize-state-between-the-device-and-cloud)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)

---

- [bugfix] intelligent update flags synchronization [#1784](https://github.com/particle-iot/device-os/pull/1784)