### PR TITLE
[gen3] hal: change wakeup pin for SoM boards

### DIFF
--- a/hal/inc/pinmap_hal.h
+++ b/hal/inc/pinmap_hal.h
@@ -228,7 +228,11 @@ STM32_Pin_Info* HAL_Pin_Map(void);
 #endif
 
 // WKP pin
+#if PLATFORM_ID == PLATFORM_XSOM || PLATFORM_ID == PLATFORM_ASOM || PLATFORM_ID == PLATFORM_BSOM
+#define WKP             A7
+#else
 #define WKP             D8
+#endif
 
 #if PLATFORM_ID == PLATFORM_XENON // Xenon
 #define TOTAL_PINS      (31)


### PR DESCRIPTION
### Problem

By default, D8 pin is the wakeup pin, but D8 pin is also used by Ethernet on BSoM EVB, when BSoM enters deep sleep mode, it will be woken up accidentally.

### Solution

Change wakeup pin from D8 to A7 on SoM boards.

### Steps to Test

N/A

### Example App
N/A

### References

[CH34764]

---

### Completeness

- [internal] [Gen3] Changes WKP pin to A7 for SoM platforms to avoid an overlap with Ethernet chip on EVB
