### PR TITLE
Fix/reload dct functions

### DIFF
--- a/bootloader/src/main.c
+++ b/bootloader/src/main.c
@@ -403,7 +403,7 @@ int main(void)
         FLASH_UpdateModules(flashModulesCallback);
 #ifdef LOAD_DCT_FUNCTIONS
         // DCT functions may need to be reloaded after updating a system module
-        load_dct_functions();
+        dct_reload_functions();
 #endif
 #else
         if (REFLASH_FROM_BACKUP == 1)

--- a/bootloader/src/photon/bootloader_dct.c
+++ b/bootloader/src/photon/bootloader_dct.c
@@ -69,7 +69,7 @@ static void init_dct_functions() {
     dct_write_app_data_func = dct_write;
 }
 
-void load_dct_functions() {
+void dct_reload_functions() {
     dct_funcs_inited = 0;
 }
 

--- a/bootloader/src/photon/bootloader_dct.h
+++ b/bootloader/src/photon/bootloader_dct.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-void load_dct_functions();
+void dct_reload_functions();
 
 #ifdef __cplusplus
 } // extern "C"

--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/dct.h
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/dct.h
@@ -229,6 +229,8 @@ int dct_read_app_data_unlock(uint32_t offset);
 
 int dct_write_app_data( const void* data, uint32_t offset, uint32_t size );
 
+void dct_reload_functions();
+
 
 #ifdef	__cplusplus
 }

--- a/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/inc/include.mk
+++ b/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/inc/include.mk
@@ -1,3 +1,6 @@
 
 TARGET_USB_FS_PATH = $(PLATFORM_MCU_PATH)/STM32_USB_Device_Driver
 INCLUDE_DIRS += $(TARGET_USB_FS_PATH)/inc
+
+# bootloader_dct.h is referenced in usbd_flash_if.c
+INCLUDE_DIRS += $(PLATFORM_MODULE_PATH)/../bootloader/src/photon

--- a/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/inc/include.mk
+++ b/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/inc/include.mk
@@ -1,6 +1,3 @@
 
 TARGET_USB_FS_PATH = $(PLATFORM_MCU_PATH)/STM32_USB_Device_Driver
 INCLUDE_DIRS += $(TARGET_USB_FS_PATH)/inc
-
-# bootloader_dct.h is referenced in usbd_flash_if.c
-INCLUDE_DIRS += $(PLATFORM_MODULE_PATH)/../bootloader/src/photon

--- a/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/src/usbd_flash_if.c
+++ b/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/src/usbd_flash_if.c
@@ -30,9 +30,10 @@
 #include "usbd_dfu_mal.h"
 #include "usb_bsp.h"
 #include "hw_config.h"
-
-#if PLATFORM_ID == 6 || PLATFORM_ID == 8
+#include "platforms.h"
+#if PLATFORM_ID == PLATFORM_PHOTON_PRODUCTION || PLATFORM_ID == PLATFORM_P1
 #include "bootloader_dct.h"
+#include "module_info.h"
 #endif
 
 /* Private typedef -----------------------------------------------------------*/
@@ -162,8 +163,8 @@ uint16_t FLASH_If_Write(uint32_t Add, uint32_t Len)
   /* This make sure that after the system parts being updated,
    * the address of DCT functions that resided in system parts are up to date,
    * otherwise, bootloader cannot access the DCT after updating the system parts without a reset. */
-#if PLATFORM_ID == 6 || PLATFORM_ID == 8
-#if MODULE_FUNCTION == 2 // Bootloader
+#if PLATFORM_ID == PLATFORM_PHOTON_PRODUCTION || PLATFORM_ID == PLATFORM_P1
+#if MODULE_FUNCTION == MOD_FUNC_BOOTLOADER
   dct_reload_functions();
 #endif
 #endif

--- a/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/src/usbd_flash_if.c
+++ b/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/src/usbd_flash_if.c
@@ -31,6 +31,10 @@
 #include "usb_bsp.h"
 #include "hw_config.h"
 
+#if PLATFORM_ID == 6 || PLATFORM_ID == 8
+#include "bootloader_dct.h"
+#endif
+
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
 /* Private macro -------------------------------------------------------------*/
@@ -154,6 +158,15 @@ uint16_t FLASH_If_Write(uint32_t Add, uint32_t Len)
 
   /* Lock the internal flash */
   FLASH_Lock();
+
+  /* This make sure that after the system parts being updated,
+   * the address of DCT functions that resided in system parts are up to date,
+   * otherwise, bootloader cannot access the DCT after updating the system parts without a reset. */
+#if PLATFORM_ID == 6 || PLATFORM_ID == 8
+#if MODULE_FUNCTION == 2 // Bootloader
+  dct_reload_functions();
+#endif
+#endif
 
   if (status != FLASH_COMPLETE) return MAL_FAIL;
 

--- a/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/src/usbd_flash_if.c
+++ b/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/src/usbd_flash_if.c
@@ -32,8 +32,12 @@
 #include "hw_config.h"
 #include "platforms.h"
 #if PLATFORM_ID == PLATFORM_PHOTON_PRODUCTION || PLATFORM_ID == PLATFORM_P1
-#include "bootloader_dct.h"
 #include "module_info.h"
+#include "dct.h"
+#include "ota_flash_hal.h"
+
+extern const module_bounds_t module_system_part1;
+extern const module_bounds_t module_system_part2;
 #endif
 
 /* Private typedef -----------------------------------------------------------*/
@@ -165,7 +169,9 @@ uint16_t FLASH_If_Write(uint32_t Add, uint32_t Len)
    * otherwise, bootloader cannot access the DCT after updating the system parts without a reset. */
 #if PLATFORM_ID == PLATFORM_PHOTON_PRODUCTION || PLATFORM_ID == PLATFORM_P1
 #if MODULE_FUNCTION == MOD_FUNC_BOOTLOADER
-  dct_reload_functions();
+  if (Add >= module_system_part1.start_address && Add < module_system_part2.end_address) {
+      dct_reload_functions();
+  }
 #endif
 #endif
 


### PR DESCRIPTION
### Problem

Particle Update fails to update a Photon/P1 from Device OS <1.2.1-rc.3 to 1.2.1 via DFU mode. This is caused by that after updating the system parts, the address of DCT functions that resided in system parts aren't consistent, so when bootloader tries accessing the DCT after that, it then crashes.

### Solution

Dirty a flag after every DFU write operation to the internal flash, so that after updating the system parts, next time when bootloader calls DCT functions, it will reload the DCT functions to make sure that the address of the DCT functions in new system parts are valid.

### Steps to Test

1. Build and flash the new bootloader
2. Flash older DeviceOS e.g. 1.0.0 onto the device
3. Reset and go into DFU
4. Write into DCT
5. Write system-part1 and system-part2 of DeviceOS release v1.2.1 without resetting
6. Write into DCT again, this should succeed and not crash the device

### Example App

N/A

### References

https://github.com/particle-iot/particle-cli/pull/499
https://community.particle.io/t/device-os-1-2-1-and-particle-cli-1-43-fail-in-particle-update/51140

- [bugfix] [Photon/P1] Bootloader correctly re-imports the DCT functions from system firmware after its modification through DFU.