### PR TITLE
BLE: fixes that setValue() doesn't work with BleTxRxType::AUTO if characteristic has WRITE property.

### DIFF
--- a/user/tests/wiring/ble_central_peripheral/ble_central/central.cpp
+++ b/user/tests/wiring/ble_central_peripheral/ble_central/central.cpp
@@ -7,14 +7,24 @@
 
 BleScanResult results[SCAN_RESULT_COUNT];
 
-BleCharacteristic peerTxCharacteristic;
-BleCharacteristic peerRxCharacteristic;
+BleCharacteristic peerCharRead;
+BleCharacteristic peerCharWrite;
+BleCharacteristic peerCharWriteWoRsp;
+BleCharacteristic peerCharWriteAndWriteWoRsp;
+BleCharacteristic peerCharNotify;
+BleCharacteristic peerCharIndicate;
+BleCharacteristic peerCharNotifyAndIndicate;
 BlePeerDevice peer;
 
-const String str1("This is string 1.");
-const String str2("Hello from Particle.");
-const String str3("Have a good day!");
-bool str1Rec = false, str2Rec = false, str3Rec = false;
+const String str1("05a9ae9588dd");
+const String str2("4f62bd40046a");
+const String str3("6619918032a2");
+const String str4("359b4deb3f37");
+const String str5("a2ef18ec6eaa");
+const String str6("7223b5dd3342");
+const String str7("d4b4249bbbe3");
+
+bool str1Rec = false, str2Rec = false, str3Rec = false, str4Rec = false, str5Rec = false, str6Rec = false, str7Rec = false;
 
 static void onDataReceived(const uint8_t* data, size_t len, const BlePeerDevice& peer, void* context) {
     String str((const char*)data, len);
@@ -27,10 +37,24 @@ static void onDataReceived(const uint8_t* data, size_t len, const BlePeerDevice&
     if (str == str3) {
         str3Rec = true;
     }
+    if (str == str4) {
+        str4Rec = true;
+    }
+    if (str == str5) {
+        str5Rec = true;
+    }
+    if (str == str6) {
+        str6Rec = true;
+    }
+    if (str == str7) {
+        str7Rec = true;
+    }
 }
 
 test(BLE_01_Central_Scan_And_Connect) {
-    peerTxCharacteristic.onDataReceived(onDataReceived, &peerTxCharacteristic);
+    peerCharNotify.onDataReceived(onDataReceived, &peerCharNotify);
+    peerCharIndicate.onDataReceived(onDataReceived, &peerCharIndicate);
+    peerCharNotifyAndIndicate.onDataReceived(onDataReceived, &peerCharNotifyAndIndicate);
 
     int ret = BLE.setScanTimeout(100); // Scan timeout: 1s
     assertEqual(ret, 0);
@@ -44,11 +68,16 @@ test(BLE_01_Central_Scan_And_Connect) {
             for (uint8_t i = 0; i < count; i++) {
                 BleUuid foundServiceUUID;
                 size_t svcCount = results[i].advertisingData.serviceUUID(&foundServiceUUID, 1);
-                if (svcCount > 0 && foundServiceUUID == "6E400001-B5A3-F393-E0A9-E50E24DCCA9E") {
+                if (svcCount > 0 && foundServiceUUID == "6E400000-B5A3-F393-E0A9-E50E24DCCA9E") {
                     peer = BLE.connect(results[i].address);
                     if (peer.connected()) {
-                        peer.getCharacteristicByDescription(peerTxCharacteristic, "tx");
-                        peer.getCharacteristicByUUID(peerRxCharacteristic, "6E400002-B5A3-F393-E0A9-E50E24DCCA9E");
+                        assertTrue(peer.getCharacteristicByDescription(peerCharRead, "read"));
+                        assertTrue(peer.getCharacteristicByDescription(peerCharWrite, "write"));
+                        assertTrue(peer.getCharacteristicByDescription(peerCharWriteWoRsp, "write_wo_rsp"));
+                        assertTrue(peer.getCharacteristicByDescription(peerCharWriteAndWriteWoRsp, "write_write_wo_rsp"));
+                        assertTrue(peer.getCharacteristicByUUID(peerCharNotify, "6E400005-B5A3-F393-E0A9-E50E24DCCA9E"));
+                        assertTrue(peer.getCharacteristicByUUID(peerCharIndicate, "6E400006-B5A3-F393-E0A9-E50E24DCCA9E"));
+                        assertTrue(peer.getCharacteristicByUUID(peerCharNotifyAndIndicate, "6E400007-B5A3-F393-E0A9-E50E24DCCA9E"));
                     }
                     break;
                 }
@@ -61,23 +90,70 @@ test(BLE_01_Central_Scan_And_Connect) {
     Serial.println("BLE connected.");
 }
 
-test(BLE_02_Central_Send_Characteristic_Value_With_Auto_Ack) {
-    int ret = peerRxCharacteristic.setValue(str1);
-    assertTrue(ret == str1.length());
+test(BLE_02_Central_Read_Peer_characteristic_With_Read_Property) {
+    const char* str = "6dd902629e1d";
+    String getStr;
+    int ret = peerCharRead.getValue(getStr);
+    assertTrue(ret > 0);
+    assertTrue(getStr == str);
 }
 
-test(BLE_03_Central_Send_Characteristic_Value_With_Ack) {
-    int ret = peerRxCharacteristic.setValue(str2, BleTxRxType::ACK);
-    assertTrue(ret == str2.length());
+test(BLE_03_Central_Write_Characteristic_With_Write_Property_Auto) {
+    const String str("6b4bf92a37f3");
+    int ret = peerCharWrite.setValue(str);
+    assertTrue(ret == (int)str.length());
 }
 
-test(BLE_04_Central_Send_Characteristic_Value_Without_Ack) {
-    int ret = peerRxCharacteristic.setValue(str3, BleTxRxType::NACK);
-    assertTrue(ret == str3.length());
+test(BLE_04_Central_Write_Characteristic_With_Write_Property_Ack) {
+    const String str("df3b41caedac");
+    int ret = peerCharWrite.setValue(str, BleTxRxType::ACK);
+    assertTrue(ret == (int)str.length());
 }
 
-test(BLE_05_Central_Receive_Characteristic_Value_String1) {
-    size_t wait = 5; //Wait for 5s to receive the data from BLE peripheral.
+test(BLE_05_Central_Write_Characteristic_With_Write_Property_Nack) {
+    const String str("febe08cc1f96");
+    int ret = peerCharWrite.setValue(str, BleTxRxType::NACK);
+    assertTrue(ret < 0);
+}
+
+test(BLE_06_Central_Write_Characteristic_With_Write_Wo_Rsp_Property_Auto) {
+    const String str("2ad4bffbb8c7");
+    int ret = peerCharWriteWoRsp.setValue(str);
+    assertTrue(ret == (int)str.length());
+}
+
+test(BLE_07_Central_Write_Characteristic_With_Write_Wo_Rsp_Property_Ack) {
+    const String str("ad2cb5697c37");
+    int ret = peerCharWriteWoRsp.setValue(str, BleTxRxType::ACK);
+    assertTrue(ret < 0);
+}
+
+test(BLE_08_Central_Write_Characteristic_With_Write_Wo_Rsp_Property_Nack) {
+    const String str("203a02992be0");
+    int ret = peerCharWriteWoRsp.setValue(str, BleTxRxType::NACK);
+    assertTrue(ret == (int)str.length());
+}
+
+test(BLE_09_Central_Write_Characteristic_With_Write_Write_Wo_Rsp_Property_Auto) {
+    const String str("86d7a840079f");
+    int ret = peerCharWriteAndWriteWoRsp.setValue(str);
+    assertTrue(ret == (int)str.length());
+}
+
+test(BLE_10_Central_Write_Characteristic_With_Write_Write_Wo_Rsp_Property_Ack) {
+    const String str("77982c283c65");
+    int ret = peerCharWriteAndWriteWoRsp.setValue(str, BleTxRxType::ACK);
+    assertTrue(ret == (int)str.length());
+}
+
+test(BLE_11_Central_Write_Characteristic_With_Write_Write_Wo_Rsp_Property_Nack) {
+    const String str("21ec57d28a0c");
+    int ret = peerCharWriteAndWriteWoRsp.setValue(str, BleTxRxType::NACK);
+    assertTrue(ret == (int)str.length());
+}
+
+test(BLE_12_Central_Received_Characteristic_With_Notify_Property_Auto) {
+    size_t wait = 20; //Wait for 2s to receive the data from BLE peripheral.
     while (!str1Rec && wait > 0) {
         delay(100);
         wait--;
@@ -85,8 +161,8 @@ test(BLE_05_Central_Receive_Characteristic_Value_String1) {
     assertTrue(wait > 0);
 }
 
-test(BLE_06_Central_Receive_Characteristic_Value_String2) {
-    size_t wait = 5; //Wait for 5s to receive the data from BLE peripheral.
+test(BLE_13_Central_Received_Characteristic_With_Notify_Property_Nack) {
+    size_t wait = 20; //Wait for 2s to receive the data from BLE peripheral.
     while (!str2Rec && wait > 0) {
         delay(100);
         wait--;
@@ -94,9 +170,45 @@ test(BLE_06_Central_Receive_Characteristic_Value_String2) {
     assertTrue(wait > 0);
 }
 
-test(BLE_07_Central_Receive_Characteristic_Value_String3) {
-    size_t wait = 5; //Wait for 5s to receive the data from BLE peripheral.
+test(BLE_14_Central_Received_Characteristic_With_Indicate_Property_Auto) {
+    size_t wait = 20; //Wait for 2s to receive the data from BLE peripheral.
     while (!str3Rec && wait > 0) {
+        delay(100);
+        wait--;
+    }
+    assertTrue(wait > 0);
+}
+
+test(BLE_15_Central_Received_Characteristic_With_Indicate_Property_Ack) {
+    size_t wait = 20; //Wait for 2s to receive the data from BLE peripheral.
+    while (!str4Rec && wait > 0) {
+        delay(100);
+        wait--;
+    }
+    assertTrue(wait > 0);
+}
+
+test(BLE_16_Central_Received_Characteristic_With_Notify_Indicate_Property_Auto) {
+    size_t wait = 20; //Wait for 2s to receive the data from BLE peripheral.
+    while (!str5Rec && wait > 0) {
+        delay(100);
+        wait--;
+    }
+    assertTrue(wait > 0);
+}
+
+test(BLE_17_Central_Received_Characteristic_With_Notify_Indicate_Property_Ack) {
+    size_t wait = 20; //Wait for 2s to receive the data from BLE peripheral.
+    while (!str6Rec && wait > 0) {
+        delay(100);
+        wait--;
+    }
+    assertTrue(wait > 0);
+}
+
+test(BLE_18_Central_Received_Characteristic_With_Notify_Indicate_Property_Nack) {
+    size_t wait = 20; //Wait for 2s to receive the data from BLE peripheral.
+    while (!str7Rec && wait > 0) {
         delay(100);
         wait--;
     }

--- a/user/tests/wiring/ble_central_peripheral/ble_peripheral/peripheral.cpp
+++ b/user/tests/wiring/ble_central_peripheral/ble_peripheral/peripheral.cpp
@@ -4,25 +4,34 @@
 #if Wiring_BLE == 1
 void onDataReceived(const uint8_t* data, size_t len, const BlePeerDevice& peer, void* context);
 
-const char* serviceUuid = "6E400001-B5A3-F393-E0A9-E50E24DCCA9E";
-const char* rxUuid = "6E400002-B5A3-F393-E0A9-E50E24DCCA9E";
-const char* txUuid = "6E400003-B5A3-F393-E0A9-E50E24DCCA9E";
+const char* serviceUuid = "6E400000-B5A3-F393-E0A9-E50E24DCCA9E";
+const char* charReadUuid = "6E400001-B5A3-F393-E0A9-E50E24DCCA9E";
+const char* charWriteUuid = "6E400002-B5A3-F393-E0A9-E50E24DCCA9E";
+const char* charWriteWoRspUuid = "6E400003-B5A3-F393-E0A9-E50E24DCCA9E";
+const char* charWriteAndWriteWoRspUuid = "6E400004-B5A3-F393-E0A9-E50E24DCCA9E";
+const char* charNotifyUuid = "6E400005-B5A3-F393-E0A9-E50E24DCCA9E";
+const char* charIndicateUuid = "6E400006-B5A3-F393-E0A9-E50E24DCCA9E";
+const char* charNotifyAndIndicateUuid = "6E400007-B5A3-F393-E0A9-E50E24DCCA9E";
 
-const String str1("This is string 1.");
-const String str2("Hello from Particle.");
-const String str3("Have a good day!");
-bool str1Rec = false, str2Rec = false, str3Rec = false;
+const String str1("6b4bf92a37f3");
+const String str2("df3b41caedac");
+const String str3("2ad4bffbb8c7");
+const String str4("203a02992be0");
+const String str5("86d7a840079f");
+const String str6("77982c283c65");
+const String str7("21ec57d28a0c");
 
-BleCharacteristic txCharacteristic("tx",
-                                   BleCharacteristicProperty::NOTIFY | BleCharacteristicProperty::INDICATE,
-                                   txUuid,
-                                   serviceUuid);
+bool str1Rec = false, str2Rec = false, str3Rec = false, str4Rec = false, str5Rec = false, str6Rec = false, str7Rec = false;
 
-BleCharacteristic rxCharacteristic("rx",
-                                   BleCharacteristicProperty::WRITE_WO_RSP | BleCharacteristicProperty::WRITE,
-                                   rxUuid,
-                                   serviceUuid,
-                                   onDataReceived, &rxCharacteristic);
+BleCharacteristic charRead("read", BleCharacteristicProperty::READ, charReadUuid, serviceUuid);
+
+BleCharacteristic charWrite("write", BleCharacteristicProperty::WRITE, charWriteUuid, serviceUuid, onDataReceived, &charWrite);
+BleCharacteristic charWriteWoRsp("write_wo_rsp", BleCharacteristicProperty::WRITE_WO_RSP, charWriteWoRspUuid, serviceUuid, onDataReceived, &charWriteWoRsp);
+BleCharacteristic charWriteAndWriteWoRsp("write_write_wo_rsp", BleCharacteristicProperty::WRITE_WO_RSP | BleCharacteristicProperty::WRITE, charWriteAndWriteWoRspUuid, serviceUuid, onDataReceived, &charWriteAndWriteWoRsp);
+
+BleCharacteristic charNotify("notify", BleCharacteristicProperty::NOTIFY, charNotifyUuid, serviceUuid);
+BleCharacteristic charIndicate("indicate", BleCharacteristicProperty::INDICATE, charIndicateUuid, serviceUuid);
+BleCharacteristic charNotifyAndIndicate("notify_indicate", BleCharacteristicProperty::NOTIFY | BleCharacteristicProperty::INDICATE, charNotifyAndIndicateUuid, serviceUuid);
 
 void onDataReceived(const uint8_t* data, size_t len, const BlePeerDevice& peer, void* context) {
     String str((const char*)data, len);
@@ -35,15 +44,39 @@ void onDataReceived(const uint8_t* data, size_t len, const BlePeerDevice& peer, 
     if (str == str3) {
         str3Rec = true;
     }
+    if (str == str4) {
+        str4Rec = true;
+    }
+    if (str == str5) {
+        str5Rec = true;
+    }
+    if (str == str6) {
+        str6Rec = true;
+    }
+    if (str == str7) {
+        str7Rec = true;
+    }
 }
 
 test(BLE_01_Peripheral_Advertising) {
     int ret;
     BleCharacteristic temp;
 
-    temp = BLE.addCharacteristic(txCharacteristic);
+    temp = BLE.addCharacteristic(charRead);
     assertTrue(temp.valid());
-    temp = BLE.addCharacteristic(rxCharacteristic);
+    ret = charRead.setValue("6dd902629e1d");
+    assertEqual(ret, 12);
+    temp = BLE.addCharacteristic(charWrite);
+    assertTrue(temp.valid());
+    temp = BLE.addCharacteristic(charWriteWoRsp);
+    assertTrue(temp.valid());
+    temp = BLE.addCharacteristic(charWriteAndWriteWoRsp);
+    assertTrue(temp.valid());
+    temp = BLE.addCharacteristic(charNotify);
+    assertTrue(temp.valid());
+    temp = BLE.addCharacteristic(charIndicate);
+    assertTrue(temp.valid());
+    temp = BLE.addCharacteristic(charNotifyAndIndicate);
     assertTrue(temp.valid());
 
     BleAdvertisingData data;
@@ -67,8 +100,10 @@ test(BLE_02_Peripheral_Connected) {
     Serial.println("BLE connected.");
 }
 
-test(BLE_03_Peripheral_Receive_Characteristic_Value_String1) {
-    size_t wait = 50; //Wait for 5s to receive the data from BLE central.
+// For the first data transmission, we need to wait longer to make sure
+// the Central device has discovered the services and characteristics.
+test(BLE_03_Peripheral_Receive_Characteristic_With_Write_Property_Auto) {
+    size_t wait = 100; //Wait for 10s to receive the data from BLE peripheral.
     while (!str1Rec && wait > 0) {
         delay(100);
         wait--;
@@ -76,8 +111,8 @@ test(BLE_03_Peripheral_Receive_Characteristic_Value_String1) {
     assertTrue(wait > 0);
 }
 
-test(BLE_04_Peripheral_Receive_Characteristic_Value_String2) {
-    size_t wait = 50; //Wait for 5s to receive the data from BLE central.
+test(BLE_04_Peripheral_Receive_Characteristic_With_Write_Property_Ack) {
+    size_t wait = 20; //Wait for 2s to receive the data from BLE peripheral.
     while (!str2Rec && wait > 0) {
         delay(100);
         wait--;
@@ -85,8 +120,8 @@ test(BLE_04_Peripheral_Receive_Characteristic_Value_String2) {
     assertTrue(wait > 0);
 }
 
-test(BLE_05_Peripheral_Receive_Characteristic_Value_String3) {
-    size_t wait = 50; //Wait for 5s to receive the data from BLE central.
+test(BLE_05_Peripheral_Receive_Characteristic_With_Write_Wo_Rsp_Property_Auto) {
+    size_t wait = 20; //Wait for 2s to receive the data from BLE peripheral.
     while (!str3Rec && wait > 0) {
         delay(100);
         wait--;
@@ -94,19 +129,94 @@ test(BLE_05_Peripheral_Receive_Characteristic_Value_String3) {
     assertTrue(wait > 0);
 }
 
-test(BLE_06_Peripheral_Send_Characteristic_Value_With_Auto_Ack) {
-    int ret = txCharacteristic.setValue(str1);
-    assertTrue(ret == str1.length());
+test(BLE_06_Peripheral_Receive_Characteristic_With_Write_Wo_Rsp_Property_Nack) {
+    size_t wait = 20; //Wait for 2s to receive the data from BLE peripheral.
+    while (!str4Rec && wait > 0) {
+        delay(100);
+        wait--;
+    }
+    assertTrue(wait > 0);
 }
 
-test(BLE_07_Peripheral_Send_Characteristic_Value_With_Ack) {
-    int ret = txCharacteristic.setValue(str2, BleTxRxType::ACK);
-    assertTrue(ret == str2.length());
+test(BLE_07_Peripheral_Receive_Characteristic_With_Write_Write_Wo_Rsp_Property_Auto) {
+    size_t wait = 20; //Wait for 2s to receive the data from BLE peripheral.
+    while (!str5Rec && wait > 0) {
+        delay(100);
+        wait--;
+    }
+    assertTrue(wait > 0);
 }
 
-test(BLE_08_Peripheral_Send_Characteristic_Value_Without_Ack) {
-    int ret = txCharacteristic.setValue(str3, BleTxRxType::NACK);
-    assertTrue(ret == str3.length());
+test(BLE_08_Peripheral_Receive_Characteristic_With_Write_Write_Wo_Rsp_Property_Ack) {
+    size_t wait = 20; //Wait for 2s to receive the data from BLE peripheral.
+    while (!str6Rec && wait > 0) {
+        delay(100);
+        wait--;
+    }
+    assertTrue(wait > 0);
+}
+
+test(BLE_09_Peripheral_Receive_Characteristic_With_Write_Write_Wo_Rsp_Property_Nack) {
+    size_t wait = 20; //Wait for 2s to receive the data from BLE peripheral.
+    while (!str7Rec && wait > 0) {
+        delay(100);
+        wait--;
+    }
+    assertTrue(wait > 0);
+}
+
+test(BLE_10_Peripheral_Notify_Characteristic_With_Notify_Property_Auto) {
+    const String str("05a9ae9588dd");
+    int ret = charNotify.setValue(str);
+    assertTrue(ret == (int)str.length());
+}
+
+test(BLE_11_Peripheral_Notify_Characteristic_With_Notify_Property_Ack) {
+    const String str("b551f6ca1329");
+    int ret = charNotify.setValue(str, BleTxRxType::ACK);
+    assertTrue(ret < 0);
+}
+
+test(BLE_12_Peripheral_Notify_Characteristic_With_Notify_Property_Nack) {
+    const String str("4f62bd40046a");
+    int ret = charNotify.setValue(str, BleTxRxType::NACK);
+    assertTrue(ret == (int)str.length());
+}
+
+test(BLE_13_Peripheral_Notify_Characteristic_With_Indicate_Property_Auto) {
+    const String str("6619918032a2");
+    int ret = charIndicate.setValue(str);
+    assertTrue(ret == (int)str.length());
+}
+
+test(BLE_14_Peripheral_Notify_Characteristic_With_Indicate_Property_Ack) {
+    const String str("359b4deb3f37");
+    int ret = charIndicate.setValue(str, BleTxRxType::ACK);
+    assertTrue(ret == (int)str.length());
+}
+
+test(BLE_15_Peripheral_Notify_Characteristic_With_Indicate_Property_Nack) {
+    const String str("06d0be9e185b");
+    int ret = charIndicate.setValue(str, BleTxRxType::NACK);
+    assertTrue(ret < 0);
+}
+
+test(BLE_16_Peripheral_Notify_Characteristic_With_Notify_Indicate_Property_Auto) {
+    const String str("a2ef18ec6eaa");
+    int ret = charNotifyAndIndicate.setValue(str);
+    assertTrue(ret == (int)str.length());
+}
+
+test(BLE_17_Peripheral_Notify_Characteristic_With_Notify_Indicate_Property_Ack) {
+    const String str("7223b5dd3342");
+    int ret = charNotifyAndIndicate.setValue(str, BleTxRxType::ACK);
+    assertTrue(ret == (int)str.length());
+}
+
+test(BLE_18_Peripheral_Notify_Characteristic_With_Notify_Indicate_Property_Nack) {
+    const String str("d4b4249bbbe3");
+    int ret = charNotifyAndIndicate.setValue(str, BleTxRxType::NACK);
+    assertTrue(ret == (int)str.length());
 }
 
 #endif // #if Wiring_BLE == 1


### PR DESCRIPTION
### Problem

https://github.com/particle-iot/device-os/issues/1913

### Solution

Send characteristic value, which property is `WRITE`, when `BleTxRxType::AUTO` is used by default.

### Steps to Test

1. Build and flash the test applications `user/tests/wiring/ble_central_peripheral` to two Gen3 devices respectively.
2. Simply connect them to serial terminals and type `t` on the terminal to start the test.

### Example App

N/A

### References

- Closes #1913
- Closes #1924

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)