### PR TITLE
add encrypted slack token

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,6 +124,7 @@ env:
   - secure: Iq58mKqq5Nz4B6OEZu1nmnquhvlQncxT4T3f1x+M/0I6VW5xirMWFlpeke8QyyPOZlwNLDnB5QVjsR2UQspNIhMT4rCfDeCCr9AeinoMDmqPbzpmLLmtaUpz0uTZyJVx7+IRe9QtljPfbzlAxybmrx1HdCCw++F/+qhgFoGLi9o=
   - secure: O8Zu2sWO63svmSTdOk+7Z7N2oUcg3N07WckMoy1m7AYmRZydX5hdVXlbagA06FCtpu1Kvvwc7QYB+1wpoxZYZnxt2mVetVsAcSpOz3c03LodM+yKaHm9luqLfQobuC7oyNdumpqMLsWiELM9rxEpIazYDYM2QI+lh7fTUTHnQ3s=
   - secure: A83drTFobkGvgrPNwGwNS3ZSHX35iNELjH6W9h07pw/n1YSssBHxtLF8aVAEwfIF1VyUoHvQ4HYLNd+9RMyo162xxiWne+/4/gSFyUJNi11w3YX5bwodKPl7OwEO/YnJgHYk8YAAfdnZT4470Fpt6ytcOhEhMsB/IFeepMUiZZA=
-
 notifications:
-    slack: s:uyDgDeY2Sric20NcE50P11QS
+  slack:
+    rooms:
+      secure: Q+HuLmEeqSkRfiMYvqQpT7R6pfVghZ1OIXSm2hTAu3HVrMGBj6Jyp23k8EBnwjUnKxP/XZ88ARd3rOZF/vZF7wXixBhQtTdThUMUdKXAhvUkRHU0vmF7t+atsucwu1yp21jjWL7csnHmuH4qAoNdgLnoJYFImgRFoxB3weqVnEs=


### PR DESCRIPTION
### Problem

When merging the private and public repo after Gen3 development, the private repo was using an unencrypted slack token. This was inadvertently copied to the public repo during the merge.

### Solution

Re-generate the token and re-encrypt it.

### Steps to Test

Let's see if this PR shows up in slack ;-)


---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
