### PR TITLE
BLE: minor fixes

### DIFF
--- a/hal/src/nRF52840/ble_hal.cpp
+++ b/hal/src/nRF52840/ble_hal.cpp
@@ -974,9 +974,12 @@ int BleObject::Broadcaster::setAdvertisingParams(const hal_ble_adv_params_t* par
     CHECK(suspend());
     if (connHandle_ != BLE_INVALID_CONN_HANDLE) {
         tempParams.type = BLE_ADV_SCANABLE_UNDIRECTED_EVT;
-        if (configure(&tempParams) != SYSTEM_ERROR_NONE) {
-            LOG(ERROR, "Failed to configure advertising parameters.");
-            return resume();
+        int ret = configure(&tempParams);
+        if (ret != SYSTEM_ERROR_NONE) {
+            if (resume() != SYSTEM_ERROR_NONE) {
+                LOG(ERROR, "Failed to resume BLE advertising.");
+            }
+            return ret;
         }
         if (params == nullptr) {
             tempParams.type = BLE_ADV_CONNECTABLE_SCANNABLE_UNDIRECRED_EVT;
@@ -988,15 +991,18 @@ int BleObject::Broadcaster::setAdvertisingParams(const hal_ble_adv_params_t* par
         advParams_.version = BLE_API_VERSION;
         connectedAdvParams_ = true; // Set the flag after the advParams_ being updated.
     } else {
-        if (configure(&tempParams) != SYSTEM_ERROR_NONE) {
-            LOG(ERROR, "Failed to configure advertising parameters.");
-            return resume();
+        int ret = configure(&tempParams);
+        if (ret != SYSTEM_ERROR_NONE) {
+            if (resume() != SYSTEM_ERROR_NONE) {
+                LOG(ERROR, "Failed to resume BLE advertising.");
+            }
+            return ret;
         }
         memcpy(&advParams_, &tempParams, std::min(advParams_.size, tempParams.size));
         advParams_.size = sizeof(hal_ble_adv_params_t);
         advParams_.version = BLE_API_VERSION;
     }
-    return resume();
+    return CHECK(resume());
 }
 
 int BleObject::Broadcaster::getAdvertisingParams(hal_ble_adv_params_t* params) const {
@@ -1015,10 +1021,14 @@ int BleObject::Broadcaster::setAdvertisingData(const uint8_t* buf, size_t len) {
         len = 0;
     }
     advDataLen_ = len;
-    if (configure(nullptr) != SYSTEM_ERROR_NONE) {
-        LOG(ERROR, "Failed to configure advertising data.");
+    int ret = configure(nullptr);
+    if (ret != SYSTEM_ERROR_NONE) {
+        if (resume() != SYSTEM_ERROR_NONE) {
+            LOG(ERROR, "Failed to resume BLE advertising.");
+        }
+        return ret;
     }
-    return resume();
+    return CHECK(resume());
 }
 
 ssize_t BleObject::Broadcaster::getAdvertisingData(uint8_t* buf, size_t len) const {
@@ -1040,10 +1050,14 @@ int BleObject::Broadcaster::setScanResponseData(const uint8_t* buf, size_t len) 
         len = 0;
     }
     scanRespDataLen_ = len;
-    if (configure(nullptr) != SYSTEM_ERROR_NONE) {
-        LOG(ERROR, "Failed to configure scan response data.");
+    int ret = configure(nullptr);
+    if (ret != SYSTEM_ERROR_NONE) {
+        if (resume() != SYSTEM_ERROR_NONE) {
+            LOG(ERROR, "Failed to resume BLE advertising.");
+        }
+        return ret;
     }
-    return resume();
+    return CHECK(resume());
 }
 
 ssize_t BleObject::Broadcaster::getScanResponseData(uint8_t* buf, size_t len) const {

--- a/hal/src/nRF52840/ble_hal.cpp
+++ b/hal/src/nRF52840/ble_hal.cpp
@@ -975,6 +975,7 @@ int BleObject::Broadcaster::setAdvertisingParams(const hal_ble_adv_params_t* par
     if (connHandle_ != BLE_INVALID_CONN_HANDLE) {
         tempParams.type = BLE_ADV_SCANABLE_UNDIRECTED_EVT;
         if (configure(&tempParams) != SYSTEM_ERROR_NONE) {
+            LOG(ERROR, "Failed to configure advertising parameters.");
             return resume();
         }
         if (params == nullptr) {
@@ -988,6 +989,7 @@ int BleObject::Broadcaster::setAdvertisingParams(const hal_ble_adv_params_t* par
         connectedAdvParams_ = true; // Set the flag after the advParams_ being updated.
     } else {
         if (configure(&tempParams) != SYSTEM_ERROR_NONE) {
+            LOG(ERROR, "Failed to configure advertising parameters.");
             return resume();
         }
         memcpy(&advParams_, &tempParams, std::min(advParams_.size, tempParams.size));
@@ -1013,7 +1015,9 @@ int BleObject::Broadcaster::setAdvertisingData(const uint8_t* buf, size_t len) {
         len = 0;
     }
     advDataLen_ = len;
-    configure(nullptr);
+    if (configure(nullptr) != SYSTEM_ERROR_NONE) {
+        LOG(ERROR, "Failed to configure advertising data.");
+    }
     return resume();
 }
 
@@ -1036,7 +1040,9 @@ int BleObject::Broadcaster::setScanResponseData(const uint8_t* buf, size_t len) 
         len = 0;
     }
     scanRespDataLen_ = len;
-    configure(nullptr);
+    if (configure(nullptr) != SYSTEM_ERROR_NONE) {
+        LOG(ERROR, "Failed to configure scan response data.");
+    }
     return resume();
 }
 
@@ -1159,7 +1165,8 @@ int BleObject::Broadcaster::configure(const hal_ble_adv_params_t* params) {
                   bleGapAdvParams.interval*0.625, bleGapAdvParams.duration*10);
         ret = sd_ble_gap_adv_set_configure(&advHandle_, &bleGapAdvData, &bleGapAdvParams);
     }
-    return nrf_system_error(ret);
+    CHECK(nrf_system_error(ret));
+    return SYSTEM_ERROR_NONE;
 }
 
 int8_t BleObject::Broadcaster::roundTxPower(int8_t value) {

--- a/hal/src/nRF52840/ble_hal.cpp
+++ b/hal/src/nRF52840/ble_hal.cpp
@@ -722,7 +722,7 @@ static BleGapImpl bleGapImpl;
 
 int BleObject::BleGap::init() {
     // Set the default device name
-    char devName[32] = {};
+    char devName[BLE_MAX_DEV_NAME_LEN] = {};
     CHECK(get_device_name(devName, sizeof(devName)));
     CHECK(setDeviceName(devName, strlen(devName)));
     bleGapImpl.instance = this;
@@ -732,7 +732,7 @@ int BleObject::BleGap::init() {
 }
 
 int BleObject::BleGap::setDeviceName(const char* deviceName, size_t len) const {
-    char name[32] = {};
+    char name[BLE_MAX_DEV_NAME_LEN] = {};
     if (deviceName == nullptr || len == 0) {
         CHECK(get_device_name(name, sizeof(name)));
         len = strlen(name);
@@ -749,8 +749,7 @@ int BleObject::BleGap::setDeviceName(const char* deviceName, size_t len) const {
 int BleObject::BleGap::getDeviceName(char* deviceName, size_t len) const {
     CHECK_TRUE(deviceName, SYSTEM_ERROR_INVALID_ARGUMENT);
     CHECK_TRUE(len, SYSTEM_ERROR_INVALID_ARGUMENT);
-    // non NULL-terminated string returned.
-    uint16_t nameLen = len - 1;
+    uint16_t nameLen = len - 1; // Reserve 1 byte for the NULL-terminated character.
     int ret = sd_ble_gap_device_name_get((uint8_t*)deviceName, &nameLen);
     CHECK_NRF_RETURN(ret, nrf_system_error(ret));
     nameLen = std::min(len - 1, (size_t)nameLen);

--- a/hal/src/nRF52840/ble_hal.cpp
+++ b/hal/src/nRF52840/ble_hal.cpp
@@ -167,6 +167,7 @@ hal_ble_addr_t chipDefaultAddress() {
     localAddr.addr[3] = (uint8_t)((addrLsb >> 24) & 0x000000FF);
     localAddr.addr[4] = (uint8_t)(addrMsb & 0x000000FF);
     localAddr.addr[5] = (uint8_t)((addrMsb >> 8) & 0x000000FF);
+    localAddr.addr[5] |= 0xC0; // For random static address, the two most significant bits of the address shall be equal to 1.
     return localAddr;
 }
 

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -67,7 +67,7 @@ enum class BleCharacteristicProperty : uint8_t {
 
 inline BleCharacteristicProperty operator&(BleCharacteristicProperty lhs, BleCharacteristicProperty rhs) {
     return static_cast<BleCharacteristicProperty>(
-        static_cast<std::underlying_type<BleCharacteristicProperty>::type>(lhs) |
+        static_cast<std::underlying_type<BleCharacteristicProperty>::type>(lhs) &
         static_cast<std::underlying_type<BleCharacteristicProperty>::type>(rhs)
     );
 }

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -319,6 +319,8 @@ public:
         }
     }
 
+    size_t resize(size_t size);
+
     void clear();
     void remove(BleAdvertisingDataType type);
 

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -1759,8 +1759,7 @@ ssize_t BleLocalDevice::getAdvertisingData(BleAdvertisingData* advertisingData) 
         return SYSTEM_ERROR_INVALID_ARGUMENT;
     }
     advertisingData->clear();
-    ssize_t len = hal_ble_gap_get_advertising_data(advertisingData->data(), BLE_MAX_ADV_DATA_LEN, nullptr);
-    CHECK(len);
+    size_t len = CHECK(hal_ble_gap_get_advertising_data(advertisingData->data(), BLE_MAX_ADV_DATA_LEN, nullptr));
     advertisingData->resize(len);
     return len;
 }
@@ -1771,8 +1770,7 @@ ssize_t BleLocalDevice::getScanResponseData(BleAdvertisingData* scanResponse) co
         return SYSTEM_ERROR_INVALID_ARGUMENT;
     }
     scanResponse->clear();
-    ssize_t len = hal_ble_gap_get_scan_response_data(scanResponse->data(), BLE_MAX_ADV_DATA_LEN, nullptr);
-    CHECK(len);
+    size_t len = CHECK(hal_ble_gap_get_scan_response_data(scanResponse->data(), BLE_MAX_ADV_DATA_LEN, nullptr));
     scanResponse->resize(len);
     return len;
 }

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -1664,7 +1664,7 @@ ssize_t BleLocalDevice::getDeviceName(char* name, size_t len) const {
 
 String BleLocalDevice::getDeviceName() const {
     String name;
-    char buf[BLE_MAX_DEV_NAME_LEN] = {};
+    char buf[BLE_MAX_DEV_NAME_LEN + 1] = {}; // NULL-terminated string is returned.
     if (getDeviceName(buf, sizeof(buf)) > 0) {
         name.concat(buf);
     }

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -593,6 +593,11 @@ size_t BleAdvertisingData::appendCustomData(const uint8_t* buf, size_t len, bool
     return append(BleAdvertisingDataType::MANUFACTURER_SPECIFIC_DATA, buf, len, force);
 }
 
+size_t BleAdvertisingData::resize(size_t size) {
+    selfLen_ = std::min(size, (size_t)BLE_MAX_ADV_DATA_LEN);
+    return selfLen_;
+}
+
 void BleAdvertisingData::clear() {
     selfLen_ = 0;
     memset(selfData_, 0x00, sizeof(selfData_));
@@ -1753,7 +1758,11 @@ ssize_t BleLocalDevice::getAdvertisingData(BleAdvertisingData* advertisingData) 
     if (advertisingData == nullptr) {
         return SYSTEM_ERROR_INVALID_ARGUMENT;
     }
-    return hal_ble_gap_get_advertising_data(advertisingData->data(), BLE_MAX_ADV_DATA_LEN, nullptr);
+    advertisingData->clear();
+    ssize_t len = hal_ble_gap_get_advertising_data(advertisingData->data(), BLE_MAX_ADV_DATA_LEN, nullptr);
+    CHECK(len);
+    advertisingData->resize(len);
+    return len;
 }
 
 ssize_t BleLocalDevice::getScanResponseData(BleAdvertisingData* scanResponse) const {
@@ -1761,7 +1770,11 @@ ssize_t BleLocalDevice::getScanResponseData(BleAdvertisingData* scanResponse) co
     if (scanResponse == nullptr) {
         return SYSTEM_ERROR_INVALID_ARGUMENT;
     }
-    return hal_ble_gap_get_scan_response_data(scanResponse->data(), BLE_MAX_ADV_DATA_LEN, nullptr);
+    scanResponse->clear();
+    ssize_t len = hal_ble_gap_get_scan_response_data(scanResponse->data(), BLE_MAX_ADV_DATA_LEN, nullptr);
+    CHECK(len);
+    scanResponse->resize(len);
+    return len;
 }
 
 int BleLocalDevice::advertise() const {


### PR DESCRIPTION
### Bugfixes

- Restored default BLE device address is incorrect.
- Read BLE device name might be contracted.
- `operator&` of the `BleCharacteristicProperty` enum class doesn't work as expected.
- The length of got advertising and scan response data is not updated.