### PR TITLE
Add gcc preprocesor macro with git msg

### DIFF
--- a/build/version.mk
+++ b/build/version.mk
@@ -5,3 +5,15 @@ VERSION_STRING = 1.4.2
 VERSION = 1404
 
 CFLAGS += -DSYSTEM_VERSION_STRING=$(VERSION_STRING)
+
+ifneq "$(wildcard $(APPDIR)/.git )" "" #check if local repo exist
+#Create variable GIT_MSG with:
+#1) git sha and additionally dirty flag
+GIT_MSG := sha:$(shell git --git-dir=${APPDIR}/.git --work-tree=${APPDIR} --no-pager describe --tags --always --dirty)
+#2) last commit msg
+GIT_MSG += msg:$(shell git --git-dir=${APPDIR}/.git --work-tree=${APPDIR} --no-pager log -1 --pretty=%B)
+else
+GIT_MSG := Can't find git repo
+endif
+#add user define macro (-D) for gcc preprocessor
+CFLAGS += -DGIT_MSG=\"$(strip "$(GIT_MSG)")\"

--- a/user/tests/wiring/api/system.cpp
+++ b/user/tests/wiring/api/system.cpp
@@ -181,6 +181,7 @@ test(system_version) {
 
     API_COMPILE(Serial.println(stringify(SYSTEM_VERSION_STRING)));
     API_COMPILE(Serial.println(SYSTEM_VERSION));
+    API_COMPILE(Serial.println(GIT_MSG));
 }
 
 


### PR DESCRIPTION
### Problem

Add macro GIT_MSG associated with the application local git repository
### Solution

Modified file build/version.mk and add new macro GIT_MSG
```
GIT_MSG := sha:$(shell git --git-dir=${APPDIR}/.git --work-tree=${APPDIR} --no-pager describe --tags --always --dirty)
CFLAGS += -DGIT_MSG=\"$(strip "$(GIT_MSG)")\"
```
### Steps to Test

Add test in user/tests/wiring/api/system.cpp

### Example App

```c
void setup() {
  /* A minimal example app is super helpful 
   * for testing new features and fixes. 
   * A link to a Docs PR is even better!
   */
Serial.printf("Git: %s\n", GIT_MSG);
}

void loop() {

}
```

### References

https://community.particle.io/t/add-gcc-preprocesor-macro-with-git-msg/53231

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
