### PR TITLE
[hal] Fixes WIFIEN pin mode for ASoM

### DIFF
--- a/hal/src/argon/network/esp32_ncp_client.cpp
+++ b/hal/src/argon/network/esp32_ncp_client.cpp
@@ -95,7 +95,11 @@ Esp32NcpClient::~Esp32NcpClient() {
 int Esp32NcpClient::init(const NcpClientConfig& conf) {
     // Make sure ESP32 is powered down
     HAL_Pin_Mode(ESPBOOT, OUTPUT);
+#if PLATFORM_ID == PLATFORM_ARGON
     HAL_Pin_Mode(ESPEN, OUTPUT_OPEN_DRAIN);
+#elif PLATFORM_ID == PLATFORM_ASOM
+    HAL_Pin_Mode(ESPEN, OUTPUT);
+#endif
     espOff();
     // Initialize serial stream
     std::unique_ptr<SerialStream> serial(new(std::nothrow) SerialStream(HAL_USART_SERIAL2, 921600,


### PR DESCRIPTION
### Problem

ASOM has a pull-down resistor on ESPEN pin, it's different from ARGON, so the pin mode should be output drain on ARGON, output on ASOM.

### Solution

Fix the pin mode.

### Steps to Test

Connect ARGON and ASOM to the cloud.

Test result: Passed.

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)

---

- [bugfix] [hal] Fixes WIFIEN pin mode for ASoM [#1889](https://github.com/particle-iot/device-os/pull/1889)