### PR TITLE
Ensure gpio pin map is initialized on first use for gcc build

### DIFF
--- a/hal/src/gcc/gpio_hal.cpp
+++ b/hal/src/gcc/gpio_hal.cpp
@@ -178,7 +178,13 @@ public:
     }
 };
 
-GpioPinMap PIN_MAP;
+GpioPinMap& _fetch_PIN_MAP()
+{
+    static GpioPinMap pinMap;
+    return pinMap;
+}
+
+#define PIN_MAP _fetch_PIN_MAP()
 
 
 PinFunction HAL_Validate_Pin_Function(pin_t pin, PinFunction pinFunction)


### PR DESCRIPTION
### Problem

Fixes init order bug as described in #1962 

### Solution

Replaced global with fetch function that initializes static object on first use and returns a ref.

### Completeness

- [x] User is totes amazing for contributing!
- [x ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
