### PR TITLE
[gen 3] [bootloader] External flash sleep refactoring

### DIFF
--- a/hal/inc/exflash_hal.h
+++ b/hal/inc/exflash_hal.h
@@ -32,7 +32,9 @@ typedef enum {
 
 typedef enum {
     HAL_EXFLASH_COMMAND_NONE            = 0,
-    HAL_EXFLASH_COMMAND_LOCK_ENTIRE_OTP = 1
+    HAL_EXFLASH_COMMAND_LOCK_ENTIRE_OTP = 1,
+    HAL_EXFLASH_COMMAND_SLEEP           = 2,
+    HAL_EXFLASH_COMMAND_WAKEUP          = 3
 } hal_exflash_command_t;
 
 int hal_exflash_init(void);

--- a/hal/src/nRF52840/core_hal.c
+++ b/hal/src/nRF52840/core_hal.c
@@ -565,7 +565,8 @@ int HAL_Core_Enter_Stop_Mode_Ext(const uint16_t* pins, size_t pins_count, const 
     // Disable SysTick
     SysTick->CTRL &= ~SysTick_CTRL_ENABLE_Msk;
 
-    // Disable external flash
+    // Put external flash into sleep and disable QSPI peripheral
+    hal_exflash_special_command(HAL_EXFLASH_COMMAND_NONE, HAL_EXFLASH_COMMAND_SLEEP, NULL, NULL, 0);
     hal_exflash_uninit();
 
     uint32_t exit_conditions = STOP_MODE_EXIT_CONDITION_NONE;
@@ -961,7 +962,8 @@ int HAL_Core_Execute_Standby_Mode_Ext(uint32_t flags, void* reserved) {
     // Disable SysTick
     SysTick->CTRL &= ~SysTick_CTRL_ENABLE_Msk;
 
-    // Disable external flash
+    // Put external flash into sleep mode and disable QSPI peripheral
+    hal_exflash_special_command(HAL_EXFLASH_COMMAND_NONE, HAL_EXFLASH_COMMAND_SLEEP, NULL, NULL, 0);
     hal_exflash_uninit();
 
     // Uninit GPIOTE


### PR DESCRIPTION
### Problem

We've introduced an incompatibility in the bootloader with older versions of system firmware in the releases containing https://github.com/particle-iot/device-os/pull/1725.

When you have a bootloader that has this feature on your device, before we jump into the system-part1 the QSPI flash is put into low power mode and requires a special command to wake it up. So, when you have a system-part1 that doesn't send that special command, the QSPI flash is left in low power mode and anything dealing with it fails, e.g. filesystem.

### Solution

This PR does a couple of things:

1. External QSPI flash is no longer implicitly being put into lower power mode when executing `hal_exflash_uninit()`. This call only disables the QSPI peripheral on nRF52840. 
2. External flash sleep functionality has been decoupled into `hal_exflash_special_command()` with `HAL_EXFLASH_COMMAND_SLEEP` and `HAL_EXFLASH_COMMAND_WAKEUP` commands.
3. `core_hal` sleep functions no explicitly call `hal_exflash_special_command()` to put the external flash into sleep mode.
4. `hal_exflash_init()` still implicitly wakes up the external flash, but now through a call to `hal_exflash_special_command()`

### Steps to Test

1. 0.9.0 + bootloader from this branch shouldn't cause a panic mode
2. bootlader and system-part1 from this branch shouldn't case a panic mode
3. Deep sleep and STOP mode sleep tests should pass as previously

### Example App

N/A

### References

- [CH33621]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [x] Added to CHANGELOG.md after merging (add links to docs and issues)

---

- [bugfix] [gen 3] [bootloader] fixes SOS 10 when upgrading bootloader first from older system firmware.  External flash sleep refactoring [#1799](https://github.com/particle-iot/device-os/pull/1799)