### PR TITLE
Fix/gen3 i2c timeout

### DIFF
--- a/hal/src/nRF52840/i2c_hal.cpp
+++ b/hal/src/nRF52840/i2c_hal.cpp
@@ -236,13 +236,13 @@ static int twi_init(HAL_I2C_Interface i2c) {
 }
 
 void HAL_I2C_Init(HAL_I2C_Interface i2c, void* reserved) {
-    if (m_i2c_map[i2c].enabled) {
-        twi_uninit(i2c);
-    }
-
     os_thread_scheduling(false, NULL);
     if (m_i2c_map[i2c].mutex == NULL) {
         os_mutex_recursive_create(&m_i2c_map[i2c].mutex);
+    } else {
+        // Already initialized
+        os_thread_scheduling(true, NULL);
+        return;
     }
 
     HAL_I2C_Acquire(i2c, NULL);

--- a/user/tests/wiring/i2c_master_slave/i2c_slave/i2c_slave.cpp
+++ b/user/tests/wiring/i2c_master_slave/i2c_slave/i2c_slave.cpp
@@ -17,7 +17,8 @@ static uint32_t requestedLength = 0;
 
 static int random_range(int minVal, int maxVal)
 {
-    return rand() % (maxVal - minVal + 1) + minVal;
+    static unsigned int seed = HAL_RNG_GetRandomNumber();
+    return rand_r(&seed) % (maxVal - minVal + 1) + minVal;
 }
 
 void I2C_Slave_On_Request_Callback(void) {
@@ -57,6 +58,9 @@ test(I2C_Master_Slave_Slave_Transfer)
     USE_WIRE.stretchClock(true);
     USE_WIRE.onRequest(I2C_Slave_On_Request_Callback);
     USE_WIRE.onReceive(I2C_Slave_On_Receive_Callback);
+
+    // Dummy call to initialize the seed
+    (void)random_range(0, 1);
 
     while(done == 0) {
         delay(100);


### PR DESCRIPTION
### Problem

The I2C driver on Gen3 device doesn't support timeout, once the external I2C slave device dies, the I2C bus will be held, Device OS gets stuck in the endless wait, the user application doesn't run anymore.

### Solution

Add timeout to the driver.

This PR also fixes an assertion failure on `rand()` usage from an ISR in `i2c_master_slave/i2c_slave` test.

### Steps to Test

#### Unit Test
1. Make sure this fix can pass the unit test under `user/tests/wiring/i2c_master_slave`

#### Test App
1. Download below application to Xenon-I2C-Master and Xenon-I2C-Slave devices
2. Connect Xenon-I2C-Master's SCL pin to the GND
3. Connect Xenon-I2C-Master's SCL pin back to the  Xenon-I2C-Slave's SCL pin
4. Observe the log, the user application of I2C master should not be blocked and the data should be correct.

### Example App

```c
#include "application.h"

#define MASTER 1
#define speed 100000
#define SLAVE_ADDRESS 0x18

SYSTEM_MODE(MANUAL);

Serial1LogHandler logHandler(115200, LOG_LEVEL_ALL, {{"app", LOG_LEVEL_ALL}});

#if MASTER
int sendData(String cmd) {
   for (int i = 0; i < 1; ++i) {
        uint8_t count = Wire.requestFrom(SLAVE_ADDRESS, 6);
        // delay(10); // doesn't change anything
        while(Wire.available()) {
            char c = Wire.read();
            Serial.print(c);
        }
        Serial.println();
    }
    return 0;
}

void setup() {
    Serial.begin(115200);
    Wire.begin();
}

void loop() {
    if (Serial.available()) {
        uint8_t cmd = Serial.read();
        switch(cmd) {
            case '1': {
                Serial.println("send hello...");
                sendData("hello");
                break;
            }
            default:
                break;
        }
    }
    delay(1000);
    Serial.println("loop");
}

#else 
void requestEvent() {
    Wire.print("123456789");
}

void setup() {  
    //Wire.setSpeed(speed); // optional but same result
    Wire.begin(SLAVE_ADDRESS);    
    Wire.onRequest(requestEvent);
}
#endif
```

### References

[CH36348]
---

### Completeness

- [enhancement] [Gen3] Adds timeouts to I2C HAL operations