### PR TITLE
[gen 2] hal: enables reporting of serial and mobile secret from OTP area in listening mode (`i` command)

### DIFF
--- a/hal/src/electron/ota_flash_hal.cpp
+++ b/hal/src/electron/ota_flash_hal.cpp
@@ -32,20 +32,16 @@
 
 void HAL_OTA_Add_System_Info(hal_system_info_t* info, bool create, void* reserved)
 {
+    const int additional = 2;
+    int count = add_system_properties(info, create, additional);
     if (create) {
-        info->key_value_count = 2;
-        info->key_values = new key_value[info->key_value_count];
+        info->key_value_count = count + additional;
 
         CellularDevice device = {};
         device.size = sizeof(device);
         cellular_device_info(&device, NULL);
 
-        set_key_value(info->key_values, "imei", device.imei);
-        set_key_value(info->key_values+1, "iccid", device.iccid);
-    }
-    else
-    {
-        delete info->key_values;
-        info->key_values = NULL;
+        set_key_value(info->key_values + count, "imei", device.imei);
+        set_key_value(info->key_values + count + 1, "iccid", device.iccid);
     }
 }

--- a/hal/src/photon/ota_flash_hal.cpp
+++ b/hal/src/photon/ota_flash_hal.cpp
@@ -31,8 +31,6 @@
 
 void HAL_OTA_Add_System_Info(hal_system_info_t* info, bool create, void* reserved)
 {
-    // presently no additional key/value pairs to send back
-    info->key_values = NULL;
-    info->key_value_count = 0;
+    add_system_properties(info, create, 0);
 }
 

--- a/hal/src/stm32f2xx/ota_flash_hal_stm32f2xx.h
+++ b/hal/src/stm32f2xx/ota_flash_hal_stm32f2xx.h
@@ -73,5 +73,20 @@ int store_server_address(server_protocol_type type, const ServerAddress* addr);
 
 void set_key_value(key_value* kv, const char* key, const char* value);
 
+/**
+ * Fetches the key-value instances and the count of system properties for mesh.
+ * @param storage	When not-null, points to storage with keyCount free entries.
+ * 					When null, is used to retrieve the number of keys available.
+ * @return The number of keys available, when storage is null, or the number of keys
+ * copied to storage when not null.
+ */
+int fetch_system_properties(key_value* storage, int keyCount);
+
+/**
+ * Adds the system properties for mesh devices to the system info, allocating the storage required
+ * plus an additional amount for platform-specific properties.
+ */
+int add_system_properties(hal_system_info_t* info, bool create, size_t additional);
+
 #endif	/* OTA_FLASH_HAL_STM32F2XX_H */
 


### PR DESCRIPTION
### Problem

#1927 did not completely enabled reporting of device serial and secret in `i` command in listening mode.

### Solution

This PR fixes that.

### Steps to Test

1. Run the test app from #1927 to populate the OTP on Photon or Electron.
2. Put the device into listening mode
3. `i` command should output serial number and secret

### Example App

N/A

### References

- #1927

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
