### PR TITLE
Increase maximum DTLS handshake timeout

### DIFF
--- a/communication/src/dtls_message_channel.cpp
+++ b/communication/src/dtls_message_channel.cpp
@@ -201,7 +201,7 @@ ProtocolError DTLSMessageChannel::init(
 			MBEDTLS_SSL_TRANSPORT_DATAGRAM, MBEDTLS_SSL_PRESET_DEFAULT);
 	EXIT_ERROR(ret, "unable to configure defaults");
 
-	mbedtls_ssl_conf_handshake_timeout(&conf, 3000, 6000);
+	mbedtls_ssl_conf_handshake_timeout(&conf, 3000, 24000);
 
 	mbedtls_ssl_conf_rng(&conf, mbedtls_default_rng, nullptr); // todo - would like to make this a callback
 	mbedtls_ssl_conf_dbg(&conf, my_debug, nullptr);


### PR DESCRIPTION
### Problem

The comms library sets the maximum DTLS handshake timeout (see [RFC 6347](https://tools.ietf.org/html/rfc6347#section-4.2.4.1)) to 6 seconds: [dtls_message_channel.cpp#L204](https://github.com/particle-iot/device-os/blob/dfc2f2cc0e31e62809c3cbdb835d98d55a3e7dc2/communication/src/dtls_message_channel.cpp#L204). Effectively, this causes mbedtls to retransmit an unacknowledged handshake packet only once before failing with a timeout error:

send packet
_...wait 3 seconds..._
resend packet
_...wait 6 seconds..._
timeout

(device log: [6_seconds.txt](https://github.com/particle-iot/device-os/files/3603310/6_seconds.txt))

This PR sets the maximum timeout to 24 seconds, which gives nice 3 retransmission attempts while keeping the overall handshake timeout limited to reasonable 45 seconds:

send packet
_...wait 3 seconds..._
resend packet
_...wait 6 seconds..._
resend packet
_...wait 12 seconds..._
resend packet
_...wait 24 seconds..._
timeout

(device log: [24_seconds.txt](https://github.com/particle-iot/device-os/files/3603311/24_seconds.txt))

Note that this change does not affect session resumption and only changes the number of retransmissions and overall timeout of the DTLS handshake, which is performed as part of the full handshake with the cloud.

#### Further considerations:

RFC 6347 recommends setting the minimum and maximum timeouts to 1 and 60 seconds respectively. The 60-second timeout extends the overall handshake timeout to 2+ minutes and seems to be an overkill, but how about lowering the minimum timeout from the current 3 seconds to 1 or 2 seconds? This would potentially lower the latency of both the session resumption and full handshake.

### Steps to Test

Flash this branch to a UDP device, point it to a non-existing server, and verify via the logs that the full handshake performed by the device takes about 45 seconds to fail.
