### PR TITLE
Exports part of mbedtls to the user application

### DIFF
--- a/hal/src/nRF52840/mbedtls/sha1_alt_cc310.c
+++ b/hal/src/nRF52840/mbedtls/sha1_alt_cc310.c
@@ -79,4 +79,28 @@ int mbedtls_internal_sha1_process( mbedtls_sha1_context *ctx,
     return mbedtls_sha1_update_ret( ctx, data, 64 );
 }
 
+void mbedtls_sha1_process( mbedtls_sha1_context *ctx,
+                           const unsigned char data[64] )
+{
+    mbedtls_internal_sha1_process( ctx, data );
+}
+
+void mbedtls_sha1_starts( mbedtls_sha1_context *ctx )
+{
+    mbedtls_sha1_starts_ret( ctx );
+}
+
+void mbedtls_sha1_update( mbedtls_sha1_context *ctx,
+                          const unsigned char *input,
+                          size_t ilen )
+{
+    mbedtls_sha1_update_ret( ctx, input, ilen );
+}
+
+void mbedtls_sha1_finish( mbedtls_sha1_context *ctx,
+                          unsigned char output[20] )
+{
+    mbedtls_sha1_finish_ret( ctx, output );
+}
+
 #endif // MBEDTLS_SHA1_ALT

--- a/modules/argon/system-part1/module_system_part1_export.ld
+++ b/modules/argon/system-part1/module_system_part1_export.ld
@@ -43,3 +43,4 @@ PROVIDE ( dynalib_location_hal_resolvapi = system_part1_module_table + 88 );
 PROVIDE ( dynalib_location_hal_wlan = system_part1_module_table + 92 );
 PROVIDE ( dynalib_location_hal_ble = system_part1_module_table + 96 );
 PROVIDE ( dynalib_location_hal_nfc = system_part1_module_table + 100 );
+PROVIDE ( dynalib_location_crypto = system_part1_module_table + 104 );

--- a/modules/argon/system-part1/src/export_crypto.c
+++ b/modules/argon/system-part1/src/export_crypto.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2019 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define DYNALIB_EXPORT
+#include "crypto_dynalib.h"

--- a/modules/argon/user-part/makefile
+++ b/modules/argon/user-part/makefile
@@ -9,13 +9,13 @@ PLATFORM_DFU_LEAVE = y
 export COMPILE_LTO=n
 
 # communication used only for header declarations
-DEPENDENCIES = user dynalib services services-dynalib hal hal-dynalib system system-dynalib rt-dynalib wiring communication-dynalib modules/argon/system-part1 platform wiring_globals
-MAKE_DEPENDENCIES = user hal-dynalib services-dynalib system-dynalib rt-dynalib wiring communication-dynalib platform wiring_globals
+DEPENDENCIES = user dynalib services services-dynalib hal hal-dynalib system system-dynalib rt-dynalib wiring communication-dynalib modules/argon/system-part1 platform wiring_globals crypto-dynalib
+MAKE_DEPENDENCIES = user hal-dynalib services-dynalib system-dynalib rt-dynalib wiring communication-dynalib platform wiring_globals crypto-dynalib
 include ../modular.mk
 include $(PROJECT_ROOT)/build/platform-id.mk
 
 LIBS += $(MAKE_DEPENDENCIES)
-LIB_DEPS += $(USER_LIB_DEP) $(SERVICES_DYNALIB_LIB_DEP) $(HAL_DYNALIB_LIB_DEP) $(SYSTEM_DYNALIB_LIB_DEP) $(RT_DYNALIB_LIB_DEP) $(WIRING_LIB_DEP) $(COMMUNICATION_DYNALIB_LIB_DEP) $(PLATFORM_LIB_DEP) $(WIRING_GLOBALS_LIB_DEP)
+LIB_DEPS += $(USER_LIB_DEP) $(SERVICES_DYNALIB_LIB_DEP) $(HAL_DYNALIB_LIB_DEP) $(SYSTEM_DYNALIB_LIB_DEP) $(RT_DYNALIB_LIB_DEP) $(WIRING_LIB_DEP) $(COMMUNICATION_DYNALIB_LIB_DEP) $(PLATFORM_LIB_DEP) $(WIRING_GLOBALS_LIB_DEP) $(CRYPTO_DYNALIB_LIB_DEP)
 LIB_DIRS += $(dir $(LIB_DEPS))
 
 

