### PR TITLE
Implement HandshakeComplete message

### DIFF
--- a/communication/inc/protocol.h
+++ b/communication/inc/protocol.h
@@ -130,6 +130,8 @@ class Protocol
 
 	uint8_t flags;
 
+	bool handshake_complete_enabled;
+
 public:
 	enum Flags
 	{
@@ -318,7 +320,8 @@ public:
 			product_firmware_version(PRODUCT_FIRMWARE_VERSION),
 			publisher(this),
 			last_ack_handlers_update(0),
-			initialized(false)
+			initialized(false),
+			handshake_complete_enabled(false)
 	{
 	}
 
@@ -340,6 +343,11 @@ public:
 	void set_fast_ota(unsigned data)
 	{
 		chunkedTransfer.set_fast_ota(data);
+	}
+
+	void set_handshake_complete_enabled(bool enabled)
+	{
+		handshake_complete_enabled = enabled;
 	}
 
 	void set_handlers(CommunicationsHandlers& handlers)

--- a/communication/inc/protocol.h
+++ b/communication/inc/protocol.h
@@ -128,7 +128,7 @@ class Protocol
 
 	uint8_t initialized;
 
-	uint8_t flags;
+	uint32_t flags;
 
 	bool handshake_complete_enabled;
 
@@ -166,7 +166,7 @@ protected:
 	CompletionHandlerMap<message_id_t> ack_handlers;
 
 
-	void set_protocol_flags(int flags)
+	void set_protocol_flags(uint32_t flags)
 	{
 		this->flags = flags;
 	}
@@ -220,7 +220,8 @@ protected:
 	{
 		Message msg;
 		channel.create(msg);
-		const size_t n = Messages::handshake_complete(msg.buf(), msg.capacity(), 0, channel.is_unreliable());
+		const bool session_resumed = (flags & SKIP_SESSION_RESUME_HELLO);
+		const size_t n = Messages::handshake_complete(msg.buf(), msg.capacity(), 0, session_resumed, channel.is_unreliable());
 		if (n > msg.capacity()) {
 			return INSUFFICIENT_STORAGE;
 		}
@@ -321,6 +322,7 @@ public:
 			publisher(this),
 			last_ack_handlers_update(0),
 			initialized(false),
+			flags(0),
 			handshake_complete_enabled(false)
 	{
 	}

--- a/communication/inc/protocol.h
+++ b/communication/inc/protocol.h
@@ -212,6 +212,21 @@ protected:
 	}
 
 	/**
+	 * Send a HandshakeComplete message over the channel.
+	 */
+	ProtocolError send_handshake_complete()
+	{
+		Message msg;
+		channel.create(msg);
+		const size_t n = Messages::handshake_complete(msg.buf(), msg.capacity(), 0, channel.is_unreliable());
+		if (n > msg.capacity()) {
+			return INSUFFICIENT_STORAGE;
+		}
+		msg.set_length(n);
+		return channel.send(msg);
+	}
+
+	/**
 	 * Background processing when there are no messages to handle.
 	 */
 	ProtocolError event_loop_idle()

--- a/communication/inc/protocol_defs.h
+++ b/communication/inc/protocol_defs.h
@@ -111,10 +111,14 @@ enum DescriptionType {
 
 namespace Connection
 {
+/**
+ * Connection properties.
+ */
 enum Enum
 {
-    PING = 0,
-    FAST_OTA = 1
+    PING = 0, ///< Set keepalive interval.
+    FAST_OTA = 1, ///< Enable/disable fast OTA.
+    HANDSHAKE_COMPLETE_ENABLED = 2 ///< Enable/disable HandshakeComplete message.
 };
 }
 

--- a/communication/inc/spark_protocol_functions.h
+++ b/communication/inc/spark_protocol_functions.h
@@ -229,7 +229,8 @@ namespace ProtocolCommands {
     WAKE,
     DISCONNECT,
     TERMINATE,
-    FORCE_PING
+    FORCE_PING,
+    HANDSHAKE_COMPLETE
   };
 };
 

--- a/communication/src/core_protocol.cpp
+++ b/communication/src/core_protocol.cpp
@@ -1883,7 +1883,7 @@ inline void CoreProtocol::coded_ack(unsigned char *buf,
 
 int CoreProtocol::command(ProtocolCommands::Enum command, uint32_t data)
 {
-  int result = UNKNOWN;
+  int result = NOT_IMPLEMENTED;
   switch (command) {
   case ProtocolCommands::SLEEP:
   case ProtocolCommands::DISCONNECT:

--- a/communication/src/dtls_protocol.h
+++ b/communication/src/dtls_protocol.h
@@ -101,6 +101,10 @@ public:
 			}
 			break;
 		}
+		case ProtocolCommands::HANDSHAKE_COMPLETE: {
+			result = send_handshake_complete();
+			break;
+		}
 		}
 		return result;
 	}

