### PR TITLE
[hal] Fixes USB send failed

### DIFF
--- a/hal/inc/usb_hal.h
+++ b/hal/inc/usb_hal.h
@@ -48,6 +48,8 @@ extern "C" {
 #endif
 
 typedef enum HAL_USB_State {
+    HAL_USB_STATE_NONE = 0,
+    HAL_USB_STATE_DISABLED,
     HAL_USB_STATE_DETACHED,
     HAL_USB_STATE_ATTACHED,
     HAL_USB_STATE_POWERED,

--- a/hal/src/nRF52840/usb_hal.cpp
+++ b/hal/src/nRF52840/usb_hal.cpp
@@ -60,6 +60,7 @@ void HAL_USB_USART_Init(HAL_USB_USART_Serial serial, const HAL_USB_USART_Config*
 }
 
 void HAL_USB_USART_Begin(HAL_USB_USART_Serial serial, uint32_t baud, void *reserved) {
+    HAL_USB_Attach();
     usb_uart_set_baudrate(baud);
 }
 

--- a/hal/src/nRF52840/usb_hal_cdc.c
+++ b/hal/src/nRF52840/usb_hal_cdc.c
@@ -353,7 +353,7 @@ int usb_uart_init(uint8_t *rx_buf, uint16_t rx_buf_size, uint8_t *tx_buf, uint16
 }
 
 int usb_uart_send(uint8_t data[], uint16_t size) {
-    if (!m_usb_instance.com_opened || m_usb_instance.state != HAL_USB_STATE_POWERED) {
+    if (!m_usb_instance.com_opened || m_usb_instance.state != HAL_USB_STATE_DEFAULT) {
         return -1;
     }
 

--- a/hal/src/nRF52840/usb_hal_cdc.c
+++ b/hal/src/nRF52840/usb_hal_cdc.c
@@ -316,6 +316,9 @@ static void usbd_user_ev_handler(app_usbd_event_type_t event)
             // trigger an assertion
             if (nrfx_usbd_is_enabled()) {
                 app_usbd_stop();
+            } else if (m_usb_instance.enabled) {
+                // Just in case go into detached state
+                set_usb_state(HAL_USB_STATE_DETACHED);
             }
             break;
         }
@@ -505,6 +508,9 @@ void usb_hal_detach(void) {
     if (nrf_drv_usbd_is_enabled()) {
         app_usbd_disable();
     }
+
+    // Go to disabled state just in case
+    set_usb_state(HAL_USB_STATE_DISABLED);
 }
 
 int usb_uart_available_rx_data(void) {

--- a/hal/src/nRF52840/usb_hal_cdc.c
+++ b/hal/src/nRF52840/usb_hal_cdc.c
@@ -129,6 +129,20 @@ static void reset_rx_tx_state(void) {
 
 static void set_usb_state(HAL_USB_State state) {
     if (m_usb_instance.state != state) {
+#ifdef DEBUG_BUILD
+    static const char* s_usb_state_names[] = {
+        "NONE",
+        "DISABLED",
+        "DETACHED",
+        "ATTACHED",
+        "POWERED",
+        "DEFAULT",
+        "ADDRESSED",
+        "CONFIGURED",
+        "SUSPENDED",
+    };
+#endif // DEBUG_BUILD
+        LOG_DEBUG(TRACE, "USB state %s -> %s", s_usb_state_names[m_usb_instance.state], s_usb_state_names[state]);
         m_usb_instance.state = state;
         for (int i = 0; i < MAX_USB_STATE_CB_NUM; i++) {
             if (m_usb_instance.state_callback[i]) {
@@ -229,6 +243,32 @@ static void cdc_acm_user_ev_handler(app_usbd_class_inst_t const * p_inst,
     }
 }
 
+static HAL_USB_State nrf_usb_state_to_hal_usb_state(app_usbd_state_t state) {
+    switch (state) {
+        case APP_USBD_STATE_Disabled: {
+            return HAL_USB_STATE_DISABLED;
+        }
+        case APP_USBD_STATE_Unattached: {
+            return HAL_USB_STATE_DETACHED;
+        }
+        case APP_USBD_STATE_Powered: {
+            return HAL_USB_STATE_POWERED;
+        }
+        case APP_USBD_STATE_Default: {
+            return HAL_USB_STATE_DEFAULT;
+        }
+        case APP_USBD_STATE_Addressed: {
+            return HAL_USB_STATE_ADDRESSED;
+        }
+        case APP_USBD_STATE_Configured: {
+            return HAL_USB_STATE_CONFIGURED;
+        }
+        default: {
+            return HAL_USB_STATE_NONE;
+        }
+    }
+}
+
 static void usbd_user_ev_handler(app_usbd_event_type_t event)
 {
     switch (event) {
@@ -239,37 +279,38 @@ static void usbd_user_ev_handler(app_usbd_event_type_t event)
         }
         case APP_USBD_EVT_DRV_RESUME: {
             LOG_DEBUG(TRACE, "APP_USBD_EVT_DRV_RESUME");
-            set_usb_state(HAL_USB_STATE_DEFAULT);
+            set_usb_state(nrf_usb_state_to_hal_usb_state(app_usbd_core_state_get()));
             break;
         }
         case APP_USBD_EVT_STARTED: {
             // triggered by app_usbd_start()
             m_usb_instance.com_opened = false;
             reset_rx_tx_state();
-            set_usb_state(HAL_USB_STATE_DEFAULT);
+            set_usb_state(nrf_usb_state_to_hal_usb_state(app_usbd_core_state_get()));
             break;
         }
         case APP_USBD_EVT_STOPPED: {
             // triggered by app_usbd_stop()
             app_usbd_disable();
-            set_usb_state(HAL_USB_STATE_DETACHED);
+            set_usb_state(nrf_usb_state_to_hal_usb_state(app_usbd_core_state_get()));
             break;
         }
         case APP_USBD_EVT_POWER_DETECTED: {
             if (!nrf_drv_usbd_is_enabled()) {
                 app_usbd_enable();
             }
-            set_usb_state(HAL_USB_STATE_ATTACHED);
             break;
         }
         case APP_USBD_EVT_POWER_REMOVED: {
             app_usbd_stop();
-            set_usb_state(HAL_USB_STATE_DETACHED);
             break;
         }
         case APP_USBD_EVT_POWER_READY: {
             app_usbd_start();
-            set_usb_state(HAL_USB_STATE_POWERED);
+            break;
+        }
+        case APP_USBD_EVT_STATE_CHANGED: {
+            set_usb_state(nrf_usb_state_to_hal_usb_state(app_usbd_core_state_get()));
             break;
         }
         default:
@@ -353,7 +394,7 @@ int usb_uart_init(uint8_t *rx_buf, uint16_t rx_buf_size, uint8_t *tx_buf, uint16
 }
 
 int usb_uart_send(uint8_t data[], uint16_t size) {
-    if (!m_usb_instance.com_opened || m_usb_instance.state != HAL_USB_STATE_DEFAULT) {
+    if (m_usb_instance.state != HAL_USB_STATE_CONFIGURED || m_usb_instance.com_opened) {
         return -1;
     }
 
@@ -417,7 +458,7 @@ uint32_t usb_uart_get_baudrate(void) {
 }
 
 void usb_hal_attach(void) {
-    if (m_usb_instance.state == HAL_USB_STATE_DETACHED) {
+    if (m_usb_instance.state <= HAL_USB_STATE_DISABLED) {
         return;
     }
 
@@ -430,7 +471,7 @@ void usb_hal_attach(void) {
 }
 
 void usb_hal_detach(void) {
-    if (m_usb_instance.state == HAL_USB_STATE_DETACHED) {
+    if (m_usb_instance.state >= HAL_USB_STATE_DETACHED) {
         return;
     }
 

--- a/system/src/system_power_manager.cpp
+++ b/system/src/system_power_manager.cpp
@@ -161,7 +161,7 @@ void PowerManager::handleUpdate() {
         // and decrease input voltage limit to 3880mV.
         // More details are in clubhouse [CH34730]
         auto usb_state = HAL_USB_Get_State();
-        if (usb_state == HAL_USB_STATE_DETACHED || usb_state == HAL_USB_STATE_SUSPENDED) {
+        if (usb_state <= HAL_USB_STATE_DETACHED) {
           if (power.getInputCurrentLimit() != DEFAULT_INPUT_CURRENT_LIMIT) {
             power.setInputCurrentLimit(DEFAULT_INPUT_CURRENT_LIMIT);
             power.setInputVoltageLimit(3880);


### PR DESCRIPTION
### Problem

We Introduced USB state in #1846 , the USB sending API didn't update its available condition.

### Solution

Change The available state of USB serial from `HAL_USB_STATE_POWERED ` to `HAL_USB_STATE_DEFAULT`

### Steps to Test

Make sure the USB can send data.

### Example App

```c
void setup() {
    Serial.begin();
}

void loop() {
    Serial.print("hello");
    delay(1000);
}
```

### References



---

### Completeness

- [bugfix] [Gen3] Resolved a HardFault after USB cable is unplugged under certain conditions
- [enhancement] [Gen3] USB state tracking enhancements
