### PR TITLE
[NFC] Context parameter is missing and NFC.update() will remove callback

### DIFF
--- a/wiring/inc/spark_wiring_nfc.h
+++ b/wiring/inc/spark_wiring_nfc.h
@@ -387,7 +387,7 @@ public:
         return inst;
     }
 
-    int on(nfc_event_callback_t cb=nullptr);
+    int on(nfc_event_callback_t cb=nullptr, void* context=nullptr);
     int off();
     int update();
 
@@ -419,6 +419,8 @@ private:
     Vector<uint8_t>      uid_;
     Vector<uint8_t>      encode_;
     NdefMessage          ndefMessage_;
+    nfc_event_callback_t callback_;
+    void*                context_;
 };
 
 #define NFC NfcTagType2::instance()

--- a/wiring/src/spark_wiring_nfc.cpp
+++ b/wiring/src/spark_wiring_nfc.cpp
@@ -149,7 +149,7 @@ void NdefMessage::arrangeRecords(void) {
     }
 }
 
-int NfcTagType2::on(nfc_event_callback_t cb) {
+int NfcTagType2::on(nfc_event_callback_t cb, void* context) {
     if (!enable_) {
         enable_ = true;
         hal_nfc_type2_init(nullptr);
@@ -159,8 +159,11 @@ int NfcTagType2::on(nfc_event_callback_t cb) {
     LOG_DEBUG(TRACE, "size: %d", encode_.size());
     hal_nfc_type2_stop_emulation(nullptr);
     hal_nfc_type2_set_payload(encode_.data(), encode_.size());
-    hal_nfc_type2_set_callback(cb, nullptr);
+    hal_nfc_type2_set_callback(cb, context);
     hal_nfc_type2_start_emulation(nullptr);
+
+    callback_ = cb;
+    context_ = context;
 
     return 0;
 }
@@ -174,7 +177,7 @@ int NfcTagType2::off() {
 
 int NfcTagType2::update() {
     off();
-    on();
+    on(callback_, context_);
 
     return 0;
 }


### PR DESCRIPTION
### Problem

Context parameter is missing and NFC.update() will remove callback

### Steps to Test

Flash the example, use Serial to observe the log to see whether the callback is called and whether the context value is right.

### Example App

```c
#include "application.h"

SYSTEM_MODE(MANUAL);

Serial1LogHandler logHandler(115200, LOG_LEVEL_ALL, {{"app", LOG_LEVEL_ALL}});

void nfc_event_callback(nfc_event_type_t type, nfc_event_t* event, void* context) {
    switch (type) {
        case NFC_EVENT_FIELD_ON: {
            Serial.printf("on, context: %d\r\n", *reinterpret_cast<int*>(context));
            break;
        };
        case NFC_EVENT_FIELD_OFF: {
            Serial.printf("off, context: %d\r\n", *reinterpret_cast<int*>(context));
            break;
        };
        default:
            break;
    }
}

void setup(void) {
    Serial.begin();
    static int context = 123;
    void *p = &context;
    NFC.setText("Hello Particle!", "en");
    NFC.on(nfc_event_callback, p);
    NFC.update();
}

void loop() {

}
```

### References

[CH34412]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
