### PR TITLE
[user] fixes weird alignment error with the dynalib table location

### DIFF
--- a/modules/shared/nRF52840/user.ld
+++ b/modules/shared/nRF52840/user.ld
@@ -7,16 +7,16 @@ SECTIONS
     INCLUDE module_start.ld
     INCLUDE module_info.ld
 
-    .text :
+    .dynalib :
     {
-        expected_dynalib_start = ORIGIN (APP_FLASH) + 24 ;
+        expected_dynalib_start = ORIGIN(APP_FLASH) + 24 ;
         link_dynalib_start = .;
         KEEP(*(*.user_part_module))
         link_dynalib_end = . ;
-        link_length_start = .;
-        KEEP(*(*.user_part_length))
-        link_length_end = .;
+    } > APP_FLASH AT> APP_FLASH
 
+    .text :
+    {
         . = ALIGN(4);
 
         link_code_location = .;

--- a/modules/shared/stm32f2xx/user.ld
+++ b/modules/shared/stm32f2xx/user.ld
@@ -7,16 +7,16 @@ SECTIONS
     INCLUDE module_start.ld
     INCLUDE module_info.ld
 
-    .text :
+    .dynalib :
     {
-        expected_dynalib_start = ORIGIN (APP_FLASH) + 24 ;
+        expected_dynalib_start = ORIGIN(APP_FLASH) + 24 ;
         link_dynalib_start = .;
         KEEP(*(*.user_part_module))
         link_dynalib_end = . ;
-        link_length_start = .;
-        KEEP(*(*.user_part_length))
-        link_length_end = .;
+    } > APP_FLASH AT> APP_FLASH
 
+    .text :
+    {
         . = ALIGN(4);
 
         link_code_location = .;


### PR DESCRIPTION
### Problem

Closes #1843

### Solution

Putting the dynalib into a separate section in the linker file seems to help.

### Steps to Test

Build the test application from #1843. It should build without linker errors.

### Example App

N/A

### References

- #1843

---

### Changelog

- [bugfix] [Gen2 / Gen3] Fixes dynalib alignment issue when compiling relatively large applications potentially due to an unconfirmed bug in GCC by moving the dynalib into a separate section (`.dynalib`)