### PR TITLE
Increase VitalsPublisher coverage

### DIFF
--- a/system/src/system_publish_vitals.cpp
+++ b/system/src/system_publish_vitals.cpp
@@ -7,16 +7,33 @@
 #include "system_cloud.h"
 #include "system_threading.h"
 
-namespace {
+namespace
+{
 
 using namespace particle::system;
 
-int postDescription() {
-    const auto r = spark_protocol_post_description(spark_protocol_instance(), particle::protocol::DESCRIBE_METRICS, nullptr);
-    return spark_protocol_to_system_error(r);
+inline int postDescription()
+{
+    int error;
+
+    if (spark_cloud_flag_connected())
+    {
+        // Transmit CoAP message via communication layer
+        error = spark_protocol_post_description(
+            spark_protocol_instance(), particle::protocol::DESCRIBE_METRICS, nullptr);
+
+        // Convert `protocol` error to `system` error
+        error = spark_protocol_to_system_error(error);
+    }
+    else
+    {
+        error = SYSTEM_ERROR_INVALID_STATE;
+    }
+
+    return error;
 }
 
-} // unnamed
+} // namespace
 
 template <class Timer>
 VitalsPublisher<Timer>::VitalsPublisher(Timer* timer_)
@@ -84,12 +101,15 @@ void VitalsPublisher<Timer>::period(system_tick_t period_s_)
 template <class Timer>
 int VitalsPublisher<Timer>::publish(void)
 {
-    if (!spark_cloud_flag_connected()) {
-        return SYSTEM_ERROR_INVALID_STATE;
-    }
     return postDescription();
 }
 
+// Functionality covered by E2E tests
+#define LCOV_EXCL_START
+/*
+ * TODO: CH38588 - Abstract ISRTaskQueue boilerplate
+ * https://app.clubhouse.io/particle/story/38588/abstract-isrtaskqueue-boilerplate
+ */
 template <class Timer>
 void VitalsPublisher<Timer>::publishFromTimer(void)
 {
@@ -100,12 +120,11 @@ void VitalsPublisher<Timer>::publishFromTimer(void)
     }
     task->func = [](ISRTaskQueue::Task* task) {
         delete task;
-        if (spark_cloud_flag_connected()) {
-            postDescription();
-        }
+        postDescription();
     };
     SystemISRTaskQueue.enqueue(task);
 }
+#define LCOV_EXCL_STOP
 
 #include "spark_wiring_timer.h"
 
@@ -120,15 +139,5 @@ template class VitalsPublisher<particle::NullTimer>;
 #include "../test/unit_tests/mock/mock_types.h"
 
 template class VitalsPublisher<particle::mock_type::Timer>;
-
-inline bool spark_cloud_flag_connected()
-{
-    return true;
-}
-
-inline int spark_protocol_to_system_error(int error)
-{
-    return error;
-}
 
 #endif // UNIT_TEST

--- a/system/src/system_publish_vitals.cpp
+++ b/system/src/system_publish_vitals.cpp
@@ -12,6 +12,15 @@ namespace
 
 using namespace particle::system;
 
+/**
+ * @brief Post description message via the CoAP protocol
+ *
+ * This function is shared internally by both the `publish` and `publishFromTimer` methods. It is
+ * static to ensure it can be called on the system thread via the `ISRTaskQueue`.
+ *
+ * @sa template <class Timer> particle::cloud::VitalsPublisher<Timer>::publish
+ * @sa template <class Timer> particle::cloud::VitalsPublisher<Timer>::publishFromTimer
+ */
 inline int postDescription()
 {
     int error;
@@ -19,8 +28,8 @@ inline int postDescription()
     if (spark_cloud_flag_connected())
     {
         // Transmit CoAP message via communication layer
-        error = spark_protocol_post_description(
-            spark_protocol_instance(), particle::protocol::DESCRIBE_METRICS, nullptr);
+        error = spark_protocol_post_description(spark_protocol_instance(),
+                                                particle::protocol::DESCRIBE_METRICS, nullptr);
 
         // Convert `protocol` error to `system` error
         error = spark_protocol_to_system_error(error);

--- a/system/src/system_publish_vitals.h
+++ b/system/src/system_publish_vitals.h
@@ -73,9 +73,10 @@ public:
     /**
      * @brief Publish vitals information to the cloud (immediately)
      *
-     * @returns \p ProtocolError result code
-     * @retval \p ProtocolError::NO_ERROR
-     * @retval \p ProtocolError::IO_ERROR_GENERIC_SEND
+     * @returns \p system_error_t result code
+     * @retval \p system_error_t::SYSTEM_ERROR_NONE
+     * @retval \p system_error_t::SYSTEM_ERROR_INVALID_STATE
+     * @retval \p system_error_t::SYSTEM_ERROR_IO
      */
     int publish(void);
 


### PR DESCRIPTION
### Problem

Despite VitalsPublisher being a new class, it is not fully covered.

### Solution

Added test to improve coverage. Mark all untestable code and create a CH ticket to identify the work required to make it testable.

### Steps to Test

Run the DeviceOS CMake Catch2 tests

```bash
cd <particle-iot/device-os>/test/unit-tests/
mkdir .build && cd .build/
cmake ..
make all test coverage
```

### References

CH38583: Improve VitalsPublisher Coverage

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
