### PR TITLE
[system] Fixes radio initialization sequence for Softdevice S140v6.1.1

### DIFF
--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -737,6 +737,11 @@ void app_setup_and_loop(void)
         }
     }
 
+#if HAL_PLATFORM_BLE
+    // FIXME: Move BLE and Thread initialization to an appropriate place
+    ble_init(nullptr);
+#endif // HAL_PLATFORM_BLE
+
 #if HAL_PLATFORM_LWIP
     if_init();
 #endif /* HAL_PLATFORM_LWIP */
@@ -744,11 +749,6 @@ void app_setup_and_loop(void)
 #if HAL_PLATFORM_OPENTHREAD
     system::threadInit();
 #endif /* HAL_PLATFORM_OPENTHREAD */
-
-#if HAL_PLATFORM_BLE
-    // FIXME: Move BLE and Thread initialization to an appropriate place
-    ble_init(nullptr);
-#endif // HAL_PLATFORM_BLE
 
 #if SYSTEM_CONTROL_ENABLED
     system::SystemControl::instance()->init();


### PR DESCRIPTION
### Problem

Softdevice assertion failed when initializing radio on Softdevice S140v6.1.1.

### Solution

Change the initialization sequence for BLE and thread.

### Steps to Test
1. Flash  Softdevice S140v6.1.1
1. Flash Device OS 1.2.1-rc.1
1. Device enters PANIC

After applying this fix, PANIC issue disappears.

### Example App
N/A
### References

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [x] Added to CHANGELOG.md after merging (add links to docs and issues)

---

- [bugfix] [gen 3] Fixes radio initialization sequence for SoftDevice S140v6.1.1 [#1794](https://github.com/particle-iot/device-os/pull/1794)