### PR TITLE
Fix: BLE scanning memory leak

### DIFF
--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -1038,7 +1038,8 @@ private:
  */
 void BleCharacteristicImpl::onBleCharEvents(const hal_ble_char_evt_t *event, void* context) {
     auto impl = static_cast<BleCharacteristicImpl*>(context);
-    WiringBleLock lk;
+    // This callback won't modified any data in wiring.
+    //WiringBleLock lk;
     switch (event->type) {
         case BLE_EVT_DATA_NOTIFIED:
         case BLE_EVT_DATA_WRITTEN: {
@@ -1875,6 +1876,7 @@ private:
             if (delegator->foundCount_ < delegator->targetCount_) {
                 delegator->resultsPtr_[delegator->foundCount_++] = result;
                 if (delegator->foundCount_ >= delegator->targetCount_) {
+                    LOG_DEBUG(TRACE, "Target number of devices found. Stop scanning...");
                     hal_ble_gap_stop_scan(nullptr);
                 }
             }


### PR DESCRIPTION
### Problem

BLE memory leak during scanning.
Issue: https://github.com/particle-iot/device-os/issues/1926

### Solution

- Release the memory allocated for scanned advertising data if that event is not processed
- Do not acquire BLE wiring lock in characteristic data received callback.

### Steps to Test

1. Build the test applications below with `DEBUG_BUILD=y MODULAR=n` under the main folder
2. Flash the Central test app into a Xenon and flash the Peripheral test app into 3 Xenons respectively.
3. Run it for a long period and observe the log on the Central side.

### Example App

Central:
```c
#include "Particle.h"

SYSTEM_MODE(MANUAL);

Serial1LogHandler log(115200, LOG_LEVEL_ALL);

#define SCAN_RESULT_COUNT       50

BleScanResult results[SCAN_RESULT_COUNT];

BleCharacteristic peerTxCharacteristic[3];
BlePeerDevice peers[3];

void onDataReceived(const uint8_t* data, size_t len, const BlePeerDevice& peer, void* context) {
    for (uint8_t i = 0; i < 3; i++) {
        if (peer == peers[i]) {
            LOG(TRACE, "Received data from peer %d, %s", i, peer.address().toString().c_str());
            return;
        }
    }
    LOG(TRACE, "Received data from unknown peer device, %s", peer.address().toString().c_str());
}

void setup() {
    for (uint8_t i = 0; i < 3; i++) {
        peerTxCharacteristic[i].onDataReceived(onDataReceived, &peerTxCharacteristic[i]);
    }
}

void loop() {
    delay(3000);

    size_t count = BLE.scan(results, SCAN_RESULT_COUNT);
    if (count > 0) {
        for (uint8_t i = 0; i < count; i++) {
            BleUuid foundServiceUUID;
            size_t svcCount = results[i].advertisingData.serviceUUID(&foundServiceUUID, 1);
            if (svcCount > 0 && foundServiceUUID == "12340001-B5A3-F393-E0A9-E50E24DCCA9E") {
                for (uint8_t j = 0; j < 3; j++) {
                    if (peers[j].connected()) {
                        continue;
                    }
                    LOG(TRACE, "Peer %d is connecting to %s", j, results[i].address.toString().c_str());
                    peers[j] = BLE.connect(results[i].address);
                    if (peers[j].connected()) {
                        peers[j].getCharacteristicByDescription(peerTxCharacteristic[j], "tx");
                    }
                    break;
                }
            }
        }
    }
}
```

Peripheral:
```c
#include "Particle.h"

SYSTEM_MODE(MANUAL);

Serial1LogHandler log(115200, LOG_LEVEL_ALL);

const char* serviceUuid = "12340001-B5A3-F393-E0A9-E50E24DCCA9E";
const char* txUuid = "12340002-B5A3-F393-E0A9-E50E24DCCA9E";

BleCharacteristic txCharacteristic("tx",
                                   BleCharacteristicProperty::NOTIFY,
                                   txUuid,
                                   serviceUuid);
void setup() {
    LOG(TRACE, "Application started.");

    BLE.addCharacteristic(txCharacteristic);

    BleAdvertisingData data;
    data.appendServiceUUID(serviceUuid);
    BLE.advertise(&data);
}

void loop() {
    if (BLE.connected()) {
        txCharacteristic.setValue("hello from particle");
        delay(1000);
    }

```

### References

Closes: https://github.com/particle-iot/device-os/issues/1926

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)