### PR TITLE
fixes #1811 - increases the number of event handlers to 6 to accommod…

### DIFF
--- a/communication/src/core_protocol.h
+++ b/communication/src/core_protocol.h
@@ -235,7 +235,7 @@ class CoreProtocol
     unsigned char core_private_key[MAX_DEVICE_PRIVATE_KEY_LENGTH];
     aes_context aes;
 
-    FilteringEventHandler event_handlers[5];    // 1 system event listener + 4 application event listeners
+    FilteringEventHandler event_handlers[MAX_SUBSCRIPTIONS];
     SparkCallbacks callbacks;
     SparkDescriptor descriptor;
 

--- a/communication/src/protocol_defs.h
+++ b/communication/src/protocol_defs.h
@@ -18,6 +18,8 @@ namespace particle { namespace protocol {
 #define PRODUCT_FIRMWARE_VERSION (0xffff)
 #endif
 
+#define MAX_SUBSCRIPTIONS (6)       // 2 system and 4 application
+
 enum ProtocolError
 {
     /* 00 */ NO_ERROR,

--- a/communication/src/subscriptions.h
+++ b/communication/src/subscriptions.h
@@ -35,7 +35,7 @@ public:
 	typedef uint32_t (*calculate_crc_fn)(const unsigned char *buf, uint32_t buflen);
 
 private:
-	FilteringEventHandler event_handlers[5];
+	FilteringEventHandler event_handlers[MAX_SUBSCRIPTIONS];
 
 protected:
 

--- a/communication/tests/catch/protocol.cpp
+++ b/communication/tests/catch/protocol.cpp
@@ -66,11 +66,11 @@ void event_handler(const char* event, const char* data)
 {
 }
 
-SCENARIO("5 subscribe messages are registered")
+SCENARIO("6 subscribe messages are registered")
 {
 	MessageChannel* channel = nullptr;
 	AbstractProtocol p(*channel);	// channel is not used
-	for (int i=0; i<5; i++) {
+	for (int i=0; i<6; i++) {
 		INFO("adding event " << i);
 		char buf[2];
 		buf[1] = 0;


### PR DESCRIPTION
## This PR should be cherry picked into another PR based on `release/1.2.1` as well.

### Problem

See #1811

### Solution

The number of event handlers is fixed and these are shared between application and system event handlers.  We recently added a new system handler for `particle` events, which took one slot away from applications.  The fix is to increase the number of event handler slots by 1. 

The PR also centralizes the maximum number of event handlers. 



### References

- #1811 

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [x] Added to CHANGELOG.md after merging (add links to docs and issues)

---

- [bugfix] fixes #1811 - increases the number of event handlers to 6 [#1822](https://github.com/particle-iot/device-os/pull/1822)