### PR TITLE
Add two-digit mnc diagnostic flag

### DIFF
--- a/hal/inc/cellular_hal.h
+++ b/hal/inc/cellular_hal.h
@@ -121,8 +121,8 @@ cellular_result_t cellular_credentials_clear(void* reserved);
  * be determined using CGI of the cell which is covering that cell phone. A more specific
  * application of the CGI is to roughly determine a mobile phone's geographical position.
  *
- * @param[in,out] cgi An allocated struct with the size member specified (contents will be
- * overwritten)
+ * @param[in,out] cgi An allocated struct with both the \c size and \c version members specified
+ * (contents will be overwritten)
  * @param[in] reserved Reserved for future use (defaulted to `NULL`)
  *
  * @returns \c cellular_result_t code

--- a/hal/inc/cellular_hal_cellular_global_identity.h
+++ b/hal/inc/cellular_hal_cellular_global_identity.h
@@ -20,6 +20,8 @@
 
 #include <stdint.h>
 
+#include "static_assert.h"
+
 /*! Cellular Global Identity Structure Version */
 enum __attribute__((__packed__)) CgiVersion
 {
@@ -32,6 +34,8 @@ enum __attribute__((__packed__)) CgiFlags
 {
     CGI_FLAG_TWO_DIGIT_MNC = 0b00000001, /*!< Indicates two-digit format of Mobile Network Code */
 };
+
+PARTICLE_STATIC_ASSERT(CgiFlags_size, sizeof(enum CgiFlags) == 1);
 
 /*!
  * \brief Cellular Global Identity (CGI)

--- a/hal/inc/cellular_hal_cellular_global_identity.h
+++ b/hal/inc/cellular_hal_cellular_global_identity.h
@@ -23,19 +23,21 @@
 #include "static_assert.h"
 
 /*! Cellular Global Identity Structure Version */
-enum __attribute__((__packed__)) CgiVersion
+typedef enum __attribute__((__packed__)) CgiVersion
 {
     CGI_VERSION_1,
     CGI_VERSION_LATEST = CGI_VERSION_1,
-};
+} CgiVersion;
+
+PARTICLE_STATIC_ASSERT(CgiVersion_size, sizeof(CgiVersion) <= sizeof(uint16_t));
 
 /*! Cellular Global Identity Flags */
-enum __attribute__((__packed__)) CgiFlags
+typedef enum __attribute__((__packed__)) CgiFlags
 {
     CGI_FLAG_TWO_DIGIT_MNC = 0b00000001, /*!< Indicates two-digit format of Mobile Network Code */
-};
+} CgiFlags;
 
-PARTICLE_STATIC_ASSERT(CgiFlags_size, sizeof(enum CgiFlags) == 1);
+PARTICLE_STATIC_ASSERT(CgiFlags_size, sizeof(CgiFlags) <= sizeof(uint8_t));
 
 /*!
  * \brief Cellular Global Identity (CGI)

--- a/hal/inc/cellular_hal_cellular_global_identity.h
+++ b/hal/inc/cellular_hal_cellular_global_identity.h
@@ -51,8 +51,8 @@ typedef struct __attribute__((__packed__))
 {
     uint16_t size; /*!< \c size is specified by the user application, to inform the device-os of the
                       amount of space allocated to the structure */
-    uint16_t version;  /*!< \c version is specified by the device-os, to inform the user-application
-                           of the version of the information returned */
+    uint16_t version;  /*!< \c version is specified by the user application, to inform the
+                          device-os of the version of the information to be returned */
     uint8_t reserved;  /*!< \c reserved is allocated for future usage */
     uint8_t cgi_flags; /*!< \c cgi_flags Indicates the structure/configuration of the values in
                            CellularGlobalIdentity */

--- a/hal/inc/cellular_hal_cellular_global_identity.h
+++ b/hal/inc/cellular_hal_cellular_global_identity.h
@@ -20,6 +20,19 @@
 
 #include <stdint.h>
 