--- a/modules/boron/system-part1/module_system_part1_export.ld
+++ b/modules/boron/system-part1/module_system_part1_export.ld
@@ -43,3 +43,4 @@ PROVIDE ( dynalib_location_hal_resolvapi = system_part1_module_table + 88 );
 PROVIDE ( dynalib_location_hal_cellular = system_part1_module_table + 92 );
 PROVIDE ( dynalib_location_hal_ble = system_part1_module_table + 96 );
 PROVIDE ( dynalib_location_hal_nfc = system_part1_module_table + 100 );
+PROVIDE ( dynalib_location_crypto = system_part1_module_table + 104 );

--- a/modules/boron/system-part1/src/export_crypto.c
+++ b/modules/boron/system-part1/src/export_crypto.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2019 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define DYNALIB_EXPORT
+#include "crypto_dynalib.h"

--- a/modules/boron/user-part/makefile
+++ b/modules/boron/user-part/makefile
@@ -9,13 +9,13 @@ PLATFORM_DFU_LEAVE = y
 export COMPILE_LTO=n
 
 # communication used only for header declarations
-DEPENDENCIES = user dynalib services services-dynalib hal hal-dynalib system system-dynalib rt-dynalib wiring communication-dynalib modules/boron/system-part1 platform wiring_globals
-MAKE_DEPENDENCIES = user hal-dynalib services-dynalib system-dynalib rt-dynalib wiring communication-dynalib platform wiring_globals
+DEPENDENCIES = user dynalib services services-dynalib hal hal-dynalib system system-dynalib rt-dynalib wiring communication-dynalib modules/boron/system-part1 platform wiring_globals crypto-dynalib
+MAKE_DEPENDENCIES = user hal-dynalib services-dynalib system-dynalib rt-dynalib wiring communication-dynalib platform wiring_globals crypto-dynalib
 include ../modular.mk
 include $(PROJECT_ROOT)/build/platform-id.mk
 
 LIBS += $(MAKE_DEPENDENCIES)
-LIB_DEPS += $(USER_LIB_DEP) $(SERVICES_DYNALIB_LIB_DEP) $(HAL_DYNALIB_LIB_DEP) $(SYSTEM_DYNALIB_LIB_DEP) $(RT_DYNALIB_LIB_DEP) $(WIRING_LIB_DEP) $(COMMUNICATION_DYNALIB_LIB_DEP) $(PLATFORM_LIB_DEP) $(WIRING_GLOBALS_LIB_DEP)
+LIB_DEPS += $(USER_LIB_DEP) $(SERVICES_DYNALIB_LIB_DEP) $(HAL_DYNALIB_LIB_DEP) $(SYSTEM_DYNALIB_LIB_DEP) $(RT_DYNALIB_LIB_DEP) $(WIRING_LIB_DEP) $(COMMUNICATION_DYNALIB_LIB_DEP) $(PLATFORM_LIB_DEP) $(WIRING_GLOBALS_LIB_DEP) $(CRYPTO_DYNALIB_LIB_DEP)
 LIB_DIRS += $(dir $(LIB_DEPS))
 
 

--- a/modules/electron/user-part/makefile
+++ b/modules/electron/user-part/makefile
@@ -7,13 +7,13 @@ PLATFORM_DFU = $(USER_FIRMWARE_IMAGE_LOCATION)
 PLATFORM_DFU_LEAVE = y
 
 # communication used only for header declarations
-DEPENDENCIES = user dynalib services services-dynalib hal hal-dynalib system system-dynalib rt-dynalib wiring communication-dynalib modules/electron/system-part1 modules/electron/system-part2 modules/electron/system-part3 platform wiring_globals
-MAKE_DEPENDENCIES = user hal-dynalib services-dynalib system-dynalib rt-dynalib wiring communication-dynalib platform wiring_globals
+DEPENDENCIES = user dynalib services services-dynalib hal hal-dynalib system system-dynalib rt-dynalib wiring communication-dynalib modules/electron/system-part1 modules/electron/system-part2 modules/electron/system-part3 platform wiring_globals crypto-dynalib
+MAKE_DEPENDENCIES = user hal-dynalib services-dynalib system-dynalib rt-dynalib wiring communication-dynalib platform wiring_globals crypto-dynalib
 include ../modular.mk
 include $(PROJECT_ROOT)/build/platform-id.mk
 
 LIBS += $(MAKE_DEPENDENCIES)
