### PR TITLE
BLE: alternately broadcast user's and Particle-specific advertising d…

### DIFF
--- a/hal/inc/ble_hal.h
+++ b/hal/inc/ble_hal.h
@@ -381,7 +381,7 @@ int hal_ble_unlock(void* reserved);
  *
  * @returns    0 on success, system_error_t on error.
  */
-int hal_ble_notify_enter_listening_mode(void* reserved);
+int hal_ble_enter_locked_mode(void* reserved);
 
 /**
  * Notify that device has exited the Listening mode, BLE advertising data/parameters and
@@ -391,7 +391,7 @@ int hal_ble_notify_enter_listening_mode(void* reserved);
  *
  * @returns    0 on success, system_error_t on error.
  */
-int hal_ble_notify_exit_listening_mode(void* reserved);
+int hal_ble_exit_locked_mode(void* reserved);
 
 /**
  * Initialize the BLE stack. This function must be called previous to any other BLE APIs.

--- a/hal/inc/ble_hal.h
+++ b/hal/inc/ble_hal.h
@@ -374,6 +374,26 @@ int hal_ble_lock(void* reserved);
 int hal_ble_unlock(void* reserved);
 
 /**
+ * Notify that device has entered the Listening mode, in which case the BLE
+ * advertising data/parameters and connection parameters are not allowed to be modified.
+ *
+ * @param      reserved  The reserved
+ *
+ * @returns    0 on success, system_error_t on error.
+ */
+int hal_ble_notify_enter_listening_mode(void* reserved);
+
+/**
+ * Notify that device has exited the Listening mode, BLE advertising data/parameters and
+ * connection parameters are allowed to be modified.
+ *
+ * @param      reserved  The reserved
+ *
+ * @returns    0 on success, system_error_t on error.
+ */
+int hal_ble_notify_exit_listening_mode(void* reserved);
+
+/**
  * Initialize the BLE stack. This function must be called previous to any other BLE APIs.
  *
  * @param[in]   reserved    Reserved for future use.

--- a/hal/inc/ble_hal.h
+++ b/hal/inc/ble_hal.h
@@ -410,6 +410,15 @@ int hal_ble_select_antenna(hal_ble_ant_type_t antenna, void* reserved);
 int hal_ble_set_callback_on_adv_events(hal_ble_on_adv_evt_cb_t callback, void* context, void* reserved);
 
 /**
+ * Deregister the callback on BLE advertising events.
+ *
+ * @param[in]   callback    The callback function.
+ *
+ * @returns     0 on success, system_error_t on error.
+ */
+int hal_ble_cancel_callback_on_adv_events(hal_ble_on_adv_evt_cb_t callback, void* context, void* reserved);
+
+/**
  * Set the callback on BLE Peripheral link events.
  *
  * @param[in]   callback    The callback function.

--- a/hal/inc/hal_dynalib_ble.h
+++ b/hal/inc/hal_dynalib_ble.h
@@ -92,6 +92,8 @@ DYNALIB_FN(58, hal_ble, hal_ble_gap_get_connection_info, int(hal_ble_conn_handle
 DYNALIB_FN(59, hal_ble, hal_ble_gatt_server_add_characteristic, int(const hal_ble_char_init_t*, hal_ble_char_handles_t*, void*))
 DYNALIB_FN(60, hal_ble, hal_ble_set_callback_on_periph_link_events, int(hal_ble_on_link_evt_cb_t, void*, void*))
 DYNALIB_FN(61, hal_ble, hal_ble_gatt_client_configure_cccd, int(const hal_ble_cccd_config_t*, void*))
+DYNALIB_FN(62, hal_ble, hal_ble_set_callback_on_adv_events, int(hal_ble_on_adv_evt_cb_t, void*, void*))
+DYNALIB_FN(63, hal_ble, hal_ble_cancel_callback_on_adv_events, int(hal_ble_on_adv_evt_cb_t, void*, void*))
 
 DYNALIB_END(hal_ble)
 

--- a/hal/src/nRF52840/ble_hal.cpp
+++ b/hal/src/nRF52840/ble_hal.cpp
@@ -946,6 +946,7 @@ void BleObject::Broadcaster::cancelAdvEventCallback(hal_ble_on_adv_evt_cb_t call
         const auto& handler = advEventHandlers_[i];
         if (handler.callback == callback && handler.context == context) {
             advEventHandlers_.removeAt(i);
+            continue;
         }
         i++;
     }

--- a/hal/src/nRF52840/ble_hal.cpp
+++ b/hal/src/nRF52840/ble_hal.cpp
@@ -288,8 +288,16 @@ public:
     int stopAdvertising();
     int setAutoAdvertiseScheme(hal_ble_auto_adv_cfg_t config);
     int getAutoAdvertiseScheme(hal_ble_auto_adv_cfg_t* cfg);
+    int onAdvEventCallback(hal_ble_on_adv_evt_cb_t callback, void* context);
+    void cancelAdvEventCallback(hal_ble_on_adv_evt_cb_t callback, void* context);
+    int processAdvStoppedEventFromThread(const ble_evt_t* event);
 
 private:
+    struct BleAdvEventHandler {
+        hal_ble_on_adv_evt_cb_t callback;
+        void* context;
+    };
+
     int suspend();
     int resume();
     ble_gap_adv_data_t toPlatformAdvData(void);
@@ -311,6 +319,7 @@ private:
     bool advPending_;                               /**< Advertising is pending. */
     bool connectedAdvParams_;                       /**< Whether it is using the advertising parameters being set when connected as Peripheral. */
     volatile hal_ble_conn_handle_t connHandle_;     /**< Connection handle. It is assigned once device is connected as Peripheral. It is used for re-start advertising. */