+/*! Cellular Global Identity Structure Version */
+enum __attribute__((__packed__)) CgiVersion
+{
+    CGI_VERSION_1,
+    CGI_VERSION_LATEST = CGI_VERSION_1,
+};
+
+/*! Cellular Global Identity Flags */
+enum __attribute__((__packed__)) CgiFlags
+{
+    CGI_FLAG_TWO_DIGIT_MNC = 0b00000001, /*!< Indicates two-digit format of Mobile Network Code */
+};
+
 /*!
  * \brief Cellular Global Identity (CGI)
  *
@@ -35,8 +48,10 @@ typedef struct __attribute__((__packed__))
     uint16_t size; /*!< \c size is specified by the user application, to inform the device-os of the
                       amount of space allocated to the structure */
     uint16_t version;  /*!< \c version is specified by the device-os, to inform the user-application
-                          of the version of the information returned */
-    uint16_t reserved; /*!< \c reserved is allocated for future usage */
+                           of the version of the information returned */
+    uint8_t reserved;  /*!< \c reserved is allocated for future usage */
+    uint8_t cgi_flags; /*!< \c cgi_flags Indicates the structure/configuration of the values in
+                           CellularGlobalIdentity */
     uint16_t mobile_country_code; /*!< \c mobile_country_code consists of three decimal digits and
                                      identifies uniquely the country of domicile of the mobile
                                      subscription */

