### PR TITLE
[gen3] hal: fixes early wakeup by RTC from STOP sleep mode

### DIFF
--- a/hal/src/nRF52840/openthread/alarm.c
+++ b/hal/src/nRF52840/openthread/alarm.c
@@ -454,7 +454,14 @@ void nrf5AlarmInit(void)
     NVIC_ClearPendingIRQ(RTC_IRQN);
     NVIC_EnableIRQ(RTC_IRQN);
 
-    nrf_rtc_prescaler_set(RTC_INSTANCE, 0);
+    // Particle: this is a workaround for a situation we've seen happen:
+    // despite the fact that the RTC should be stopped and prescaler should be R/W,
+    // we've seen it stay R/O for some reason :|
+    while (rtc_prescaler_get(RTC_INSTANCE) != 0) {
+        nrf_rtc_prescaler_set(RTC_INSTANCE, 0);
+        __DSB();
+        __ISB();
+    }
 
     nrf_rtc_event_clear(RTC_INSTANCE, NRF_RTC_EVENT_OVERFLOW);
     nrf_rtc_event_enable(RTC_INSTANCE, RTC_EVTEN_OVRFLW_Msk);


### PR DESCRIPTION
### Problem

See #1789.

For some reason when we are configuring the RTC before going into STOP sleep mode, the prescaler writes don't take effect. This can only happen if the RTC is not stopped, but it should have been stopped by that point.

### Solution

This PR adds an ugly hack of looping and checking that the prescaler setting did take effect. We are also adding a similar hack to OpenThread alarm code just in case.

If anybody has better ideas on how to resolve this, I'll be more than willing to change this. I've tried various barriers (DMB, DSB and ISB) at multiple places but wasn't completely able to mitigate the issue. Perhaps a dummy prescaler read is what actually helps? :man_shrugging: 

### Steps to Test / Example App 

See a test from #1789

### References

- Closes #1789 
- [CH33538]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] N/A Added documentation
- [x] Added to CHANGELOG.md after merging (add links to docs and issues)

---

- [bgufix] [gen3] hal: fixes early wakeup by RTC from STOP sleep mode [#1803](https://github.com/particle-iot/device-os/pull/1803)