### PR TITLE
BLE: wiring minor fixes

### DIFF
--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -359,15 +359,15 @@ public:
             : BleCharacteristic(desc.c_str(), properties, callback, context) {
     }
 
-    template<typename T>
-    BleCharacteristic(const char* desc, BleCharacteristicProperty properties, T charUuid, T svcUuid, BleOnDataReceivedCallback callback = nullptr, void* context = nullptr) {
+    template<typename T1, typename T2>
+    BleCharacteristic(const char* desc, BleCharacteristicProperty properties, T1 charUuid, T2 svcUuid, BleOnDataReceivedCallback callback = nullptr, void* context = nullptr) {
         BleUuid cUuid(charUuid);
         BleUuid sUuid(svcUuid);
         construct(desc, properties, cUuid, sUuid, callback, context);
     }
 
-    template<typename T>
-    BleCharacteristic(const String& desc, BleCharacteristicProperty properties, T charUuid, T svcUuid, BleOnDataReceivedCallback callback = nullptr, void* context = nullptr)
+    template<typename T1, typename T2>
+    BleCharacteristic(const String& desc, BleCharacteristicProperty properties, T1 charUuid, T2 svcUuid, BleOnDataReceivedCallback callback = nullptr, void* context = nullptr)
             : BleCharacteristic(desc.c_str(), properties, charUuid, svcUuid, callback, context) {
     }
     ~BleCharacteristic();
@@ -568,15 +568,15 @@ public:
     BleCharacteristic addCharacteristic(const char* desc, BleCharacteristicProperty properties, BleOnDataReceivedCallback callback = nullptr, void* context = nullptr);
     BleCharacteristic addCharacteristic(const String& desc, BleCharacteristicProperty properties, BleOnDataReceivedCallback callback = nullptr, void* context = nullptr);
 
-    template<typename T>
-    BleCharacteristic addCharacteristic(const char* desc, BleCharacteristicProperty properties, T charUuid, T svcUuid, BleOnDataReceivedCallback callback = nullptr, void* context = nullptr) {
+    template<typename T1, typename T2>
+    BleCharacteristic addCharacteristic(const char* desc, BleCharacteristicProperty properties, T1 charUuid, T2 svcUuid, BleOnDataReceivedCallback callback = nullptr, void* context = nullptr) {
         BleCharacteristic characteristic(desc, properties, charUuid, svcUuid, callback, context);
         addCharacteristic(characteristic);
         return characteristic;
     }
 
-    template<typename T>
-    BleCharacteristic addCharacteristic(const String& desc, BleCharacteristicProperty properties, T charUuid, T svcUuid, BleOnDataReceivedCallback callback = nullptr, void* context = nullptr) {
+    template<typename T1, typename T2>
+    BleCharacteristic addCharacteristic(const String& desc, BleCharacteristicProperty properties, T1 charUuid, T2 svcUuid, BleOnDataReceivedCallback callback = nullptr, void* context = nullptr) {
         BleCharacteristic characteristic(desc.c_str(), properties, charUuid, svcUuid, callback, context);
         addCharacteristic(characteristic);
         return characteristic;

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -386,7 +386,8 @@ public:
     ssize_t getValue(String& str) const;
 
     template<typename T>
-    ssize_t getValue(T* val) const {
+    typename std::enable_if<std::is_integral<T>::value, ssize_t>::type
+    getValue(T* val) const {
         size_t len = sizeof(T);
         return getValue(reinterpret_cast<uint8_t*>(val), len);
     }
@@ -397,7 +398,8 @@ public:
     ssize_t setValue(const char* str);
 
     template<typename T>
-    ssize_t setValue(T val) {
+    typename std::enable_if<std::is_integral<T>::value, ssize_t>::type
+    setValue(T val) {
         uint8_t buf[BLE_MAX_ATTR_VALUE_PACKET_SIZE];
         size_t len = std::min(sizeof(T), (unsigned)BLE_MAX_ATTR_VALUE_PACKET_SIZE);
         for (size_t i = 0, j = len - 1; i < len; i++, j--) {

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -428,11 +428,13 @@ bool BleUuid::operator==(const BleUuid& uuid) const {
 }
 
 bool BleUuid::operator==(const char* uuid) const {
-    return !strcmp(uuid, toString().c_str());
+    BleUuid temp(uuid);
+    return *this == temp;
 }
 
 bool BleUuid::operator==(const String& uuid) const {
-    return (*this == uuid.c_str());
+    BleUuid temp(uuid);
+    return *this == temp;
 }
 
 bool BleUuid::operator==(uint16_t uuid) const {

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -1512,7 +1512,6 @@ int BlePeerDevice::connect(const BleAddress& addr, uint16_t interval, uint16_t l
     connParams.max_conn_interval = interval;
     connParams.slave_latency = latency;
     connParams.conn_sup_timeout = timeout;
-    hal_ble_gap_set_ppcp(&connParams, nullptr);
     return connect(addr, &connParams, automatic);
 }
 


### PR DESCRIPTION
### Bugfixes

- Independent template type of the characteristic and service UUID arguments.
- Add restriction for the `BleCharacteristic::setValue()` template type.
- BLE UUID fails to compare with lower case string.