--- a/hal/src/boron/cellular_hal.cpp
+++ b/hal/src/boron/cellular_hal.cpp
@@ -256,9 +256,10 @@ cellular_result_t cellular_global_identity(CellularGlobalIdentity* cgi_, void* r
     CHECK(client->getCellularGlobalIdentity(&cgi));
 
     // Validate cache
-    CHECK_TRUE((0 != cgi.mobile_country_code && 0 != cgi.mobile_network_code &&
-                0xFFFF != cgi.location_area_code && 0xFFFFFFFF != cgi.cell_id),
-               SYSTEM_ERROR_BAD_DATA);
+    CHECK_TRUE(0 != cgi.mobile_country_code, SYSTEM_ERROR_BAD_DATA);
+    CHECK_TRUE(0 != cgi.mobile_network_code, SYSTEM_ERROR_BAD_DATA);
+    CHECK_TRUE(0xFFFF != cgi.location_area_code, SYSTEM_ERROR_BAD_DATA);
+    CHECK_TRUE(0xFFFFFFFF != cgi.cell_id, SYSTEM_ERROR_BAD_DATA);
 
     // Update result
     *cgi_ = cgi;

--- a/hal/src/boron/cellular_hal.cpp
+++ b/hal/src/boron/cellular_hal.cpp
@@ -240,7 +240,7 @@ int cellular_credentials_clear(void* reserved) {
 }
 
 cellular_result_t cellular_global_identity(CellularGlobalIdentity* cgi_, void* reserved_) {
-    CellularGlobalIdentity cgi;
+    CellularGlobalIdentity cgi;  // Intentionally left uninitialized
 
     // Acquire Cellular NCP Client
     const auto mgr = cellularNetworkManager();

--- a/hal/src/boron/network/sara_ncp_client.cpp
+++ b/hal/src/boron/network/sara_ncp_client.cpp
@@ -457,15 +457,16 @@ int SaraNcpClient::getCellularGlobalIdentity(CellularGlobalIdentity* cgi) {
     CHECK(checkParser());
     CHECK(queryAndParseAtCops(nullptr));
 
-    switch (cgi_.version)
+    switch (cgi->version)
     {
     case CGI_VERSION_1:
     default:
     {
         // Confirm user is expecting the correct amount of data
-        CHECK_TRUE((cgi->size >= cgi_.size), SYSTEM_ERROR_INVALID_ARGUMENT);
+        CHECK_TRUE((cgi->size >= sizeof(cgi_)), SYSTEM_ERROR_INVALID_ARGUMENT);
 
         *cgi = cgi_;
+        cgi->size = sizeof(cgi_);
         cgi->version = CGI_VERSION_1;
         break;
     }

--- a/hal/src/boron/network/sara_ncp_client.cpp
+++ b/hal/src/boron/network/sara_ncp_client.cpp
@@ -412,6 +412,15 @@ int SaraNcpClient::queryAndParseAtCops(CellularSignalQuality* qual) {
     r = CHECK_PARSER(resp.readResult());
     CHECK_TRUE(r == AtResponse::OK, SYSTEM_ERROR_AT_NOT_OK);
 
+    // Preserve digit format data
+    const int mnc_digits = ::strnlen(mobileNetworkCode, 4);
+    CHECK_TRUE((2 == mnc_digits || 3 == mnc_digits), SYSTEM_ERROR_BAD_DATA);
+    if (2 == mnc_digits) {
+        cgi_.cgi_flags |= CGI_FLAG_TWO_DIGIT_MNC;
+    } else {
+        cgi_.cgi_flags &= ~CGI_FLAG_TWO_DIGIT_MNC;
+    }
+
     // `atoi` returns zero on error, which is an invalid `mcc` and `mnc`
     cgi_.mobile_country_code = static_cast<uint16_t>(::atoi(mobileCountryCode));
     cgi_.mobile_network_code = static_cast<uint16_t>(::atoi(mobileNetworkCode));
@@ -448,7 +457,19 @@ int SaraNcpClient::getCellularGlobalIdentity(CellularGlobalIdentity* cgi) {
     CHECK(checkParser());
     CHECK(queryAndParseAtCops(nullptr));
 
-    *cgi = cgi_;
+    switch (cgi_.version)
+    {
+    case CGI_VERSION_1:
+    default:
+    {
+        // Confirm user is expecting the correct amount of data
+        CHECK_TRUE((cgi->size >= cgi_.size), SYSTEM_ERROR_INVALID_ARGUMENT);
+
+        *cgi = cgi_;
+        cgi->version = CGI_VERSION_1;
+        break;
+    }
+    }
 
     return SYSTEM_ERROR_NONE;
 }

--- a/hal/src/boron/network/sara_ncp_client.cpp
+++ b/hal/src/boron/network/sara_ncp_client.cpp
@@ -413,7 +413,7 @@ int SaraNcpClient::queryAndParseAtCops(CellularSignalQuality* qual) {
     CHECK_TRUE(r == AtResponse::OK, SYSTEM_ERROR_AT_NOT_OK);
 
     // Preserve digit format data
-    const int mnc_digits = ::strnlen(mobileNetworkCode, 4);
+    const int mnc_digits = ::strnlen(mobileNetworkCode, sizeof(mobileNetworkCode));
     CHECK_TRUE((2 == mnc_digits || 3 == mnc_digits), SYSTEM_ERROR_BAD_DATA);
     if (2 == mnc_digits) {
         cgi_.cgi_flags |= CGI_FLAG_TWO_DIGIT_MNC;

--- a/hal/src/boron/network/sara_ncp_client.h
+++ b/hal/src/boron/network/sara_ncp_client.h
@@ -77,7 +77,7 @@ private:
     gsm0710::Muxer<particle::Stream, StaticRecursiveMutex> muxer_;
     std::unique_ptr<particle::MuxerChannelStream<decltype(muxer_)> > muxerAtStream_;
     CellularNetworkConfig netConf_;
-    CellularGlobalIdentity cgi_ = {0};
+    CellularGlobalIdentity cgi_ = {};
 
     enum class RegistrationState {
         NotRegistered = 0,

--- a/hal/src/boron/network/sara_ncp_client.h
+++ b/hal/src/boron/network/sara_ncp_client.h
@@ -77,7 +77,7 @@ private:
     gsm0710::Muxer<particle::Stream, StaticRecursiveMutex> muxer_;
     std::unique_ptr<particle::MuxerChannelStream<decltype(muxer_)> > muxerAtStream_;
     CellularNetworkConfig netConf_;
-    CellularGlobalIdentity cgi_;
+    CellularGlobalIdentity cgi_ = {0};
 
     enum class RegistrationState {
         NotRegistered = 0,

--- a/hal/src/electron/cellular_hal.cpp
+++ b/hal/src/electron/cellular_hal.cpp
@@ -371,9 +371,10 @@ cellular_result_t cellular_global_identity(CellularGlobalIdentity* cgi_, void* r
     CHECK_TRUE(electronMDM.getCellularGlobalIdentity(cgi), SYSTEM_ERROR_AT_NOT_OK);
 
     // Validate cache
-    CHECK_TRUE((0 != cgi.mobile_country_code && 0 != cgi.mobile_network_code &&
-                0xFFFF != cgi.location_area_code && 0xFFFFFFFF != cgi.cell_id),
-               SYSTEM_ERROR_BAD_DATA);
+    CHECK_TRUE(0 != cgi.mobile_country_code, SYSTEM_ERROR_BAD_DATA);
+    CHECK_TRUE(0 != cgi.mobile_network_code, SYSTEM_ERROR_BAD_DATA);
+    CHECK_TRUE(0xFFFF != cgi.location_area_code, SYSTEM_ERROR_BAD_DATA);
+    CHECK_TRUE(0xFFFFFFFF != cgi.cell_id, SYSTEM_ERROR_BAD_DATA);
 
     // Update result
     *cgi_ = cgi;

--- a/hal/src/electron/cellular_hal.cpp
+++ b/hal/src/electron/cellular_hal.cpp
@@ -361,7 +361,7 @@ cellular_result_t cellular_band_available_get(MDM_BandSelect* bands, void* reser
 
 cellular_result_t cellular_global_identity(CellularGlobalIdentity* cgi_, void* reserved_)
 {
-    CellularGlobalIdentity cgi;
+    CellularGlobalIdentity cgi;  // Intentionally left uninitialized
 
     // Validate Argument(s)
     (void)reserved_;

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1340,10 +1340,11 @@ bool MDMParser::getCellularGlobalIdentity(CellularGlobalIdentity& cgi_) {
     default:
     {
         // Confirm user is expecting the correct amount of data
-        if (cgi_.size < _net.cgi.size)
+        if (cgi_.size < sizeof(_net.cgi))
             goto failure;
 
         cgi_ = _net.cgi;
+        cgi_.size = sizeof(_net.cgi);
         cgi_.version = CGI_VERSION_1;
         break;
     }

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1513,14 +1513,17 @@ int MDMParser::_cbCOPS(int type, const char* buf, int len, NetStatus* status)
         char mobileNetworkCode[4] = {0};
 
         // +COPS: <mode>[,<format>,<oper>[,<AcT>]]
-        if (sscanf(buf, "\r\n+COPS: %*d,%*d,\"%3[0-9]%3[0-9]\",%d", mobileCountryCode,
+        if (::sscanf(buf, "\r\n+COPS: %*d,%*d,\"%3[0-9]%3[0-9]\",%d", mobileCountryCode,
                    mobileNetworkCode, &act) >= 1)
         {
             // Preserve digit format data
-            const int mnc_digits = ::strnlen(mobileNetworkCode, 4);
-            if (2 == mnc_digits) {
+            const int mnc_digits = ::strnlen(mobileNetworkCode, sizeof(mobileNetworkCode));
+            if (2 == mnc_digits)
+            {
                 status->cgi.cgi_flags |= CGI_FLAG_TWO_DIGIT_MNC;
-            } else {
+            }
+            else
+            {
                 status->cgi.cgi_flags &= ~CGI_FLAG_TWO_DIGIT_MNC;
             }
 

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1210,8 +1210,6 @@ bool MDMParser::checkNetStatus(NetStatus* status /*= NULL*/)
     // TODO: optimize, add a param/variable to prevent clearing _net if
     // arriving here after break() from inner while() in registerNet().
     memset(&_net, 0, sizeof(_net));
-    _net.cgi.mobile_country_code = 0;
-    _net.cgi.mobile_network_code = 0;
     _net.cgi.location_area_code = 0xFFFF;
     _net.cgi.cell_id = 0xFFFFFFFF;
     if (_dev.dev == DEV_SARA_R410) {
@@ -1336,9 +1334,22 @@ bool MDMParser::getCellularGlobalIdentity(CellularGlobalIdentity& cgi_) {
     if (RESP_OK != waitFinalResp(_cbCOPS, &_net, COPS_TIMEOUT))
         goto failure;
 
-    // CGI value has been updated successfully
-    cgi_ = _net.cgi;
+    switch (cgi_.version)
+    {
+    case CGI_VERSION_1:
+    default:
+    {
+        // Confirm user is expecting the correct amount of data
+        if (cgi_.size >= _net.cgi.size)
+            goto failure;
 
+        cgi_ = _net.cgi;
+        cgi_.version = CGI_VERSION_1;
+        break;
+    }
+    }
+
+    // CGI value has been updated successfully
     UNLOCK();
     return true;
 failure:
@@ -1505,6 +1516,14 @@ int MDMParser::_cbCOPS(int type, const char* buf, int len, NetStatus* status)
         if (sscanf(buf, "\r\n+COPS: %*d,%*d,\"%3[0-9]%3[0-9]\",%d", mobileCountryCode,
                    mobileNetworkCode, &act) >= 1)
         {
+            // Preserve digit format data
+            const int mnc_digits = ::strnlen(mobileNetworkCode, 4);
+            if (2 == mnc_digits) {
+                status->cgi.cgi_flags |= CGI_FLAG_TWO_DIGIT_MNC;
+            } else {
+                status->cgi.cgi_flags &= ~CGI_FLAG_TWO_DIGIT_MNC;
+            }
+
             // `atoi` returns zero on error, which is an invalid `mcc` and `mnc`
             status->cgi.mobile_country_code = static_cast<uint16_t>(::atoi(mobileCountryCode));
             status->cgi.mobile_network_code = static_cast<uint16_t>(::atoi(mobileNetworkCode));
@@ -2906,7 +2925,12 @@ void MDMParser::dumpNetStatus(NetStatus *status)
     if (status->cgi.mobile_country_code != 0)
         DEBUG_D("  Mobile Country Code: %d\r\n", status->cgi.mobile_country_code);
     if (status->cgi.mobile_network_code != 0)
-        DEBUG_D("  Mobile Network Code: %d\r\n", status->cgi.mobile_network_code);
+    {
+        if (CGI_FLAG_TWO_DIGIT_MNC & status->cgi.cgi_flags)
+            DEBUG_D("  Mobile Network Code: %02d\r\n", status->cgi.mobile_network_code);
+        else
+            DEBUG_D("  Mobile Network Code: %03d\r\n", status->cgi.mobile_network_code);
+    }
     if (status->cgi.location_area_code != 0xFFFF)
         DEBUG_D("  Location Area Code:  %04X\r\n", status->cgi.location_area_code);
     if (status->cgi.cell_id != 0xFFFFFFFF)

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1340,7 +1340,7 @@ bool MDMParser::getCellularGlobalIdentity(CellularGlobalIdentity& cgi_) {
     default:
     {
         // Confirm user is expecting the correct amount of data
-        if (cgi_.size >= _net.cgi.size)
+        if (cgi_.size < _net.cgi.size)
             goto failure;
 
         cgi_ = _net.cgi;

--- a/system/src/system_network_diagnostics.cpp
+++ b/system/src/system_network_diagnostics.cpp
@@ -279,7 +279,7 @@ public:
 
     virtual int get(IntType& val)
     {
-        CellularGlobalIdentity cgi{sizeof(CellularGlobalIdentity),CGI_VERSION_LATEST};
+        CellularGlobalIdentity cgi{.size = sizeof(CellularGlobalIdentity), .version = CGI_VERSION_LATEST};
         cellular_global_identity(&cgi, nullptr);
         val = static_cast<IntType>(cgi.mobile_country_code);
 
@@ -300,7 +300,7 @@ public:
 
     virtual int get(IntType& val)
     {
-        CellularGlobalIdentity cgi{sizeof(CellularGlobalIdentity),CGI_VERSION_LATEST};
+        CellularGlobalIdentity cgi{.size = sizeof(CellularGlobalIdentity), .version = CGI_VERSION_LATEST};
         cellular_global_identity(&cgi, nullptr);
         if (CGI_FLAG_TWO_DIGIT_MNC & cgi.cgi_flags)
         {
@@ -328,7 +328,7 @@ public:
 
     virtual int get(IntType& val)
     {
-        CellularGlobalIdentity cgi{sizeof(CellularGlobalIdentity),CGI_VERSION_LATEST};
+        CellularGlobalIdentity cgi{.size = sizeof(CellularGlobalIdentity), .version = CGI_VERSION_LATEST};
         cellular_global_identity(&cgi, nullptr);
         val = static_cast<IntType>(cgi.location_area_code);
 
@@ -347,7 +347,7 @@ public:
 
     virtual int get(IntType& val)
     {
-        CellularGlobalIdentity cgi{sizeof(CellularGlobalIdentity),CGI_VERSION_LATEST};
+        CellularGlobalIdentity cgi{.size = sizeof(CellularGlobalIdentity), .version = CGI_VERSION_LATEST};
         cellular_global_identity(&cgi, nullptr);
         val = static_cast<IntType>(cgi.cell_id);
 

--- a/system/src/system_network_diagnostics.cpp
+++ b/system/src/system_network_diagnostics.cpp
@@ -302,7 +302,14 @@ public:
     {
         CellularGlobalIdentity cgi;
         cellular_global_identity(&cgi, nullptr);
-        val = static_cast<IntType>(cgi.mobile_network_code);
+        if (CGI_FLAG_TWO_DIGIT_MNC & cgi.cgi_flags)
+        {
+            val = static_cast<IntType>(cgi.mobile_network_code * -1);
+        }
+        else
+        {
+            val = static_cast<IntType>(cgi.mobile_network_code);
+        }
 
         return SYSTEM_ERROR_NONE;
     }

--- a/system/src/system_network_diagnostics.cpp
+++ b/system/src/system_network_diagnostics.cpp
@@ -279,7 +279,7 @@ public:
 
     virtual int get(IntType& val)
     {
-        CellularGlobalIdentity cgi;
+        CellularGlobalIdentity cgi{sizeof(CellularGlobalIdentity),CGI_VERSION_LATEST};
         cellular_global_identity(&cgi, nullptr);
         val = static_cast<IntType>(cgi.mobile_country_code);
 
@@ -300,7 +300,7 @@ public:
 
     virtual int get(IntType& val)
     {
-        CellularGlobalIdentity cgi;
+        CellularGlobalIdentity cgi{sizeof(CellularGlobalIdentity),CGI_VERSION_LATEST};
         cellular_global_identity(&cgi, nullptr);
         if (CGI_FLAG_TWO_DIGIT_MNC & cgi.cgi_flags)
         {
@@ -328,7 +328,7 @@ public:
 
     virtual int get(IntType& val)
     {
-        CellularGlobalIdentity cgi;
+        CellularGlobalIdentity cgi{sizeof(CellularGlobalIdentity),CGI_VERSION_LATEST};
         cellular_global_identity(&cgi, nullptr);
         val = static_cast<IntType>(cgi.location_area_code);
 
@@ -347,7 +347,7 @@ public:
 
     virtual int get(IntType& val)
     {
-        CellularGlobalIdentity cgi;
+        CellularGlobalIdentity cgi{sizeof(CellularGlobalIdentity),CGI_VERSION_LATEST};
         cellular_global_identity(&cgi, nullptr);
         val = static_cast<IntType>(cgi.cell_id);
 

--- a/user/tests/accept/hal-api-test-plan.md
+++ b/user/tests/accept/hal-api-test-plan.md
@@ -46,8 +46,8 @@ HAL API Test Plan
     "cell_global_identity": {
       "mobile_country_code": 310,
       "mobile_network_code": 410,
-      "location_area_code": 25876,
-      "cell_id": 88078104
+      "location_area_code": 25878,
+      "cell_id": 88213008
     },
     "radio_access_technology": "LTE"
   }

--- a/user/tests/app/cellular_global_identity/cellular_global_identity.cpp
+++ b/user/tests/app/cellular_global_identity/cellular_global_identity.cpp
@@ -11,7 +11,7 @@
 // Log handler processing all messages
 SerialLogHandler logHandler(LOG_LEVEL_ALL);
 
-CellularGlobalIdentity cgi;
+CellularGlobalIdentity cgi{sizeof(CellularGlobalIdentity), CGI_VERSION_LATEST};
 
 // setup() runs once, when the device is first turned on.
 void setup()
@@ -29,7 +29,11 @@ void loop()
   case SYSTEM_ERROR_NONE:
     Log("/%%%%%%%%%%%%%%%%%%%%%% Cellular Global Identity %%%%%%%%%%%%%%%%%%%%%%/");
     Log("\tMobile Country Code: %d", cgi.mobile_country_code);
-    Log("\tMobile Network Code: %d", cgi.mobile_network_code);
+    if (CGI_FLAG_TWO_DIGIT_MNC & cgi.cgi_flags) {
+      Log("\tMobile Network Code: %02d", cgi.mobile_network_code);
+    } else {
+      Log("\tMobile Network Code: %03d", cgi.mobile_network_code);
+    }
     Log("\tLocation Area Code: 0x%x", cgi.location_area_code);
     Log("\tCell Identification: 0x%lx", cgi.cell_id);
     Log("/%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%/");

--- a/user/tests/app/cellular_global_identity/cellular_global_identity.cpp
+++ b/user/tests/app/cellular_global_identity/cellular_global_identity.cpp
@@ -11,7 +11,7 @@
 // Log handler processing all messages
 SerialLogHandler logHandler(LOG_LEVEL_ALL);
 
-CellularGlobalIdentity cgi{sizeof(CellularGlobalIdentity), CGI_VERSION_LATEST};
+CellularGlobalIdentity cgi{.size = sizeof(CellularGlobalIdentity), .version = CGI_VERSION_LATEST};
 
 // setup() runs once, when the device is first turned on.
 void setup()


### PR DESCRIPTION
<details>
  <summary><i>The two-digit `mnc` diagnostic allows the original `mnc` to be reconstructed accurately.</i></summary>
</details>

### Problem

Currently, the `mnc` is translated to and stored as a decimal value. According to the specification, `40` and `040` are not equal values. Currently when using the `mcc` and `mnc` tuple, there does not appear to be a clash. However, maintaining this distinction is important is important to ensure future bugs do not appear in the system.

### Solution

By sending an indicator as to the original form of the information, we are able to reconstruct the original value in a lossless manner.

### Steps to Test

user/tests/accept/hal-api-test-plan.md

### Example App

user/tests/app/cellular_global_identity/cellular_global_identity.cpp

### Tickets
- ch33501
---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [x] Added to CHANGELOG.md after merging (add links to docs and issues)