--- a/communication/src/lightssl_protocol.cpp
+++ b/communication/src/lightssl_protocol.cpp
@@ -34,6 +34,9 @@ int LightSSLProtocol::command(ProtocolCommands::Enum command, uint32_t data)
     ack_handlers.clear();
     result = NO_ERROR;
     break;
+  case ProtocolCommands::HANDSHAKE_COMPLETE:
+    result = send_handshake_complete();
+    break;
   }
   return result;
 }

--- a/communication/src/messages.cpp
+++ b/communication/src/messages.cpp
@@ -381,7 +381,7 @@ size_t Messages::handshake_complete(unsigned char* buf, size_t size, message_id_
 	b.append((message_id >> 8) & 0xff); // Message ID
 	b.append(message_id & 0xff);
 	b.append(0xb1); // Uri-Path (11), length: 1
-	b.append('C');
+	b.append('H');
 	if (!confirmable) {
 		// No-Response (258), length: 0
 		b.append(0xd0);
@@ -389,7 +389,5 @@ size_t Messages::handshake_complete(unsigned char* buf, size_t size, message_id_
 	}
 	return b.dataSize();
 }
-
-const size_t Messages::MAX_HANDSHAKE_COMPLETE_MESSAGE_SIZE = 8; // CoAP header, options
 
 }}

