### PR TITLE
[photon] wlan: limit WPA Enterprise maximum TLS version to 1.1

### DIFF
--- a/hal/src/photon/wlan_hal.cpp
+++ b/hal/src/photon/wlan_hal.cpp
@@ -55,6 +55,7 @@
 #ifdef LWIP_DHCP
 #include "lwip/dhcp.h"
 #endif // LWIP_DHCP
+#include "tls_cipher_suites.h"
 
 uint64_t tls_host_get_time_ms_local() {
     uint64_t time_ms;
@@ -813,6 +814,14 @@ wlan_result_t wlan_activate()
         wiced_network_register_link_callback(HAL_NET_notify_connected, HAL_NET_notify_disconnected,
                                              WICED_STA_INTERFACE);
     wlan_refresh_antenna();
+
+    // XXX: By default WICED sets maximum TLS version to 1.2, however testing WPA Enterprise authentication
+    // in various environemnts showed that its implementation is flawed at least in WICED 3.7.0-7.
+    // Limiting the maximum TLS version to 1.1 seems to resolve the issues for a number of the environemnts
+    // where the authentication was previously failing with TLS 1.2.
+    extern tls_version_num_t tls_maximum_version;
+    tls_maximum_version = TLS1_1;
+
     return result;
 }
 


### PR DESCRIPTION
### Problem

WPA Enterprise authentication fails in some environments.

### Solution

By default WICED sets maximum TLS version to 1.2, however testing WPA Enterprise authentication in various environemnts showed that its implementation is flawed at least in WICED 3.7.0-7.

Limiting the maximum TLS version to 1.1 seems to resolve the issues for a number of the environemnts where the authentication was previously failing with TLS 1.2.

### Steps to Test

N/A

### Example App

N/A

### References

- [CH35409]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
