### PR TITLE
[Gen 3] Fixes mesh pub/sub socket consuming all packet buffers

### DIFF
--- a/hal/src/nRF52840/lwip/lwipopts.h
+++ b/hal/src/nRF52840/lwip/lwipopts.h
@@ -650,7 +650,7 @@ void sys_unlock_tcpip_core(void);
  * IP_MULTICAST_TTL/IP_MULTICAST_IF/IP_MULTICAST_LOOP, as well as (currently only)
  * core support for the corresponding IPv6 options.
  */
-// #define LWIP_MULTICAST_TX_OPTIONS       ((LWIP_IGMP || LWIP_IPV6_MLD) && (LWIP_UDP || LWIP_RAW))
+#define LWIP_MULTICAST_TX_OPTIONS       ((LWIP_IGMP || LWIP_IPV6_MLD) && (LWIP_UDP || LWIP_RAW))
 
 /*
    ----------------------------------

--- a/user/tests/wiring/no_fixture/mesh.cpp
+++ b/user/tests/wiring/no_fixture/mesh.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2019 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "application.h"
+#include "unit-test/unit-test.h"
+#include "random.h"
+
+#if Wiring_Mesh
+
+test(MESH_01_PublishWithoutSubscribeStillReadsDataOutOfPubSubSocket) {
+    static const constexpr unsigned MAX_ITERATIONS = 1000;
+
+    assertTrue(network_has_credentials(NETWORK_INTERFACE_MESH, 0, nullptr));
+
+    // Make sure the device is a known (deinitialized) state
+    Mesh.uninitializeUdp();
+
+    // This creates a pubsub socket
+    Mesh.publish("test", "123");
+
+    // Bombard ourselves
+    std::unique_ptr<UDP> udp(new UDP());
+    assertTrue((bool)udp);
+
+    assertTrue(udp->setBuffer(MeshPublish::MAX_PACKET_LEN));
+    // Get OpenThread interface index (interface is named "th1" on all Mesh devices)
+    uint8_t idx = 0;
+    assertEqual(if_name_to_index("th1", &idx), (int)SYSTEM_ERROR_NONE);
+    // Create UDP socket and bind to OpenThread interface
+    assertTrue((bool)udp->begin(0, idx));
+
+    // Enable multicast loop option
+    uint8_t loop = 1;
+    assertTrue(sock_setsockopt(udp->socket(), IPPROTO_IP, IP_MULTICAST_LOOP, &loop, sizeof(loop)) == 0);
+
+    IPAddress addr;
+    // Localhost
+    addr.raw().v = 6;
+    assertEqual(inet_inet_pton(AF_INET6, MeshPublish::MULTICAST_ADDR, addr.raw().ipv6), 1);
+
+    Random rng;
+    for (unsigned i = 0; i < MAX_ITERATIONS; i++) {
+        rng.gen((char*)udp->buffer(), MeshPublish::MAX_PACKET_LEN);
+        udp->sendPacket(udp->buffer(), MeshPublish::MAX_PACKET_LEN, addr, MeshPublish::PORT);
+    }
+}
+
+#endif // Wiring_Mesh

--- a/user/tests/wiring/no_fixture/mesh.cpp
+++ b/user/tests/wiring/no_fixture/mesh.cpp
@@ -22,6 +22,8 @@
 #if Wiring_Mesh
 
 test(MESH_01_PublishWithoutSubscribeStillReadsDataOutOfPubSubSocket) {
+    // https://github.com/particle-iot/device-os/issues/1828
+
     static const constexpr unsigned MAX_ITERATIONS = 1000;
 
     assertTrue(network_has_credentials(NETWORK_INTERFACE_MESH, 0, nullptr));
@@ -52,11 +54,15 @@ test(MESH_01_PublishWithoutSubscribeStillReadsDataOutOfPubSubSocket) {
     addr.raw().v = 6;
     assertEqual(inet_inet_pton(AF_INET6, MeshPublish::MULTICAST_ADDR, addr.raw().ipv6), 1);
 
+    // Send a number of random data packets
     Random rng;
     for (unsigned i = 0; i < MAX_ITERATIONS; i++) {
         rng.gen((char*)udp->buffer(), MeshPublish::MAX_PACKET_LEN);
         udp->sendPacket(udp->buffer(), MeshPublish::MAX_PACKET_LEN, addr, MeshPublish::PORT);
     }
+
+    // Ensure that packet buffers were freed correctly by simply sending a cloud publish
+    assertTrue((bool)Particle.publish("test", "123", WITH_ACK));
 }
 
 #endif // Wiring_Mesh

--- a/wiring/inc/spark_wiring_mesh.h
+++ b/wiring/inc/spark_wiring_mesh.h
@@ -72,10 +72,19 @@ public:
     }
 };
 
-
-int mesh_loop();
-
 class MeshPublish {
+public:
+    MeshPublish() : exit_(false) {
+        // System thread gets blocked while connecting to cloud, while it's connecting to it
+        // RX packet buffer pool may easily get exhausted, because nobody is reading the data
+        // out of the socket. Create a separate thread here with a higher priority than application
+        // and system.
+    }
+
+    int publish(const char* topic, const char* data = nullptr);
+
+    int subscribe(const char* prefix, EventHandler handler);
+
 private:
     class Subscriptions {
         FilteringEventHandler event_handlers[5];
@@ -99,41 +108,21 @@ private:
         void send(const char* event_name, const char* data);
     };
 
-
     static const uint16_t PORT = 36969;
     static constexpr const char* MULTICAST_ADDR = "ff03::1:1001";
     static const uint16_t MAX_PACKET_LEN = 1232;
 
-    std::unique_ptr<UDP> udp;
-    Subscriptions subscriptions;
-
     static int fetchMulticastAddress(IPAddress& mcastAddr);
+    int initializeUdp();
+    int uninitializeUdp();
+    int poll();
 
-    int initialize_udp();
-
-    int uninitialize_udp();
-
+    std::unique_ptr<UDP> udp_;
+    Subscriptions subscriptions_;
     std::unique_ptr<Thread> thread_;
     RecursiveMutex mutex_;
     std::unique_ptr<uint8_t[]> buffer_;
-
-public:
-
-    MeshPublish() : udp(nullptr) {
-        // System thread gets blocked while connecting to cloud, while it's connecting to it
-        // RX packet buffer pool may easily get exhausted, because nobody is reading the data
-        // out of the socket. Create a separate thread here with a higher priority than application
-        // and system.
-    }
-
-    int publish(const char* topic, const char* data = nullptr);
-
-    int subscribe(const char* prefix, EventHandler handler);
-
-    /**
-     * Pull data from the socket and handle as required.
-     */
-    int poll();
+    std::atomic_bool exit_;
 };
 
 class MeshClass : public NetworkClass, public MeshPublish {

--- a/wiring/inc/spark_wiring_mesh.h
+++ b/wiring/inc/spark_wiring_mesh.h
@@ -85,6 +85,13 @@ public:
 
     int subscribe(const char* prefix, EventHandler handler);
 
+    // This shouldn't be public, but we use it in tests
+    int uninitializeUdp();
+
+    static const uint16_t PORT = 36969;
+    static constexpr const char* MULTICAST_ADDR = "ff03::1:1001";
+    static const uint16_t MAX_PACKET_LEN = 1232;
+
 private:
     class Subscriptions {
         FilteringEventHandler event_handlers[5];
@@ -108,13 +115,8 @@ private:
         void send(const char* event_name, const char* data);
     };
 
-    static const uint16_t PORT = 36969;
-    static constexpr const char* MULTICAST_ADDR = "ff03::1:1001";
-    static const uint16_t MAX_PACKET_LEN = 1232;
-
     static int fetchMulticastAddress(IPAddress& mcastAddr);
     int initializeUdp();
-    int uninitializeUdp();
     int poll();
 
     std::unique_ptr<UDP> udp_;

--- a/wiring/inc/spark_wiring_thread.h
+++ b/wiring/inc/spark_wiring_thread.h
@@ -32,6 +32,7 @@
 #include <functional>
 #include <type_traits>
 #include <memory>
+#include "delay_hal.h"
 
 typedef std::function<os_thread_return_t(void)> wiring_thread_fn_t;
 
@@ -103,7 +104,9 @@ public:
             goto error;
         }
         while (!d_->started) {
-            os_thread_yield();
+            // FIXME: This used to be os_thread_yield() but for some unknown reasons sometimes
+            // it doesn't let the new thread to run.
+            HAL_Delay_Milliseconds(1);
         }
         return;
     error:
