### PR TITLE
[Gen 3] Fix memory usage diagnostics

### DIFF
--- a/hal/src/nRF52840/core_hal.c
+++ b/hal/src/nRF52840/core_hal.c
@@ -314,11 +314,7 @@ void HAL_Core_Config(void) {
         if (new_heap_end > malloc_heap_end()) {
             malloc_set_heap_end(new_heap_end);
         }
-    }
-    else {
-        // Set the heap end to the stack start to make most use of the SRAM.
-        malloc_set_heap_end(&_Stack_Init);
-
+    } else {
         // Update the user module if needed
         user_update_if_needed();
     }

--- a/modules/shared/nRF52840/part1.ld
+++ b/modules/shared/nRF52840/part1.ld
@@ -255,7 +255,7 @@ SECTIONS
     PROVIDE ( _end = _ebss );
     
     link_heap_location = _ebss;
-    link_heap_location_end = link_heap_location + min_heap_size;
+    link_heap_location_end = __Stack_Init;
 
 
     /DISCARD/ :
@@ -286,7 +286,7 @@ SECTIONS
 PROVIDE( _heap = link_heap_location );
 
 /* End of the heap is top of RAM, aligned 8 byte */
-PROVIDE( _eheap = ALIGN( link_heap_location_end, 8 ) );
+PROVIDE( _eheap = ALIGN( link_heap_location_end - 7, 8 ) );
 
 /* ThreadX aliases */
 PROVIDE( __RAM_segment_used_end__ = link_stack_end );
@@ -310,7 +310,7 @@ ASSERT ( chk_system_pre_init_start < chk_system_pre_init_end , "system_part1_pre
 ASSERT ( chk_system_init_start < chk_system_init_end , "system_part1_init function not included" );
 
 /* Heap assertion*/
-ASSERT ( link_heap_location_end < user_static_ram_start, "Insufficient room for heap" );
+ASSERT ( link_heap_location + min_heap_size <= __Stack_Init, "Insufficient room for heap" );
 
 ASSERT ( PLATFORM_DFU == ORIGIN(APP_FLASH), "Platform DFU and APP_FLASH origin differ" );
 


### PR DESCRIPTION
### Note: This fix needs to be back-ported to 1.2.1-rc.3.
---

### Problem

The memory usage diagnostics report negative values in the safe mode. The problem is caused by `HAL_Core_Runtime_Info()` which uses an incorrect initial heap size for calculations.

### Solution

Set the initial end address of the heap to the start address of the stack (see the diagram [here](https://github.com/particle-iot/device-os/blob/feature/part1_sram/build/arm/linker/nrf52840/platform_ram.ld#L4)). This address is normally adjusted according to the size of the static RAM allocated in the user part, but is used as is in the safe mode.

### Steps to Test

1. Apply [this patch](https://github.com/particle-iot/device-os/files/3276515/test.diff.txt) via `git apply` and flash the system firmware to a Gen 3 device.
2. Flash an incompatible user part to the device to make it enter the safe mode (it's not enough to put the device into safe mode via the bootloader).
3. Put the device into listening mode, open the serial console and press `t`.
4. Verify that `total_init_heap` is larger than `freeheap` and `user_static_ram` is 0.

### References

- [ch34131]

---

- [bugfix] [gen 3] fixes memory usage diagnostics (reported negative values in safe mode) [#1819](https://github.com/particle-iot/device-os/pull/1819)