### PR TITLE
Extract version from release scripts

### DIFF
--- a/build/print-version.sh
+++ b/build/print-version.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+VERSION_FILE="../version.semver.json"
+
+# Confirm version file exists and is readable
+if [ ! -r "$VERSION_FILE" ]; then
+    echo "ERROR: Cannot locate version file, \"$VERSION_FILE\"!";
+    exit 1;
+fi
+
+function json () {
+    local object_string=$1
+    local member=$2
+    echo $object_string | base64 --decode | jq --raw-output $member
+}
+
+VERSION_OBJECT=$(jq --raw-output '.semver.version | @base64' ${VERSION_FILE})
+
+MAJOR=$(json $VERSION_OBJECT .major)
+MINOR=$(json $VERSION_OBJECT .minor)
+PATCH=$(json $VERSION_OBJECT .patch)
+DOT_SEPARATED_PRE_RELEASE_IDENTIFIERS=""
+DOT_SEPARATED_BUILD_METADATA_IDENTIFIERS=""
+
+# Generate dot-seperated pre-release identifiers
+for pre_release_identifier in $(json $VERSION_OBJECT .[\"pre-release\"][]); do
+    if [ ! -e $DOT_SEPARATED_PRE_RELEASE_IDENTIFIERS ]; then
+        DOT_SEPARATED_PRE_RELEASE_IDENTIFIERS+=".";
+    fi
+    DOT_SEPARATED_PRE_RELEASE_IDENTIFIERS+="$pre_release_identifier";
+done
+
+# Generate dot-seperated pre-release identifiers
+for build_metadata_identifier in $(json $VERSION_OBJECT .[\"build-metadata\"][]); do
+    if [ ! -e $DOT_SEPARATED_BUILD_METADATA_IDENTIFIERS ]; then
+        DOT_SEPARATED_BUILD_METADATA_IDENTIFIERS+=".";
+    fi
+    DOT_SEPARATED_BUILD_METADATA_IDENTIFIERS+="$build_metadata_identifier";
+done
+
+# print version
+VERSION="${MAJOR}.${MINOR}.${PATCH}"
+if [ ! -z $DOT_SEPARATED_PRE_RELEASE_IDENTIFIERS ]; then
+    VERSION="$VERSION-$DOT_SEPARATED_PRE_RELEASE_IDENTIFIERS"
+fi
+if [ ! -z $DOT_SEPARATED_BUILD_METADATA_IDENTIFIERS ]; then
+    VERSION="$VERSION+$DOT_SEPARATED_BUILD_METADATA_IDENTIFIERS"
+fi
+echo $VERSION

--- a/build/release.sh
+++ b/build/release.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -o errexit -o pipefail -o noclobber -o nounset
 
-VERSION="1.4.1-rc.1"
-
 function display_help ()
 {
     echo '
@@ -306,6 +304,12 @@ else
     esac
 fi
 
+# Import version data
+VERSION="$(./print-version.sh)"
+if [ -z $VERSION ]; then
+    exit 8
+fi
+
 # Eliminate relative paths
 mkdir -p $OUTPUT_DIRECTORY
 pushd $OUTPUT_DIRECTORY > /dev/null
@@ -448,7 +452,7 @@ fi
 
 # Generate test binaries for platform
 if [ $GENERATE_TESTS = true ]; then
-    ../build/release-tests.sh --output-directory $ABSOLUTE_OUTPUT_DIRECTORY --platform $PLATFORM --version $VERSION
+    ../build/release-tests.sh --output-directory $ABSOLUTE_OUTPUT_DIRECTORY --platform $PLATFORM
 fi
 
 #############################

--- a/version.semver.json
+++ b/version.semver.json
@@ -1,0 +1,15 @@
+{
+    "semver": {
+        "spec": "2.0",
+        "version": {
+            "major": 1,
+            "minor": 4,
+            "patch": 1,
+            "pre-release": [
+                "rc",
+                "1"
+            ],
+            "build-metadata": []
+        }
+    }
+}


### PR DESCRIPTION
### Problem

Currently, version information is captured in the `./build/release.sh` script. This makes sharing the version information with other consumers unnecessarily difficult.

### Solution

Extract version information into its own file, then refactor the release scripts, `./build/release.sh` and `./build/release-tests.sh` to consume the information from that file.

### Steps to Test

Invoke the `./build/make_release.sh` with the `--tests` flag.

### Example App

```bash
./make_release.sh --platform photon --tests
```

### References

Links to the Community, Docs, Other Issues, etc..
- [ch39831](https://app.clubhouse.io/particle/story/39831/refactor-release-sh-and-release-publish-sh-to-consume-the-new-version-file) - Refactor `release.sh` and `release-publish.sh` to consume the new version file
- Preparation for build system unification.

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
