### PR TITLE
Implement a command to reset all network interfaces of a device remotely

### DIFF
--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -25,7 +25,7 @@
 #include "spark_wiring_led.h"
 #include "system_cloud_internal.h"
 #include "system_mode.h"
-#include "system_network.h"
+#include "system_network_internal.h"
 #include "system_task.h"
 #include "system_threading.h"
 #include "system_user.h"
@@ -388,12 +388,16 @@ void SystemEvents(const char* name, const char* data)
     }
     else if (!strcmp(name, RESET_EVENT)) {
         if (data && *data) {
-            if (!strcmp("safe mode", data))
+            if (!strcmp("safe mode", data)) {
                 System.enterSafeMode();
-            else if (!strcmp("dfu", data))
+            } else if (!strcmp("dfu", data)) {
                 System.dfu(false);
-            else if (!strcmp("reboot", data))
+            } else if (!strcmp("reboot", data)) {
                 System.reset();
+            } else if (!strcmp("network", data)) {
+                LOG(WARN, "Received a command to reset the network");
+                particle::resetNetworkInterfaces();
+            }
         }
     }
     else if (!strncmp(name, KEY_RESTORE_EVENT, strlen(KEY_RESTORE_EVENT))) {

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -25,7 +25,6 @@
 #include "spark_wiring_led.h"
 #include "system_cloud_internal.h"
 #include "system_mode.h"
-#include "system_network_internal.h"
 #include "system_task.h"
 #include "system_threading.h"
 #include "system_user.h"
@@ -48,6 +47,7 @@
 #include "bytes2hexbuf.h"
 #include "system_event.h"
 #include "system_cloud_connection.h"
+#include "system_network_internal.h"
 #include "str_util.h"
 #include <stdio.h>
 #include <stdint.h>

--- a/system/src/system_network_internal.cpp
+++ b/system/src/system_network_internal.cpp
@@ -23,6 +23,7 @@ namespace particle {
 
 namespace {
 
+[[gnu::unused]] // Suppress a warning on the newhal platform
 bool turnOffNetworkIfNeeded(network_interface_index iface) {
     if (network_ready(iface, NETWORK_READY_TYPE_ANY, nullptr) || network_connecting(iface, 0, nullptr)) {
         network_off(iface, 0, 0, nullptr);

--- a/system/src/system_network_internal.cpp
+++ b/system/src/system_network_internal.cpp
@@ -36,6 +36,7 @@ void networkOn(network_interface_index iface) {
 } // namespace
 
 void resetNetworkInterfaces() {
+    // TODO: There's no cross-platform API to enumerate available network interfaces
 #if HAL_PLATFORM_MESH
     const bool resetMesh = networkOff(NETWORK_INTERFACE_MESH);
 #endif // HAL_PLATFORM_MESH

--- a/system/src/system_network_internal.cpp
+++ b/system/src/system_network_internal.cpp
@@ -17,6 +17,61 @@
 
 #include "system_network_internal.h"
 
+namespace particle {
+
+namespace {
+
+bool networkOff(network_interface_index iface) {
+    if (network_ready(iface, NETWORK_READY_TYPE_ANY, nullptr)) {
+        network_off(iface, 0, 0, nullptr);
+        return true;
+    }
+    return false;
+}
+
+void networkOn(network_interface_index iface) {
+    network_on(iface, 0, 0, nullptr);
+}
+
+} // namespace
+
+void resetNetworkInterfaces() {
+#if HAL_PLATFORM_MESH
+    const bool resetMesh = networkOff(NETWORK_INTERFACE_MESH);
+#endif // HAL_PLATFORM_MESH
+#if HAL_PLATFORM_ETHERNET
+    const bool resetEthernet = networkOff(NETWORK_INTERFACE_ETHERNET);
+#endif // HAL_PLATFORM_ETHERNET
+#if HAL_PLATFORM_CELLULAR
+    const bool resetCellular = networkOff(NETWORK_INTERFACE_CELLULAR);
+#endif // HAL_PLATFORM_CELLULAR
+#if HAL_PLATFORM_WIFI
+    const bool resetWifi = networkOff(NETWORK_INTERFACE_WIFI_STA);
+#endif // HAL_PLATFORM_WIFI
+#if HAL_PLATFORM_MESH
+    if (resetMesh) {
+        networkOn(NETWORK_INTERFACE_MESH);
+    }
+#endif // HAL_PLATFORM_MESH
+#if HAL_PLATFORM_ETHERNET
+    if (resetEthernet) {
+        networkOn(NETWORK_INTERFACE_ETHERNET);
+    }
+#endif // HAL_PLATFORM_ETHERNET
+#if HAL_PLATFORM_CELLULAR
+    if (resetCellular) {
+        networkOn(NETWORK_INTERFACE_CELLULAR);
+    }
+#endif // HAL_PLATFORM_CELLULAR
+#if HAL_PLATFORM_WIFI
+    if (resetWifi) {
+        networkOn(NETWORK_INTERFACE_WIFI_STA);
+    }
+#endif // HAL_PLATFORM_WIFI
+}
+
+} // namespace particle
+
 /* FIXME: there should be a define that tells whether there is NetworkManager available
  * or not */
 #if !HAL_PLATFORM_IFAPI

--- a/system/src/system_network_internal.h
+++ b/system/src/system_network_internal.h
@@ -24,6 +24,7 @@
 #include "spark_macros.h"
 #include "hal_platform.h"
 #include "timer_hal.h"
+#include "system_network.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -70,6 +71,15 @@ inline void CLR_WLAN_WD() {
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
+
+namespace particle {
+
+/**
+ * Reset all active network interfaces.
+ */
+void resetNetworkInterfaces();
+
+} // namespace particle
 
 /* FIXME: there should be a define that tells whether there is NetworkManager available
  * or not */

--- a/system/src/system_network_internal.h
+++ b/system/src/system_network_internal.h
@@ -69,7 +69,7 @@ inline void CLR_WLAN_WD() {
 }
 
 #ifdef __cplusplus
-}
+} // extern "C"
 #endif /* __cplusplus */
 
 namespace particle {


### PR DESCRIPTION
### Problem

We'd like to have a way to reset the modem of a cellular device remotely. This PR extends the existing system handler for `device/reset` events to support a new reset type (`network`), which toggles all active network interfaces off an on.

### Steps to Test

Testing requires manipulating the Device Service to send the above event to a device. As of now, there's no easy way to send a reserved event to a device.

### References

- [ch39772]
