### PR TITLE
[nrf52840] platform: disable clock driver in Reset_System() before jumping into system firmware

### DIFF
--- a/platform/MCU/nRF52840/src/hw_config.c
+++ b/platform/MCU/nRF52840/src/hw_config.c
@@ -157,6 +157,15 @@ void Reset_System(void) {
 
     RGB_LED_Uninit();
 
+    // XXX: POWER_CLOCK_IRQn needs to be masked!
+    // We've seen cases where the POWER_CLOCK interrupt comes in-between the jump
+    // from the bootloader into the system firmware and when the clock driver is initialized
+    // again in system firmware. This causes a jump into 0x0000000 address because the clock
+    // event handler hasn't been registered.
+    // Surprisingly the event that triggers the interrupt is EVENTS_LFCLKSTARTED,
+    // despite the fact that we are specifically waiting for LFCLK to start in Set_System()
+    NVIC_DisableIRQ(POWER_CLOCK_IRQn);
+
     __DSB();
 }
 


### PR DESCRIPTION
### Problem

Originally reported in https://community.particle.io/t/workbench-local-flash-occasionally-requires-hard-reset/52744

The main issue is that `POWER_CLOCK_IRQn` interrupt comes in immediately after we jump from bootloader into the system part and before we initialize all the necessary power/clock related things in the Nordic SDK which causes a jump to `0x00000000` because the clock event handler has not been registered.

The problem comes from the fact that we are not stopping the clocks or disabling interrupts (all or at least `POWER_CLOCK_IRQn` specifically) before jumping into the system part.

I have no explanation on why we haven't seen this previously, perhaps a compiler started optimizing things slightly differently due to the Nordic SDK update in 1.2.1.

Surprisingly the event that causes the interrupt is `EVENTS_LFCLKSTARTED`, despite the fact that we have a busy loop waiting for LFCLK to start in `Set_System()`

#### Stack trace

```
#0  nrfx_clock_irq_handler () at nrf5_sdk/modules/nrfx/drivers/src/nrfx_clock.c:335
#1  <signal handler called>
#2  Set_System () at MCU/nRF52840/src/hw_config.c:75
#3  0x00048778 in HAL_Core_Config () at src/nRF52840/core_hal.c:301
#4  0x000302aa in Reset_Handler () at ../../../build/arm/startup/spark_init.S:3
```

#### Affected versions

Bootloaders in DeviceOS 1.2.1 - 1.4.1.

### Solution

Mask `POWER_CLOCK_IRQn` interrupt in `Reset_System()` before jumping into system firmware. It will get re-enabled again once clock driver is initialized.

### Steps to Test

I was able to reproduce this issue so far only in some cases on Borons only either:

1. Flashing a bootloader binary 1.2.1+ over serial repeatedly (at least with 1.4.1 DeviceOS on device)
2. Quickly clicking reset button once the device boots into system firmware

Building Boron bootloader out of this branch (or using [boron-bootloader-1948.zip](https://github.com/particle-iot/device-os/files/3740722/boron-bootloader-1948.zip)) and flashing onto the device should resolve the issue.

### Binaries

[boron-bootloader-1948.zip](https://github.com/particle-iot/device-os/files/3740722/boron-bootloader-1948.zip)

### References

- [CH39975]
- https://community.particle.io/t/workbench-local-flash-occasionally-requires-hard-reset/52744

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
