### PR TITLE
[test] i2c_mcp23017: implements HighPriorityInterruptInterferer for nRF52840-based platforms

### DIFF
--- a/user/tests/wiring/i2c_mcp23017/interferer.cpp
+++ b/user/tests/wiring/i2c_mcp23017/interferer.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2019 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "interferer.h"
+
+unsigned int HighPriorityInterruptInterferer::randSeed = (unsigned int)HAL_RNG_GetRandomNumber();

--- a/user/tests/wiring/i2c_mcp23017/interferer.h
+++ b/user/tests/wiring/i2c_mcp23017/interferer.h
@@ -3,6 +3,10 @@
 
 #include "application.h"
 
+#if HAL_PLATFORM_NRF52840
+#include "nrf_timer.h"
+#endif // HAL_PLATFORM_NRF52840
+
 struct HighPriorityInterruptInterferer {
     HighPriorityInterruptInterferer() {
 #if PLATFORM_ID==0 || (PLATFORM_ID>=6 && PLATFORM_ID<=10)
@@ -11,27 +15,58 @@ struct HighPriorityInterruptInterferer {
         // D0 uses TIM2 and channel 2 equally on Core and Photon/Electron
         // Run at 4khz (T=250us)
         analogWrite(D0, 1, 4000);
-        randomSeed(micros());
         // Set higher than SysTick_IRQn priority for TIM4_IRQn
         NVIC_SetPriority(TIM4_IRQn, 3);
         TIM_ITConfig(TIM4, TIM_IT_CC2, ENABLE);
         NVIC_EnableIRQ(TIM4_IRQn);
         attachSystemInterrupt(SysInterrupt_TIM4_IRQ, [&] {
             // Do some work up to 200 microseconds
-            delayMicroseconds(random(200));
+            delayMicroseconds(rand_r(&HighPriorityInterruptInterferer::randSeed) % 200);
             TIM_ClearITPendingBit(TIM4, TIM_IT_CC2);
         });
+#elif HAL_PLATFORM_NRF52840
+        nrf_timer_mode_set(NRF_TIMER2, NRF_TIMER_MODE_TIMER);
+        nrf_timer_task_trigger(NRF_TIMER2, NRF_TIMER_TASK_STOP);
+        nrf_timer_task_trigger(NRF_TIMER2, NRF_TIMER_TASK_CLEAR);
+        nrf_timer_frequency_set(NRF_TIMER2, NRF_TIMER_FREQ_500kHz);
+        nrf_timer_bit_width_set(NRF_TIMER2, NRF_TIMER_BIT_WIDTH_32);
+        nrf_timer_cc_write(NRF_TIMER2, NRF_TIMER_CC_CHANNEL0, nrf_timer_us_to_ticks(250, NRF_TIMER_FREQ_500kHz));
+        nrf_timer_int_disable(NRF_TIMER2, NRF_TIMER_INT_COMPARE0_MASK |
+                NRF_TIMER_INT_COMPARE1_MASK |
+                NRF_TIMER_INT_COMPARE2_MASK |
+                NRF_TIMER_INT_COMPARE3_MASK |
+                NRF_TIMER_INT_COMPARE4_MASK |
+                NRF_TIMER_INT_COMPARE5_MASK);
+        nrf_timer_int_enable(NRF_TIMER2, NRF_TIMER_INT_COMPARE0_MASK);
+        nrf_timer_event_clear(NRF_TIMER2, NRF_TIMER_EVENT_COMPARE0);
+        nrf_timer_shorts_enable(NRF_TIMER2, NRF_TIMER_SHORT_COMPARE0_CLEAR_MASK);
+        NVIC_ClearPendingIRQ(TIMER2_IRQn);
+        NVIC_SetPriority(TIMER2_IRQn, 2);
+        attachInterruptDirect(TIMER2_IRQn, [](void) -> void {
+            // Do some work up to 200 microseconds
+            delayMicroseconds(rand_r(&HighPriorityInterruptInterferer::randSeed) % 200);
+            nrf_timer_event_clear(NRF_TIMER2, NRF_TIMER_EVENT_COMPARE0);
+        }, true);
+        nrf_timer_task_trigger(NRF_TIMER2, NRF_TIMER_TASK_START);
+#else
+#warning "HighPriorityInterruptInterferer is not implemented for this platform"
 #endif
     };
 
     ~HighPriorityInterruptInterferer() {
 #if PLATFORM_ID==0 || (PLATFORM_ID>=6 && PLATFORM_ID<=10)
-    NVIC_DisableIRQ(TIM4_IRQn);
-    detachSystemInterrupt(SysInterrupt_TIM4_IRQ);
-    TIM_ITConfig(TIM4, TIM_IT_CC2, DISABLE);
-    digitalWrite(D0, HIGH);
+        NVIC_DisableIRQ(TIM4_IRQn);
+        detachSystemInterrupt(SysInterrupt_TIM4_IRQ);
+        TIM_ITConfig(TIM4, TIM_IT_CC2, DISABLE);
+        digitalWrite(D0, HIGH);
+#elif HAL_PLATFORM_NRF52840
+        nrf_timer_task_trigger(NRF_TIMER2, NRF_TIMER_TASK_STOP);
+        detachInterruptDirect(TIMER2_IRQn, true);
+        NVIC_ClearPendingIRQ(TIMER2_IRQn);
 #endif
     };
+
+    static unsigned int randSeed;
 };
 
 struct ContextSwitchBlockingInteferer {


### PR DESCRIPTION
### Problem

`HighPriorityInterruptInterferer` is not properly implemented for Gen 3 devices in `wiring/i2c_mcp23017` test.

### Solution

Implement it :)

### Steps to Test

- Run `wiring/i2c_mcp23017` test on Gen 3 platforms

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