@@ -125,7 +128,9 @@ public:
             goto error;
         }
         while (!d_->started) {
-            os_thread_yield();
+            // FIXME: This used to be os_thread_yield() but for some unknown reasons sometimes
+            // it doesn't let the new thread to run.
+            HAL_Delay_Milliseconds(1);
         }
         return;
     error:

--- a/wiring/inc/spark_wiring_udp.h
+++ b/wiring/inc/spark_wiring_udp.h
@@ -241,6 +241,13 @@ public:
      */
     int leaveMulticast(const IPAddress& ip);
 
+    /*
+     * Returns the socket handle
+     */
+    sock_handle_t socket() {
+        return _sock;
+    }
+
     using Print::write;
 };
 

--- a/wiring/src/spark_wiring_mesh.cpp
+++ b/wiring/src/spark_wiring_mesh.cpp
@@ -176,11 +176,9 @@ int MeshPublish::uninitializeUdp() {
 
     // Use atomic exit_ as a simple synchronization primitive to ensure thread-safety
     // instead of a mutex here.
-    if (exit_) {
+    if (exit_.exchange(true)) {
         return SYSTEM_ERROR_BUSY;
     }
-
-    exit_ = true;
 
     // NB: This should not be run under a lock
     if (thread_) {


### PR DESCRIPTION
### Problem

See #1828

### Solution

This PR mainly simply starts mesh pub/sub thread that reads the data out of the socket even if only `publish()` is called.

Apart from that it:
1. Refactors/cleans up `MeshPublish` class
2. Provides a workaround for wiring `Thread` class where the thread being started was not given processing time due to `os_thread_yield`
3. Enables mutlicast loop LwIP options which enables on-device testing of mesh pub/sub and adds the `MESH_01_PublishWithoutSubscribeStillReadsDataOutOfPubSubSocket` test.

### Steps to Test

- `wiring/no_fixture`: `MESH_01_PublishWithoutSubscribeStillReadsDataOutOfPubSubSocket`

### Example App

N/A

### References

- Closes #1828 
- [CH35133]

---

### Completeness

- [bugfix] [Gen 3] Fixes mesh pub/sub socket consuming all packet buffers 
