### PR TITLE
Enable Workbench DeviceOS local development

### DIFF
--- a/.workbench/manifest.json
+++ b/.workbench/manifest.json
@@ -1,0 +1,197 @@
+{
+    "version": "1.0.0",
+    "toolchains": [
+        {
+            "firmware": "deviceOS@source",
+            "compilers": "gcc-arm@5.3.1",
+            "debuggers": "openocd@0.11.2-adhoc6ea4372.0",
+            "platforms": [6, 8, 10, 12, 13, 14, 23],
+            "scripts": "buildscripts@1.8.0",
+            "tools": "buildtools@1.1.1"
+        }
+    ],
+    "compilers": {
+        "windows": {
+            "x64": [
+                {
+                    "name": "gcc-arm",
+                    "version": "5.3.1",
+                    "main": "./bin",
+                    "url": "https://binaries.particle.io/gcc-arm/windows/x64/gcc-arm-v5.3.1.tar.gz",
+                    "sha256": "9d5106811e6ad8f3fd63ac266fb3e6e31798e14333b50f849130f604e331ba3d"
+                }
+            ],
+            "x86": []
+        },
+        "darwin": {
+            "x64": [
+                {
+                    "name": "gcc-arm",
+                    "version": "5.3.1",
+                    "main": "./bin",
+                    "url": "https://binaries.particle.io/gcc-arm/darwin/x64/gcc-arm-v5.3.1.tar.gz",
+                    "sha256": "f41f32436188c3017422635b187378c8bf0938a3ad396506b2d3b8ce1fb402c9"
+                }
+            ],
+            "x86": []
+        },
+        "linux": {
+            "x64": [
+                {
+                    "name": "gcc-arm",
+                    "version": "5.3.1",
+                    "main": "./bin",
+                    "url": "https://binaries.particle.io/gcc-arm/linux/x64/gcc-arm-v5.3.1.tar.gz",
+                    "sha256": "99c8dc248a6f39c92268d680fc661b51b38b773db1148204cdf59792d170bfdc"
+                }
+            ],
+            "x86": []
+        }
+    },
+    "debuggers": {
+        "windows": {
+            "x64": [
+                {
+                    "name": "openocd",
+                    "version": "0.11.2-adhoc6ea4372.0",
+                    "main": ".",
+                    "url": "https://binaries.particle.io/openocd/windows/x64/openocd-v0.11.2-adhoc6ea4372.0.tar.gz",
+                    "sha256": "790954533100e5bd6c2e22085c6c7b099176c51d798fde9895779e12562ee134"
+                }
+            ],
+            "x86": []
+        },
+        "darwin": {
+            "x64": [
+                {
+                    "name": "openocd",
+                    "version": "0.11.2-adhoc6ea4372.0",
+                    "main": ".",
+                    "url": "https://binaries.particle.io/openocd/darwin/x64/openocd-v0.11.2-adhoc6ea4372.0.tar.gz",
+                    "sha256": "c2b30c3e933d69c7b9608c7814dbc998e775a6c104c144c567f2835e3f0d862c"
+                }
+            ],
+            "x86": []
+        },
+        "linux": {
+            "x64": [
+                {
+                    "name": "openocd",
+                    "version": "0.11.2-adhoc6ea4372.0",
+                    "main": ".",
+                    "url": "https://binaries.particle.io/openocd/linux/x64/openocd-v0.11.2-adhoc6ea4372.0.tar.gz",
+                    "sha256": "42272bd1f012af43bb2fd80656e9f08a04e97bc8ffdc2d1e3e5062ea46ce657e"
+                }
+            ],
+            "x86": []
+        }
+    },
+    "platforms": [
+        {
+            "id": 6,
+            "name": "photon",
+            "generation": 2
+        },
+        {
+            "id": 10,
+            "name": "electron",
+            "generation": 2
+        },
+        {
+            "id": 12,
+            "name": "argon",
+            "generation": 3
+        },
+        {
+            "id": 13,
+            "name": "boron",
+            "generation": 3
+        },
+        {
+            "id": 14,
+            "name": "xenon",
+            "generation": 3
+        },
+        {
+            "id": 23,
+            "name": "bsom",
+            "generation": 3
+        }
+    ],
+    "scripts": {
+        "windows": {
+            "x64": [
+                {
+                    "name": "buildscripts",
+                    "version": "1.8.0",
+                    "main": ".",
+                    "url": "https://binaries.particle.io/buildscripts/windows/x64/buildscripts-v1.8.0.tar.gz",
+                    "sha256": "78e73a1d1eaf0fcc38575d2f4476f097ec4f6ca930c3b517e43686aed865a4b4"
+                }
+            ],
+            "x86": []
+        },
+        "darwin": {
+            "x64": [
+                {
+                    "name": "buildscripts",
+                    "version": "1.8.0",
+                    "main": ".",
+                    "url": "https://binaries.particle.io/buildscripts/darwin/x64/buildscripts-v1.8.0.tar.gz",
+                    "sha256": "78e73a1d1eaf0fcc38575d2f4476f097ec4f6ca930c3b517e43686aed865a4b4"
+                }
+            ],
+            "x86": []
+        },
+        "linux": {
+            "x64": [
+                {
+                    "name": "buildscripts",
+                    "version": "1.8.0",
+                    "main": ".",
+                    "url": "https://binaries.particle.io/buildscripts/linux/x64/buildscripts-v1.8.0.tar.gz",
+                    "sha256": "78e73a1d1eaf0fcc38575d2f4476f097ec4f6ca930c3b517e43686aed865a4b4"
+                }
+            ],
+            "x86": []
+        }
+    },
+    "tools": {
+        "windows": {
+            "x64": [
+                {
+                    "name":  "buildtools",
+                    "version":  "1.1.1",
+                    "main":  "./bin",
+                    "url":  "https://binaries.particle.io/buildtools/windows/x64/buildtools-v1.1.1.tar.gz",
+                    "sha256":  "674c9c0bca32f8f6345199e7f97834476182210c9e15a79eb4942df8988c28fe"
+                }
+            ],
+            "x86": []
+        },
+        "darwin": {
+            "x64": [
+                {
+                    "name": "buildtools",
+                    "version":  "1.1.1",
+                    "main": ".",
+                    "url": "https://binaries.particle.io/buildtools/darwin/x64/buildtools-v1.1.1.tar.gz",
+                    "sha256": "789f7b5bdd4213b5bb5e57f3aad4f99ff775fff721bef40c65b8abf59c57c630"
+                }
+            ],
+            "x86": []
+        },
+        "linux": {
+            "x64": [
+                {
+                    "name": "buildtools",
+                    "version":  "1.1.1",
+                    "main": ".",
+                    "url": "https://binaries.particle.io/buildtools/linux/x64/buildtools-v1.1.1.tar.gz",
+                    "sha256": "a7c15b28966ed4d77d010001eee19de4385732e765c199051bc3bcdfb1e55846"
+                }
+            ],
+            "x86": []
+        }
+    }
+}


### PR DESCRIPTION
Utilize temporary manifest.json to enable current tooling
manifest.json stored in hidden `.workbench` folder until a more permanent solution has been settled upon

### Problem

A `manifest.json` file is required to enable DeviceOS development in the Workbench.

### Solution

Provides a manifest.json file that allows us to take advantage of this functionality

### Steps to Test

Enable local development from the "Settings" menu in the workbench.

### References

Links to the Community, Docs, Other Issues, etc..
[Slack convo](https://s.slack.com/archives/CB4R2N05V/p1572557308140800)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