-LIB_DEPS += $(USER_LIB_DEP) $(SERVICES_DYNALIB_LIB_DEP) $(HAL_DYNALIB_LIB_DEP) $(SYSTEM_DYNALIB_LIB_DEP) $(RT_DYNALIB_LIB_DEP) $(WIRING_LIB_DEP) $(COMMUNICATION_DYNALIB_LIB_DEP) $(PLATFORM_LIB_DEP) $(WIRING_GLOBALS_LIB_DEP)
+LIB_DEPS += $(USER_LIB_DEP) $(SERVICES_DYNALIB_LIB_DEP) $(HAL_DYNALIB_LIB_DEP) $(SYSTEM_DYNALIB_LIB_DEP) $(RT_DYNALIB_LIB_DEP) $(WIRING_LIB_DEP) $(COMMUNICATION_DYNALIB_LIB_DEP) $(PLATFORM_LIB_DEP) $(WIRING_GLOBALS_LIB_DEP) $(CRYPTO_DYNALIB_LIB_DEP)
 LIB_DIRS += $(dir $(LIB_DEPS))
 
 

--- a/modules/photon/user-part/makefile
+++ b/modules/photon/user-part/makefile
@@ -9,13 +9,13 @@ PLATFORM_DFU_LEAVE = y
 export COMPILE_LTO=n
 
 # communication used only for header declarations
-DEPENDENCIES = user dynalib services services-dynalib hal hal-dynalib system system-dynalib rt-dynalib wiring communication-dynalib modules/photon/system-part1 modules/photon/system-part2 platform wiring_globals
-MAKE_DEPENDENCIES = user hal-dynalib services-dynalib system-dynalib rt-dynalib wiring communication-dynalib platform wiring_globals
+DEPENDENCIES = user dynalib services services-dynalib hal hal-dynalib system system-dynalib rt-dynalib wiring communication-dynalib modules/photon/system-part1 modules/photon/system-part2 platform wiring_globals crypto-dynalib
+MAKE_DEPENDENCIES = user hal-dynalib services-dynalib system-dynalib rt-dynalib wiring communication-dynalib platform wiring_globals crypto-dynalib
 include ../modular.mk
 include $(PROJECT_ROOT)/build/platform-id.mk
 
 LIBS += $(MAKE_DEPENDENCIES)
-LIB_DEPS += $(USER_LIB_DEP) $(SERVICES_DYNALIB_LIB_DEP) $(HAL_DYNALIB_LIB_DEP) $(SYSTEM_DYNALIB_LIB_DEP) $(RT_DYNALIB_LIB_DEP) $(WIRING_LIB_DEP) $(COMMUNICATION_DYNALIB_LIB_DEP) $(PLATFORM_LIB_DEP) $(WIRING_GLOBALS_LIB_DEP)
+LIB_DEPS += $(USER_LIB_DEP) $(SERVICES_DYNALIB_LIB_DEP) $(HAL_DYNALIB_LIB_DEP) $(SYSTEM_DYNALIB_LIB_DEP) $(RT_DYNALIB_LIB_DEP) $(WIRING_LIB_DEP) $(COMMUNICATION_DYNALIB_LIB_DEP) $(PLATFORM_LIB_DEP) $(WIRING_GLOBALS_LIB_DEP) $(CRYPTO_DYNALIB_LIB_DEP)
 LIB_DEPS += $(PROJECT_ROOT)/hal/src/photon/lib/STM32F2xx_Peripheral_Libraries.a
 LIB_DIRS += $(dir $(LIB_DEPS))
 

--- a/modules/shared/nRF52840/inc/system-part1/module_system_part1.inc
+++ b/modules/shared/nRF52840/inc/system-part1/module_system_part1.inc
@@ -46,6 +46,7 @@ DYNALIB_TABLE_EXTERN(hal_ble);
 #if HAL_PLATFORM_NFC
 DYNALIB_TABLE_EXTERN(hal_nfc);
 #endif // HAL_PLATFORM_NFC
