### PR TITLE
Backports into 1.3.1

### DIFF
--- a/communication/src/protocol.cpp
+++ b/communication/src/protocol.cpp
@@ -313,7 +313,12 @@ int Protocol::begin()
 	if (session_resumed && channel.is_unreliable() && (flags & SKIP_SESSION_RESUME_HELLO))
 	{
 		LOG(INFO,"resumed session - not sending HELLO message");
-		return ping(true);
+		const auto r = ping(true);
+		if (r != NO_ERROR) {
+			error = r;
+		}
+		// Note: Make sure SESSION_RESUMED gets returned to the calling code
+		return error;
 	}
 
 	// todo - this will return code 0 even when the session was resumed,

--- a/hal/network/lwip/ifapi.cpp
+++ b/hal/network/lwip/ifapi.cpp
@@ -21,6 +21,7 @@ LOG_SOURCE_CATEGORY("net.ifapi")
 #include "ifapi.h"
 #include "ipsockaddr.h"
 #include "lwiplock.h"
+#include "rng_hal.h"
 #include <lwip/tcpip.h>
 #include <lwip/netif.h>
 #include <lwip/netifapi.h>
@@ -321,6 +322,7 @@ void netif_ext_callback_handler(struct netif* netif, netif_nsc_reason_t reason, 
 int if_init(void) {
     tcpip_init([](void* arg) {
         LOG(TRACE, "LwIP started");
+        srand(HAL_RNG_GetRandomNumber());
     }, /* &sem */ nullptr);
 
     LwipTcpIpCoreLock lk;

--- a/hal/src/argon/platform_ncp_argon.cpp
+++ b/hal/src/argon/platform_ncp_argon.cpp
@@ -117,12 +117,33 @@ int platform_ncp_fetch_module_info(hal_system_info_t* sys_info, bool create) {
                 info->platform_id = PLATFORM_ID;
                 info->module_function = MODULE_FUNCTION_NCP_FIRMWARE;
 
-                module->info = info;
                 // assume all checks pass since it was validated when being flashed to the NCP
                 module->validity_result = module->validity_checked;
+
+                // IMPORTANT: a valid suffix with SHA is required for the communication layer to detect a change
+                // in the SYSTEM DESCRIBE state and send a HELLO after the NCP update to
+                // cause the DS to request new DESCRIBE info
+                auto suffix = new module_info_suffix_t();
+                if (!suffix) {
+                    delete info;
+                    return SYSTEM_ERROR_NO_MEMORY;
+                }
+                memset(suffix, 0, sizeof(module_info_suffix_t));
+
+                // FIXME: NCP firmware should return some kind of a unique string/hash
+                // For now we simply fill the SHA field with version
+                for (uint16_t* sha = (uint16_t*)suffix->sha;
+                        sha < (uint16_t*)(suffix->sha + sizeof(suffix->sha));
+                        ++sha) {
+                    *sha = version;
+                }
+
+                module->info = info;
+                module->suffix = suffix;
             }
             else {
                 delete module->info;
+                delete ((module_info_suffix_t*)module->suffix);
             }
         }
     }

--- a/hal/src/nRF52840/core_hal.c
+++ b/hal/src/nRF52840/core_hal.c
@@ -349,6 +349,10 @@ void HAL_Core_Setup(void) {
 
     // Initialize stdlib PRNG with a seed from hardware RNG
     srand(HAL_RNG_GetRandomNumber());
+
+#if !defined(MODULAR_FIRMWARE) || !MODULAR_FIRMWARE
+    module_user_init_hook();
+#endif
 }
 
 #if defined(MODULAR_FIRMWARE) && MODULAR_FIRMWARE

--- a/hal/src/nRF52840/core_hal.c
+++ b/hal/src/nRF52840/core_hal.c
@@ -346,6 +346,9 @@ void HAL_Core_Setup(void) {
     if (bootloader_update_if_needed()) {
         HAL_Core_System_Reset();
     }
+
+    // Initialize stdlib PRNG with a seed from hardware RNG
+    srand(HAL_RNG_GetRandomNumber());
 }
 
 #if defined(MODULAR_FIRMWARE) && MODULAR_FIRMWARE

