### PR TITLE
[gcc] fixes virtual platform exception on startup #1878 [ch35243]

### DIFF
--- a/hal/src/gcc/ota_flash_hal.cpp
+++ b/hal/src/gcc/ota_flash_hal.cpp
@@ -60,8 +60,7 @@ int HAL_FLASH_OTA_Validate(hal_module_t* mod, bool userDepsOptional, module_vali
 
 hal_update_complete_t HAL_FLASH_ApplyPendingUpdate(hal_module_t* module, bool dryRun, void* reserved)
 {
-    HAL_FLASH_End(module);
-    return HAL_UPDATE_APPLIED_PENDING_RESTART;
+    return HAL_UPDATE_ERROR;
 }
 
 /**


### PR DESCRIPTION
<details>
  <summary><i>submission notes</i></summary>
</details>

### Problem

The Gen2 virtual platform failed on startup due to a coding error. 

### Solution

Fix the coding error.  This was clearly a remnant from early thoughts on the code design.

### Steps to Test

Start the executable produced when building platform 3. 

Note that I was unable to test this since the cross compile build was not working on my system. 

### Reference

Closes #1842

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [x] Added to CHANGELOG.md after merging (add links to docs and issues)

---

- [bugfix] [gcc] fixes virtual platform exception on startup [#1878](https://github.com/particle-iot/device-os/pull/1878)