### PR TITLE
Git: fix submodules whitespace

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,11 @@
 [submodule "proto"]
 	path = proto
-  url = https://github.com/particle-iot/firmware-protobuf.git
-  branch = master
+	url = https://github.com/particle-iot/firmware-protobuf.git
+	branch = master
 [submodule "third_party/nrf5_sdk/nrf5_sdk"]
 	path = third_party/nrf5_sdk/nrf5_sdk
-  url = https://github.com/particle-iot/nrf5_sdk.git
-  branch = particle
+	url = https://github.com/particle-iot/nrf5_sdk.git
+	branch = particle
 [submodule "third_party/lwip/lwip"]
 	path = third_party/lwip/lwip
 	url = https://github.com/particle-iot/lwip.git
@@ -28,12 +28,12 @@
 	branch = particle
 [submodule "third_party/openthread/openthread"]
 	path = third_party/openthread/openthread
-  url = https://github.com/particle-iot/openthread.git
-  branch = particle
+	url = https://github.com/particle-iot/openthread.git
+	branch = particle
 [submodule "third_party/littlefs/littlefs"]
 	path = third_party/littlefs/littlefs
-  url = https://github.com/particle-iot/littlefs.git
-  branch = particle
+	url = https://github.com/particle-iot/littlefs.git
+	branch = particle
 [submodule "third_party/wiznet_driver/wiznet_driver"]
 	path = third_party/wiznet_driver/wiznet_driver
 	url = https://github.com/particle-iot/ioLibrary_Driver.git
@@ -44,14 +44,14 @@
 	branch = particle
 [submodule "gsm0710muxer/gsm0710muxer"]
 	path = gsm0710muxer/gsm0710muxer
-  url = https://github.com/particle-iot/gsm0710muxer.git
-  branch = master
+	url = https://github.com/particle-iot/gsm0710muxer.git
+	branch = master
 [submodule "third_party/catch2/catch2"]
 	path = third_party/catch2/catch2
-  url = https://github.com/particle-iot/Catch2.git
-  branch = particle
+	url = https://github.com/particle-iot/Catch2.git
+	branch = particle
 [submodule "third_party/fakeit/fakeit"]
 	path = third_party/fakeit/fakeit
-  url = https://github.com/particle-iot/Fakeit.git
-  branch = particle
+	url = https://github.com/particle-iot/Fakeit.git
+	branch = particle
 


### PR DESCRIPTION
<details>
  <summary><i>Whitespace changes to `.gitmodules` were (almost certainly accidentally) introduced in v.1.4.0-rc with https://github.com/particle-iot/device-os/pull/1864, via commit
504114b0af67fb8dc0a61791fb9d75469efb2086. As a result, these changes cause
merge conflicts with feature branches. This commit removes those so that
merges are clean again.
</i></summary>
</details>

### Problem

A change in 1.4.0-rc1 causes merge conflicts. This is important to fix before 1.4.0 goes live so that feature branch maintainers don't suffer needless headaches when targeting new `device-os` releases.

### Solution

Removing the additional whitespace returns the file to the condition in https://github.com/particle-iot/device-os/tree/release/v1.3.1

### Steps to Test

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
