### PR TITLE
Do not mix logging and serial console output

### DIFF
--- a/wiring/src/spark_wiring_logging.cpp
+++ b/wiring/src/spark_wiring_logging.cpp
@@ -473,9 +473,11 @@ int spark::detail::LogFilter::nodeIndex(const Vector<Node> &nodes, const char *n
 // spark::StreamLogHandler
 void spark::StreamLogHandler::logMessage(const char *msg, LogLevel level, const char *category, const LogAttributes &attr) {
     // TODO: Move this check to a base class (see also JSONStreamLogHandler::logMessage())
+#if PLATFORM_ID != PLATFORM_GCC
     if (stream_ == &Serial && Network.listening()) {
         return; // Do not mix logging and serial console output
     }
+#endif
     const char *s = nullptr;
     // Timestamp
     if (attr.has_time) {
@@ -540,9 +542,11 @@ void spark::StreamLogHandler::logMessage(const char *msg, LogLevel level, const 
 // spark::JSONStreamLogHandler
 void spark::JSONStreamLogHandler::logMessage(const char *msg, LogLevel level, const char *category, const LogAttributes &attr) {
     // TODO: Move this check to a base class (see also StreamLogHandler::logMessage())
+#if PLATFORM_ID != PLATFORM_GCC
     if (this->stream() == &Serial && Network.listening()) {
         return; // Do not mix logging and serial console output
     }
+#endif
     JSONStreamWriter json(*this->stream());
     json.beginObject();
     // Level


### PR DESCRIPTION
### Problem

This PR cherry-picks cae58bcdd84d1d6d5fa1a1c5fa0bf2b88608e221 from https://github.com/particle-iot/device-os/pull/1748 to make sure logging over `Serial` does not interfere with the serial console in listening mode.

### Steps to Test

Flash `tinker-serial-debugging` and verify that the device can be flashed over the serial interface without errors.
