### PR TITLE
[gen 2][lte] TCP socket closing slowly and TCPClient::connect() return values are incorrect

### DIFF
--- a/user/tests/wiring/no_fixture/tcp.cpp
+++ b/user/tests/wiring/no_fixture/tcp.cpp
@@ -3,6 +3,9 @@
 #include "application.h"
 #include "unit-test/unit-test.h"
 
+// issue #1865 - TCPClient connect() return values
+// added asserts for TCPClient::connect()
+
 test(TCP_01_tcp_client_failed_connect_invalid_ip)
 {
     TCPClient client;
@@ -21,10 +24,15 @@ test(TCP_02_tcp_client_failed_connect_invalid_fqdn)
 
 test(TCP_03_tcp_client_success_connect_valid_ip)
 {
+    IPAddress ip;
+    ip = Network.resolve("www.httpbin.org");
+    assertTrue(ip > 0);
     TCPClient client;
-    assertTrue(client.connect(IPAddress(8,8,8,8), 53));
+    assertTrue(client.connect(ip, 80));
     assertTrue(client.connected());
+    system_tick_t start = millis();
     client.stop();
+    assertTrue(millis() - start < 2000UL); // ch35609 - TCP sockets should close quickly
     assertFalse(client.connected());
 }
 
@@ -33,6 +41,8 @@ test(TCP_04_tcp_client_success_connect_valid_fqdn)
     TCPClient client;
     assertTrue(client.connect("www.httpbin.org", 80));
     assertTrue(client.connected());
+    system_tick_t start = millis();
     client.stop();
+    assertTrue(millis() - start < 2000UL); // ch35609 - TCP sockets should close quickly
     assertFalse(client.connected());
 }

--- a/user/tests/wiring/no_fixture/tcp.cpp
+++ b/user/tests/wiring/no_fixture/tcp.cpp
@@ -6,7 +6,7 @@
 test(TCP_01_tcp_client_failed_connect_invalid_ip)
 {
     TCPClient client;
-    client.connect(IPAddress(0,0,0,0), 567);
+    assertFalse(client.connect(IPAddress(0,0,0,0), 567));
     assertFalse(client.connected());
     client.stop();
 }
@@ -14,7 +14,25 @@ test(TCP_01_tcp_client_failed_connect_invalid_ip)
 test(TCP_02_tcp_client_failed_connect_invalid_fqdn)
 {
     TCPClient client;
-    client.connect("does.not.exist", 567);
+    assertFalse(client.connect("does.not.exist", 567));
     assertFalse(client.connected());
     client.stop();
+}
+
+test(TCP_03_tcp_client_success_connect_valid_ip)
+{
+    TCPClient client;
+    assertTrue(client.connect(IPAddress(8,8,8,8), 53));
+    assertTrue(client.connected());
+    client.stop();
+    assertFalse(client.connected());
+}
+
+test(TCP_04_tcp_client_success_connect_valid_fqdn)
+{
+    TCPClient client;
+    assertTrue(client.connect("www.httpbin.org", 80));
+    assertTrue(client.connected());
+    client.stop();
+    assertFalse(client.connected());
 }

--- a/wiring/src/spark_wiring_tcpclient.cpp
+++ b/wiring/src/spark_wiring_tcpclient.cpp
@@ -53,24 +53,24 @@ TCPClient::TCPClient(sock_handle_t sock) :
   flush_buffer();
 }
 
+// return 0 on error, 1 on success
 int TCPClient::connect(const char* host, uint16_t port, network_interface_t nif)
 {
     stop();
-      int rv = 0;
-      if(Network.ready())
-      {
+    if (Network.ready())
+    {
         IPAddress ip_addr;
-
-        if((rv = inet_gethostbyname(host, strlen(host), ip_addr, nif, NULL)) == 0)
-        {
-                return connect(ip_addr, port, nif);
-        }
-        else
+        if (inet_gethostbyname(host, strlen(host), ip_addr, nif, NULL) == 0) {
+            return connect(ip_addr, port, nif);
+        } else {
             DEBUG("unable to get IP for hostname");
-      }
-      return rv;
+        }
+    }
+
+    return 0; // error, could not connect
 }
 
+// return 0 on error, 1 on success
 int TCPClient::connect(IPAddress ip, uint16_t port, network_interface_t nif)
 {
     stop();


### PR DESCRIPTION
### Problem

- See #1865 where TCPClient::connect() return values are not working as documented (1 = connected, 0 = all errors)
- [gen 2][lte] TCP Sockets generally take much longer to close on the SARA-R410M-02B vs. U260, U201 and other modems.

### Solution

- fixes #1865, TCPClient::connect() return values by ensuring Gen 2 and 3 both return only 1 for success and 0 for all errors.
- [gen 2][lte] fixes slow to close TCP sockets on SARA-R410M-02B [ch35609] by using the USOSO TCP linger option for TCP sockets only, and setting the timeout to 0 which forces a disconnect immediately when the USOCL socket close command is used.
- Added TCP_03 and TCP_04 and updated TCP_01 and TCP_02 tests.

### Steps to Test

Run TEST=wiring/no_fixture (i, TCP*, i, MDM* to run all TCP related tests)

### References

- fixes #1865 
- closes [ch35609] 

### Device OS build from this PR for Electron/E Series
🔽  [particle-device-os@1.4.0-rc.1+debug.pr1911.zip](https://www.dropbox.com/s/hdfz0iglm80p3om/particle-device-os%401.4.0-rc.1%2Bdebug.pr1911.zip?dl=1)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [x] Added to CHANGELOG.md after merging (add links to docs and issues)

---

- fixes [#1865](https://github.com/particle-iot/device-os/issues/1865), TCPClient::connect() return values [#1909](https://github.com/particle-iot/device-os/pull/1909)
- [gen 2][lte] fixes slow to close TCP sockets on SARA-R410M-02B [ch35609] [#1909](https://github.com/particle-iot/device-os/pull/1909)
