### PR TITLE
Fixes D7 pin interrupt unit test: be #if instead of #ifdef

### DIFF
--- a/user/tests/wiring/no_fixture/interrupts.cpp
+++ b/user/tests/wiring/no_fixture/interrupts.cpp
@@ -212,7 +212,7 @@ test(INTERRUPTS_04_attachInterruptDirect_1) {
 }
 #endif // PLATFORM_ID == PLATFORM_PHOTON_PRODUCTION || PLATFORM_ID == PLATFORM_P1 || PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION
 
-#ifdef PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION
+#if PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION
 test(INTERRUPTS_05_attachInterruptD7) {
 	const pin_t pin = D7;
 	bool res = attachInterrupt(pin, nullptr, FALLING);


### PR DESCRIPTION

</details>

### Problem

D7 pin interrupt unit tests for platform ID macro judgment. 

### Solution

Fixes D7 pin interrupt unit test: be #if instead of #ifdef

### Steps to Test

Unit test about the D7 pin interrupt 

### Example App

NULL



---

### Completeness

- [ ] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
