### PR TITLE
[electron, gen2] fixes RSSI failing due to Power Saving mode active [ch38428]

### DIFF
--- a/hal/src/boron/network/sara_ncp_client.cpp
+++ b/hal/src/boron/network/sara_ncp_client.cpp
@@ -870,10 +870,16 @@ int SaraNcpClient::initReady() {
             }
         }
         CHECK_PARSER_OK(lastError);
-        // Force Power Saving mode to be disabled for good measure
+        // Force Power Saving mode to be disabled
+        //
+        // TODO: if we enable this feature in the future add logic to CHECK_PARSER macro(s)
+        // to wait longer for device to become active (see MDMParser::_atOk)
         CHECK_PARSER_OK(parser_.execCommand("AT+CPSMS=0"));
     } else {
-        // Power saving
+        // Force Power Saving mode to be disabled
+        //
+        // TODO: if we enable this feature in the future add logic to CHECK_PARSER macro(s)
+        // to wait longer for device to become active (see MDMParser::_atOk)
         CHECK_PARSER_OK(parser_.execCommand("AT+UPSV=0"));
     }
 


### PR DESCRIPTION
### Problem

PR #1886 added some AT / OK checks before commands with long delays, to force a quicker timeout when the AT interface was not responsive.  Unfortunately this negatively affected Gen 2 2G/3G modems due to the Power Saving mode being set to UPSV=1 by default which enables low power mode after about 9.2 seconds in most cases.  The issue is that when power saving mode is active, the AT / OK check can take longer than the 1 second timeout is currently has set, while the modem is transitioning from the IDLE to ACTIVE state.  In practice, I see this take anywhere from 0.5 seconds to 3 seconds.  The U2/G3 integration manual does not state how long this should take.

Gen 2 & Gen 3 LTE devices are not affected due to power saving mode being disabled by default.

Gen 3 2G/3G devices are also not affected due to power saving mode being disabled by default.

### Solution

If AT / OK check does not respond in 1 second, and the device is not an LTE device and does have power savings mode enabled (Gen 2 2G/3G devices), wait up to 5 seconds for the OK response and CTS line to indicate the modem is ready.

### Steps to Test

Test the example app with U260, U201, R410, and G350.  Every time getSignalStrength() is called, initial AT / OK check should succeed and not timeout before successive commands are sent.  This requires inspecting the logs.
✅ R410
✅ U201
✅ U260
✅ G350

### Device OS for this PR (use debug version)

⬇️ [particle-device-os@1.4.0+pr1917.zip](https://www.dropbox.com/s/5cxcpwapmguirc1/particle-device-os%401.4.0%2Bpr1917.zip?dl=1)

### Example App

```c
SerialLogHandler logHandler(LOG_LEVEL_ALL);
SYSTEM_MODE(SEMI_AUTOMATIC)
char myData[1024];

void setup() {    
    Particle.connect();
}

void loop() {
    if (Particle.connected()) {
        CellularSignal sig = Cellular.RSSI();
        snprintf(myData, 620, "FW: %s FreeMem: %d Up: %ds %.0f%%/%.0f%%/%d", (const char*)System.version(), System.freeMemory(), millis() / 1000, sig.getStrength(),sig.getQuality(),sig.getAccessTechnology());
        Particle.publish("Info", myData, 300, PRIVATE);
    }
    delay(20000);
}
```

### References

Fixes #1892 

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] N/A Added documentation
- [x] Added to CHANGELOG.md after merging (add links to docs and issues)

---

- [bugfix] [electron, gen2] fixes RSSI failing due to Power Saving mode active [#1917](https://github.com/particle-iot/device-os/pull/1917)