### PR TITLE
fixes RSSI regression on G350 (2G) devices [ch35194]

### DIFF
--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1346,9 +1346,9 @@ bool MDMParser::checkNetStatus(NetStatus* status /*= NULL*/)
         if (RESP_OK != waitFinalResp(_cbCSQ, &_net, CSQ_TIMEOUT)) {
             goto failure;
         }
-        // +CREG, +CGREG, +COPS does not contain <AcT> for G350 devices.
-        // After we are registered to CSD or PSD, populate _net.act with ACT_GSM to ensure
-        // Device Diagnostics and RSSI() API have a RAT for conversion lookup purposes.
+        // +CREG, +CGREG, +COPS do not contain <AcT> for G350 devices.
+        // Force _net.act to ACT_GSM to ensure Device Diagnostics and
+        // RSSI() API's have a RAT for conversion lookup purposes.
         if (_dev.dev == DEV_SARA_G350) {
             _net.act = ACT_GSM;
         }
@@ -1391,6 +1391,13 @@ bool MDMParser::getSignalStrength(NetStatus &status)
         sendFormated("AT+COPS?\r\n");
         if (RESP_OK != waitFinalResp(_cbCOPS, &_net, COPS_TIMEOUT)) {
             goto cleanup;
+        }
+
+        // +CREG, +CGREG, +COPS do not contain <AcT> for G350 devices.
+        // Force _net.act to ACT_GSM to ensure Device Diagnostics and
+        // RSSI() API's have a RAT for conversion lookup purposes.
+        if (_dev.dev == DEV_SARA_G350) {
+            _net.act = ACT_GSM;
         }
 
         sendFormated("AT+CSQ\r\n");
@@ -1453,6 +1460,13 @@ bool MDMParser::getCellularGlobalIdentity(CellularGlobalIdentity& cgi_) {
         cgi_.version = CGI_VERSION_1;
         break;
     }
+    }
+
+    // +CREG, +CGREG, +COPS do not contain <AcT> for G350 devices.
+    // Force _net.act to ACT_GSM to ensure Device Diagnostics and
+    // RSSI() API's have a RAT for conversion lookup purposes.
+    if (_dev.dev == DEV_SARA_G350) {
+        _net.act = ACT_GSM;
     }
 
     // CGI value has been updated successfully

--- a/user/tests/wiring/no_fixture/cellular.cpp
+++ b/user/tests/wiring/no_fixture/cellular.cpp
@@ -142,6 +142,22 @@ test(CELLULAR_06_resolve) {
     assertEqual(addr, 0);
 }
 
+// FIXME: This test is failing on Gen 3 Boron / B SoM as of 1.1.0 or earlier
+test(CELLULAR_07_rssi_is_valid) {
+    connect_to_cloud(6*60*1000);
+    CellularSignal s;
+    for (int x = 0; x < 10; x++) {
+        s = Cellular.RSSI();
+        if (s.rssi < 0) {
+            break;
+        }
+        Serial.println(s);
+        delay(5000);
+    }
+    assertLessOrEqual(s.rssi, -20);
+    assertMoreOrEqual(s.rssi, -150);
+}
+
 #define LOREM "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque ut elit nec mi bibendum mollis. Nam nec nisl mi. Donec dignissim iaculis purus, ut condimentum arcu semper quis. Phasellus efficitur ut arcu ac dignissim. In interdum sem id dictum luctus. Ut nec mattis sem. Nullam in aliquet lacus. Donec egestas nisi volutpat lobortis sodales. Aenean elementum magna ipsum, vitae pretium tellus lacinia eu. Phasellus commodo nisi at quam tincidunt, tempor gravida mauris facilisis. Duis tristique ligula ac pulvinar consectetur. Cras aliquam, leo ut eleifend molestie, arcu odio semper odio, quis sollicitudin metus libero et lorem. Donec venenatis congue commodo. Vivamus mattis elit metus, sed fringilla neque viverra eu. Phasellus leo urna, elementum vel pharetra sit amet, auctor non sapien. Phasellus at justo ac augue rutrum vulputate. In hac habitasse platea dictumst. Pellentesque nibh eros, placerat id laoreet sed, dapibus efficitur augue. Praesent pretium diam ac sem varius fermentum. Nunc suscipit dui risus sed"
 
 test(MDM_01_socket_writes_with_length_more_than_1023_work_correctly) {


### PR DESCRIPTION
# This PR also needs to be cherry-picked to `release/v1.2.1` for the 1.2.1 default release.

### Problem

A regression in the Cellular.RSSI() API was introduced in Device OS 1.2.0-rc.1 PR #1779 where the G350 RSSI functionality was broken.

### Solution

Forces ACT_GSM for G350 in functions that query AT+COPS?

### Steps to Test

- Run new test CELLULAR_07_rssi_is_valid in TEST=wiring/no_fixture
- Try pressing the MODE button on G350 one time to see Signal Strength indicated in "Bars" flashed with a green LED.  With 1.2.0-rc.1 / 1.2.1-rc.3 / 1.3.0-rc.1, the G350 will NOT flash 1-5 blips of the green LED.  With this PR it should at least flash 1 green blip, if not more.

### References

https://community.particle.io/t/no-signal-strength-information-for-electron-2g-on-device-os-1-0-0/47460/16

### Known Issues

With the added test CELLULAR_07_rssi_is_valid, it became clear that on Gen 3 devices Boron & B SoM, the Cellular.RSSI() API was not implemented correctly and needs to be fixed.  This will be fixed in a future PR to reduce risk to this fix which will make its way into 1.2.1 default without a 1.2.1-rc.4.

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [N/A] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)

---

- [bugfix] fixes RSSI regression on G350 (2G) devices [#1841](https://github.com/particle-iot/device-os/pull/1841)