+DYNALIB_TABLE_EXTERN(crypto);
 
 // strange that this is needed given that the entire block is scoped extern "C"
 // without it, the section name doesn't match *.system_part2_module as expected in the linker script
@@ -91,6 +92,7 @@ extern "C" __attribute__((externally_visible)) const void* const system_part1_mo
 #if HAL_PLATFORM_NFC
     , DYNALIB_TABLE_NAME(hal_nfc)
 #endif // HAL_PLATFORM_NFC
+    , DYNALIB_TABLE_NAME(crypto)
 };
 
 #include "system_part1_loader.c"

--- a/modules/xenon/system-part1/module_system_part1_export.ld
+++ b/modules/xenon/system-part1/module_system_part1_export.ld
@@ -42,3 +42,4 @@ PROVIDE ( dynalib_location_hal_ifapi = system_part1_module_table + 84 );
 PROVIDE ( dynalib_location_hal_resolvapi = system_part1_module_table + 88 );
 PROVIDE ( dynalib_location_hal_ble = system_part1_module_table + 92 );
 PROVIDE ( dynalib_location_hal_nfc = system_part1_module_table + 96 );
+PROVIDE ( dynalib_location_crypto = system_part1_module_table + 100 );

--- a/modules/xenon/system-part1/src/export_crypto.c
+++ b/modules/xenon/system-part1/src/export_crypto.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2019 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define DYNALIB_EXPORT
+#include "crypto_dynalib.h"

--- a/modules/xenon/user-part/makefile
+++ b/modules/xenon/user-part/makefile
@@ -9,13 +9,13 @@ PLATFORM_DFU_LEAVE = y
 export COMPILE_LTO=n
 
 # communication used only for header declarations
-DEPENDENCIES = user dynalib services services-dynalib hal hal-dynalib system system-dynalib rt-dynalib wiring communication-dynalib modules/xenon/system-part1 platform wiring_globals
-MAKE_DEPENDENCIES = user hal-dynalib services-dynalib system-dynalib rt-dynalib wiring communication-dynalib platform wiring_globals
+DEPENDENCIES = user dynalib services services-dynalib hal hal-dynalib system system-dynalib rt-dynalib wiring communication-dynalib modules/xenon/system-part1 platform wiring_globals crypto-dynalib
+MAKE_DEPENDENCIES = user hal-dynalib services-dynalib system-dynalib rt-dynalib wiring communication-dynalib platform wiring_globals crypto-dynalib
 include ../modular.mk
 include $(PROJECT_ROOT)/build/platform-id.mk
 
 LIBS += $(MAKE_DEPENDENCIES)
-LIB_DEPS += $(USER_LIB_DEP) $(SERVICES_DYNALIB_LIB_DEP) $(HAL_DYNALIB_LIB_DEP) $(SYSTEM_DYNALIB_LIB_DEP) $(RT_DYNALIB_LIB_DEP) $(WIRING_LIB_DEP) $(COMMUNICATION_DYNALIB_LIB_DEP) $(PLATFORM_LIB_DEP) $(WIRING_GLOBALS_LIB_DEP)
+LIB_DEPS += $(USER_LIB_DEP) $(SERVICES_DYNALIB_LIB_DEP) $(HAL_DYNALIB_LIB_DEP) $(SYSTEM_DYNALIB_LIB_DEP) $(RT_DYNALIB_LIB_DEP) $(WIRING_LIB_DEP) $(COMMUNICATION_DYNALIB_LIB_DEP) $(PLATFORM_LIB_DEP) $(WIRING_GLOBALS_LIB_DEP) $(CRYPTO_DYNALIB_LIB_DEP)
 LIB_DIRS += $(dir $(LIB_DEPS))
 
 
@@ -55,4 +55,3 @@ $(TARGET_BASE)_fi.elf: $(ALLOBJ) $(LIB_DEPS) $(LINKER_DEPS) $(TARGET_BASE).elf $
 	$(call echo,)
 
 .PHONY: elf_fi
-


### PR DESCRIPTION
### Problem

We'd like to have access to mbedTLS functions available in system-firmware from user application in certain cases.

### Solution

This PR exports crypto dynalib from system side and imports it from the user part.

### Steps to Test

TODO

### Example App

TODO

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
