### PR TITLE
Add encrypted Coveralls key to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,6 +125,7 @@ env:
   - secure: Iq58mKqq5Nz4B6OEZu1nmnquhvlQncxT4T3f1x+M/0I6VW5xirMWFlpeke8QyyPOZlwNLDnB5QVjsR2UQspNIhMT4rCfDeCCr9AeinoMDmqPbzpmLLmtaUpz0uTZyJVx7+IRe9QtljPfbzlAxybmrx1HdCCw++F/+qhgFoGLi9o=
   - secure: O8Zu2sWO63svmSTdOk+7Z7N2oUcg3N07WckMoy1m7AYmRZydX5hdVXlbagA06FCtpu1Kvvwc7QYB+1wpoxZYZnxt2mVetVsAcSpOz3c03LodM+yKaHm9luqLfQobuC7oyNdumpqMLsWiELM9rxEpIazYDYM2QI+lh7fTUTHnQ3s=
   - secure: A83drTFobkGvgrPNwGwNS3ZSHX35iNELjH6W9h07pw/n1YSssBHxtLF8aVAEwfIF1VyUoHvQ4HYLNd+9RMyo162xxiWne+/4/gSFyUJNi11w3YX5bwodKPl7OwEO/YnJgHYk8YAAfdnZT4470Fpt6ytcOhEhMsB/IFeepMUiZZA=
+  - secure: cYFs7Z2XK92cWUQekpjx65Z2210/xTLVPue1a0gznZp15ouZypq3nE+RVi9aty7+h5sDUaw5ML2LWLtbpOGHNaXJSwJEMxthD4+Mv/d/9eJjeYvl2JnUjrAEJvpzSq6+yafOYnlBiXibE0Spz9RvphblWhdW+/WsRONpCYwPVnE=
 notifications:
   slack:
     rooms:


### PR DESCRIPTION
### Problem

Pull requests from external sources are not compatible with our Coveralls key handling, and therefore cannot be merged.

### Solution

Encrypt the Coveralls token with the Travis CLI and amend `.travis.yml` with the resulting value.

### Steps to Test

If this automated build show coverage statistics, then the test will be confirmed.

### References

Defining encrypted variables in .travis.yml:
https://docs.travis-ci.com/user/environment-variables/#defining-encrypted-variables-in-travisyml

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device