### PR TITLE
[photon] wlan: add wiced_wlan_connectivity_initialized() check in wlan_fetch_ipconfig()

### DIFF
--- a/hal/src/photon/wlan_hal.cpp
+++ b/hal/src/photon/wlan_hal.cpp
@@ -1395,25 +1395,28 @@ int wlan_fetch_ipconfig(WLanConfig* config)
 #endif // LWIP_DHCP
     }
 
-    wiced_mac_t my_mac_address;
-    if (wiced_wifi_get_mac_address( &my_mac_address)==WICED_SUCCESS)
-        memcpy(config->nw.uaMacAddr, &my_mac_address, 6);
+    // XXX: calling wiced_wifi_get_mac_address or potentially other functions
+    // before wiced_wlan_connectivity_initialized() returns true will lead to a hardfaul
+    if (wiced_wlan_connectivity_initialized()) {
+        wiced_mac_t my_mac_address;
+        if (wiced_wifi_get_mac_address( &my_mac_address)==WICED_SUCCESS)
+            memcpy(config->nw.uaMacAddr, &my_mac_address, 6);
 
-    wl_bss_info_t ap_info;
-    wiced_security_t sec;
+        wl_bss_info_t ap_info;
+        wiced_security_t sec;
 
-    if ( wwd_wifi_get_ap_info( &ap_info, &sec ) == WWD_SUCCESS )
-    {
-        uint8_t len = std::min(ap_info.SSID_len, uint8_t(32));
-        memcpy(config->uaSSID, ap_info.SSID, len);
-        config->uaSSID[len] = 0;
-
-        if (config->size >= WLanConfig_Size_V2)
+        if ( wwd_wifi_get_ap_info( &ap_info, &sec ) == WWD_SUCCESS )
         {
-            memcpy(config->BSSID, ap_info.BSSID.octet, sizeof(config->BSSID));
+            uint8_t len = std::min(ap_info.SSID_len, uint8_t(32));
+            memcpy(config->uaSSID, ap_info.SSID, len);
+            config->uaSSID[len] = 0;
+
+            if (config->size >= WLanConfig_Size_V2)
+            {
+                memcpy(config->BSSID, ap_info.BSSID.octet, sizeof(config->BSSID));
+            }
         }
     }
-    // todo DNS and DHCP servers
 
     return 0;
 }


### PR DESCRIPTION
### Problem

https://github.com/particle-iot/device-os/issues/1858

### Solution

Calling `wiced_wifi_get_mac_address())` or potentially other functions before `wiced_wlan_connectivity_initialized()` returns true seems to lead to a hardfault. Add `wiced_wlan_connectivity_initialized()` check.

### Steps to Test

Test app shouldn't cause a hardfault.

### Example App

```c++
SYSTEM_MODE(MANUAL);
SYSTEM_THREAD(ENABLED);

void setup() {
    WiFi.on();
    uint8_t mac[6] = {};
    WiFi.macAddress(mac);
}

void loop() {
    Particle.process();
}
```

### References

- Closes #1858 

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
