### PR TITLE
Set path to Boost libraries

### DIFF
--- a/ci/build_boost.sh
+++ b/ci/build_boost.sh
@@ -1,4 +1,4 @@
 pushd $BOOST_ROOT
 ./bootstrap.sh
-./b2  --with-thread  --with-system --with-program_options --with-random --with-regex --threading=single
+./b2  --with-thread  --with-system --with-program_options --with-random --with-regex --threading=multi
 popd

--- a/ci/install_boost.sh
+++ b/ci/install_boost.sh
@@ -2,10 +2,10 @@ BOOST_VERSION=1_59_0
 
 # this was previously hardcoded to 1.59.0 in the path, replacing with a fast source
 #test -f boost_$BOOST_VERSION.tar.gz || wget --quiet http://downloads.sourceforge.net/project/boost/boost/1.59.0/boost_$BOOST_VERSION.tar.gz
-export BOOST_HOME=$HOME/.ci/boost
-export BOOST_ROOT=$BOOST_HOME/boost_$BOOST_VERSION
+export BOOST_ROOT=$HOME/.ci/boost/boost_$BOOST_VERSION
+export BOOST_LIBRARYDIR=$BOOST_ROOT/stage/lib
 mkdir -p $BOOST_ROOT
 test -d $BOOST_ROOT || ( echo "boost root $BOOST_ROOT not created." && exit 1)
 test -f $BOOST_ROOT/INSTALL || wget --quiet https://s3.amazonaws.com/spark-assets/boost_${BOOST_VERSION}.tar.gz -O - | tar -xz -C $BOOST_ROOT --strip-components 1
-export DYLD_LIBRARY_PATH="$BOOST_ROOT/stage/lib:$DYLD_LIBRARY_PATH"
-export LD_LIBRARY_PATH="$BOOST_ROOT/stage/lib:$LD_LIBRARY_PATH"
+export DYLD_LIBRARY_PATH="${BOOST_LIBRARYDIR}:$DYLD_LIBRARY_PATH"
+export LD_LIBRARY_PATH="${BOOST_LIBRARYDIR}:$LD_LIBRARY_PATH"

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -10,7 +10,6 @@ if contains "${BUILD_PLATFORM[*]}" unit-test; then
 	( source ./ci/install_gcovr.sh
 	source ./ci/install_boost.sh
 	./ci/build_boost.sh &&
-	cp -r ${BOOST_ROOT}/boost/ /usr/include/ &&
 	./ci/unit_tests.sh ) || die
 fi
 

--- a/test/unit_tests/CMakeLists.txt
+++ b/test/unit_tests/CMakeLists.txt
@@ -45,6 +45,11 @@ link_libraries(
   gcov
 )
 
+# TODO: These should be coming from the dependency's CMake module or find_package()
+include_directories($ENV{BOOST_ROOT})
+link_directories($ENV{BOOST_ROOT}/stage/lib)
+link_libraries(boost_program_options boost_regex boost_system boost_thread)
+
 # Build and discover unit-tests
 add_subdirectory(cellular)
 add_subdirectory(cloud)

--- a/test/unit_tests/CMakeLists.txt
+++ b/test/unit_tests/CMakeLists.txt
@@ -18,7 +18,6 @@ set(TEST_DIR ${DEVICE_OS_DIR}/test)
 set(THIRD_PARTY_DIR ${DEVICE_OS_DIR}/third_party)
 
 # Add Boost from git submodule
-set(Boost_USE_MULTITHREADED OFF)
 find_package(Boost
   1.59.0 EXACT
   REQUIRED
@@ -42,6 +41,7 @@ enable_testing()
 add_definitions(-DLOG_DISABLE)
 add_definitions(-DRELEASE_BUILD)
 add_definitions(-DUNIT_TEST)
+add_definitions(-DBOOST_NO_AUTO_PTR)
 
 # Link against dependencies of all tests
 link_libraries(

--- a/test/unit_tests/CMakeLists.txt
+++ b/test/unit_tests/CMakeLists.txt
@@ -14,16 +14,20 @@ get_filename_component(
   ${CMAKE_CURRENT_LIST_DIR}/../..
   REALPATH
 )
-get_filename_component(
-  TEST_DIR
-  ${DEVICE_OS_DIR}/test
-  REALPATH
+set(TEST_DIR ${DEVICE_OS_DIR}/test)
+set(THIRD_PARTY_DIR ${DEVICE_OS_DIR}/third_party)
+
+# Add Boost from git submodule
+set(Boost_USE_MULTITHREADED OFF)
+find_package(Boost
+  1.59.0 EXACT
+  REQUIRED
+  COMPONENTS program_options random regex system thread
 )
-get_filename_component(
-  THIRD_PARTY_DIR
-  ${DEVICE_OS_DIR}/third_party
-  REALPATH
-)
+if(Boost_FOUND)
+  include_directories(${Boost_INCLUDE_DIRS})
+  link_libraries(${Boost_LIBRARIES})
+endif()
 
 # Add Catch2 from git submodule
 set(CATCH2_DIR ${THIRD_PARTY_DIR}/catch2/catch2)
@@ -44,11 +48,6 @@ link_libraries(
   Catch2::Catch2
   gcov
 )
-
-# TODO: These should be coming from the dependency's CMake module or find_package()
-include_directories($ENV{BOOST_ROOT})
-link_directories($ENV{BOOST_ROOT}/stage/lib)
-link_libraries(boost_program_options boost_regex boost_system boost_thread)
 
 # Build and discover unit-tests
 add_subdirectory(cellular)


### PR DESCRIPTION
### Problem

It is now required to have Boost libraries installed globally in the system to build CMake-based unit tests locally (this change was introduced in https://github.com/particle-iot/device-os/pull/1869). This PR changes the paths to Boost libraries back to `$BOOST_ROOT` which is set by CI scripts.

Note: This is a temporary solution. Ideally, we'd want all necessary paths to be detected and set using built-in CMake mechanisms.

### Steps to Test

- Run `source ci/install_boost.sh`.
- Run `ci/build_boost.sh`.
- Compile and run CMake-based unit tests.
