### PR TITLE
BLE: introduces BLE.begin() and BLE.end() wiring APIs.

### DIFF
--- a/system/src/ble_listening_mode_handler.cpp
+++ b/system/src/ble_listening_mode_handler.cpp
@@ -26,6 +26,7 @@ LOG_SOURCE_CATEGORY("system.listen.ble")
 #include "check.h"
 #include "scope_guard.h"
 #include "device_code.h"
+#include "service_debug.h"
 
 namespace {
 
@@ -271,6 +272,8 @@ int BleListeningModeHandler::enter() {
             exit();
         }
     });
+
+    SPARK_ASSERT(hal_ble_stack_init(nullptr) == SYSTEM_ERROR_NONE);
 
     // Now the BLE configurations are non-modifiable.
     CHECK(hal_ble_enter_locked_mode(nullptr));

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -507,6 +507,9 @@ private:
 
 class BleLocalDevice {
 public:
+    int begin() const;
+    int end() const;
+
     // Local device identifies.
     int setAddress(const BleAddress& address) const;
     int setAddress(const char* address, BleAddressType type = BleAddressType::PUBLIC) const;
@@ -520,8 +523,8 @@ public:
     String getDeviceName() const;
 
     // Access radio performance
-    int on();
-    int off();
+    int on() const;
+    int off() const;
     int setTxPower(int8_t txPower) const;
     int txPower(int8_t* txPower) const;
     int selectAntenna(BleAntennaType antenna) const;

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -1609,6 +1609,7 @@ int BleLocalDevice::end() const {
 
 int BleLocalDevice::on() const {
     WiringBleLock lk;
+    CHECK(hal_ble_stack_init(nullptr));
     return SYSTEM_ERROR_NONE;
 }
 

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -1583,12 +1583,36 @@ void BleLocalDevice::onDisconnected(BleOnDisconnectedCallback callback, void* co
     impl()->onDisconnectedCallback(callback, context);
 }
 
-int BleLocalDevice::on() {
+int BleLocalDevice::begin() const {
     WiringBleLock lk;
     return SYSTEM_ERROR_NONE;
 }
 
-int BleLocalDevice::off() {
+int BleLocalDevice::end() const {
+    /*
+     * 1. Disconnects all the connections initiated by user application.
+     * 2. Disconnects Peripheral connection if it is not in the Listening mode.
+     * 3. Stops advertising if it is not in the Listening mode.
+     * 4. Stops scanning if initiated.
+     *
+     * FIXME: If device is broadcasting before entering the Listening mode and
+     * then this API is called during device in the Listening mode, device will
+     * restart broadcasting automatically when device exits the Listening mode.
+     */
+    WiringBleLock lk;
+    disconnectAll(); // BLE HAL will guard that the Peripheral connection is remained if device is in the Listening mode.
+    impl()->peers().clear();
+    stopAdvertising(); // BLE HAL will guard that device keeps broadcasting if device is in the Listening mode.
+    stopScanning();
+    return SYSTEM_ERROR_NONE;
+}
+
+int BleLocalDevice::on() const {
+    WiringBleLock lk;
+    return SYSTEM_ERROR_NONE;
+}
+
+int BleLocalDevice::off() const {
     WiringBleLock lk;
     CHECK(hal_ble_stack_deinit(nullptr));
     impl()->peers().clear();


### PR DESCRIPTION
### Problem

In Device OS 1.3.1-rc.1 and below, to terminate all the BLE activities initiated by user application, we can call `BLE.off()` to just shut off the BLE radio. While this API will also prevent the mobile setup from going further when device is in the Listening mode, since BLE will stop advertising and Peripheral connection is dropped if connected when that API is called.

### Solution

By introducing the `BLE.end()` API, it makes sure that only the BLE activities initiated by user application is terminated, leaving the mobile setup works as expected.

### Examples App

1. BLE scanner
```c
#include "Particle.h"

SYSTEM_MODE(MANUAL);

Serial1LogHandler log(115200, LOG_LEVEL_ALL);

void bleOnScanResultCallback(const BleScanResult* result, void* context) {
    LOG(TRACE, "---------- END ----------");
    BLE.end()
}

void setup() {
}

void loop() {
    BLE.scan(bleOnScanResultCallback, nullptr);
    delay(3000);
}
```
2. BLE Peripheral
```c
#include "Particle.h"

SYSTEM_MODE(MANUAL);
SYSTEM_THREAD(ENABLED);

Serial1LogHandler log(115200, LOG_LEVEL_ALL);

const char* serviceUuid = "6E400001-B5A3-F393-E0A9-E50E24DCCA9E";

void setup() {
    BleAdvertisingData data;
    data.appendServiceUUID(serviceUuid);
    BLE.advertise(&data);
}

void loop() {
    delay(20000);
    LOG(TRACE, "---------- END ----------");
    BLE.end()
}
```
3. BLE Central
```c
#include "Particle.h"

SYSTEM_MODE(MANUAL);
SYSTEM_THREAD(ENABLED);

Serial1LogHandler log(115200, LOG_LEVEL_ALL);

#define SCAN_RESULT_COUNT       20

BleScanResult results[SCAN_RESULT_COUNT];

BlePeerDevice peer;

void setup() {
}

void loop() {
    if (peer.connected()) {
        delay(10000);
        LOG(TRACE, "---------- END ----------");
        BLE.end()
    }
    else {
        delay(3000);
        size_t count = BLE.scan(results, SCAN_RESULT_COUNT);
        if (count > 0) {
            for (uint8_t i = 0; i < count; i++) {
                BleUuid foundServiceUUID;
                size_t svcCount = results[i].advertisingData.serviceUUID(&foundServiceUUID, 1);
                if (svcCount > 0 && foundServiceUUID == "6E400001-B5A3-F393-E0A9-E50E24DCCA9E") {
                    peer = BLE.connect(results[i].address);
                    break;
                }
            }
        }
    }
}
```

### Steps to Test

1. Build and flash the 1st application, see if BLE stops scanning on device scanned.
2. Build and flash the 2nd application:
    - See if BLE stops advertising after 20 seconds.
    - On device started, make it enter the Listening mode, see if BLE is still advertising after 20 seconds.
    - On device started, make it enter the Listening mode and connect to the device using a mobile App, see if BLE connection is retained after 20 seconds.
3. Build and flash the 3rd application (need another device that is running the 1st application but without the `BLE.end()` is called), see if BLE connection is dropped after device being connected for 10 seconds.

### References

Known issue: https://github.com/particle-iot/device-os/pull/1847