### PR TITLE
Minor test fixes for 1.4.0

### DIFF
--- a/user/tests/wiring/no_fixture/gpio.cpp
+++ b/user/tests/wiring/no_fixture/gpio.cpp
@@ -55,7 +55,7 @@ test(GPIO_01_PinModeSetResultsInCorrectMode) {
 }
 
 test(GPIO_02_NoDigitalWriteWhenPinModeIsNotSetToOutput) {
-    pin_t pin = D0;//pin under test
+    pin_t pin = A0;//pin under test
     // when
     // pin set to INPUT_PULLUP mode, to keep pin from floating and test failing
     pinMode(pin, INPUT_PULLUP);
@@ -76,7 +76,7 @@ test(GPIO_03_NoDigitalWriteWhenPinSelectedIsOutOfRange) {
 }
 
 test(GPIO_04_DigitalWriteOnPinResultsInCorrectDigitalRead) {
-    pin_t pin = D0;//pin under test
+    pin_t pin = A0;//pin under test
     // when
     pinMode(pin, OUTPUT);
     digitalWrite(pin, HIGH);

--- a/user/tests/wiring/no_fixture_long_running/network.cpp
+++ b/user/tests/wiring/no_fixture_long_running/network.cpp
@@ -65,6 +65,12 @@ bool udpEchoTest(UDP* udp, const IPAddress& ip, uint16_t port, const uint8_t* se
 test(NETWORK_01_LargePacketsDontCauseIssues_ResolveMtu) {
     Network.on();
     Network.connect();
+
+    SCOPE_GUARD({
+        Network.disconnect();
+        Network.off();
+    });
+
     waitFor(Network.ready, 60000);
     assertTrue(Network.ready());
 
@@ -96,7 +102,7 @@ test(NETWORK_01_LargePacketsDontCauseIssues_ResolveMtu) {
 
     // FIXME: Hosted by @avtolstoy, should be changed to something else
     const char UDP_ECHO_SERVER[] = "particle-udp-echo.rltm.org";
-    uint16_t UDP_ECHO_PORT = 40000;
+    const uint16_t UDP_ECHO_PORT = 40000;
 
     // Resolve UDP echo server hostname to ip address, so that DNS resolutions
     // no longer affect us after this point
@@ -145,9 +151,4 @@ test(NETWORK_01_LargePacketsDontCauseIssues_ResolveMtu) {
     assertFalse((bool)state.disconnected);
 
     assertTrue((mtu - IPV4_PLUS_UDP_HEADER_LENGTH) >= MBEDTLS_SSL_MAX_CONTENT_LEN);
-
-    SCOPE_GUARD({
-        Network.disconnect();
-        Network.off();
-    });
 }

--- a/wiring/src/spark_wiring_ipaddress.cpp
+++ b/wiring/src/spark_wiring_ipaddress.cpp
@@ -65,7 +65,7 @@ IPAddress::operator bool() const
     if (version() == 4) {
         return address.ipv4 != 0;
     } else if (version() == 6) {
-        return address.ipv6[0] != 0 && address.ipv6[1] != 0 && address.ipv6[2] != 0 && address.ipv6[3] != 0;
+        return address.ipv6[0] != 0 || address.ipv6[1] != 0 || address.ipv6[2] != 0 || address.ipv6[3] != 0;
     } else {
         return false;
     }


### PR DESCRIPTION
### Description

1. Fixes a bug in `IPAddress::operator bool()` for IPv6 addresses
2. Changes a default pin from `D0` to `A0` in GPIO tests. `D0` is usually an I2C pin as well, so the test might not work depending on how things are wired (e.g. on SoM EVB)
3. Minor fixes in `NETWORK_01_LargePacketsDontCauseIssues_ResolveMtu`

### Steps to Test

- `wiring/no_fixture` `GPIO*` on BSoM
- `wiring/no_fixture_long_running` on a Xenon

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
