### PR TITLE
[electron, gen3] Temporarily increase IDLE task priority whenever a thread exits (calls vTaskDelete)

### DIFF
--- a/hal/src/electron/FreeRTOSConfig.h
+++ b/hal/src/electron/FreeRTOSConfig.h
@@ -103,8 +103,11 @@
  * See http://www.freertos.org/a00110.html.
  *----------------------------------------------------------*/
 
+extern void vApplicationTaskDeleteHook(void *pvTaskToDelete, volatile long* pxPendYield);
+#define portPRE_TASK_DELETE_HOOK(pvTaskToDelete, pxYieldPending) vApplicationTaskDeleteHook((pvTaskToDelete), (pxYieldPending))
+
 #define configUSE_PREEMPTION		1
-#define configUSE_IDLE_HOOK			0
+#define configUSE_IDLE_HOOK			1
 #define configUSE_TICK_HOOK			0
 #define configCPU_CLOCK_HZ			( ( unsigned long ) 120000000 )
 #define configTICK_RATE_HZ			( ( TickType_t ) 1000 )
@@ -144,6 +147,7 @@ to exclude the API function. */
 #define INCLUDE_vTaskDelayUntil			1
 #define INCLUDE_vTaskDelay				1
 #define INCLUDE_eTaskGetState			1
+#define INCLUDE_xTaskGetIdleTaskHandle	1
 
 /* This is the raw value as per the Cortex-M3 NVIC.  Values can be 255
 (lowest) to 0 (1?) (highest). */

--- a/hal/src/electron/rtos_hook.cpp
+++ b/hal/src/electron/rtos_hook.cpp
@@ -1,6 +1,24 @@
+/*
+ * Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "FreeRTOS.h"
 #include "task.h"
 #include "service_debug.h"
+#include "concurrent_hal.h"
 
 extern "C" {
 
@@ -9,5 +27,23 @@ void vApplicationStackOverflowHook(TaskHandle_t, char*) {
     PANIC(StackOverflow, "Stack overflow detected");
 }
 #endif
+
+void vApplicationTaskDeleteHook(void *pvTaskToDelete, volatile BaseType_t* pxPendYield) {
+    (void)pvTaskToDelete;
+    (void)pxPendYield;
+
+    // Temporarily raise IDLE thread priority to (configMAX_PRIORITIES - 1) (maximum)
+    // to give it some processing time to clean up the deleted task resources.
+    vTaskPrioritySet(xTaskGetIdleTaskHandle(), configMAX_PRIORITIES - 1);
+
+    // Immediately request the scheduler to yield to now higher priority IDLE thread
+    *pxPendYield = pdTRUE;
+}
+
+void vApplicationIdleHook(void) {
+    // Restore IDLE thread priority back to the default one
+    vTaskPrioritySet(xTaskGetIdleTaskHandle(), tskIDLE_PRIORITY);
+}
+
 
 } // extern "C"

--- a/hal/src/nRF52840/freertos/FreeRTOSConfig.h
+++ b/hal/src/nRF52840/freertos/FreeRTOSConfig.h
@@ -114,8 +114,11 @@
  * See http://www.freertos.org/a00110.html.
  *----------------------------------------------------------*/
 
+extern void vApplicationTaskDeleteHook(void *pvTaskToDelete, volatile long* pxPendYield);
+#define portPRE_TASK_DELETE_HOOK(pvTaskToDelete, pxYieldPending) vApplicationTaskDeleteHook((pvTaskToDelete), (pxYieldPending))
+
 #define configUSE_PREEMPTION        1
-#define configUSE_IDLE_HOOK         0
+#define configUSE_IDLE_HOOK         1
 #define configUSE_TICK_HOOK         0
 #define configCPU_CLOCK_HZ          ( SystemCoreClock )
 #define configTICK_RATE_HZ          ( ( TickType_t ) 1000 )
@@ -160,6 +163,7 @@ to exclude the API function. */
 #define INCLUDE_vTaskDelayUntil         1
 #define INCLUDE_vTaskDelay              1
 #define INCLUDE_eTaskGetState           1
+#define INCLUDE_xTaskGetIdleTaskHandle  1
 
 /* The lowest interrupt priority that can be used in a call to a "set priority"
 function. */


### PR DESCRIPTION
### Problem

Due to the busy-loop nature of the application thread and higher priority (2) FreeRTOS IDLE thread responsible for thread resources cleanup (stack) is not being given CPU time, causing memory leaks, unless the application thread goes into a blocked state (waiting on a synchronization primitive or delaying).

### Solution

Temporarily increase IDLE thread priority to `configMAX_PRIORITIES - 1` (maximum) whenever `vTaskDelete(NULL)` is called using `portPRE_TASK_DELETE_HOOK` to clean up the stack as soon as possible and restore it back to `tskIDLE_PRIORITY` once IDLE thread runs using idle hook.

### Steps to Test

Set a breakpoint to `vApplicationIdleHook`, make some thread exit, it should get executed.

### Example App

N/A

### References

- [CH36038]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
