### PR TITLE
Add analogReference function to switch between default VDD/4 reference and internal reference for ADC.

### DIFF
--- a/hal/inc/adc_hal.h
+++ b/hal/inc/adc_hal.h
@@ -32,6 +32,12 @@
 
 /* Exported types ------------------------------------------------------------*/
 
+typedef enum
+{
+    VDD4,
+    INTERNAL,
+} vref_e;
+
 /* Exported constants --------------------------------------------------------*/
 
 /* Exported macros -----------------------------------------------------------*/
@@ -45,6 +51,7 @@ extern "C" {
 void HAL_ADC_Set_Sample_Time(uint8_t ADC_SampleTime);
 int32_t HAL_ADC_Read(pin_t pin);
 void HAL_ADC_DMA_Init();
+void HAL_ADC_Set_VREF(vref_e v_e);
 
 #ifdef __cplusplus
 }

--- a/hal/inc/hal_dynalib_gpio.h
+++ b/hal/inc/hal_dynalib_gpio.h
@@ -87,7 +87,8 @@ DYNALIB_FN(34, hal_gpio, HAL_PWM_Get_Max_Frequency, uint32_t(uint16_t))
 DYNALIB_FN(35, hal_gpio, HAL_Interrupts_Detach_Ext, void(uint16_t, uint8_t, void*))
 DYNALIB_FN(36, hal_gpio, HAL_Set_Direct_Interrupt_Handler, int(IRQn_Type irqn, HAL_Direct_Interrupt_Handler handler, uint32_t flags, void* reserved))
 
+DYNALIB_FN(37, hal_gpio, HAL_ADC_Set_VREF, void(vref_e))
+
 DYNALIB_END(hal_gpio)
 
 #endif	/* HAL_DYNALIB_GPIO_H */
-

--- a/hal/src/nRF52840/adc_hal.cpp
+++ b/hal/src/nRF52840/adc_hal.cpp
@@ -20,14 +20,18 @@
 #include "adc_hal.h"
 #include "pinmap_impl.h"
 
+
 static volatile bool m_adc_initiated = false;
 
-static const nrfx_saadc_config_t saadc_config = 
+static const nrfx_saadc_config_t saadc_config =
 {
     .resolution         = NRF_SAADC_RESOLUTION_12BIT,
     .oversample         = NRF_SAADC_OVERSAMPLE_DISABLED,
     .interrupt_priority = NRFX_SAADC_CONFIG_IRQ_PRIORITY
 };
