### PR TITLE
BLE: discovered descriptor is incorrect

### DIFF
--- a/hal/src/nRF52840/ble_hal.cpp
+++ b/hal/src/nRF52840/ble_hal.cpp
@@ -3014,7 +3014,10 @@ int BleObject::GattClient::processCharDiscEventFromThread(const ble_evt_t* event
         const ble_gattc_evt_desc_disc_rsp_t& descDiscRsp = event->evt.gattc_evt.params.desc_disc_rsp;
         if (event->evt.gattc_evt.gatt_status == BLE_GATT_STATUS_SUCCESS) {
             for (uint8_t i = 0; i < descDiscRsp.count; i++) {
-                // It will report all attributes with 16-bits UUID, filter descriptors.
+                // It will report all attributes, filter descriptors only.
+                if (descDiscRsp.descs[i].uuid.type != BLE_UUID_TYPE_BLE) {
+                    continue;
+                }
                 hal_ble_char_t* characteristic = findDiscoveredCharacteristic(descDiscRsp.descs[i].handle);
                 if (characteristic) {
                     switch (descDiscRsp.descs[i].uuid.uuid) {


### PR DESCRIPTION
### Problem

Discovered descriptor of peer characteristic with 128-bits UUID is incorrect. That would report a fake CCCD handle, which is the same as the characteristic value handle, even if that characteristic has no CCCD presented. As a result, BLE Central device will send two byte, which is supposed to be the CCCD value, to the characteristic value instead upon connected when automatic connecting scheme is adopted.

### Solution

Filter the discovered descriptors with bluetooth SIG 16-bits UUID.

### Steps to Test

1. Build and flash the example apps `user/tests/app/ble/uart_central` and `user/tests/app/ble/uart_peripheral` to two Gen3 devices respectively with debug enabled.
2. Observe the log on the Peripheral device side and see if it received two bytes from Central device upon connected.

### Example App

N/A

### References

https://github.com/particle-iot/device-os/issues/1913#issuecomment-530637797

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)