### PR TITLE
Building platform BSOM results flash overflow.

### DIFF
--- a/hal/build.mk
+++ b/hal/build.mk
@@ -9,7 +9,7 @@ include $(call rwildcard,$(HAL_PLATFORM_SRC_PATH)/,sources.mk)
 
 LOG_MODULE_CATEGORY = hal
 
-ifeq ($(PLATFORM_ID),13)
+ifneq (,$(filter $(PLATFORM_ID),13 23))
 ifneq ($(DEBUG_BUILD),y)
 ifneq ($(HYBRID_BUILD),y)
 CFLAGS += -DLOG_COMPILE_TIME_LEVEL=LOG_LEVEL_ERROR


### PR DESCRIPTION
Normally, the flash consumption of the DeviceOS building for platform Boron and BSoM are nearly the same. But when building for platform BSoM, it results flash overflow.

This issue is encountered due to the `LOG_COMPILE_TIME_LEVEL` in "./hal/build.mk" being not applied to platform BSoM.