--- a/hal/src/nRF52840/core_hal.c
+++ b/hal/src/nRF52840/core_hal.c
@@ -311,7 +311,7 @@ void HAL_Core_Config(void) {
 #if defined(MODULAR_FIRMWARE)
     if (HAL_Core_Validate_User_Module()) {
         new_heap_end = module_user_pre_init();
-        if (new_heap_end > malloc_heap_end()) {
+        if (new_heap_end < malloc_heap_end()) {
             malloc_set_heap_end(new_heap_end);
         }
     } else {

--- a/hal/src/nRF52840/platform_radio_stack.cpp
+++ b/hal/src/nRF52840/platform_radio_stack.cpp
@@ -37,11 +37,28 @@ int platform_radio_stack_fetch_module_info(hal_system_info_t* sys_info, bool cre
             info->platform_id = PLATFORM_ID;
             info->module_function = MODULE_FUNCTION_RADIO_STACK;
 
-            module->info = info;
             // FIXME: assuming that all checks passed for now
             module->validity_result = module->validity_checked;
+
+            // IMPORTANT: a valid suffix with SHA is required for the communication layer to detect a change
+            // in the SYSTEM DESCRIBE state and send a HELLO after the SoftDevice update to
+            // cause the DS to request new DESCRIBE info
+            auto suffix = new module_info_suffix_t();
+            if (!suffix) {
+                delete info;
+                return SYSTEM_ERROR_NO_MEMORY;
+            }
+            memset(suffix, 0, sizeof(module_info_suffix_t));
+
+            // Use a unique SoftDevice string in place of an SHA
+            auto addr = SD_UNIQUE_STR_ADDR_GET(MBR_SIZE);
+            memcpy(suffix->sha, addr, SD_UNIQUE_STR_SIZE);
+
+            module->info = info;
+            module->suffix = suffix;
         } else {
             delete module->info;
+            delete ((module_info_suffix_t*)module->suffix);
         }
 
         break;

--- a/hal/src/stm32f2xx/core_hal_stm32f2xx.c
+++ b/hal/src/stm32f2xx/core_hal_stm32f2xx.c
@@ -370,10 +370,6 @@ void HAL_Core_Config(void)
 
     HAL_RNG_Configuration();
 
-    // Initialize system-part2 stdlib PRNG with a seed from hardware PRNG
-    // in case some system code happens to use rand()
-    srand(HAL_RNG_GetRandomNumber());
-
 #ifdef DFU_BUILD_ENABLE
     Load_SystemFlags();
 #endif
@@ -418,6 +414,9 @@ void HAL_Core_Setup(void) {
     }
 
     HAL_save_device_id(DCT_DEVICE_ID_OFFSET);
+
+    // Initialize stdlib PRNG with a seed from hardware RNG
+    srand(HAL_RNG_GetRandomNumber());
 
 #if !defined(MODULAR_FIRMWARE) || !MODULAR_FIRMWARE
     module_user_init_hook();

--- a/modules/shared/nRF52840/user.ld
+++ b/modules/shared/nRF52840/user.ld
@@ -7,16 +7,16 @@ SECTIONS
     INCLUDE module_start.ld
     INCLUDE module_info.ld
 
-    .text :
+    .dynalib :
     {
-        expected_dynalib_start = ORIGIN (APP_FLASH) + 24 ;
+        expected_dynalib_start = ORIGIN(APP_FLASH) + 24 ;
         link_dynalib_start = .;
         KEEP(*(*.user_part_module))
         link_dynalib_end = . ;
-        link_length_start = .;
-        KEEP(*(*.user_part_length))
-        link_length_end = .;
+    } > APP_FLASH AT> APP_FLASH
 
+    .text :
+    {
         . = ALIGN(4);
 
         link_code_location = .;

--- a/modules/shared/stm32f2xx/user.ld
+++ b/modules/shared/stm32f2xx/user.ld
@@ -7,16 +7,16 @@ SECTIONS
     INCLUDE module_start.ld
     INCLUDE module_info.ld
 
-    .text :
+    .dynalib :
     {
-        expected_dynalib_start = ORIGIN (APP_FLASH) + 24 ;
+        expected_dynalib_start = ORIGIN(APP_FLASH) + 24 ;
         link_dynalib_start = .;
         KEEP(*(*.user_part_module))
         link_dynalib_end = . ;
-        link_length_start = .;
-        KEEP(*(*.user_part_length))
-        link_length_end = .;
+    } > APP_FLASH AT> APP_FLASH
 
+    .text :
+    {
         . = ALIGN(4);
 
         link_code_location = .;

--- a/platform/MCU/nRF52840/src/flash_mal.c
+++ b/platform/MCU/nRF52840/src/flash_mal.c
@@ -194,14 +194,23 @@ int FLASH_CopyMemory(flash_device_t sourceDeviceID, uint32_t sourceAddress,
     if (flags & MODULE_VERIFY_MASK)
     {
         const module_info_t* info = FLASH_ModuleInfo(sourceDeviceID, sourceAddress);
-        // NB: We have corner cases where the module info is not located in the
-        // front of the module but for example after the vector table and we
-        // only want to enable this feature in the case it is in the front,
-        // hence the module_info_t located at the the source address check.
-        if (info->flags & MODULE_INFO_FLAG_DROP_MODULE_INFO && (uintptr_t)info == (uintptr_t)sourceAddress)
-        {
-            // Skip module header
-            sourceAddress += sizeof(module_info_t);
+        if (info->flags & MODULE_INFO_FLAG_DROP_MODULE_INFO) {
+            // NB: We have corner cases where the module info is not located in the
+            // front of the module but for example after the vector table and we
+            // only want to enable this feature in the case it is in the front,
+            // hence the module_info_t located at the the source address check.
+            module_info_t front = {0};
+            if (sourceDeviceID == FLASH_SERIAL) {
+                hal_exflash_read(sourceAddress, (uint8_t*)&front, sizeof(front));
+            } else {
+                hal_flash_read(sourceAddress, (uint8_t*)&front, sizeof(front));
+            }
+            if (!memcmp(info, &front, sizeof(module_info_t))) {
+                // Skip module header
+                sourceAddress += sizeof(module_info_t);
+            } else {
+                return FLASH_ACCESS_RESULT_ERROR;
+            }
         }
     }
 

--- a/system/src/active_object.cpp
+++ b/system/src/active_object.cpp
@@ -27,6 +27,7 @@
 #include <string.h>
 #include "concurrent_hal.h"
 #include "timer_hal.h"
+#include "rng_hal.h"
 
 void ActiveObjectBase::start_thread()
 {
@@ -47,6 +48,9 @@ void ActiveObjectBase::run()
     /* It's not even used anywhere */
     // std::lock_guard<std::mutex> lck (_start);
     started = true;
+
+    // This ensures that rand() is properly seeded in the system thread
+    srand(HAL_RNG_GetRandomNumber());
 
     uint32_t last_background_run = 0;
     for (;;)

--- a/system/src/usb_control_request_channel.cpp
+++ b/system/src/usb_control_request_channel.cpp
@@ -165,6 +165,7 @@ inline bool isServiceRequestType(uint8_t bRequest) {
     return (bRequest >= 0x01 && bRequest <= 0x0f);
 }
 
+// Note: This function is called from an ISR
 inline void cancelNetworkConnectionIfNeeded(uint16_t type) {
     switch (type) {
     case CTRL_REQUEST_RESET:
@@ -174,6 +175,10 @@ inline void cancelNetworkConnectionIfNeeded(uint16_t type) {
     case CTRL_REQUEST_START_LISTENING: {
         network_connect_cancel(NETWORK_INTERFACE_ALL, 1, 0, nullptr); // Cancel network connection attempt
         Spark_Abort(); // Abort cloud connection
+        if (type != CTRL_REQUEST_START_LISTENING) {
+            // Prevent the system from reconnecting to the cloud if the device is going to be reset
+            spark_cloud_flag_disconnect();
+        }
         break;
     }
     default:

--- a/user/applications/tinker/tinker.mk
+++ b/user/applications/tinker/tinker.mk
@@ -13,7 +13,6 @@ endif
 ifeq ("$(LOG_SERIAL)","y")
 CFLAGS += -DLOG_SERIAL
 CXXFLAGS += -DLOG_SERIAL
-$(error "test")
 endif
 
 ifeq ("$(LOG_SERIAL1)","y")

--- a/user/tests/wiring/no_fixture/cellular.cpp
+++ b/user/tests/wiring/no_fixture/cellular.cpp
@@ -141,7 +141,6 @@ test(CELLULAR_06_resolve) {
     assertEqual(addr, 0);
 }
 
-// FIXME: This test is failing on Gen 3 Boron / B SoM as of 1.1.0 or earlier
 test(CELLULAR_07_rssi_is_valid) {
     connect_to_cloud(6*60*1000);
     CellularSignal s;
@@ -160,6 +159,15 @@ test(CELLULAR_07_rssi_is_valid) {
 #define LOREM "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque ut elit nec mi bibendum mollis. Nam nec nisl mi. Donec dignissim iaculis purus, ut condimentum arcu semper quis. Phasellus efficitur ut arcu ac dignissim. In interdum sem id dictum luctus. Ut nec mattis sem. Nullam in aliquet lacus. Donec egestas nisi volutpat lobortis sodales. Aenean elementum magna ipsum, vitae pretium tellus lacinia eu. Phasellus commodo nisi at quam tincidunt, tempor gravida mauris facilisis. Duis tristique ligula ac pulvinar consectetur. Cras aliquam, leo ut eleifend molestie, arcu odio semper odio, quis sollicitudin metus libero et lorem. Donec venenatis congue commodo. Vivamus mattis elit metus, sed fringilla neque viverra eu. Phasellus leo urna, elementum vel pharetra sit amet, auctor non sapien. Phasellus at justo ac augue rutrum vulputate. In hac habitasse platea dictumst. Pellentesque nibh eros, placerat id laoreet sed, dapibus efficitur augue. Praesent pretium diam ac sem varius fermentum. Nunc suscipit dui risus sed"
 
 test(MDM_01_socket_writes_with_length_more_than_1023_work_correctly) {
+
+#if HAL_PLATFORM_NCP
+    // CH32073
+    if (cellular_modem_type() == DEV_SARA_R410) {
+        skip();
+        return;
+    }
+#endif // HAL_PLATFORM_NCP
+
     // https://github.com/spark/firmware/issues/1104
     const char request[] =
         "POST /post HTTP/1.1\r\n"
@@ -213,9 +221,6 @@ test(MDM_01_socket_writes_with_length_more_than_1023_work_correctly) {
     assertTrue(contains);
 }
 
-// TODO: Cellular.command() is not implemented on Gen 3 devices
-#if !HAL_PLATFORM_NCP
-
 static int atCallback(int type, const char* buf, int len, int* lines) {
     if (len && type == TYPE_UNKNOWN)
         (*lines)++;
@@ -242,6 +247,8 @@ test(MDM_02_at_commands_with_long_response_are_correctly_parsed_and_flow_control
     assertMoreOrEqual(lines, 200);
 }
 
-#endif // !HAL_PLATFORM_NCP
+test(MDM_03_restore_cloud_connection) {
+    connect_to_cloud(6*60*1000);
+}
 
 #endif // Wiring_Cellular == 1

--- a/user/tests/wiring/no_fixture/mesh.cpp
+++ b/user/tests/wiring/no_fixture/mesh.cpp
@@ -26,7 +26,11 @@ test(MESH_01_PublishWithoutSubscribeStillReadsDataOutOfPubSubSocket) {
 
     static const constexpr unsigned MAX_ITERATIONS = 1000;
 
-    assertTrue(network_has_credentials(NETWORK_INTERFACE_MESH, 0, nullptr));
+    if (!network_has_credentials(NETWORK_INTERFACE_MESH, 0, nullptr)) {
+        // Simply skip this test if there are no mesh credentials
+        skip();
+        return;
+    }
 
     // Make sure the device is a known (deinitialized) state
     Mesh.uninitializeUdp();

--- a/user/tests/wiring/no_fixture/pwm.cpp
+++ b/user/tests/wiring/no_fixture/pwm.cpp
@@ -52,6 +52,17 @@ const uint8_t pwm_pins[] = {
 
 static pin_t pin = pwm_pins[0];
 
+test(PWM_00_prepare) {
+#if (PLATFORM_ID == 8) // P1
+    // disable POWERSAVE_CLOCK on P1S6
+    System.disableFeature(FEATURE_WIFI_POWERSAVE_CLOCK);
+#endif // (PLATFORM_ID == 8) // P1
+
+    // Disconnect network and cloud
+    Particle.disconnect();
+    Network.disconnect();
+}
+
 #if (PLATFORM_ID == 8) // P1
 test(PWM_00_P1S6SetupForP1) {
     // disable POWERSAVE_CLOCK on P1S6
@@ -546,9 +557,14 @@ test(PWM_10_HighFrequencyAnalogWriteOnPinResultsInCorrectPulseWidth) {
 	});
 }
 
+test(PWM_11_restore) {
 #if (PLATFORM_ID == 8) // P1
-test(PWM_11_P1S6CleanupForP1) {
     // enable POWERSAVE_CLOCK on P1S6
     System.enableFeature(FEATURE_WIFI_POWERSAVE_CLOCK);
+#endif // (PLATFORM_ID == 8)
+
+    // Restore network and cloud connection
+    Network.connect();
+    Particle.connect();
+    waitFor(Particle.connected, 6*60*1000);
 }
-#endif

--- a/user/tests/wiring/no_fixture/wifi.cpp
+++ b/user/tests/wiring/no_fixture/wifi.cpp
@@ -69,8 +69,6 @@ void checkEtherAddress(const uint8_t* address)
 test(WIFI_04_config)
 {
     checkIPAddress("local", WiFi.localIP());
-    checkIPAddress("dnsServer", WiFi.dnsServerIP());
-    checkIPAddress("dhcpServer", WiFi.dhcpServerIP());
     checkIPAddress("gateway", WiFi.gatewayIP());
 
     uint8_t ether[6];
@@ -88,7 +86,13 @@ test(WIFI_04_config)
     assertTrue(WiFi.BSSID(ether)==ether);
     assertTrue(WiFi.BSSID(ether2)==ether2);
     checkEtherAddress(ether);
-    assertTrue(!memcmp(ether, ether2, 6))
+    assertTrue(!memcmp(ether, ether2, 6));
+
+#if !HAL_PLATFORM_NCP
+    // FIXME: this is not available on Gen 3 devices yet
+    checkIPAddress("dnsServer", WiFi.dnsServerIP());
+    checkIPAddress("dhcpServer", WiFi.dhcpServerIP());
+#endif // !HAL_PLATFORM_NCP
 }
 
 test(WIFI_05_scan)


### PR DESCRIPTION
### Description

Backports a number of bugfixes from 1.4.0-rc.1 and develop.

1. #1905 
2. #1894 
3. #1897
4. Everything from #1898 except for https://github.com/particle-iot/device-os/pull/1898/commits/f5ccd79aaad659416d4d1385ae0a7f06eea2f30e, https://github.com/particle-iot/device-os/pull/1898/commits/2d983d357f054b0cdce5e2204d161ff9681a2f88 and https://github.com/particle-iot/device-os/pull/1898/commits/580cfaf08736b11a83e87c8e17380fc368cfef4e

---

## CHANGELOG

### BUGFIXES

- [Gen 3] Fixes heap and application static RAM overlap introduced in 1.3.0-rc.1 [#1898](https://github.com/particle-iot/device-os/pull/1898)
- Fixes tinker build errors when building with `LOG_SERIAL=y` [#1898](https://github.com/particle-iot/device-os/pull/1898)
- Fixes dynalib alignment issue when compiling relatively large applications potentially due to an unconfirmed bug in GCC by moving the dynalib into a separate section (`.dynalib`) [#1894](https://github.com/particle-iot/device-os/pull/1894)
- [Gen 3] Fixes incorrect handling of `MODULE_INFO_FLAG_DROP_MODULE_INFO` in the bootloader [#1897](https://github.com/particle-iot/device-os/pull/1897)
- [Gen 3] Adds a dummy suffix to the NCP and SoftDevice modules' module info with unique SHA to cause the communication layer to detect the change in SYSTEM DESCRIBE after NCP or SoftDevice update [#1897](https://github.com/particle-iot/device-os/pull/1897)
- Fixes a regression introduced in 1.1.0 where the system layer was always sending its handshake messages even if the session was resumed causing increased data usage [#1905](https://github.com/particle-iot/device-os/pull/1905)
- Properly seeds `rand()` in multiple threads including system thread. Fixes ephemeral port allocation in LwIP on Gen 3 platforms [#1905](https://github.com/particle-iot/device-os/pull/1905)
- Control requests that reset the device (e.g. `particle usb dfu`) no longer cause unnecessary reconnection to the cloud [#1905](https://github.com/particle-iot/device-os/pull/1905)
- Initialize user module in monolithic builds [#1905](https://github.com/particle-iot/device-os/pull/1905)

### INTERNAL
- Adjusts on-device tests [#1898](https://github.com/particle-iot/device-os/pull/1898)
