### PR TITLE
[gen 3] update bootloader dependency to v302

### DIFF
--- a/build/platform-id.mk
+++ b/build/platform-id.mk
@@ -2,15 +2,16 @@ ifeq ($(included_productid_mk),)
 included_productid_mk := 1
 
 # defines
-# PLATFORM_NAME - a unique name for the platform, can be used to organise sources
+# PLATFORM_NAME - a unique name for the platform, can be used to organize sources
 #                 by platform
+# PLATFORM_GEN  - a number that identifies the generation of device
 # PLATFORM_MCU  - an identifier for the MCU family
 # PLATFORM_NET  - the network subsystem
 # STM32_DEVICE  - the specific device being targeted for STM32 platform builds
-# ARCH		- architecture (ARM/GCC)
+# ARCH          - architecture (ARM/GCC)
 # PRODUCT_DESC  - text description of the product ID
 # PLATFORM_DYNALIB_MODULES - if the device supports a modular build, the name
-#		- of the subdirectory containing
+#                          - of the subdirectory containing
 
 # Default USB Device Vendor ID for Spark Products
 USBD_VID_SPARK=0x1D50
@@ -112,6 +113,7 @@ ARCH=arm
 ifeq ("$(PLATFORM_ID)","0")
 STM32_DEVICE=STM32F10X_MD
 PLATFORM=core
+PLATFORM_GEN=1
 PLATFORM_NAME=core
 PLATFORM_MCU=STM32F1xx
 PLATFORM_NET=CC3000
@@ -133,6 +135,7 @@ ifeq ("$(PLATFORM_ID)","2")
 PLATFORM=core-hd
 STM32_DEVICE=STM32F10X_HD
 PLATFORM_NAME=core
+PLATFORM_GEN=1
 PLATFORM_MCU=STM32F1xx
 PLATFORM_NET=CC3000
 PRODUCT_DESC=Spark core-HD, 256k flash, 48k ram
@@ -146,6 +149,7 @@ endif
 ifeq ("$(PLATFORM_ID)","3")
 PLATFORM=gcc
 PLATFORM_NAME=gcc
+PLATFORM_GEN=0
 PLATFORM_MCU=gcc
 PLATFORM_NET=gcc
 ARCH=gcc
@@ -159,6 +163,7 @@ ifeq ("$(PLATFORM_ID)","4")
 PLATFORM=dev-photon
 STM32_DEVICE=STM32F2XX
 PLATFORM_NAME=photon
+PLATFORM_GEN=2
 PLATFORM_MCU=STM32F2xx
 PLATFORM_NET=BCM9WCDUSI09
 PRODUCT_DESC=BM-09/WICED
@@ -175,6 +180,7 @@ ifeq ("$(PLATFORM_ID)","5")
 PLATFORM=dev-teacup-bm14
 STM32_DEVICE=STM32F2XX
 PLATFORM_NAME=photon
+PLATFORM_GEN=2
 PLATFORM_MCU=STM32F2xx
 PLATFORM_NET=BCM9WCDUSI14
 PRODUCT_DESC=BM-14/WICED
@@ -190,6 +196,7 @@ ifeq ("$(PLATFORM_ID)","6")
 PLATFORM=photon
 STM32_DEVICE=STM32F2XX
 PLATFORM_NAME=photon
+PLATFORM_GEN=2
 PLATFORM_MCU=STM32F2xx
 PLATFORM_NET=BCM9WCDUSI09
 PRODUCT_DESC=Production Photon
@@ -207,6 +214,7 @@ ifeq ("$(PLATFORM_ID)","7")
 PLATFORM=teacup-bm14
 STM32_DEVICE=STM32F2XX
 PLATFORM_NAME=photon
+PLATFORM_GEN=2
 PLATFORM_MCU=STM32F2xx
 PLATFORM_NET=BCM9WCDUSI14
 PRODUCT_DESC=Production Teacup Pigtail
@@ -222,6 +230,7 @@ ifeq ("$(PLATFORM_ID)","8")
 PLATFORM=P1
 STM32_DEVICE=STM32F2XX
 PLATFORM_NAME=photon
+PLATFORM_GEN=2
 PLATFORM_MCU=STM32F2xx
 PLATFORM_NET=BCM9WCDUSI14
 PRODUCT_DESC=Production P1
@@ -238,6 +247,7 @@ ifeq ("$(PLATFORM_ID)","9")
 PLATFORM=ethernet
 STM32_DEVICE=STM32F2XX
 PLATFORM_NAME=photon
+PLATFORM_GEN=2
 PLATFORM_MCU=STM32F2xx
 PLATFORM_NET=STM32F2xx
 PRODUCT_DESC=Proto Wired Ethernet
@@ -252,6 +262,7 @@ ifeq ("$(PLATFORM_ID)","10")
 PLATFORM=electron
 STM32_DEVICE=STM32F2XX
 PLATFORM_NAME=electron
+PLATFORM_GEN=2
 PLATFORM_MCU=STM32F2xx
 PLATFORM_NET=UBLOXSARA
 PRODUCT_DESC=Production Electron
@@ -267,6 +278,7 @@ endif
 ifeq ("$(PLATFORM_ID)","12")
 PLATFORM=argon
 PLATFORM_NAME=$(PLATFORM)
+PLATFORM_GEN=3
 PLATFORM_MCU=nRF52840
 PLATFORM_NET=ESP32
 PLATFORM_WIZNET=W5500
@@ -285,6 +297,7 @@ endif
 ifeq ("$(PLATFORM_ID)","13")
 PLATFORM=boron
 PLATFORM_NAME=$(PLATFORM)
