### PR TITLE
[gen2] hal: Fixes I2C bus missing stretch configuration

### DIFF
--- a/hal/src/stm32f2xx/i2c_hal.c
+++ b/hal/src/stm32f2xx/i2c_hal.c
@@ -1026,6 +1026,9 @@ static void HAL_I2C_EV_InterruptHandler(HAL_I2C_Interface i2c)
             // the device will continue pulling SCL low. To avoid that, disable clock stretching
             // when the tx buffer is exhausted to release SCL.
             I2C_StretchClockCmd(i2cMap[i2c]->I2C_Peripheral, DISABLE);
+            __DSB();
+            __ISB();
+            I2C_StretchClockCmd(i2cMap[i2c]->I2C_Peripheral, i2cMap[i2c]->clkStretchingEnabled ? ENABLE : DISABLE);
         }
         break;
 

--- a/user/tests/wiring/i2c_master_slave/i2c_master/i2c_master.cpp
+++ b/user/tests/wiring/i2c_master_slave/i2c_master/i2c_master.cpp
@@ -110,24 +110,27 @@ test(I2C_Master_Slave_Master_Variable_Length_Transfer_Slave_Tx_Buffer_Underflow)
         if (requestedLength == 0)
             break;
 
-        // Now read out requestedLength bytes
-        memset(I2C_Master_Rx_Buffer, 0, sizeof(I2C_Master_Rx_Buffer));
-        USE_WIRE.requestFrom(I2C_ADDRESS, requestedLength + (requestedLength & 0x01));
-        if (USE_WIRE.available() != 0) {
-            assertEqual(requestedLength + (requestedLength & 0x01), USE_WIRE.available());
+        // Now read out requestedLength bytes a couple of times
+        int count = random(4, 20);
+        while (count--) {
+            memset(I2C_Master_Rx_Buffer, 0, sizeof(I2C_Master_Rx_Buffer));
+            USE_WIRE.requestFrom(I2C_ADDRESS, requestedLength + (requestedLength & 0x01));
+            if (USE_WIRE.available() != 0) {
+                assertEqual(requestedLength + (requestedLength & 0x01), USE_WIRE.available());
 
-            uint32_t count = 0;
-            while(USE_WIRE.available()) {
-                I2C_Master_Rx_Buffer[count++] = USE_WIRE.read();
+                uint32_t count = 0;
+                while(USE_WIRE.available()) {
+                    I2C_Master_Rx_Buffer[count++] = USE_WIRE.read();
+                }
+                // Serial.print("< ");
+                // Serial.println((const char *)I2C_Master_Rx_Buffer);
+                assertTrue(strncmp((const char *)I2C_Master_Rx_Buffer, SLAVE_TEST_MESSAGE_2, requestedLength) == 0);
+            } else if (requestedLength & 0x01) {
+                Serial.println("Error reading from Slave, checking if we can recover");
+            } else {
+                Serial.println("Failed to recover");
+                assertTrue(false);
             }
-            // Serial.print("< ");
-            // Serial.println((const char *)I2C_Master_Rx_Buffer);
-            assertTrue(strncmp((const char *)I2C_Master_Rx_Buffer, SLAVE_TEST_MESSAGE_2, requestedLength) == 0);
-        } else if (requestedLength & 0x01) {
-            Serial.println("Error reading from Slave, checking if we can recover");
-        } else {
-            Serial.println("Failed to recover");
-            assertTrue(false);
         }
 
         requestedLength--;


### PR DESCRIPTION
### Problem

This PR is a proposed solution for issue #1809 , we found when Gen2 device acts as an I2C slave device, it will send an extra address byte before its data bytes. This is because the stretch configuration is disabled after a transmission. 
```
    /* Check on EV3 */
    case I2C_EVENT_SLAVE_BYTE_TRANSMITTING:
    case I2C_EVENT_SLAVE_BYTE_TRANSMITTED:
        if (i2cMap[i2c]->txBufferIndex < i2cMap[i2c]->txBufferLength)
        {
            I2C_SendData(i2cMap[i2c]->I2C_Peripheral, i2cMap[i2c]->txBuffer[i2cMap[i2c]->txBufferIndex++]);
        }
        else
        {
            // If no data is loaded into DR register and clock stretching is enabled,
            // the device will continue pulling SCL low. To avoid that, disable clock stretching
            // when the tx buffer is exhausted to release SCL.
            I2C_StretchClockCmd(i2cMap[i2c]->I2C_Peripheral, DISABLE); 👈👈👈
        }
        break;
```

Even though the configuration is restored in I2C slave event handler when detecting the STOP signal. However, for some user scenario, they will continue to occupy the I2C bus without sending a STOP signal, e.g. our example app. In this case, the restore operation is missed.
```
    /* EV4 */
    if (sr1 & I2C_EVENT_SLAVE_STOP_DETECTED)
    {
        /* software sequence to clear STOPF */
        I2C_GetFlagStatus(i2cMap[i2c]->I2C_Peripheral, I2C_FLAG_STOPF);
        // Restore clock stretching settings 👈👈👈
        // This will also clear EV4
        I2C_StretchClockCmd(i2cMap[i2c]->I2C_Peripheral, i2cMap[i2c]->clkStretchingEnabled ? ENABLE : DISABLE);   
...
``` 

Can we restore stretch configuration once entering the slave event handler?
No, it's too late to enable the configuration in the event callback.

### Solution
I don't know the background of this workaround, I propose to release the I2C bus for a very short time to wait for I2C master capturing it, and then restore stretch configuration.
```
// If no data is loaded into DR register and clock stretching is enabled,
// the device will continue pulling SCL low. To avoid that, disable clock stretching
// when the tx buffer is exhausted to release SCL.
```

### Steps to Test
1. Flash example app on Gen3 device, set `MASTER` to 1, use it as an I2C master.
2. Flash example app on Gen2 device, set `MASTER` to 0 use it as an I2C slave.
3. Type `1` to request 6 bytes from I2C slave via Serial on I2C master device.

### Example App

```c
#include "application.h"

#define MASTER 0
#define speed 100000
#define SLAVE_ADDRESS 0x18

SYSTEM_MODE(MANUAL);

#if MASTER
int sendData(String cmd) {
   for (int i = 0; i < 1; ++i) {
        uint8_t count = Wire.requestFrom(SLAVE_ADDRESS, 6);
        // delay(10); // doesn't change anything
        while(Wire.available()) {
            char c = Wire.read();
            Serial.print(c);
        }
        Serial.println();
    }
    return 0;
}

void setup() {
    Serial.begin(115200);
    // Particle.function("sendData", sendData);
    //Wire.setSpeed(speed); // optional but same result
    Wire.begin();
}

void loop() {
    if (Serial.available()) {
        uint8_t cmd = Serial.read();
        switch(cmd) {
            case '1': {
                Serial.print("send hello");
                sendData("hello");
                break;
            }
            default:
                break;
        }
    }
}

#else 
void requestEvent() {
    Wire.print("456789");
}

void setup() {  
    //Wire.setSpeed(speed); // optional but same result
    Wire.begin(SLAVE_ADDRESS);    
    Wire.onRequest(requestEvent);
}
#endif

```

### References

[CH34361]

---

### Completeness

- [bugfix] [Gen 2] Fixes an issue with clock stretching in I2C slave mode with underrun reads with certain I2C masters (e.g. Gen 3 devices)