+    Vector<BleAdvEventHandler> advEventHandlers_;
     static const int8_t validTxPower_[8];           /**< Valid TX power values. */
 };
 
@@ -372,17 +381,6 @@ private:
 
 class BleObject::ConnectionsManager {
 public:
-    struct BleLinkEventHandler {
-        hal_ble_on_link_evt_cb_t callback;
-        void* context;
-    };
-
-    struct BleConnection {
-        hal_ble_conn_info_t info;
-        BleLinkEventHandler handler; // It is used for central link only.
-        bool isMtuExchanged;
-    };
-
     ConnectionsManager()
             : connMgrInitialized_(false),
               isConnecting_(false),
@@ -423,6 +421,17 @@ public:
     int processAttMtuExchangeEventFromThread(const ble_evt_t* event);
 
 private:
+    struct BleLinkEventHandler {
+        hal_ble_on_link_evt_cb_t callback;
+        void* context;
+    };
+
+    struct BleConnection {
+        hal_ble_conn_info_t info;
+        BleLinkEventHandler handler; // It is used for central link only.
+        bool isMtuExchanged;
+    };
+
     int configureAttMtu(hal_ble_conn_handle_t connHandle, size_t effective);
     bool attMtuExchanged(hal_ble_conn_handle_t connHandle);
     BleConnection* fetchConnection(hal_ble_conn_handle_t connHandle);
@@ -643,6 +652,10 @@ os_thread_return_t BleObject::BleEventDispatcher::processBleEventFromThread(void
                 dispatcher->freeEventData(event);
             });
             switch (event->header.evt_id) {
+                case BLE_GAP_EVT_ADV_SET_TERMINATED: {
+                    BleObject::getInstance().broadcaster()->processAdvStoppedEventFromThread(event);
+                    break;
+                }
                 case BLE_GAP_EVT_ADV_REPORT: {
                     BleObject::getInstance().observer()->processAdvReportEventFromThread(event);
                     break;
@@ -920,6 +933,24 @@ int BleObject::Broadcaster::init() {
     return SYSTEM_ERROR_NONE;
 }
 
+int BleObject::Broadcaster::onAdvEventCallback(hal_ble_on_adv_evt_cb_t callback, void* context) {
+    BleAdvEventHandler handler = {};
+    handler.callback = callback;
+    handler.context = context;
+    CHECK_TRUE(advEventHandlers_.append(handler), SYSTEM_ERROR_NO_MEMORY);
+    return SYSTEM_ERROR_NONE;
+}
+
+void BleObject::Broadcaster::cancelAdvEventCallback(hal_ble_on_adv_evt_cb_t callback, void* context) {
+    for (int i = 0; i < advEventHandlers_.size(); i = i) {
+        const auto& handler = advEventHandlers_[i];
+        if (handler.callback == callback && handler.context == context) {
+            advEventHandlers_.removeAt(i);
+        }
+        i++;
+    }
+}
+
 bool BleObject::Broadcaster::advertising() const {
     return isAdvertising_;
 }
@@ -1137,12 +1168,35 @@ int8_t BleObject::Broadcaster::roundTxPower(int8_t value) {
     return BLE_MAX_TX_POWER;
 }
 
+int BleObject::Broadcaster::processAdvStoppedEventFromThread(const ble_evt_t* event) {
+    const ble_gap_evt_adv_set_terminated_t& advStopped = event->evt.gap_evt.params.adv_set_terminated;
+    hal_ble_adv_evt_t advEvent = {};
+    advEvent.type = BLE_EVT_ADV_STOPPED;
+    advEvent.params.reason = (hal_ble_adv_stopped_reason_t)advStopped.reason;
+    for (const auto& handler : advEventHandlers_) {
+        if (handler.callback) {
+            handler.callback(&advEvent, handler.context);
+        }
+    }
+    return SYSTEM_ERROR_NONE;
+}
+
 void BleObject::Broadcaster::processBroadcasterEvents(const ble_evt_t* event, void* context) {
     Broadcaster* broadcaster = static_cast<BroadcasterImpl*>(context)->instance;
     switch (event->header.evt_id) {
         case BLE_GAP_EVT_ADV_SET_TERMINATED: {
             LOG_DEBUG(TRACE, "BLE GAP event: advertising stopped.");
+            if (!broadcaster->isAdvertising_) {
+                break;
+            }
             broadcaster->isAdvertising_ = false;
+            ble_evt_t* advStoppedEvent = (ble_evt_t*)BleObject::getInstance().dispatcher()->allocEventData(sizeof(ble_evt_t));
+            if (!advStoppedEvent) {
+                LOG(ERROR, "Allocate memory for BLE event failed.");
+                break;
+            }
+            memcpy(advStoppedEvent, event, sizeof(ble_evt_t));
+            BleObject::getInstance().dispatcher()->enqueue(&advStoppedEvent);
             break;
         }
         case BLE_GAP_EVT_CONNECTED: {
@@ -3357,6 +3411,22 @@ int hal_ble_stack_deinit(void* reserved) {
 
 int hal_ble_select_antenna(hal_ble_ant_type_t antenna, void* reserved) {
     return BleObject::getInstance().selectAntenna(antenna);
+}
+
+int hal_ble_set_callback_on_adv_events(hal_ble_on_adv_evt_cb_t callback, void* context, void* reserved) {
+    BleLock lk;
+    LOG_DEBUG(TRACE, "hal_ble_set_callback_on_adv_events().");
+    CHECK_TRUE(BleObject::getInstance().initialized(), SYSTEM_ERROR_INVALID_STATE);
+    CHECK(BleObject::getInstance().broadcaster()->onAdvEventCallback(callback, context));
+    return SYSTEM_ERROR_NONE;
+}
+
+int hal_ble_cancel_callback_on_adv_events(hal_ble_on_adv_evt_cb_t callback, void* context, void* reserved) {
+    BleLock lk;
+    LOG_DEBUG(TRACE, "hal_ble_cancel_callback_on_adv_events().");
+    CHECK_TRUE(BleObject::getInstance().initialized(), SYSTEM_ERROR_INVALID_STATE);
+    BleObject::getInstance().broadcaster()->cancelAdvEventCallback(callback, context);
+    return SYSTEM_ERROR_NONE;
 }
 
 int hal_ble_set_callback_on_periph_link_events(hal_ble_on_link_evt_cb_t callback, void* context, void* reserved) {

--- a/hal/src/nRF52840/ble_hal.cpp
+++ b/hal/src/nRF52840/ble_hal.cpp
@@ -72,7 +72,7 @@ namespace {
 
 StaticRecursiveMutex s_bleMutex;
 
-bool bleInListeningMode = false;
+bool bleInLockedMode = false;
 
 const auto BLE_CONN_CFG_TAG = 1;
 
@@ -3395,13 +3395,13 @@ int hal_ble_unlock(void* reserved) {
     return !s_bleMutex.unlock();
 }
 
-int hal_ble_notify_enter_listening_mode(void* reserved) {
-    bleInListeningMode = true;
+int hal_ble_enter_locked_mode(void* reserved) {
+    bleInLockedMode = true;
     return SYSTEM_ERROR_NONE;
 }
 
-int hal_ble_notify_exit_listening_mode(void* reserved) {
-    bleInListeningMode = false;
+int hal_ble_exit_locked_mode(void* reserved) {
+    bleInLockedMode = false;
     return SYSTEM_ERROR_NONE;
 }
 
@@ -3498,7 +3498,7 @@ int hal_ble_gap_set_ppcp(const hal_ble_conn_params_t* ppcp, void* reserved) {
     BleLock lk;
     LOG_DEBUG(TRACE, "hal_ble_gap_set_ppcp().");
     CHECK_TRUE(BleObject::getInstance().initialized(), SYSTEM_ERROR_INVALID_STATE);
-    CHECK_FALSE(bleInListeningMode, SYSTEM_ERROR_INVALID_STATE);
+    CHECK_FALSE(bleInLockedMode, SYSTEM_ERROR_INVALID_STATE);
     return BleObject::getInstance().connMgr()->setPpcp(ppcp);
 }
 
@@ -3527,7 +3527,7 @@ int hal_ble_gap_set_tx_power(int8_t tx_power, void* reserved) {
     BleLock lk;
     LOG_DEBUG(TRACE, "hal_ble_gap_set_tx_power().");
     CHECK_TRUE(BleObject::getInstance().initialized(), SYSTEM_ERROR_INVALID_STATE);
-    CHECK_FALSE(bleInListeningMode, SYSTEM_ERROR_INVALID_STATE);
+    CHECK_FALSE(bleInLockedMode, SYSTEM_ERROR_INVALID_STATE);
     return BleObject::getInstance().broadcaster()->setTxPower(tx_power);
 }
 
@@ -3542,7 +3542,7 @@ int hal_ble_gap_set_advertising_parameters(const hal_ble_adv_params_t* adv_param
     BleLock lk;
     LOG_DEBUG(TRACE, "hal_ble_gap_set_advertising_parameters().");
     CHECK_TRUE(BleObject::getInstance().initialized(), SYSTEM_ERROR_INVALID_STATE);
-    CHECK_FALSE(bleInListeningMode, SYSTEM_ERROR_INVALID_STATE);
+    CHECK_FALSE(bleInLockedMode, SYSTEM_ERROR_INVALID_STATE);
     return BleObject::getInstance().broadcaster()->setAdvertisingParams(adv_params);
 }
 
@@ -3557,7 +3557,7 @@ int hal_ble_gap_set_advertising_data(const uint8_t* buf, size_t len, void* reser
     BleLock lk;
     LOG_DEBUG(TRACE, "hal_ble_gap_set_advertising_data().");
     CHECK_TRUE(BleObject::getInstance().initialized(), SYSTEM_ERROR_INVALID_STATE);
-    CHECK_FALSE(bleInListeningMode, SYSTEM_ERROR_INVALID_STATE);
+    CHECK_FALSE(bleInLockedMode, SYSTEM_ERROR_INVALID_STATE);
     return BleObject::getInstance().broadcaster()->setAdvertisingData(buf, len);
 }
 
@@ -3572,7 +3572,7 @@ int hal_ble_gap_set_scan_response_data(const uint8_t* buf, size_t len, void* res
     BleLock lk;
     LOG_DEBUG(TRACE, "hal_ble_gap_set_scan_response_data().");
     CHECK_TRUE(BleObject::getInstance().initialized(), SYSTEM_ERROR_INVALID_STATE);
-    CHECK_FALSE(bleInListeningMode, SYSTEM_ERROR_INVALID_STATE);
+    CHECK_FALSE(bleInLockedMode, SYSTEM_ERROR_INVALID_STATE);
     return BleObject::getInstance().broadcaster()->setScanResponseData(buf, len);
 }
 
@@ -3594,7 +3594,7 @@ int hal_ble_gap_set_auto_advertise(hal_ble_auto_adv_cfg_t config, void* reserved
     BleLock lk;
     LOG_DEBUG(TRACE, "hal_ble_gap_set_auto_advertise().");
     CHECK_TRUE(BleObject::getInstance().initialized(), SYSTEM_ERROR_INVALID_STATE);
-    CHECK_FALSE(bleInListeningMode, SYSTEM_ERROR_INVALID_STATE);
+    CHECK_FALSE(bleInLockedMode, SYSTEM_ERROR_INVALID_STATE);
     return BleObject::getInstance().broadcaster()->setAutoAdvertiseScheme(config);
 }
 
@@ -3609,7 +3609,7 @@ int hal_ble_gap_stop_advertising(void* reserved) {
     BleLock lk;
     LOG_DEBUG(TRACE, "hal_ble_gap_stop_advertising().");
     CHECK_TRUE(BleObject::getInstance().initialized(), SYSTEM_ERROR_INVALID_STATE);
-    CHECK_FALSE(bleInListeningMode, SYSTEM_ERROR_INVALID_STATE);
+    CHECK_FALSE(bleInLockedMode, SYSTEM_ERROR_INVALID_STATE);
     return BleObject::getInstance().broadcaster()->stopAdvertising();
 }
 
@@ -3684,7 +3684,7 @@ int hal_ble_gap_disconnect(hal_ble_conn_handle_t conn_handle, void* reserved) {
     CHECK_TRUE(BleObject::getInstance().initialized(), SYSTEM_ERROR_INVALID_STATE);
     hal_ble_conn_info_t info = {};
     CHECK(BleObject::getInstance().connMgr()->getConnectionInfo(conn_handle, &info));
-    CHECK_FALSE(bleInListeningMode && info.role == BLE_ROLE_PERIPHERAL, SYSTEM_ERROR_INVALID_STATE);
+    CHECK_FALSE(bleInLockedMode && info.role == BLE_ROLE_PERIPHERAL, SYSTEM_ERROR_INVALID_STATE);
     return BleObject::getInstance().connMgr()->disconnect(conn_handle);
 }
 
@@ -3694,7 +3694,7 @@ int hal_ble_gap_update_connection_params(hal_ble_conn_handle_t conn_handle, cons
     CHECK_TRUE(BleObject::getInstance().initialized(), SYSTEM_ERROR_INVALID_STATE);
     hal_ble_conn_info_t info = {};
     CHECK(BleObject::getInstance().connMgr()->getConnectionInfo(conn_handle, &info));
-    CHECK_FALSE(bleInListeningMode && info.role == BLE_ROLE_PERIPHERAL, SYSTEM_ERROR_INVALID_STATE);
+    CHECK_FALSE(bleInLockedMode && info.role == BLE_ROLE_PERIPHERAL, SYSTEM_ERROR_INVALID_STATE);
     return BleObject::getInstance().connMgr()->updateConnectionParams(conn_handle, conn_params);
 }
 

--- a/system/src/ble_listening_mode_handler.cpp
+++ b/system/src/ble_listening_mode_handler.cpp
@@ -296,17 +296,16 @@ int BleListeningModeHandler::exit() {
     // FIXME: BLE is still connected to finalize the mobile setup when this function is called. In that case,
     // there is a chance that the mobile setup process is terminated by other thread or user application.
 
-    preAdvData_.clear();
-    preSrData_.clear();
-    ctrlReqAdvData_.clear();
-    ctrlReqSrData_.clear();
-
     // It should not CHECK() in this function, in case that the BLE HAL status cannot be restored correctly.
 
     // Do not allow other thread to modify the BLE configurations until this function exits.
     hal_ble_lock(nullptr);
     SCOPE_GUARD ({
         hal_ble_unlock(nullptr);
+        preAdvData_.clear();
+        preSrData_.clear();
+        ctrlReqAdvData_.clear();
+        ctrlReqSrData_.clear();
     });
 
     // Now the BLE configurations are modifiable.

--- a/system/src/ble_listening_mode_handler.cpp
+++ b/system/src/ble_listening_mode_handler.cpp
@@ -26,6 +26,7 @@ LOG_SOURCE_CATEGORY("system.listen.ble")
 #include "check.h"
 #include "scope_guard.h"
 #include "device_code.h"
+#include "service_debug.h"
 
 namespace {
 
@@ -271,6 +272,8 @@ int BleListeningModeHandler::enter() {
             exit();
         }
     });
+
+    SPARK_ASSERT(hal_ble_stack_init(nullptr) == SYSTEM_ERROR_NONE);
 
     // Now the BLE configurations are non-modifiable.
     CHECK(hal_ble_enter_locked_mode(nullptr));

--- a/system/src/ble_listening_mode_handler.h
+++ b/system/src/ble_listening_mode_handler.h
@@ -24,6 +24,7 @@
 
 #include <memory>
 #include "ble_hal.h"
+#include "spark_wiring_vector.h"
 
 namespace particle { namespace system {
 
@@ -52,23 +53,24 @@ private:
     const uint16_t BLE_CTRL_REQ_ADV_INTERVAL = BLE_MSEC_TO_UNITS(50, BLE_UNIT_0_625_MS); // Advertising interval: 50ms
     const uint16_t BLE_CTRL_REQ_ADV_TIMEOUT = BLE_MSEC_TO_UNITS(500, BLE_UNIT_10_MS); // Advertising timeout: 500ms
 
+    const int8_t BLE_CTRL_REQ_TX_POWER = 0; //0dBm
+
     const uint8_t BLE_CTRL_REQ_SVC_UUID[BLE_SIG_UUID_128BIT_LEN] = {0xfc,0x36,0x6f,0x54,0x30,0x80,0xf4,0x94,0xa8,0x48,0x4e,0x5c,0x01,0x00,0xa9,0x6f};
 
-    std::unique_ptr<uint8_t[]> preAdvData_;
-    size_t preAdvDataLen_;
-    std::unique_ptr<uint8_t[]> preSrData_;
-    size_t preSrDataLen_;
+    Vector<uint8_t> preAdvData_;
+    Vector<uint8_t> preSrData_;
     hal_ble_adv_params_t preAdvParams_;
+    int8_t preTxPower_;
     hal_ble_conn_params_t prePpcp_;
     bool preAdvertising_;
     bool preConnected_;
     hal_ble_auto_adv_cfg_t preAutoAdv_;
     bool userAdv_;
+    bool restoreUserConfig_;
+    static bool exited_;
 
-    std::unique_ptr<uint8_t[]> ctrlReqAdvData_;
-    size_t ctrlReqAdvDataLen_;
-    std::unique_ptr<uint8_t[]> ctrlReqSrData_;
-    size_t ctrlReqSrDataLen_;
+    Vector<uint8_t> ctrlReqAdvData_;
+    Vector<uint8_t> ctrlReqSrData_;
 };
 
 } } /* particle::system */

--- a/system/src/ble_listening_mode_handler.h
+++ b/system/src/ble_listening_mode_handler.h
@@ -36,6 +36,24 @@ public:
     int exit();
 
 private:
+    int constructControlRequestAdvData();
+    int cacheUserConfigurations();
+    int restoreUserConfigurations();
+    int applyControlRequestConfigurations();
+    int applyUserAdvData();
+    int applyControlRequestAdvData();
+    static void onBleAdvEvents(const hal_ble_adv_evt_t *event, void* context);
+
+    const uint16_t BLE_CTRL_REQ_MIN_CONN_INTERVAL = BLE_MSEC_TO_UNITS(30, BLE_UNIT_1_25_MS);
+    const uint16_t BLE_CTRL_REQ_MAX_CONN_INTERVAL = BLE_MSEC_TO_UNITS(50, BLE_UNIT_1_25_MS);
+    const uint16_t BLE_CTRL_REQ_SLAVE_LATENCY = 0;
+    const uint16_t BLE_CTRL_REQ_CONN_SUP_TIMEOUT = BLE_MSEC_TO_UNITS(5000, BLE_UNIT_10_MS);
+
+    const uint16_t BLE_CTRL_REQ_ADV_INTERVAL = BLE_MSEC_TO_UNITS(50, BLE_UNIT_0_625_MS); // Advertising interval: 50ms
+    const uint16_t BLE_CTRL_REQ_ADV_TIMEOUT = BLE_MSEC_TO_UNITS(500, BLE_UNIT_10_MS); // Advertising timeout: 500ms
+
+    const uint8_t BLE_CTRL_REQ_SVC_UUID[BLE_SIG_UUID_128BIT_LEN] = {0xfc,0x36,0x6f,0x54,0x30,0x80,0xf4,0x94,0xa8,0x48,0x4e,0x5c,0x01,0x00,0xa9,0x6f};
+
     std::unique_ptr<uint8_t[]> preAdvData_;
     size_t preAdvDataLen_;
     std::unique_ptr<uint8_t[]> preSrData_;
@@ -45,6 +63,12 @@ private:
     bool preAdvertising_;
     bool preConnected_;
     hal_ble_auto_adv_cfg_t preAutoAdv_;
+    bool userAdv_;
+
+    std::unique_ptr<uint8_t[]> ctrlReqAdvData_;
+    size_t ctrlReqAdvDataLen_;
+    std::unique_ptr<uint8_t[]> ctrlReqSrData_;
+    size_t ctrlReqSrDataLen_;
 };
 
 } } /* particle::system */

--- a/system/src/ble_listening_mode_handler.h
+++ b/system/src/ble_listening_mode_handler.h
@@ -50,8 +50,8 @@ private:
     const uint16_t BLE_CTRL_REQ_SLAVE_LATENCY = 0;
     const uint16_t BLE_CTRL_REQ_CONN_SUP_TIMEOUT = BLE_MSEC_TO_UNITS(5000, BLE_UNIT_10_MS);
 
-    const uint16_t BLE_CTRL_REQ_ADV_INTERVAL = BLE_MSEC_TO_UNITS(50, BLE_UNIT_0_625_MS); // Advertising interval: 50ms
-    const uint16_t BLE_CTRL_REQ_ADV_TIMEOUT = BLE_MSEC_TO_UNITS(500, BLE_UNIT_10_MS); // Advertising timeout: 500ms
+    const uint16_t BLE_CTRL_REQ_ADV_INTERVAL = BLE_MSEC_TO_UNITS(20, BLE_UNIT_0_625_MS); // Advertising interval: 20ms
+    const uint16_t BLE_CTRL_REQ_ADV_TIMEOUT = BLE_MSEC_TO_UNITS(1000, BLE_UNIT_10_MS); // Advertising timeout: 1000ms
 
     const int8_t BLE_CTRL_REQ_TX_POWER = 0; //0dBm
 

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -507,6 +507,9 @@ private:
 
 class BleLocalDevice {
 public:
+    int begin() const;
+    int end() const;
+
     // Local device identifies.
     int setAddress(const BleAddress& address) const;
     int setAddress(const char* address, BleAddressType type = BleAddressType::PUBLIC) const;
@@ -520,8 +523,8 @@ public:
     String getDeviceName() const;
 
     // Access radio performance
-    int on();
-    int off();
+    int on() const;
+    int off() const;
     int setTxPower(int8_t txPower) const;
     int txPower(int8_t* txPower) const;
     int selectAntenna(BleAntennaType antenna) const;

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -1609,6 +1609,7 @@ int BleLocalDevice::end() const {
 
 int BleLocalDevice::on() const {
     WiringBleLock lk;
+    CHECK(hal_ble_stack_init(nullptr));
     return SYSTEM_ERROR_NONE;
 }
 

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -1583,12 +1583,36 @@ void BleLocalDevice::onDisconnected(BleOnDisconnectedCallback callback, void* co
     impl()->onDisconnectedCallback(callback, context);
 }
 
-int BleLocalDevice::on() {
+int BleLocalDevice::begin() const {
     WiringBleLock lk;
     return SYSTEM_ERROR_NONE;
 }
 
-int BleLocalDevice::off() {
+int BleLocalDevice::end() const {
+    /*
+     * 1. Disconnects all the connections initiated by user application.
+     * 2. Disconnects Peripheral connection if it is not in the Listening mode.
+     * 3. Stops advertising if it is not in the Listening mode.
+     * 4. Stops scanning if initiated.
+     *
+     * FIXME: If device is broadcasting before entering the Listening mode and
+     * then this API is called during device in the Listening mode, device will
+     * restart broadcasting automatically when device exits the Listening mode.
+     */
+    WiringBleLock lk;
+    disconnectAll(); // BLE HAL will guard that the Peripheral connection is remained if device is in the Listening mode.
+    impl()->peers().clear();
+    stopAdvertising(); // BLE HAL will guard that device keeps broadcasting if device is in the Listening mode.
+    stopScanning();
+    return SYSTEM_ERROR_NONE;
+}
+
+int BleLocalDevice::on() const {
+    WiringBleLock lk;
+    return SYSTEM_ERROR_NONE;
+}
+
+int BleLocalDevice::off() const {
     WiringBleLock lk;
     CHECK(hal_ble_stack_deinit(nullptr));
     impl()->peers().clear();


### PR DESCRIPTION
### Problem

The advertising data and scan response data set by user application will not be broadcasting when device in the Listening mode. What that means is, for custom mobile App it would not be able to filter their device by the advertising data set in user application when device in the Listening mode.

### Solution

Alternately broadcast user's and Particle-specific advertising data when device in the Listening mode. By this way, both of the advertising data will be broadcasting and observed by Particle mobile App and custom mobile App. The only defect is that when device in the listening mode, the advertising and connection parameters set in user application are adjusted to appropriate values to coordinate the Particle mobile setup. But once device exits the Listening mode, these parameters are restored for user application.

Effective advertising parameters in the Listening mode:
```
|<--------------->|<--------------->|<--------------->|<--------------->|
User ADV          Particle ADV      User ADV          Particle ADV 

+----------+---------+
| Interval | Timeout |
+----------+---------+
| 20ms     | 1000ms  |
+----------+---------+
```

Effective connection parameters in the Listening mode:
```
+--------------+--------------+---------+---------+
| MIN Interval | MAX Interval | Latency | Timeout |
+--------------+--------------+---------+---------+
| 30ms         | 50ms         | 0       | 5000ms  |
+--------------+--------------+---------+---------+
```

### Steps to Test

Build and flash the monolithic firmware with log enabled:
    `$ make MODULAR=n DEBUG_BUILD=y PLATFORM=xenon TEST=<path_to_the_example>`
    `$ dfu-util -d 2b04:d00e -a 0 -s 0x30000:leave -D <path_to_the_built_binary>`

1. Device is neither broadcasting nor connected before entering the Listening mode:
    - Check the log message when device in the Listening mode, it should be only broadcasting the Particle-specific advertising data.
    - It should be able to be connected by the Particle mobile App.
    - Make the device leave the listening mode and disconnect from mobile App, device shouldn't be broadcasting.

2. Device is broadcasting before entering the Listening mode:
    - Check the log message when device in the Listening mode, it should be alternately broadcasting user's and Particle-specific advertising data in every 500ms interval.
    - It should be able to be connected by the Particle mobile App.
    - Make the device leave the listening mode and disconnect from mobile App, device should be only broadcasting the user's advertising data with the advertising parameters set in user application.

3. Device is connected before entering the Listening mode:
    - Check the log message when device in the Listening mode, it shouldn't be broadcasting.
    - Disconnect device when device in the listening mode, it should be alternately broadcasting user's and Particle-specific advertising data in every 500ms interval.
    - It should be able to be connected by the Particle mobile App.
    - Make the device leave the listening mode and disconnect from mobile App, device should be only broadcasting the user's advertising data with the advertising parameters set in user application.

### Example App

```c
#include "Particle.h"

SYSTEM_MODE(MANUAL);

Serial1LogHandler log(115200, LOG_LEVEL_ALL);

const char* serviceUuid = "6E400001-B5A3-F393-E0A9-E50E24DCCA9E";

void setup() {
    BLE.setAdvertisingTimeout(1000); // 1000 * 10 ms

    BleAdvertisingData data;
    data.appendServiceUUID(serviceUuid);
    BLE.advertise(&data);
}

void loop() {
}
```