+PLATFORM_GEN=3
 PLATFORM_MCU=nRF52840
 PLATFORM_NET=UBLOXSARA
 PLATFORM_WIZNET=W5500
@@ -303,6 +316,7 @@ endif
 ifeq ("$(PLATFORM_ID)","14")
 PLATFORM=xenon
 PLATFORM_NAME=$(PLATFORM)
+PLATFORM_GEN=3
 PLATFORM_MCU=nRF52840
 PLATFORM_NET=None
 PLATFORM_WIZNET=W5500
@@ -321,6 +335,7 @@ endif
 ifeq ("$(PLATFORM_ID)","20")
 PLATFORM=mesh-virtual
 PLATFORM_NAME=mesh-virtual
+PLATFORM_GEN=0
 PLATFORM_MCU=gcc
 PLATFORM_NET=mesh-virtual
 ARCH=gcc
@@ -335,6 +350,7 @@ endif
 ifeq ("$(PLATFORM_ID)","22")
 PLATFORM=asom
 PLATFORM_NAME=argon
+PLATFORM_GEN=3
 PLATFORM_MCU=nRF52840
 PLATFORM_NET=ESP32
 PLATFORM_WIZNET=W5500
@@ -353,6 +369,7 @@ endif
 ifeq ("$(PLATFORM_ID)","23")
 PLATFORM=bsom
 PLATFORM_NAME=boron
+PLATFORM_GEN=3
 PLATFORM_MCU=nRF52840
 PLATFORM_NET=UBLOXSARA
 PLATFORM_WIZNET=W5500
@@ -371,6 +388,7 @@ endif
 ifeq ("$(PLATFORM_ID)","24")
 PLATFORM=xsom
 PLATFORM_NAME=xenon
+PLATFORM_GEN=3
 PLATFORM_MCU=nRF52840
 PLATFORM_NET=None
 PLATFORM_WIZNET=W5500
@@ -392,6 +410,7 @@ PLATFORM=newhal
 STM32_DEVICE=newhalcpu
 # used to define the sources in hal/src/new-hal
 PLATFORM_NAME=newhal
+PLATFORM_GEN=60000
 # define MCU-specific platform defines under platform/MCU/new-hal
 PLATFORM_MCU=newhal-mcu
 PLATFORM_NET=not-defined

--- a/modules/shared/system_module_version.mk
+++ b/modules/shared/system_module_version.mk
@@ -32,7 +32,16 @@ endif
 # Skip to next 100 every v0.x.0 release (e.g. 11 for v0.6.2 to 100 for v0.7.0-rc.1),
 # but only if the bootloader has changed since the last v0.x.0 release.
 # Bump by 1 for every updated bootloader image for a release with the same v0.x.* base.
-BOOTLOADER_VERSION ?= 301
+BOOTLOADER_VERSION ?= 302
 
-# the version of the bootloader that the system firmware requires
+# The version of the bootloader that the system firmware requires
+# NOTE: this will force the device into safe mode until this dependency is met, which is why
+# this version usually lags behind the current bootloader version, to avoid non-mandatory updates.
+ifeq ($(PLATFORM_GEN),2)
 BOOTLOADER_DEPENDENCY = 201
+else ifeq ($(PLATFORM_GEN),3)
+BOOTLOADER_DEPENDENCY = 302
+else
+# Some sensible default
+BOOTLOADER_DEPENDENCY = 0
+endif


### PR DESCRIPTION
### Problem

After merging Gen 3 and Gen 2 firmware bases together, there was no way to bump the bootloader dependency separately for each generation of device.

### Solution

Separate the BOOTLOADER_DEPENDENCY for each generation based on a new definition PLATFORM_GEN, which is set to 0, 1, 2, 3, and 60000 (of course).

Backstory:
- v1.1.0 contains bootloader v301, and dependency of v201 for both platforms.  However Gen 3 devices  (except for SoMs) and Electron contained the bootloader in system firmware, so they would apply the bootloader if it was less than v301.  Photon/P1 don't contain bootloaders though, so they rely on the CLI  via `particle update` or the Cloud to update them.  The CLI only gets updated on default releases and did get v301 bootloaders for Photon/P1 added.  That said, the dependency was still v201 so if they get Cloud updated to v1.1.0 they would not request v301 bootloader from the Cloud.  There is only a minor update for Gen 2 bootloaders and the thought is that it's not absolutely required, so let's not risk an update to the bootloader just yet.

- v1.2.0-rc.1 will contain this PR which is still v302 bootloaders (bumped this release due to #1777 ), and also now will have a separate dependency for Gen 2 and Gen 3.  For now, we will leave Gen 2 as is depending on v201, but we will bump Gen 3 to v302 because also in this PR we have removed the bootloaders from Gen 3 devices.  If a user updates from 0.9.0 to 1.2.0-rc.1, they would not get the required updates via the CLI since we only update `particle update` on default releases.  So they will need to get it from the Cloud or via manual Y-Modem protocol update over USB Serial with `particle flash --serial bootloader.bin`.  To force the Cloud update we need to bump the dependency version to v302.

- v1.2.0 default - when this happens, we can update the dependency for all to v302 and Photon/P1 can get the minor update easily via the CLI or via the Cloud if they have an internet connection at the time.  And just to state it one more time, the bootloader can always be manually updated via Y-Modem protocol over USB Serial with `particle flash --serial bootloader.bin`.

### Steps to Test

- Run unit tests
- Clean build with different platforms and add an "error2" or "error3" inserted next to the BOOTLOADER_DEPENDENCY to ensure the build is picking up the correct one.

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)

---

- [gen 3] update bootloader dependency to v302 [#1785](https://github.com/particle-iot/device-os/pull/1785)