### PR TITLE
Feature/dynalib

### DIFF
--- a/dynalib/README.md
+++ b/dynalib/README.md
@@ -1,0 +1,33 @@
+# Dynamic Link Interfaces
+
+## Overview
+
+## ABI Compatibility
+
+Callers are always assumed to be at the same version or older than their dependent library. It is a general contract that dynamically linked interfaces should backwards compatible with older callers.  Since callers cannot be newer than the dynamically linked interface, there is no general requirement for forward compatibility.
+
+### General Recommendataions for Achieving ABI compatibility
+
+When designing a new function that is part of a dynamic link interface, consider the following points:
+
+* Structs passed in to functions may need to evolve over time. 
+Adding a `size` parameter that is filled by the caller ensures that as these structs evolve, the function can check the size of the struct that the client used. This ensures the implementation doesn't use members of the structs that were added after the caller was compiled, since these will not have been allocated by the caller.
+
+* If the function's parameters are numerous or are expected to
+change over time, wrapping them up in a struct can make evolution of the API easier, since ABI compatibilty is maintained when
+adding new members to the struct.
+
+* As generalization of the point above, consider adding an additional `void*` parameter named `reserved` that is set to `nullptr` by clients. This allows the function to be extended in future releases without breaking the ABI.  This can be useful even when
+the function is already taking one or more structs as arguments since the new data may not be a good semantic fit for the existing types.
+
+** The reserved parameter can be used to later add a new struct type to the API. The implementation checks that the pointer is not `nullptr` and if the struct has multiple versions, checks the size before access.
+
+## You can't break ABI compatibility, but what if you REALLY want to?
+
+If a change is required that would break ABI compatibility, this
+is done by adding a new function to the dynamic link interface with the new revised signature. The function is added after all the other functions, i.e. at a new index.
+
+The existing function can be renamed and given a suffix to indicate that it is no longer current, such as `_old` , while existing callers in system firmware and wiring are changed to use the new function name (which can be the same as the old function name.) Since dynamic link functions are invoked by index, the old function continues to exist at the same index and it will continue to be used by old clients, even though it has been renamed. New clients will use the new function found at the new index.
+
+The HAL I2C interface on Gen2 platforms went through this type of revision, since it needed to take an additional parameter for the I2D peripheral selector, that was not added to the original I2C dynamic interface.  For good measure, a `void*` reserved parameter was also added in anticipation of future changes required.
+

--- a/dynalib/inc/dynalib_abi.h
+++ b/dynalib/inc/dynalib_abi.h
@@ -62,3 +62,8 @@ inline bool struct_contains(const T2& value, T1 T2::* member) {
     return dynamic_size(value) >= size_needed;
 }
 
+template <typename T1, typename T2>
+inline bool struct_contains(const T2* value, T1 T2::* member) {
+    return struct_contains(*value, member);
+}
+

--- a/dynalib/inc/dynalib_abi.h
+++ b/dynalib/inc/dynalib_abi.h
@@ -1,0 +1,64 @@
+#pragma once
+
+/**
+  ******************************************************************************
+  Copyright (c) 2019 Particle Industries, Inc.  All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation, either
+  version 3 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, see <http://www.gnu.org/licenses/>.
+  ******************************************************************************
+  */
+
+#include <cstddef>
+
+/**
+ * @param T1 the type of the member pointer
+ * @param The member pointer (essentially an offset.)
+ */
+template <typename T1, typename T2>
+constexpr auto offset_of(T1 T2::* member) {
+    // under
+    constexpr T2 object {};
+    return size_t(&(object.*member)) - size_t(&object);
+}
+
+/**
+ * Generic template for retrieving the size from the same named property.
+ * Allows specialization for types that use a different name.
+ */
+template <typename T>
+inline auto constexpr dynamic_size(const T& t) -> decltype(t.size) {
+    return t.size;
+}
+
+/**
+ * Determines if a dynamically sized structure contains the given member. This should be used
+ * firmware receiving a struct that may vary in length depending upon the client invoking it.
+ * The struct type is expected to have a `size` member of a scalar type, plus any additional members required.
+ * The struct is considered to contain the member when the size is greater than or equal to the
+ * offset of the member in the struct plus the member's size.
+ *
+ * @param value     The struct to test.  Must have a size field.
+ * @param member    The pointer-to-member for the member of the struct to check.
+ * @returns true if the structure size is sufficient to contain the given member, false otherwise.
+ *
+ * See wiring/no_fixture/dynalib_abi.cpp for tests.
+ * Looking at the compiler output of ARM GCC 5.3.1,
+ * the template is as efficient as a hand-crafted test.
+ */
+template <typename T1, typename T2>
+inline bool struct_contains(const T2& value, T1 T2::* member) {
+    const auto size_needed = offset_of(member)+sizeof(T1);
+    return dynamic_size(value) >= size_needed;
+}
+

