### PR TITLE
Update Travis CI for Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
 
 script:
   - buildpack/scripts/run-tests-in-container
+  - 'if [ -f /home/travis/build/.build/coverage.json ]; then python ci/report/report.py /home/travis/build/.build/coverage.json; rm -f /home/travis/build/.build/coverage.json; fi'
   - buildpack/scripts/push-image
 
   # - 'if [ ! -z "$DOCKER_HUB_EMAIL" ]; then docker login --email=$DOCKER_HUB_EMAIL --username=$DOCKER_HUB_USERNAME --password=$DOCKER_HUB_PASSWORD; fi'

--- a/ci/install_gcovr.sh
+++ b/ci/install_gcovr.sh
@@ -1,14 +1,32 @@
 #!/bin/bash
 #
-# Install gcovr-4.1 as the default gcovr
+# Prerequisites:
+#   git
+#   python
+#   pip
 KERNEL_NAME=$(uname -s)
 
+# MacOS Support
 if [ "${KERNEL_NAME}" == "Darwin" ]; then
-  brew install gcovr || exit 1
+  brew install git python || exit 1
+
+# Debian Support
 else
   (apt-get -qq update &&
-  apt-get -qq install python-pip &&
-  pip install gcovr==4.1) || exit 2
+  apt-get -qq install git python-pip) || exit 1
 fi
+
+# Install custom `gcovr` to support Coveralls output
+pushd ~
+git clone https://github.com/zfields/gcovr.git -b coveralls
+cd gcovr
+if [ "${KERNEL_NAME}" == "Darwin" ]; then
+  pip3 install -e $(pwd)
+  pip3 install requests
+else
+  pip install -e $(pwd)
+  pip install requests
+fi
+popd
 
 gcovr --version

--- a/ci/report/LICENSE
+++ b/ci/report/LICENSE
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/ci/report/report.py
+++ b/ci/report/report.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+"""Module to upload Python JSON structure to Coveralls.io"""
+# -*- coding:utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+__author__ = 'Lei Xu <eddyxu@gmail.com>'
+__version__ = '0.4.2'
+
+__classifiers__ = [
+    'Development Status :: 3 - Alpha',
+    'Intended Audience :: Developers',
+    'License :: OSI Approved :: Apache Software License',
+    'Operating System :: OS Independent',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 3',
+    'Topic :: Internet :: WWW/HTTP',
+    'Topic :: Software Development :: Libraries',
+    'Topic :: Software Development :: Quality Assurance',
+    'Topic :: Utilities',
+]
+
+__copyright__ = '2019, %s ' % __author__
+__license__ = """
+    Copyright %s.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either expressed or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+    """ % __copyright__
+
+# Filename: report.py
+# Author: Lei "Eddy" Xu
+# Copyright: 2019 Lei Xu
+# Description: Module to upload Python JSON structure to Coveralls.io
+# License: Apache License, Version 2.0
+# Modification History:
+# 2019/08/26 - Zachary J. Fields: Added main to support command line file upload
+
+import requests
+import json
+import os
+import sys
+
+URL = os.getenv('COVERALLS_ENDPOINT', 'https://coveralls.io') + "/api/v1/jobs"
+
+class Args:
+    skip_ssl_verify = False
+
+
+def post_report(coverage, args):
+    """Post coverage report to coveralls.io."""
+    response = requests.post(URL, files={'json_file': json.dumps(coverage)},
+                             verify=(not args.skip_ssl_verify))
+    try:
+        result = response.json()
+    except ValueError:
+        result = {'error': 'Failure to submit data. '
+                  'Response [%(status)s]: %(text)s' % {
+                      'status': response.status_code,
+                      'text': response.text}}
+    print(result)
+    if 'error' in result:
+        return result['error']
+    return 0
+
+def main():
+    if (len(sys.argv) < 2):
+        print("USAGE: python %s <coverage.json>" % sys.argv[0])
+    else:
+        args = Args()
+        with open(sys.argv[1], 'rb') as json_coverage_file:
+            # Load coverage details from specified file
+            json_coverage_details = json.load(json_coverage_file)
+
+            # Pull environment variables
+            if (json_coverage_details['repo_token'] is None):
+                json_coverage_details['repo_token'] = os.environ.get('COVERALLS_REPO_TOKEN')
+                if (json_coverage_details['repo_token'] is None):
+                    print("Environment variable COVERALLS_REPO_TOKEN is required to upload coverage information")
+                    exit(-1)
+
+            # Consume Travis CI specific environment variables _(if available)_
+            if not json_coverage_details.has_key('service_job_id'):
+                json_coverage_details['service_job_id'] = os.environ.get('TRAVIS_JOB_ID')
+                if (json_coverage_details['service_job_id'] is not None):
+                    json_coverage_details['service_name'] = "travis-ci"
+                    json_coverage_details['service_number'] = os.environ.get('TRAVIS_BUILD_NUMBER')
+                    json_coverage_details['service_pull_request'] = os.environ.get('TRAVIS_PULL_REQUEST')
+                else:
+                    json_coverage_details['service_name'] = ""
+                    del json_coverage_details['service_job_id']
+
+            # Post report to Coveralls.io
+            post_report(json_coverage_details, args)
+
+if __name__ == '__main__':
+    main()

--- a/ci/unit_tests.sh
+++ b/ci/unit_tests.sh
@@ -47,7 +47,7 @@ set -x -e
 
 # Run CMake-based unit tests
 cd $unit_test_dir
-rm -rf .build
-mkdir .build && cd .build
+rm -rf .build/*
+mkdir .build -p && cd .build/
 cmake ..
-make all test coverage
+make all test coveralls

--- a/scripts/fetch-buildpack
+++ b/scripts/fetch-buildpack
@@ -1,1 +1,1 @@
-mkdir buildpack && wget https://api.github.com/repos/spark/firmware-buildpack-builder/tarball/feature/parallel -O - | tar -xz -C buildpack --strip-components 1
+mkdir buildpack && wget https://api.github.com/repos/particle-iot/firmware-buildpack-builder/tarball/master -O - | tar -xz -C buildpack --strip-components 1

--- a/test/unit_tests/CMakeLists.txt
+++ b/test/unit_tests/CMakeLists.txt
@@ -60,3 +60,8 @@ add_subdirectory(wiring)
 add_custom_target( coverage
   gcovr --root ${DEVICE_OS_DIR} --exclude ${TEST_DIR} --exclude ${THIRD_PARTY_DIR} -j 4 --print-summary
 )
+
+# Create `coveralls` target in the `make` command
+add_custom_target( coveralls
+  gcovr --root ${DEVICE_OS_DIR} --exclude ${TEST_DIR} --exclude ${THIRD_PARTY_DIR} -j 4 --coveralls coverage.json
+)


### PR DESCRIPTION
### Problem

Travis CI is not integrated with Coveralls

### Solution

Update scripts, called by Travis CI, to generate Coveralls formatted coverage JSON, and submit the results to Coveralls.

### Steps to Test

Run Travis CI, and see if the coverage results appear in Coveralls

### References

[Coveralls](https://coveralls.io)
[Travis CI](https://travisci.org)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
