### PR TITLE
[hal] Fixes Argon cannot be reset by external gpio

### DIFF
--- a/hal/src/argon/network/esp32_ncp_client.cpp
+++ b/hal/src/argon/network/esp32_ncp_client.cpp
@@ -95,7 +95,7 @@ Esp32NcpClient::~Esp32NcpClient() {
 int Esp32NcpClient::init(const NcpClientConfig& conf) {
     // Make sure ESP32 is powered down
     HAL_Pin_Mode(ESPBOOT, OUTPUT);
-    HAL_Pin_Mode(ESPEN, OUTPUT);
+    HAL_Pin_Mode(ESPEN, OUTPUT_OPEN_DRAIN);
     espOff();
     // Initialize serial stream
     std::unique_ptr<SerialStream> serial(new(std::nothrow) SerialStream(HAL_USART_SERIAL2, 921600,


### PR DESCRIPTION
### Problem

The reset pin (RST) on the side of the Argon is unable to reset the board by another board using a GPIO (e.g. a Xenon).

We saw two kinds of symptoms of this issue:
1. Argon cannot be reset
2. Argon can be reset, but the reset pin on Argon goes from 3.3V to 1.6V and wait for around 500ms, then it goes to 0V.

### Solution
![image](https://user-images.githubusercontent.com/7424522/62269137-adf8be00-b464-11e9-8b93-3a8ba34368ee.png)

As we can see from the picture, if we configure WIFI_EN(ESPEN) pin to OUTPUT high, the voltage decline a little after the D2 diode, given there is a pull-up resistor R30 100k, we should configuration WIFI_EN(ESPEN) pin to open drain.


### Steps to Test
#### failed case
1. Configure WIFI_EN(ESPEN) as output mode
1. Download below application to two Argon, connect Argon-A's D8 pin to Argon-B's reset pin
1. Observe the symptoms

#### Successful case
1. Configure WIFI_EN(ESPEN) as the open-drain mode
1. Repeat the above steps

### Example App

```c
void setup() {
    pinMode(D8, OUTPUT);
    digitalWrite(D8, 0);
}
```

### References

[CH36349]

---

### Completeness

- [bugfix] [Argon] Fixes the issue being unable to reset the device through RST pin by changing the
`ESPEN` mode to `OUTPUT_OPEN_DRAIN`