### PR TITLE
Export sendmsg() and recvmsg() systems calls

### DIFF
--- a/hal/inc/hal_dynalib_socket_posix.h
+++ b/hal/inc/hal_dynalib_socket_posix.h
@@ -50,6 +50,8 @@ DYNALIB_FN(14, hal_socket, sock_socket, int(int, int, int))
 DYNALIB_FN(15, hal_socket, sock_fcntl, int(int, int, ...))
 DYNALIB_FN(16, hal_socket, sock_poll, int(struct pollfd*, nfds_t, int))
 DYNALIB_FN(17, hal_socket, sock_select, int(int, fd_set*, fd_set*, fd_set*, struct timeval*))
+DYNALIB_FN(18, hal_socket, sock_recvmsg, int(int, struct msghdr*, int))
+DYNALIB_FN(19, hal_socket, sock_sendmsg, int(int, const struct msghdr*, int))
 
 DYNALIB_END(hal_socket)
 

--- a/hal/inc/socket_hal_posix.h
+++ b/hal/inc/socket_hal_posix.h
@@ -288,6 +288,29 @@ int sock_select(int nfds, fd_set* readfds, fd_set* writefds,
                 fd_set* exceptfds, struct timeval* timeout);
 
 /**
+ * Receive data from the socket.
+ *
+ * @param[in]  s        a socket that has been created with sock_socket()
+ * @param      message  message to receive
+ * @param[in]  flags    a combination of MSG_DONTWAIT, MSG_PEEK and MSG_TRUNC
+ *
+ * @return     The number of bytes received or -1 on error, with errno set
+ *             accordingly.
+ */
+ssize_t sock_recvmsg(int s, struct msghdr *message, int flags);
+
+/**
+ * Send the data through the socket.
+ *
+ * @param[in]  s        a socket that has been created with sock_socket()
+ * @param      message  message to send
+ * @param[in]  flags    a combination of MSG_MORE and MSG_DONTWAIT
+ *
+ * @return     The number of bytes sent or -1 on error, with errno set
+ *             accordingly.
+ */
+ssize_t sock_sendmsg(int s, const struct msghdr *message, int flags);
+/**
  * @}
  *
  */

--- a/hal/network/lwip/posix/sys/socket.h
+++ b/hal/network/lwip/posix/sys/socket.h
@@ -43,5 +43,7 @@
 #define socket(domain, type, protocol) sock_socket(domain, type, protocol)
 #define poll(fds, nfds, timeout) sock_poll(fds, nfds, timeout)
 #define select(nfds, readfds, writefds, exceptfds, timeout) sock_select(nfds, readfds, writefds, exceptfds, timeout)
+#define recvmsg(s, message,flags) sock_recvmsg(s, message, flags)
+#define sendmsg(s, message,flags) sock_sendmsg(s, message, flags)
 
 #endif /* SYS_SOCKET_H */

--- a/hal/network/lwip/socket_hal.cpp
+++ b/hal/network/lwip/socket_hal.cpp
@@ -103,3 +103,11 @@ int sock_select(int nfds, fd_set* readfds, fd_set* writefds,
                 fd_set* exceptfds, struct timeval* timeout) {
   return lwip_select(nfds, readfds, writefds, exceptfds, timeout);
 }
+
+ssize_t sock_recvmsg(int s, struct msghdr *message, int flags) {
+  return lwip_recvmsg(s, message, flags);
+}
+
+ssize_t sock_sendmsg(int s, const struct msghdr *message, int flags) {
+  return lwip_sendmsg(s, message, flags);
+}


### PR DESCRIPTION
### Problem

Export `sendmsg()` and `recvmsg()` systems calls

### Solution

Only `sendmsg()` and `recvmsg()` allow sending and receiving ancillary data, which is the only way to access IP TOS information.
