### PR TITLE
Fixes SoftDevice OTA updates

### DIFF
--- a/hal/src/argon/platform_ncp_argon.cpp
+++ b/hal/src/argon/platform_ncp_argon.cpp
@@ -117,12 +117,33 @@ int platform_ncp_fetch_module_info(hal_system_info_t* sys_info, bool create) {
                 info->platform_id = PLATFORM_ID;
                 info->module_function = MODULE_FUNCTION_NCP_FIRMWARE;
 
-                module->info = info;
                 // assume all checks pass since it was validated when being flashed to the NCP
                 module->validity_result = module->validity_checked;
+
+                // IMPORTANT: a valid suffix with SHA is required for the communication layer to detect a change
+                // in the SYSTEM DESCRIBE state and send a HELLO after the NCP update to
+                // cause the DS to request new DESCRIBE info
+                auto suffix = new module_info_suffix_t();
+                if (!suffix) {
+                    delete info;
+                    return SYSTEM_ERROR_NO_MEMORY;
+                }
+                memset(suffix, 0, sizeof(module_info_suffix_t));
+
+                // FIXME: NCP firmware should return some kind of a unique string/hash
+                // For now we simply fill the SHA field with version
+                for (uint16_t* sha = (uint16_t*)suffix->sha;
+                        sha < (uint16_t*)(suffix->sha + sizeof(suffix->sha));
+                        ++sha) {
+                    *sha = version;
+                }
+
+                module->info = info;
+                module->suffix = suffix;
             }
             else {
                 delete module->info;
+                delete ((module_info_suffix_t*)module->suffix);
             }
         }
     }

--- a/hal/src/nRF52840/platform_radio_stack.cpp
+++ b/hal/src/nRF52840/platform_radio_stack.cpp
@@ -37,11 +37,28 @@ int platform_radio_stack_fetch_module_info(hal_system_info_t* sys_info, bool cre
             info->platform_id = PLATFORM_ID;
             info->module_function = MODULE_FUNCTION_RADIO_STACK;
 
-            module->info = info;
             // FIXME: assuming that all checks passed for now
             module->validity_result = module->validity_checked;
+
+            // IMPORTANT: a valid suffix with SHA is required for the communication layer to detect a change
+            // in the SYSTEM DESCRIBE state and send a HELLO after the SoftDevice update to
+            // cause the DS to request new DESCRIBE info
+            auto suffix = new module_info_suffix_t();
+            if (!suffix) {
+                delete info;
+                return SYSTEM_ERROR_NO_MEMORY;
+            }
+            memset(suffix, 0, sizeof(module_info_suffix_t));
+
+            // Use a unique SoftDevice string in place of an SHA
+            auto addr = SD_UNIQUE_STR_ADDR_GET(MBR_SIZE);
+            memcpy(suffix->sha, addr, SD_UNIQUE_STR_SIZE);
+
+            module->info = info;
+            module->suffix = suffix;
         } else {
             delete module->info;
+            delete ((module_info_suffix_t*)module->suffix);
         }
 
         break;

--- a/platform/MCU/nRF52840/src/flash_mal.c
+++ b/platform/MCU/nRF52840/src/flash_mal.c
@@ -194,14 +194,23 @@ int FLASH_CopyMemory(flash_device_t sourceDeviceID, uint32_t sourceAddress,
     if (flags & MODULE_VERIFY_MASK)
     {
         const module_info_t* info = FLASH_ModuleInfo(sourceDeviceID, sourceAddress);
-        // NB: We have corner cases where the module info is not located in the
-        // front of the module but for example after the vector table and we
-        // only want to enable this feature in the case it is in the front,
-        // hence the module_info_t located at the the source address check.
-        if (info->flags & MODULE_INFO_FLAG_DROP_MODULE_INFO && (uintptr_t)info == (uintptr_t)sourceAddress)
-        {
-            // Skip module header
-            sourceAddress += sizeof(module_info_t);
+        if (info->flags & MODULE_INFO_FLAG_DROP_MODULE_INFO) {
+            // NB: We have corner cases where the module info is not located in the
+            // front of the module but for example after the vector table and we
+            // only want to enable this feature in the case it is in the front,
+            // hence the module_info_t located at the the source address check.
+            module_info_t front = {0};
+            if (sourceDeviceID == FLASH_SERIAL) {
+                hal_exflash_read(sourceAddress, (uint8_t*)&front, sizeof(front));
+            } else {
+                hal_flash_read(sourceAddress, (uint8_t*)&front, sizeof(front));
+            }
+            if (!memcmp(info, &front, sizeof(module_info_t))) {
+                // Skip module header
+                sourceAddress += sizeof(module_info_t);
+            } else {
+                return FLASH_ACCESS_RESULT_ERROR;
+            }
         }
     }
 


### PR DESCRIPTION
### Problem

1. The bootloader doesn't correctly handle `MODULE_INFO_FLAG_DROP_MODULE_INFO` flag. The returned module info for the SoftDevice module is a copy into a static variable, so direct pointer comparisons can't work.
2. The state checksum doesn't change after an update of either SoftDevice or NCP module, which causes the device to get stuck in safe mode

### Solution

1. Use `memcmp()` instead
2. Add a dummy suffix structure to module info and fill SHA for NCP and SoftDevice modules

**This should probably be backported into 1.3.0 default**

### Steps to Test

1. Flash the bootloader and then flash the SoftDevice binary OTA. It should apply correctly.
2. TBD on staging.

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
