### PR TITLE
Cancel network connection when processing a USB request that resets the device

### DIFF
--- a/user/tests/unit/stubs/system_cloud.cpp
+++ b/user/tests/unit/stubs/system_cloud.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2019 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "system_cloud.h"
+
+void Spark_Abort() {
+}

--- a/user/tests/unit/stubs/system_network.cpp
+++ b/user/tests/unit/stubs/system_network.cpp
@@ -46,3 +46,7 @@ void network_set_listen_timeout(network_handle_t network, uint16_t timeout, void
 uint16_t network_get_listen_timeout(network_handle_t network, uint32_t flags, void* reserved) {
     return 0;
 }
+
+int network_connect_cancel(network_handle_t network, uint32_t flags, uint32_t param, void* reserved) {
+    return 0;
+}


### PR DESCRIPTION
### Problem

Control requests are normally processed in the system thread, and if the thread is blocked on some operation, a request may time out. This is especially noticeable on Gen 2 platforms where networking events are processed in the system thread and such CLI commands as `usb reset` and `usb dfu` are likely to fail when the device is trying to establish a network or cloud connection.

### Solution

Cancel the current network connection attempt and break the communication loop when processing a USB request that causes the device to reset (`CTRL_REQUEST_RESET`, `CTRL_REQUEST_DFU_MODE`, etc.)

### Steps to Test

Verify that the CLI is able to reset an Electron when it's blinking green and registering in the network.
