### PR TITLE
[Electron/LTE] devices drop Cloud connection every time user firmware opens and closes a TCP socket [ch34976]

### DIFF
--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -564,7 +564,17 @@ protected:
     static int _cbUPSND(int type, const char* buf, int len, MDM_IP* ip);
     static int _cbUDNSRN(int type, const char* buf, int len, MDM_IP* ip);
     static int _cbUSOCR(int type, const char* buf, int len, int* handle);
-    static int _cbUSOCTL(int type, const char* buf, int len, int* handle);
+    struct Usoctl {
+        int handle;
+        int param_id;
+        int param_val;
+
+        Usoctl()
+        {
+            memset(this, 0, sizeof(*this));
+        }
+    };
+    static int _cbUSOCTL(int type, const char* buf, int len, Usoctl* usoctl);
     typedef struct { char* buf; int len; } USORDparam;
     static int _cbUSORD(int type, const char* buf, int len, USORDparam* param);
     typedef struct { char* buf; MDM_IP ip; int port; int len; } USORFparam;

--- a/user/tests/wiring/no_fixture/cellular.cpp
+++ b/user/tests/wiring/no_fixture/cellular.cpp
@@ -196,7 +196,10 @@ test(MDM_01_socket_writes_with_length_more_than_1023_work_correctly) {
         }
         if (!c.connected())
             break;
-        if (millis() - mil >= 60000) {
+        if (millis() - mil >= 20000UL) {
+            if (c.connected()) {
+                c.stop();
+            }
             break;
         }
     }

--- a/wiring/src/spark_wiring_tcpclient.cpp
+++ b/wiring/src/spark_wiring_tcpclient.cpp
@@ -227,7 +227,7 @@ uint8_t TCPClient::connected()
     {
       rv = available(); // Try CC3000
       if (!rv) {        // No more Data and CLOSE_WAIT
-          DEBUG("caling Stop No more Data and in CLOSE_WAIT");
+          DEBUG("calling .stop(), no more data, in CLOSE_WAIT");
           stop();       // Close our side
       }
   }


### PR DESCRIPTION
### Problem

LTE E-series R410 devices drop Cloud connection every time user firmware opens and closes a TCP socket.  This does not appear to affect U260/U201/G350 devices.

### Root cause
The timeout for the socket close command USOCL times out after 10s (has been this way since the first electron release).  Sara R410M timeout of this command is 120 seconds, but that is likely only for TCP sockets since UDP sockets can be closed immediately.  Sara U201/260/G350 timeout of this command is 1 second.  If the TCP socket took more than 10 seconds to close, the USOCL command would timeout and allow the AT interface to be accessed by the next command, but it would not ready because it's still waiting for the socket close command to finish or timeout.  If a following command happens to be a Particle Publish, Keep Alive Ping or Vitals Publish, these commands are blocked by the TCP socket closing and subsequently forces a teardown of the Cloud connection.  

### Solution
Timeouts will are adjusted so that if the socket is a TCP socket, the full 120 second timeout is respected.  If it's a UDP socket, we will continue to optimize this value down to 10 seconds.

### Steps to Test

Requires a TCP connection to a server that defaults to the `Connection: keep-alive\r\n` state, and closes slowly when `TCPClient::stop()` is called.  This is not a common case, and at this time of writing only one customer server is known to behave this way and will be tested internally.  If other public servers are noted with this issue, this PR will be updated with a test app that demonstrates this behavior and this test app will be added to the internal on-device tests.

### Workaround for slowly closing TCP sockets
Add `Connection: close\r\n` to your request header.  This should cause an immediate remote close of the socket from the server when all data has been sent by the server.

TEST=wiring/no_fixture

### Review

Review non-whitespace changes: https://github.com/particle-iot/device-os/pull/1854/files?w=1

### Test firmware for electron

[electron-system-part1@1.3.0-rc.1+debug.pr1854.zip](https://www.dropbox.com/s/5sxkog8b4pyag4z/electron-system-part1%401.3.0-rc.1%2Bdebug.pr1854.zip?dl=1)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)

---

- [bugfix] [electron/LTE] devices drop Cloud connection every time user firmware opens and closes a TCP socket [ch34976] [#1854](https://github.com/particle-iot/device-os/pull/1854)