+
+nrf_saadc_reference_t VREF = NRF_SAADC_REFERENCE_VDD4;
+
 
 static void analog_in_event_handler(nrfx_saadc_evt_t const *p_event)
 {
@@ -38,6 +42,22 @@ void HAL_ADC_Set_Sample_Time(uint8_t ADC_SampleTime)
 {
     // deprecated
 }
+
+/*
+ * @brief @brief Set the ADC reference to either VDD / 4 (VDD4) or the internal 0.6v (INTERNAL)
+ */
+
+void HAL_ADC_Set_VREF(vref_e v_e){
+    switch (v_e) {
+        case VDD4: VREF = NRF_SAADC_REFERENCE_VDD4; break;
+
+        case INTERNAL: VREF = NRF_SAADC_REFERENCE_INTERNAL; break;
+
+        default: VREF = NRF_SAADC_REFERENCE_VDD4; break;
+    }
+
+}
+
 
 /*
  * @brief Read the analog value of a pin.
@@ -77,11 +97,11 @@ int32_t HAL_ADC_Read(uint16_t pin)
     }
 
      //Single ended, negative input to ADC shorted to GND.
-    nrf_saadc_channel_config_t channel_config = {                                                   
+    nrf_saadc_channel_config_t channel_config = {
         .resistor_p = NRF_SAADC_RESISTOR_DISABLED,      \
         .resistor_n = NRF_SAADC_RESISTOR_DISABLED,      \
         .gain       = NRF_SAADC_GAIN1_4,                \
-        .reference  = NRF_SAADC_REFERENCE_VDD4,         \
+        .reference  = VREF,                             \
         .acq_time   = NRF_SAADC_ACQTIME_10US,           \
         .mode       = NRF_SAADC_MODE_SINGLE_ENDED,      \
         .burst      = NRF_SAADC_BURST_DISABLED,         \
@@ -116,6 +136,8 @@ err_ret:
     nrfx_saadc_channel_uninit(PIN_MAP[pin].adc_channel);
     return 0;
 }
+
+
 
 /*
  * @brief Initialize the ADC peripheral.

--- a/user/tests/hal/adc/test_adc.cpp
+++ b/user/tests/hal/adc/test_adc.cpp
@@ -25,11 +25,13 @@ Serial1LogHandler logHandler(115200);
 /* executes once at startup */
 void setup() {
     HAL_ADC_DMA_Init();
+    HAL_ADC_Set_VREF(INTERNAL);
+    HAL_ADC_Set_VREF(VDD4);
 }
 
 /* executes continuously after setup() runs */
 void loop() {
-    Log.info("A0: %d, A1: %d, A2: %d, A3: %d, A4: %d, A5: %d", 
+    Log.info("A0: %d, A1: %d, A2: %d, A3: %d, A4: %d, A5: %d",
              HAL_ADC_Read(A0),
              HAL_ADC_Read(A1),
              HAL_ADC_Read(A2),

--- a/wiring/inc/spark_wiring.h
+++ b/wiring/inc/spark_wiring.h
@@ -1,7 +1,7 @@
 /**
  ******************************************************************************
  * @file    spark_wiring.h
- * @author  Satish Nair, Zachary Crockett, Zach Supalla and Mohit Bhoite
+ * @author  Satish Nair, Zachary Crockett, Zach Supalla, Mohit Bhoite and Stuart Feichtinger
  * @version V1.0.0
  * @date    13-March-2013
  * @brief   Header for spark_wiring.c module
@@ -51,7 +51,6 @@
 #include "spark_wiring_cloud.h"
 #include "spark_wiring_rgb.h"
 #include "spark_wiring_ticks.h"
-#include "spark_wiring_nfc.h"
 
 /* To prevent build error, we are undefining and redefining DAC here */
 #undef DAC
@@ -66,6 +65,7 @@ extern "C" {
 */
 void setADCSampleTime(uint8_t ADC_SampleTime);
 int32_t analogRead(uint16_t pin);
+void analogReference(vref_e v);
 
 /*
 * GPIO

--- a/wiring_globals/src/spark_wiring_gpio.cpp
+++ b/wiring_globals/src/spark_wiring_gpio.cpp
@@ -153,6 +153,14 @@ int32_t digitalRead(pin_t pin)
 }
 
 /*
+ * @brief Set the ADC reference to either VDD / 4 (VDD4) or the internal 0.6v (INTERNAL)
+ */
+
+void analogReference(vref_e v){
+    HAL_ADC_Set_VREF(v);
+}
+
+/*
  * @brief Read the analog value of a pin.
  * Should return a 16-bit value, 0-65536 (0 = LOW, 65536 = HIGH)
  * Note: ADC is 12-bit. Currently it returns 0-4095
@@ -177,6 +185,7 @@ int32_t analogRead(pin_t pin)
 
   return HAL_ADC_Read(pin);
 }
+
 
 /*
  * @brief Should take an integer 0-255 and create a 500Hz PWM signal with a duty cycle from 0-100%.
@@ -251,7 +260,7 @@ uint8_t analogWriteResolution(pin_t pin, uint8_t value)
     HAL_PWM_Set_Resolution(pin, value);
     return HAL_PWM_Get_Resolution(pin);
   }
-  
+
 
   return 0;
 }


### PR DESCRIPTION
<details>
  <summary><i>submission notes</i></summary>

```
**Important:** Please sanitize/remove any confidential info like usernames, passwords, org names, product names/ids, access tokens, client ids/secrets, or anything else you don't wish to share.

Please Read and Sign the Contributor License Agreement ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md)).

You may also delete this submission notes header if you'd like. Thank you for contributing!
```
</details>

### Problem

The default analog reference for nRF52840-based boards (Xenon, Argon, Boron) uses VDD/4. This is fine for stable input voltage (usb), but super not great if you're running off a battery as the input voltage (and therefor reference voltage) decreases over time. The nRF52840 does have an internal 0.6v reference that would solve this problem, but the ability to use it is not currently implemented in the Particle OS. This is pretty annoying in a device that markets itself as a battery-based sensor node.

### Solution
I've implented an Arduino-style AnalogReference function, that allows you to select the internal 0.6v reference instead of the default VDD/4 if desired.

### Steps to Test

user/tests/hal/adc/test_adc.cpp

### Example App

```c
#include "Arduino.h"

const int16_t ANALOG_READ_PIN = A0;
int analog_value;

void setup() {
 pinMode(ANALOG_READ_PIN, INPUT);
 Serial.begin(9600);
}

void loop() {
 analog_value = analogRead(ANALOG_READ_PIN); //get value using default VDD/4 reference.
 Serial.print("Analog Value (VDD/4 reference): ");
 Serial.println(analog_value);

 delay(250);

 analogReference(INTERNAL);  // use INTERNAL 0.6v reference 
 analog_value = analogRead(ANALOG_READ_PIN); //get value using default VDD/4 reference.
 Serial.print("Analog Value (Internal 0.6v reference): ");
 Serial.println(analog_value);

 analogReference(VDD4);  // switch back to default VDD/4 ADC reference 

 delay(1000);
}
```

### References
https://community.particle.io/t/internal-voltage-reference-for-accurate-voltage-calibration/6344
https://infocenter.nordicsemi.com/index.jsp?topic=%2Fcom.nordic.infocenter.sdk5.v12.0.0%2Fgroup__nrf__drv__saadc.html
https://www.arduino.cc/reference/en/language/functions/analog-io/analogreference/

---

### Completeness

- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)