--- a/communication/src/messages.cpp
+++ b/communication/src/messages.cpp
@@ -23,6 +23,12 @@
 
 namespace particle { namespace protocol {
 
+namespace {
+
+const unsigned HANDSHAKE_COMPLETE_SESSION_RESUMED_FLAG = 0x01;
+
+} // namespace
+
 CoAPMessageType::Enum Messages::decodeType(const uint8_t* buf, size_t length)
 {
     if (length<4)
@@ -372,7 +378,8 @@ size_t Messages::coded_ack(uint8_t* buf, uint8_t token, uint8_t code,
     return sz;
 }
 
-size_t Messages::handshake_complete(unsigned char* buf, size_t size, message_id_t message_id, bool confirmable)
+size_t Messages::handshake_complete(unsigned char* buf, size_t size, message_id_t message_id, bool session_resumed,
+		bool confirmable)
 {
 	// TODO: Use the unified buffer appender from #1899 here
 	BufferAppender2 b((char*)buf, size);
@@ -387,6 +394,12 @@ size_t Messages::handshake_complete(unsigned char* buf, size_t size, message_id_
 		b.append(0xd0);
 		b.append(0xea); // 258 - 11 - 13
 	}
+	b.append(0xff); // Payload marker
+	uint8_t flags = 0;
+	if (session_resumed) {
+		flags |= HANDSHAKE_COMPLETE_SESSION_RESUMED_FLAG;
+	}
+	b.append(flags); // Flags
 	return b.dataSize();
 }
 

--- a/communication/src/messages.h
+++ b/communication/src/messages.h
@@ -46,8 +46,6 @@ inline uint8_t decode_uint8(unsigned char* buf) {
 class Messages
 {
 public:
-	static const size_t MAX_HANDSHAKE_COMPLETE_MESSAGE_SIZE;
-
 	static CoAPMessageType::Enum decodeType(const uint8_t* buf, size_t length);
 	static size_t describe_post_header(uint8_t buf[], size_t buffer_size, uint16_t message_id, uint8_t desc_flags);
 	static size_t hello(uint8_t* buf, message_id_t message_id, uint8_t flags,

--- a/communication/src/messages.h
+++ b/communication/src/messages.h
@@ -46,6 +46,8 @@ inline uint8_t decode_uint8(unsigned char* buf) {
 class Messages
 {
 public:
+	static const size_t MAX_HANDSHAKE_COMPLETE_MESSAGE_SIZE;
+
 	static CoAPMessageType::Enum decodeType(const uint8_t* buf, size_t length);
 	static size_t describe_post_header(uint8_t buf[], size_t buffer_size, uint16_t message_id, uint8_t desc_flags);
 	static size_t hello(uint8_t* buf, message_id_t message_id, uint8_t flags,
@@ -164,6 +166,7 @@ public:
         return content(buf, message_id, token);
     }
 
+    static size_t handshake_complete(unsigned char* buf, size_t size, message_id_t message_id, bool confirmable);
 };
 
 

--- a/communication/src/messages.h
+++ b/communication/src/messages.h
@@ -164,7 +164,8 @@ public:
         return content(buf, message_id, token);
     }
 
-    static size_t handshake_complete(unsigned char* buf, size_t size, message_id_t message_id, bool confirmable);
+    static size_t handshake_complete(unsigned char* buf, size_t size, message_id_t message_id, bool session_resumed,
+            bool confirmable);
 };
 
 

--- a/communication/src/protocol.cpp
+++ b/communication/src/protocol.cpp
@@ -292,8 +292,8 @@ int Protocol::begin()
 	ack_handlers.clear();
 	last_ack_handlers_update = callbacks.millis();
 
-	uint32_t channel_flags = 0;
-	ProtocolError error = channel.establish(channel_flags, application_state_checksum());
+	flags &= ~SKIP_SESSION_RESUME_HELLO;
+	ProtocolError error = channel.establish(flags, application_state_checksum());
 	bool session_resumed = (error==SESSION_RESUMED);
 	if (error && !session_resumed) {
 		LOG(ERROR,"handshake failed with code %d", error);
@@ -304,9 +304,6 @@ int Protocol::begin()
 	{
 		// for now, unconditionally move the session on resumption
 		channel.command(MessageChannel::MOVE_SESSION, nullptr);
-		if (channel_flags & SKIP_SESSION_RESUME_HELLO) {
-			flags |= SKIP_SESSION_RESUME_HELLO;
-		}
 	}
 
 	// hello not needed because it's already been sent and the server maintains device state

--- a/communication/src/spark_protocol_functions.cpp
+++ b/communication/src/spark_protocol_functions.cpp
@@ -194,15 +194,24 @@ int spark_protocol_set_connection_property(ProtocolFacade* protocol, unsigned pr
                                            unsigned data, particle::protocol::connection_properties_t* conn_prop, void* reserved)
 {
     ASSERT_ON_SYSTEM_THREAD();
-    if (property_id == particle::protocol::Connection::PING)
-    {
+    switch (property_id) {
+    case particle::protocol::Connection::PING: {
         protocol->set_keepalive(data, conn_prop->keepalive_source);
-    } else if (property_id == particle::protocol::Connection::FAST_OTA)
-    {
-        protocol->set_fast_ota(data);
+        return 0;
     }
-    return 0;
+    case particle::protocol::Connection::FAST_OTA: {
+        protocol->set_fast_ota(data);
+        return 0;
+    }
+    case particle::protocol::Connection::HANDSHAKE_COMPLETE_ENABLED: {
+        protocol->set_handshake_complete_enabled(data);
+        return 0;
+    }
+    default:
+        return particle::protocol::NOT_IMPLEMENTED;
+    }
 }
+
 int spark_protocol_command(ProtocolFacade* protocol, ProtocolCommands::Enum cmd, uint32_t data, void* reserved)
 {
     ASSERT_ON_SYSTEM_THREAD();
@@ -351,7 +360,7 @@ void spark_protocol_get_product_details(CoreProtocol* protocol, product_details_
 int spark_protocol_set_connection_property(CoreProtocol* protocol, unsigned property_id,
                                            unsigned data, particle::protocol::connection_properties_t* conn_prop, void* reserved)
 {
-    return 0;
+    return particle::protocol::NOT_IMPLEMENTED;
 }
 
 int spark_protocol_command(CoreProtocol* protocol, ProtocolCommands::Enum cmd, uint32_t data, void* reserved)

--- a/services/inc/appender.h
+++ b/services/inc/appender.h
@@ -103,6 +103,8 @@ namespace particle {
 // Buffer appender that never fails and stores an actual size of the data
 class BufferAppender2: public Appender {
 public:
+    using Appender::append;
+
     BufferAppender2(char* buf, size_t size) :
             buf_(buf),
             bufSize_(size),

--- a/system/inc/system_task.h
+++ b/system/inc/system_task.h
@@ -60,8 +60,6 @@ extern volatile uint8_t SPARK_WLAN_SLEEP;
 extern volatile uint8_t SPARK_WLAN_STARTED;
 extern volatile uint8_t SPARK_CLOUD_SOCKETED;
 extern volatile uint8_t SPARK_CLOUD_CONNECTED;
-extern volatile uint8_t SPARK_CLOUD_HANDSHAKE_PENDING;
-extern volatile uint8_t SPARK_CLOUD_HANDSHAKE_NOTIFY_DONE;
 extern volatile uint8_t SPARK_FLASH_UPDATE;
 
 extern volatile uint8_t Spark_Error_Count;

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -789,6 +789,9 @@ void Spark_Protocol_Init(void)
 
     if (!spark_protocol_is_initialized(sp))
     {
+        spark_protocol_set_connection_property(sp, particle::protocol::Connection::HANDSHAKE_COMPLETE_ENABLED, 1 /* enabled */,
+                nullptr, nullptr);
+
         product_details_t info;
         info.size = sizeof(info);
         spark_protocol_get_product_details(sp, &info);

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -562,10 +562,8 @@ const uint32_t LEDCloudSignalStatus::COLORS[] = { 0xEE82EE, 0x4B0082, 0x0000FF, 
 const size_t LEDCloudSignalStatus::COLOR_COUNT = sizeof(LEDCloudSignalStatus::COLORS) / sizeof(LEDCloudSignalStatus::COLORS[0]);
 
 void clientMessagesProcessed(void* reserved) {
-    if (SPARK_CLOUD_HANDSHAKE_PENDING) {
-        SPARK_CLOUD_HANDSHAKE_NOTIFY_DONE = 1;
-        SPARK_CLOUD_HANDSHAKE_PENDING = 0;
-        LOG(INFO, "All handshake messages have been processed");
+    if (!SPARK_CLOUD_CONNECTED) {
+        particle::cloudHandshakeMessagesProcessed();
     }
 }
 
@@ -1029,19 +1027,6 @@ int Spark_Handshake(bool presence_announce)
         ultoa((unsigned long)particle_key_errors, buf, 10);
         LOG(INFO,"Send event spark/device/key/error=%s", buf);
         publishEvent("spark/device/key/error", buf);
-    }
-    if (err == 0) {
-        protocol_status status = {};
-        status.size = sizeof(status);
-        err = spark_protocol_get_status(sp, &status, nullptr);
-        if (err == 0) {
-            if (status.flags & PROTOCOL_STATUS_HAS_PENDING_CLIENT_MESSAGES) {
-                SPARK_CLOUD_HANDSHAKE_PENDING = 1;
-                LOG(TRACE, "Waiting until all handshake messages are processed by the protocol layer");
-            } else {
-                SPARK_CLOUD_HANDSHAKE_NOTIFY_DONE = 1;
-            }
-        }
     }
     return err;
 }

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -789,9 +789,6 @@ void Spark_Protocol_Init(void)
 
     if (!spark_protocol_is_initialized(sp))
     {
-        spark_protocol_set_connection_property(sp, particle::protocol::Connection::HANDSHAKE_COMPLETE_ENABLED, 1 /* enabled */,
-                nullptr, nullptr);
-
         product_details_t info;
         info.size = sizeof(info);
         spark_protocol_get_product_details(sp, &info);
@@ -904,6 +901,9 @@ void Spark_Protocol_Init(void)
         uint8_t id[id_length];
         HAL_device_ID(id, id_length);
         spark_protocol_init(sp, (const char*) id, keys, callbacks, descriptor);
+
+        spark_protocol_set_connection_property(sp, particle::protocol::Connection::HANDSHAKE_COMPLETE_ENABLED, 1 /* enabled */,
+                nullptr, nullptr);
 
         Particle.subscribe("spark", SystemEvents, MY_DEVICES);
         Particle.subscribe("particle", SystemEvents, MY_DEVICES);

--- a/system/src/system_cloud_internal.h
+++ b/system/src/system_cloud_internal.h
@@ -71,6 +71,17 @@ extern ProtocolFacade* sp;
 
 namespace particle {
 
+/**
+ * Cloud handshake state.
+ */
+enum class CloudHandshakeState {
+    PENDING = 0, ///< Send protocol and application handshake messages.
+    WAIT_HANDSHAKE_ACKS = 1, ///< Wait until the handshake messages are acknowledged.
+    SEND_COMPLETE = 2, ///< Send a HandshakeComplete message.
+    WAIT_COMPLETE_ACK = 3, ///< Wait until the HandshakeComplete message is acknowledged.
+    DONE = 4 ///< Handshake is done.
+};
+
 class CloudDiagnostics {
 public:
     // Note: Use odd numbers to encode transitional states
@@ -135,6 +146,11 @@ private:
 inline bool publishEvent(const char* event, const char* data = nullptr, unsigned flags = 0) {
     return spark_send_event(event, data, DEFAULT_CLOUD_EVENT_TTL, flags | PUBLISH_EVENT_FLAG_PRIVATE, nullptr);
 }
+
+/**
+ * Updates the state of the cloud handshake.
+ */
+void cloudHandshakeMessagesProcessed();
 
 } // namespace particle
 

--- a/system/src/system_update.cpp
+++ b/system/src/system_update.cpp
@@ -59,8 +59,6 @@ ymodem_serial_flash_update_handler Ymodem_Serial_Flash_Update_Handler = NULL;
 // TODO: Use a single state variable instead of SPARK_CLOUD_XXX flags
 volatile uint8_t SPARK_CLOUD_SOCKETED;
 volatile uint8_t SPARK_CLOUD_CONNECTED;
-volatile uint8_t SPARK_CLOUD_HANDSHAKE_PENDING = 0;
-volatile uint8_t SPARK_CLOUD_HANDSHAKE_NOTIFY_DONE = 0;
 volatile uint8_t SPARK_FLASH_UPDATE;
 volatile uint32_t TimingFlashUpdateTimeout;
 


### PR DESCRIPTION
### Problem

At present, there is no explicit indication that the application handshake has completed. The cloud does not know with any certainty that the device has completed the application handshake and considers itself online. The possibility of out of order delivery of events compounds this problem even further.

### Solution

This PR changes the handshake procedure so that it looks as follows:

1. the application handshake is performed and various messages are sent to the cloud
2. the system waits for these messages to be acknowledged
3. once all messages are acknowledged,  a new `HandshakeComplete` CoAP message is sent to the cloud.
4. on acknowledgement of that message, `Particle.connected()` returns true.

### Steps to Test

_TBD_

### References

- [ch40066]
