### PR TITLE
Notify the cloud about keepalive interval changes

### DIFF
--- a/communication/inc/communication_dynalib.h
+++ b/communication/inc/communication_dynalib.h
@@ -68,7 +68,7 @@ DYNALIB_FN(BASE_IDX + 2, communication, extract_public_ec_key, int(uint8_t*, siz
 #define BASE_IDX2 (BASE_IDX + 1)
 #endif
 
-DYNALIB_FN(BASE_IDX2 + 0, communication, spark_protocol_set_connection_property, int(ProtocolFacade*, unsigned, unsigned, particle::protocol::connection_properties_t*, void*))
+DYNALIB_FN(BASE_IDX2 + 0, communication, spark_protocol_set_connection_property, int(ProtocolFacade*, unsigned, unsigned, const void*, void*))
 DYNALIB_FN(BASE_IDX2 + 1, communication, spark_protocol_command, int(ProtocolFacade* protocol, ProtocolCommands::Enum cmd, uint32_t data, void* reserved))
 DYNALIB_FN(BASE_IDX2 + 2, communication, spark_protocol_time_request_pending, bool(ProtocolFacade*, void*))
 DYNALIB_FN(BASE_IDX2 + 3, communication, spark_protocol_time_last_synced, system_tick_t(ProtocolFacade*, time_t*, void*))
@@ -84,6 +84,7 @@ DYNALIB_FN(BASE_IDX3 + 0, communication, spark_protocol_get_describe_data, int(P
 DYNALIB_FN(BASE_IDX3 + 1, communication, spark_protocol_post_description, int(ProtocolFacade*, int, void*))
 DYNALIB_FN(BASE_IDX3 + 2, communication, spark_protocol_to_system_error, int(int))
 DYNALIB_FN(BASE_IDX3 + 3, communication, spark_protocol_get_status, int(ProtocolFacade*, protocol_status*, void*))
+DYNALIB_FN(BASE_IDX3 + 4, communication, spark_protocol_get_connection_property, int(ProtocolFacade*, unsigned, unsigned*, void*, void*))
 
 DYNALIB_END(communication)
 

--- a/communication/inc/protocol.h
+++ b/communication/inc/protocol.h
@@ -317,14 +317,24 @@ public:
 		pinger.init(interval, timeout);
 	}
 
-	void set_keepalive(system_tick_t interval, keepalive_source_t source)
+	bool set_keepalive(system_tick_t interval, keepalive_source_t source)
 	{
-		pinger.set_interval(interval, source);
+		return pinger.set_interval(interval, source);
 	}
 
-	void set_fast_ota(unsigned data)
+	system_tick_t get_keepalive(keepalive_source_t* source = nullptr) const
 	{
-		chunkedTransfer.set_fast_ota(data);
+		return pinger.get_interval(source);
+	}
+
+	void set_fast_ota(bool enabled)
+	{
+		chunkedTransfer.set_fast_ota(enabled);
+	}
+
+	bool get_fast_ota() const
+	{
+		return chunkedTransfer.get_fast_ota();
 	}
 
 	void set_handlers(CommunicationsHandlers& handlers)

--- a/communication/inc/protocol_defs.h
+++ b/communication/inc/protocol_defs.h
@@ -50,6 +50,8 @@ enum ProtocolError
     /* 24 */ IO_ERROR_LIGHTSSL_HANDSHAKE_NONCE,
     /* 25 */ IO_ERROR_LIGHTSSL_HANDSHAKE_RECV_KEY,
     /* 26 */ NOT_IMPLEMENTED,
+    /* 27 */ INVALID_PARAM,
+    /* 28 */ NOT_CHANGED,
 
     /*
      * NOTE: when adding more ProtocolError codes, be sure to update toSystemError() in protocol_defs.cpp

--- a/communication/inc/spark_protocol_functions.h
+++ b/communication/inc/spark_protocol_functions.h
@@ -188,7 +188,8 @@ void spark_protocol_set_product_id(ProtocolFacade* protocol, product_id_t produc
 void spark_protocol_set_product_firmware_version(ProtocolFacade* protocol, product_firmware_version_t product_firmware_version, unsigned int param=0, void* reserved = NULL);
 void spark_protocol_get_product_details(ProtocolFacade* protocol, product_details_t* product_details, void* reserved=NULL);
 
-int spark_protocol_set_connection_property(ProtocolFacade* protocol, unsigned property_id, unsigned data, particle::protocol::connection_properties_t* conn_prop, void* reserved);
+int spark_protocol_set_connection_property(ProtocolFacade* protocol, unsigned property_id, unsigned value, const void* data, void* reserved);
+int spark_protocol_get_connection_property(ProtocolFacade* protocol, unsigned property_id, unsigned* value, void* data, void* reserved);
 bool spark_protocol_time_request_pending(ProtocolFacade* protocol, void* reserved=NULL);
 system_tick_t spark_protocol_time_last_synced(ProtocolFacade* protocol, time_t* tm, void* reserved=NULL);
 

--- a/communication/src/chunked_transfer.h
+++ b/communication/src/chunked_transfer.h
@@ -144,10 +144,15 @@ public:
 
 	ProtocolError idle(MessageChannel& channel);
 
-	void set_fast_ota(unsigned data)
+	void set_fast_ota(bool enabled)
 	{
-		fast_ota_value = (data > 0) ? true : false;
+		fast_ota_value = enabled;
 		fast_ota_override = true;
+	}
+
+	bool get_fast_ota() const
+	{
+		return fast_ota_value;
 	}
 
 	bool is_updating()

--- a/communication/src/ping.h
+++ b/communication/src/ping.h
@@ -45,9 +45,11 @@ public:
 		// TODO: It feels that this logic should have been implemented in the system layer
 		if ( !(this->keepalive_source == KeepAliveSource::USER && source == KeepAliveSource::SYSTEM) )
 		{
-			this->ping_interval = interval;
 			this->keepalive_source = source;
-			return true;
+			if (this->ping_interval != interval) {
+				this->ping_interval = interval;
+				return true;
+			}
 		}
 		return false;
 	}

--- a/communication/src/ping.h
+++ b/communication/src/ping.h
@@ -24,7 +24,15 @@ public:
 		this->keepalive_source = KeepAliveSource::SYSTEM;
 	}
 
-	void set_interval(system_tick_t interval, keepalive_source_t source)
+	/**
+	 * Sets the ping interval.
+	 *
+	 * @param interval New interval in milliseconds.
+	 * @param source Source of the interval change. The interval set by the user application takes
+	 *               precedence over the interval set by the system.
+	 * @return `true` if the current interval has been changed or `false` otherwise.
+	 */
+	bool set_interval(system_tick_t interval, keepalive_source_t source)
 	{
 		/**
 		 * LAST  CURRENT  UPDATE?
@@ -34,11 +42,28 @@ public:
 		 * USER  SYS      NO
 		 * USER  USER     YES
 		 */
+		// TODO: It feels that this logic should have been implemented in the system layer
 		if ( !(this->keepalive_source == KeepAliveSource::USER && source == KeepAliveSource::SYSTEM) )
 		{
 			this->ping_interval = interval;
 			this->keepalive_source = source;
+			return true;
 		}
+		return false;
+	}
+
+	/**
+	 * Returns the current ping interval.
+	 *
+	 * @param source[out] Source of the last interval change.
+	 * @return Interval in milliseconds.
+	 */
+	system_tick_t get_interval(keepalive_source_t* source = nullptr) const
+	{
+		if (source) {
+			*source = keepalive_source;
+		}
+		return ping_interval;
 	}
 
 	void reset()

--- a/communication/src/protocol_defs.cpp
+++ b/communication/src/protocol_defs.cpp
@@ -49,6 +49,10 @@ system_error_t particle::protocol::toSystemError(ProtocolError error) {
         return SYSTEM_ERROR_TOO_LARGE;
     case NOT_IMPLEMENTED:
         return SYSTEM_ERROR_NOT_SUPPORTED;
+    case INVALID_PARAM:
+        return SYSTEM_ERROR_INVALID_ARGUMENT;
+    case NOT_CHANGED:
+        return SYSTEM_ERROR_NOT_CHANGED;
     default:
         return SYSTEM_ERROR_PROTOCOL; // Generic protocol error
     }

--- a/services/inc/system_error.h
+++ b/services/inc/system_error.h
@@ -27,6 +27,7 @@
         (BUSY, "Resource busy", -110), \
         (NOT_SUPPORTED, "Not supported", -120), \
         (NOT_ALLOWED, "Not allowed", -130), \
+        (NOT_CHANGED, "Not changed", -131), \
         (CANCELLED, "Operation cancelled", -140), \
         (ABORTED, "Operation aborted", -150), \
         (TIMEOUT, "Timeout error", -160), \

--- a/system/inc/system_cloud.h
+++ b/system/inc/system_cloud.h
@@ -242,7 +242,7 @@ bool spark_cloud_flag_auto_connect(void);
 
 ProtocolFacade* system_cloud_protocol_instance(void);
 
-int spark_set_connection_property(unsigned property_id, unsigned data, particle::protocol::connection_properties_t* conn_prop, void* reserved);
+int spark_set_connection_property(unsigned property_id, unsigned value, const void* data, void* reserved);
 
 int spark_set_random_seed_from_cloud_handler(void (*handler)(unsigned int), void* reserved);
 

--- a/system/inc/system_dynalib_cloud.h
+++ b/system/inc/system_dynalib_cloud.h
@@ -48,7 +48,7 @@ DYNALIB_FN(10, system_cloud, spark_unsubscribe, void(void*))
 DYNALIB_FN(11, system_cloud, spark_sync_time, bool(void*))
 DYNALIB_FN(12, system_cloud, spark_sync_time_pending, bool(void*))
 DYNALIB_FN(13, system_cloud, spark_sync_time_last, system_tick_t(time_t*, void*))
-DYNALIB_FN(14, system_cloud, spark_set_connection_property, int(unsigned, unsigned, particle::protocol::connection_properties_t*, void*))
+DYNALIB_FN(14, system_cloud, spark_set_connection_property, int(unsigned, unsigned, const void*, void*))
 DYNALIB_FN(15, system_cloud, spark_set_random_seed_from_cloud_handler, int(void (*handler)(unsigned int), void*))
 DYNALIB_FN(16, system_cloud, spark_publish_vitals, int(system_tick_t, void*))
 

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -54,6 +54,7 @@
 
 using particle::CloudDiagnostics;
 using particle::publishEvent;
+using particle::publishKeepaliveInterval;
 
 #ifndef SPARK_NO_CLOUD
 
@@ -358,6 +359,7 @@ constexpr const char KEY_RESTORE_EVENT[] = "spark/device/key/restore";
 constexpr const char DEVICE_UPDATES_EVENT[] = "particle/device/updates/";
 constexpr const char FORCED_EVENT[] = "forced";
 constexpr const char UPDATES_PENDING_EVENT[] = "pending";
+constexpr const char KEEPALIVE_INTERVAL_EVENT[] = "particle/device/keepalive";
 
 inline bool is_suffix(const char* eventName, const char* prefix, const char* suffix) {
 	// todo - sanity check parameters?
@@ -982,6 +984,7 @@ int Spark_Handshake(bool presence_announce)
         }
 
         Send_Firmware_Update_Flags();
+        publishKeepaliveInterval();
 
         if (presence_announce) {
             Multicast_Presence_Announcement();
@@ -1002,6 +1005,7 @@ int Spark_Handshake(bool presence_announce)
         }
 
         Send_Firmware_Update_Flags();
+        publishKeepaliveInterval();
     }
     if (particle_key_errors != NO_ERROR) {
         char buf[sizeof(unsigned long)*8+1];
@@ -1093,3 +1097,21 @@ void Spark_Wake(void)
 CloudDiagnostics* CloudDiagnostics::instance() {
     return &g_cloudDiagnostics;
 }
+
+namespace particle {
+
+bool publishKeepaliveInterval(unsigned interval) {
+    if (!interval) {
+        // Get the current interval
+        const auto r = spark_protocol_get_connection_property(spark_protocol_instance(), protocol::Connection::PING,
+                &interval, nullptr, nullptr);
+        if (r != 0) {
+            return false;
+        }
+    }
+    char buf[16] = {};
+    snprintf(buf, sizeof(buf), "%u", interval);
+    return publishEvent(KEEPALIVE_INTERVAL_EVENT, buf);
+}
+
+} // particle

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -1109,6 +1109,9 @@ bool publishKeepaliveInterval(unsigned interval) {
             return false;
         }
     }
+    // TODO: Even though the keepalive interval is not supposed to be changed frequently, it would be
+    // nice to make sure the previously published event is either sent or cancelled before publishing
+    // a new event. This would help to mitigate the effect of possible out of order delivery
     char buf[16] = {};
     snprintf(buf, sizeof(buf), "%u", interval);
     return publishEvent(KEEPALIVE_INTERVAL_EVENT, buf);

--- a/system/src/system_cloud_internal.h
+++ b/system/src/system_cloud_internal.h
@@ -136,6 +136,8 @@ inline bool publishEvent(const char* event, const char* data = nullptr, unsigned
     return spark_send_event(event, data, DEFAULT_CLOUD_EVENT_TTL, flags | PUBLISH_EVENT_FLAG_PRIVATE, nullptr);
 }
 
+bool publishKeepaliveInterval(unsigned interval = 0);
+
 } // namespace particle
 
 #ifdef __cplusplus

--- a/test/unit_tests/communication/ping.cpp
+++ b/test/unit_tests/communication/ping.cpp
@@ -88,11 +88,18 @@ SCENARIO("ping requests and responses are managed")
 
 		THEN("The ping interval can be updated by the SYSTEM and then the USER")
 		{
-			pinger.set_interval(30000, KeepAliveSource::SYSTEM);
+			keepalive_source_t source;
+			REQUIRE(pinger.set_interval(30000, KeepAliveSource::SYSTEM));
+			REQUIRE(pinger.get_interval(&source) == 30000);
+			REQUIRE(source == KeepAliveSource::SYSTEM);
+
 			REQUIRE(pinger.process(15001, []{return IO_ERROR;})==NO_ERROR);
 			REQUIRE(!pinger.is_expecting_ping_ack());
 
-			pinger.set_interval(60000, KeepAliveSource::USER);
+			REQUIRE(pinger.set_interval(60000, KeepAliveSource::USER));
+			REQUIRE(pinger.get_interval(&source) == 60000);
+			REQUIRE(source == KeepAliveSource::USER);
+
 			REQUIRE(pinger.process(30001, []{return IO_ERROR;})==NO_ERROR);
 			REQUIRE(!pinger.is_expecting_ping_ack());
 
@@ -104,11 +111,17 @@ SCENARIO("ping requests and responses are managed")
 
 		THEN("The ping interval can be updated by the USER but then not the SYSTEM")
 		{
-			pinger.set_interval(30000, KeepAliveSource::USER);
+			keepalive_source_t source;
+			REQUIRE(pinger.set_interval(30000, KeepAliveSource::USER));
+			REQUIRE(pinger.get_interval(&source) == 30000);
+			REQUIRE(source == KeepAliveSource::USER);
+
 			REQUIRE(pinger.process(15001, []{return IO_ERROR;})==NO_ERROR);
 			REQUIRE(!pinger.is_expecting_ping_ack());
 
-			pinger.set_interval(60000, KeepAliveSource::SYSTEM);
+			REQUIRE(pinger.set_interval(60000, KeepAliveSource::SYSTEM) == false);
+			REQUIRE(pinger.get_interval(&source) == 30000);
+			REQUIRE(source == KeepAliveSource::USER);
 
 			bool callback_called = false;
 			REQUIRE(pinger.process(30001, [&]()->ProtocolError{callback_called = true; return NO_ERROR;})==NO_ERROR);


### PR DESCRIPTION
### Problem

User applications can change the keepalive interval of the cloud connection via the `Particle.keepAlive()` method. The interval can also be changed by the system depending on the cellular provider and/or the type of the external connectivity used by the gateway device in a mesh network.

At present, the cloud has no means to determine the keepalive interval set on a particular device, and this affects the ability of the cloud to track the online status of the device accurately.

### Solution

Publish a special private event (`particle/device/keepalive`) containing the actual value of the keepalive interval every time the interval changes.

### Steps to Test

Flash the example application to a device. Subscribe to the device's events and verify that keepalive events get published when the keepalive interval is changed.

**Note:** The cloud-side handler for the keepalive events is not yet implemented, so this test requires running a local instance of the device service, which has `particle/device/keepalive` added to the list of known internal events.

### Example App

```cpp
#include "application.h"

SYSTEM_MODE(MANUAL);

namespace {

int cloudStatus = cloud_status_disconnected;
bool done = false;

void cloudStatusChanged(system_event_t event, int param) {
    cloudStatus = param;
}

void waitCloudStatus(int status) {
    while (cloudStatus != status) {
        Particle.process();
    }
}

} // unnamed

void setup() {
    System.on(cloud_status, cloudStatusChanged);
}

void loop() {
    if (done) {
        return;
    }

    // The default keepalive interval should be published after the protocol handshake
    Particle.connect();
    waitCloudStatus(cloud_status_connected);
    delay(1000);

    // This should generate a new keepalive event
    Particle.keepAlive(10);

    // This should not generate a new event, since the interval has not changed
    Particle.keepAlive(10);

    // Disconnect from the cloud
    delay(1000);
    Particle.disconnect();
    waitCloudStatus(cloud_status_disconnected);

    // Set the interval before establishing a connection to the cloud. The interval should be
    // published after the protocol handshake
    Particle.keepAlive(20);
    Particle.connect();
    waitCloudStatus(cloud_status_connected);

    // Disconnect from the cloud
    delay(1000);
    Particle.disconnect();
    waitCloudStatus(cloud_status_disconnected);

    // Set the interval while the handshake is in progress. Two events should be published during
    // the handshake. Note: At present, the events may be delivered in the wrong order
    Particle.connect();
    waitCloudStatus(cloud_status_connecting);
    // Run one more iteration of the system loop to let the system start the handshake
    Particle.process();
    Particle.keepAlive(30);

    // Disconnect from the cloud
    delay(1000);
    Particle.disconnect();
    waitCloudStatus(cloud_status_disconnected);

    done = true;
}
```