--- a/user/tests/unit/dynalib.cpp
+++ b/user/tests/unit/dynalib.cpp
@@ -1,0 +1,40 @@
+#include "tools/catch.h"
+#include "dynalib_abi.h"
+
+
+struct struct_contains_test {
+    uint16_t size;
+    uint32_t item1;
+    uint32_t item2;
+};
+
+
+TEST_CASE("dynalib abi") {
+
+    constexpr struct_contains_test size2 { .size = 2 };
+    constexpr struct_contains_test size4 { .size = 4 };
+    constexpr struct_contains_test size6 { .size = 6 };
+    constexpr struct_contains_test size8 { .size = 8 };
+
+     SECTION("offset_of") {
+// this doesn't compile on clang on OSX Apple LLVM version 10.0.0 (clang-1000.10.44.4)
+ //         constexpr auto offsetItem1 = offset_of(&struct_contains_test::item1);
+//         static_assert(offsetItem1==4, "expected item1 at offset 4");
+         REQUIRE(offset_of(&struct_contains_test::size)==0);
+         REQUIRE(offset_of(&struct_contains_test::item1)==4);
+         REQUIRE(offset_of(&struct_contains_test::item2)==8);
+     }
+
+     SECTION("dynamic size") {
+         REQUIRE(dynamic_size(size2)==2);
+         REQUIRE(dynamic_size(size4)==4);
+         REQUIRE(dynamic_size(size6)==6);
+     }
+
+     SECTION("struct_has") {
+         REQUIRE(!struct_contains(size2, &struct_contains_test::item1));
+         REQUIRE(!struct_contains(size4, &struct_contains_test::item1));
+         REQUIRE(!struct_contains(size6, &struct_contains_test::item1));
+         REQUIRE(struct_contains(size8, &struct_contains_test::item1));
+     }
+}

--- a/user/tests/unit/led_service.cpp
+++ b/user/tests/unit/led_service.cpp
@@ -7,6 +7,8 @@
 
 #include "hippomocks.h"
 
+#include <functional>
+
 namespace {
 
 using namespace particle;

--- a/user/tests/wiring/no_fixture/dynalib_abi.cpp
+++ b/user/tests/wiring/no_fixture/dynalib_abi.cpp
@@ -28,7 +28,7 @@ test(dynalib_api_manual_struct_check) {
 }
 
 bool test_struct_pointer(test_struct* t) {
-    return struct_contains(*t, &test_struct::data);
+    return struct_contains(t, &test_struct::data);
 }
 
 test(dynalib_api_indirect_check) {

--- a/user/tests/wiring/no_fixture/dynalib_abi.cpp
+++ b/user/tests/wiring/no_fixture/dynalib_abi.cpp
@@ -1,0 +1,36 @@
+
+#include "application.h"
+#include "unit-test/unit-test.h"
+#include "dynalib_abi.h"
+
+
+struct test_struct {
+    uint16_t size;
+    uint32_t data;
+};
+
+test_struct t8 = { .size = 8 };
+test_struct t4 = { .size = 4 };
+
+
+test(dynalib_abi_struct_does_not_contain)
+{
+    assertFalse(struct_contains(t4, &test_struct::data));
+}
+
+test(dynalib_abi_struct_does_contain)
+{
+    assertTrue(struct_contains(t8, &test_struct::data));
+}
+
+test(dynalib_api_manual_struct_check) {
+    assertTrue(t8.size >= 9)
+}
+
+bool test_struct_pointer(test_struct* t) {
+    return struct_contains(*t, &test_struct::data);
+}
+
+test(dynalib_api_indirect_check) {
+    assertTrue(test_struct_pointer(&t8));
+}


### PR DESCRIPTION
### Problem

Guidance on how to maintain ABI compatibility between releases of a dynamic linked interface was missing, in particular practices on revising structs passed by callers.

### Solution

Adds documentation and a `struct_contains` function to help consistently check dynamically sized structs. 

### Steps to Test

- [ ] user/tests/unit
- [ ] user/tests/wiring/no_fixture

### Example App

```c
struct mystruct {
   int size;
   int data1;
   int data2;
}

void some_dynalib_fn(int param, mystruct* data /*was reserved*/ ) {
   if (struct_contains(data, &mystruct::data2)) {
       data->data2 = 5;   // can safely do this. 
  }
}
```

### References

- [[CH34346]](https://app.clubhouse.io/particle/story/34346/documentation-and-coding-assistance-for-maintaining-abi-compatibility-of-dynalib-interfaces)

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
