### PR TITLE
[system] Increase the input current limit from 900mA to 1500mA

### DIFF
--- a/system/src/system_power_manager.cpp
+++ b/system/src/system_power_manager.cpp
@@ -272,7 +272,7 @@ void PowerManager::initDefault(bool dpdm) {
 
   // Set recharge threshold to default value - 100mV
   power.setRechargeThreshold(100);
-  // power.setChargeCurrent(0,0,0,0,0,0); // 512mA
+  power.setChargeCurrent(0,0,0,1,1,0); // 512mA + 256mA + 128mA = 896mA
   if (dpdm) {
     // Force-start input current limit detection
     power.enableDPDM();

--- a/system/src/system_power_manager.h
+++ b/system/src/system_power_manager.h
@@ -24,7 +24,7 @@
 
 namespace particle { namespace power {
 
-static const uint16_t DEFAULT_INPUT_CURRENT_LIMIT = 900;
+static const uint16_t DEFAULT_INPUT_CURRENT_LIMIT = 1500;
 static const system_tick_t DEFAULT_FAULT_WINDOW = 1000;
 static const uint32_t DEFAULT_FAULT_COUNT_THRESHOLD = HAL_PLATFORM_PMIC_BQ24195_FAULT_COUNT_THRESHOLD;
 static const system_tick_t DEFAULT_FAULT_SUPPRESSION_PERIOD = 60000;


### PR DESCRIPTION
### Problem

Boron 2G/3G unable to connect when powered via VIN only with no Battery connected

### Solution

Increase the input current limit from 900mA to 1500mA by software, we also have the hardware limitation for the input current. It's around 1590mA.

![image](https://user-images.githubusercontent.com/7424522/65297333-0c573880-db9a-11e9-9f11-db37b3bce681.png)

![image](https://user-images.githubusercontent.com/7424522/65297270-d914a980-db99-11e9-856f-46f07eb4f10f.png)


### Steps to Test
1. Power on the device by VIN, don't connect battery.
1. Apply below patch to force to use 2G network
    ```
    diff --git a/hal/src/boron/network/sara_ncp_client.cpp b/hal/src/boron/network/sara_ncp_client.cpp
    index 043582914..b34d032a9 100644
    --- a/hal/src/boron/network/sara_ncp_client.cpp
    +++ b/hal/src/boron/network/sara_ncp_client.cpp
    @@ -881,6 +881,7 @@ int SaraNcpClient::initReady() {
             // TODO: if we enable this feature in the future add logic to CHECK_PARSER macro(s)
             // to wait longer for device to become active (see MDMParser::_atOk)
             CHECK_PARSER_OK(parser_.execCommand("AT+UPSV=0"));
    +        CHECK_PARSER_OK(parser_.execCommand("AT+URAT=0"));
         }
     
         // Send AT+CMUX and initialize multiplexer
    ```
1. Download an empty application with AUTOMATIC mode
1. Using the limitation 900mA, the device will keep rebooting while the device works normally when using the limitation 1500mA.

### Power Consumption Measurement
Below is the power consumption measurement, the peak current is 885mA which is near the old current limitation 900mA. In some test cases, the peak current is over 900mA to 935mA when using the 2G network. 

![image](https://user-images.githubusercontent.com/7424522/65297430-5c35ff80-db9a-11e9-8acc-b8dd91fd322b.png)

### References

[CH37011]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
