### PR TITLE
[system] disconnect the cloud when calling Mesh.off()

### DIFF
--- a/wiring/inc/spark_wiring_mesh.h
+++ b/wiring/inc/spark_wiring_mesh.h
@@ -138,7 +138,7 @@ public:
     }
 
     void off() {
-        network_off(*this, 0, 0, NULL);
+        network_off(*this, 1, 0, NULL);
     }
 
     void connect(unsigned flags=0) {


### PR DESCRIPTION
### Problem 

Issue: #1813 

SEMI_AUTOMATIC mode blocks loop() after calling Mesh.off()

### Solution

For user scenario like:
```
Mesh.on();
Mesh.connect(); 
Particle.connect();
...
Mesh.off();
```
`SPARK_CLOUD_AUTO_CONNECT` is set in `Particle.connect()` and it isn't cleaned in `Mesh.off()` which causes `semi_automatic_connecting()` always return `ture`, then the device assumes it is in a network connection task, it jumps over `loop()` task.

### Steps to Test
1. Use Argon as a border router
1. Connect Xenon to the Argon mesh network
1. Burn the example app to Xenon
1. Observe whether Xenon gets stuck in blinking green.

### Example App

```c
#include "application.h"

SYSTEM_MODE(SEMI_AUTOMATIC);

Serial1LogHandler logHandler(115200, LOG_LEVEL_ALL, {{"app", LOG_LEVEL_ALL}});

void setup() {
  Serial.begin();
}

void loop() {
  static uint32_t msLast = 0;
  Serial.print('.');             // <-- get only printed on first call to loop() !!!
  if (millis() - msLast < 1000) return;
  msLast = millis();

  Serial.println("Turning ON radio...");
  Mesh.on();
  Mesh.connect(); 
  if (waitFor(Mesh.ready, 10000)) {
    Particle.connect();
    if (waitFor(Particle.connected, 10000)) {
      Particle.publish("xenon-test", PRIVATE);  // tried with WITH_ACK too 
      Serial.println("published xenon-text");   //  |
      delay(100);                               // delay required (even when using WITH_ACK) 
    }
    else
      Serial.println("Couldn't connect to cloud");
  }
  else
    Serial.println("Couldn't connect to mesh");
  
  Serial.println("Turning OFF radio...");

  Mesh.off();
  Serial.println("radio is off");
}

```

### One more thing

Is this issue also with Cellular and Wifi?

![image](https://user-images.githubusercontent.com/7424522/61223647-a9879200-a74f-11e9-8a5b-a4cc158557f9.png)


### References

[CH35131]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
