### PR TITLE
Various bugfixes

### DIFF
--- a/communication/src/protocol.cpp
+++ b/communication/src/protocol.cpp
@@ -313,7 +313,12 @@ int Protocol::begin()
 	if (session_resumed && channel.is_unreliable() && (flags & SKIP_SESSION_RESUME_HELLO))
 	{
 		LOG(INFO,"resumed session - not sending HELLO message");
-		return ping(true);
+		const auto r = ping(true);
+		if (r != NO_ERROR) {
+			error = r;
+		}
+		// Note: Make sure SESSION_RESUMED gets returned to the calling code
+		return error;
 	}
 
 	// todo - this will return code 0 even when the session was resumed,

--- a/hal/network/lwip/ifapi.cpp
+++ b/hal/network/lwip/ifapi.cpp
@@ -21,6 +21,7 @@ LOG_SOURCE_CATEGORY("net.ifapi")
 #include "ifapi.h"
 #include "ipsockaddr.h"
 #include "lwiplock.h"
+#include "rng_hal.h"
 #include <lwip/tcpip.h>
 #include <lwip/netif.h>
 #include <lwip/netifapi.h>
@@ -321,6 +322,7 @@ void netif_ext_callback_handler(struct netif* netif, netif_nsc_reason_t reason, 
 int if_init(void) {
     tcpip_init([](void* arg) {
         LOG(TRACE, "LwIP started");
+        srand(HAL_RNG_GetRandomNumber());
     }, /* &sem */ nullptr);
 
     LwipTcpIpCoreLock lk;

--- a/hal/src/nRF52840/core_hal.c
+++ b/hal/src/nRF52840/core_hal.c
@@ -349,6 +349,10 @@ void HAL_Core_Setup(void) {
 
     // Initialize stdlib PRNG with a seed from hardware RNG
     srand(HAL_RNG_GetRandomNumber());
+
+#if !defined(MODULAR_FIRMWARE) || !MODULAR_FIRMWARE
+    module_user_init_hook();
+#endif
 }
 
 #if defined(MODULAR_FIRMWARE) && MODULAR_FIRMWARE

--- a/hal/src/nRF52840/core_hal.c
+++ b/hal/src/nRF52840/core_hal.c
@@ -346,6 +346,9 @@ void HAL_Core_Setup(void) {
     if (bootloader_update_if_needed()) {
         HAL_Core_System_Reset();
     }
+
+    // Initialize stdlib PRNG with a seed from hardware RNG
+    srand(HAL_RNG_GetRandomNumber());
 }
 
 #if defined(MODULAR_FIRMWARE) && MODULAR_FIRMWARE

--- a/hal/src/stm32f2xx/core_hal_stm32f2xx.c
+++ b/hal/src/stm32f2xx/core_hal_stm32f2xx.c
@@ -370,10 +370,6 @@ void HAL_Core_Config(void)
 
     HAL_RNG_Configuration();
 
-    // Initialize system-part2 stdlib PRNG with a seed from hardware PRNG
-    // in case some system code happens to use rand()
-    srand(HAL_RNG_GetRandomNumber());
-
 #ifdef DFU_BUILD_ENABLE
     Load_SystemFlags();
 #endif
@@ -418,6 +414,9 @@ void HAL_Core_Setup(void) {
     }
 
     HAL_save_device_id(DCT_DEVICE_ID_OFFSET);
+
+    // Initialize stdlib PRNG with a seed from hardware RNG
+    srand(HAL_RNG_GetRandomNumber());
 
 #if !defined(MODULAR_FIRMWARE) || !MODULAR_FIRMWARE
     module_user_init_hook();

--- a/system/src/active_object.cpp
+++ b/system/src/active_object.cpp
@@ -27,6 +27,7 @@
 #include <string.h>
 #include "concurrent_hal.h"
 #include "timer_hal.h"
+#include "rng_hal.h"
 
 void ActiveObjectBase::start_thread()
 {
@@ -47,6 +48,9 @@ void ActiveObjectBase::run()
     /* It's not even used anywhere */
     // std::lock_guard<std::mutex> lck (_start);
     started = true;
+
+    // This ensures that rand() is properly seeded in the system thread
+    srand(HAL_RNG_GetRandomNumber());
 
     uint32_t last_background_run = 0;
     for (;;)

--- a/system/src/usb_control_request_channel.cpp
+++ b/system/src/usb_control_request_channel.cpp
@@ -165,6 +165,7 @@ inline bool isServiceRequestType(uint8_t bRequest) {
     return (bRequest >= 0x01 && bRequest <= 0x0f);
 }
 
+// Note: This function is called from an ISR
 inline void cancelNetworkConnectionIfNeeded(uint16_t type) {
     switch (type) {
     case CTRL_REQUEST_RESET:
@@ -174,6 +175,10 @@ inline void cancelNetworkConnectionIfNeeded(uint16_t type) {
     case CTRL_REQUEST_START_LISTENING: {
         network_connect_cancel(NETWORK_INTERFACE_ALL, 1, 0, nullptr); // Cancel network connection attempt
         Spark_Abort(); // Abort cloud connection
+        if (type != CTRL_REQUEST_START_LISTENING) {
+            // Prevent the system from reconnecting to the cloud if the device is going to be reset
+            spark_cloud_flag_disconnect();
+        }
         break;
     }
     default:


### PR DESCRIPTION
This PR fixes a number of issues which I encountered while testing Device OS with a local device service instance:

- Due to a regression introduced in 1.1.0, the system layer always sends its handshake messages, even if the session was resumed. This causes increased data usage.

- `rand()` isn't properly seeded in multiple threads, including the system thread. On Gen 3 specifically this breaks allocation of ephemeral port numbers in LwIP.

- Control requests that reset the device (e.g. `particle usb dfu`) can cause unnecessary reconnection to the cloud.

- User module isn't initialized in monolithic builds.
