### PR TITLE
Fix call to objdump

### DIFF
--- a/modules/shared/nRF52840/build_linker_script.mk
+++ b/modules/shared/nRF52840/build_linker_script.mk
@@ -3,13 +3,15 @@ WRITE_FILE_APPEND = $(shell echo "$(2)" >> $(1))
 
 COMMA := ,
 
+include ../../../build/common-tools.mk
+
 ifneq (,$(PREBUILD))
 # Should declare enough RAM for inermediate linker script: 89K
 USER_SRAM_LENGTH = 89K
 else
-DATA_SECTION_LEN  = $(shell arm-none-eabi-objdump -h --section=.data $(INTERMEDIATE_ELF) | grep .data)
+DATA_SECTION_LEN  = $(shell $(OBJDUMP) -h --section=.data $(INTERMEDIATE_ELF) | grep .data)
 DATA_SECTION_LEN := 0x$(word 3,$(DATA_SECTION_LEN))
-BSS_SECTION_LEN   = $(shell arm-none-eabi-objdump -h --section=.bss $(INTERMEDIATE_ELF) | grep .bss)
+BSS_SECTION_LEN   = $(shell $(OBJDUMP) -h --section=.bss $(INTERMEDIATE_ELF) | grep .bss)
 BSS_SECTION_LEN  := 0x$(word 3,$(BSS_SECTION_LEN))
 
 # Note: reserving 16 bytes for alignment just in case


### PR DESCRIPTION
### Problem
Fixes a issue on Gen 3 devices when the compiler is not on the PATH

### Solution

Use configuration from `build/common-tools` to call objdump to ensure the path configured with environment is used.

fixes #1960 

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
