### PR TITLE
Fixes from 1.2.1

### DIFF
--- a/hal/src/core/ota_flash_hal.c
+++ b/hal/src/core/ota_flash_hal.c
@@ -69,10 +69,16 @@ int HAL_FLASH_OTA_Validate(hal_module_t* mod, bool userDepsOptional, module_vali
   return 0;
 }
 
-hal_update_complete_t HAL_FLASH_ApplyPendingUpdate(hal_module_t* module, bool dryRun, void* reserved)
+hal_update_complete_t HAL_FLASH_End(hal_module_t* reserved)
 {
     FLASH_End();
     return HAL_UPDATE_APPLIED_PENDING_RESTART;
+}
+
+hal_update_complete_t HAL_FLASH_ApplyPendingUpdate(hal_module_t* module, bool dryRun, void* reserved)
+{
+    // Not implemented for Core
+    return HAL_UPDATE_ERROR;
 }
 
 void HAL_FLASH_Read_ServerAddress(ServerAddress* server_addr)


### PR DESCRIPTION
### Problem

Two fixes were applied directly to v1.2.1 and need to be cherry-picked to latest `develop` for next release: `1.3.1-rc.1`
#1850 
#1851 

### Solution

This PR cherry-picks the above two commits

### Steps to Test

For #1850 
- Build firmware and bump bootloader version and dependencies to v400 on Photon
- Flash firmware with latest tinker, device should be in safe mode with older bootloader version dependency issue
- flash new bootloader via
```console
$ dfu; sleep 3; dfu-util -d 2b04:d006 -a 0 -s 0x80C0000 -D photon-bootloader\@1.3.1-rc.1-v500.bin; sleep 2; dfu-util -d 2b04:d006 -a 1 -s 1753:leave -D ota-flag-a5.bin 
```
- device should reboot with latest bootloader

For #1851 
- Build tinker firmware for Core and ensure it boots and breathes cyan

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)

---

- [bugfix] Fix to ensure device resets after bootloader update [#1873](https://github.com/particle-iot/device-os/pull/1873)
- [bugfix] Fixes boot issue for Core introduced in 1.2.1-rc.3 [#1873](https://github.com/particle-iot/device-os/pull/1873)

