### PR TITLE
Fixes boot issue for Core introduced in 1.2.1-rc.3

### DIFF
--- a/hal/src/core/ota_flash_hal.c
+++ b/hal/src/core/ota_flash_hal.c
@@ -69,10 +69,16 @@ int HAL_FLASH_OTA_Validate(hal_module_t* mod, bool userDepsOptional, module_vali
   return 0;
 }
 
-hal_update_complete_t HAL_FLASH_ApplyPendingUpdate(hal_module_t* module, bool dryRun, void* reserved)
+hal_update_complete_t HAL_FLASH_End(hal_module_t* reserved)
 {
     FLASH_End();
     return HAL_UPDATE_APPLIED_PENDING_RESTART;
+}
+
+hal_update_complete_t HAL_FLASH_ApplyPendingUpdate(hal_module_t* module, bool dryRun, void* reserved)
+{
+    // Not implemented for Core
+    return HAL_UPDATE_ERROR;
 }
 
 void HAL_FLASH_Read_ServerAddress(ServerAddress* server_addr)


### PR DESCRIPTION
Fixes issue introduced in #1788 for Core.  HAL_FLASH_End() was clobbered by mistake with an implementation of HAL_FLASH_ApplyPendingUpdate() that was intended to be a stub.