### PR TITLE
Gen3 devices now can be woken up by BLE.

### DIFF
--- a/system/inc/system_sleep.h
+++ b/system/inc/system_sleep.h
@@ -290,6 +290,27 @@ public:
         return *this;
     }
 
+    SystemSleepConfiguration& ble() {
+        // Check if BLE has been configured as wakeup source.
+        auto wakeup = wakeupSourceFeatured(HAL_WAKEUP_SOURCE_TYPE_BLE);
+        if (wakeup) {
+            return *this;
+        }
+        // Otherwise, configure BLE as wakeup source.
+        auto wakeupSource = new(std::nothrow) hal_wakeup_source_base_t();
+        if (!wakeupSource) {
+            valid_ = false;
+            return *this;
+        }
+        wakeupSource->size = sizeof(hal_wakeup_source_base_t);
+        wakeupSource->version = HAL_SLEEP_VERSION;
+        wakeupSource->type = HAL_WAKEUP_SOURCE_TYPE_BLE;
+        wakeupSource->next = config_.wakeup_sources;
+        config_.wakeup_sources = wakeupSource;
+        valid_ = true;
+        return *this;
+    }
+
 private:
     hal_sleep_config_t config_;
     bool valid_; // TODO: This should be an enum value instead to indicate different errors.


### PR DESCRIPTION
**This branch currently targets to the internal/rework_system_sleep branch.**

### Problem

N/A

### Solution

N/A

### Steps to Test

N/A

### Example App

```c
#include "Particle.h"

#define UART_TX_BUF_SIZE        20

SYSTEM_MODE(MANUAL);

Serial1LogHandler log(115200, LOG_LEVEL_ALL);

void onDataReceived(const uint8_t* data, size_t len, const BlePeerDevice& peer, void* context);

const char* serviceUuid = "6E400001-B5A3-F393-E0A9-E50E24DCCA9E";
const char* rxUuid = "6E400002-B5A3-F393-E0A9-E50E24DCCA9E";
const char* txUuid = "6E400003-B5A3-F393-E0A9-E50E24DCCA9E";

BleCharacteristic txCharacteristic("tx",
                                   BleCharacteristicProperty::NOTIFY,
                                   txUuid,
                                   serviceUuid);

BleCharacteristic rxCharacteristic("rx",
                                   BleCharacteristicProperty::WRITE_WO_RSP,
                                   rxUuid,
                                   serviceUuid,
                                   onDataReceived, &rxCharacteristic);

uint8_t txBuf[UART_TX_BUF_SIZE];
size_t txLen = 0;

SystemSleepConfiguration config;


void onDataReceived(const uint8_t* data, size_t len, const BlePeerDevice& peer, void* context) {
    BleAddress address = peer.address();
    LOG(TRACE, "Received data from: %s, length: %d", address.toString().c_str(), len);

    BleCharacteristic* characteristic = static_cast<BleCharacteristic*>(context);
    Serial1.printf("Characteristic UUID: %s\r\n", characteristic->UUID().toString().c_str());

    for (uint8_t i = 0; i < len; i++) {
        Serial1.write(data[i]);
    }
}

void sleep() {
    System.sleep(config);
}

void setup() {
    LOG(TRACE, "Application started.");

    BLE.addCharacteristic(txCharacteristic);
    BLE.addCharacteristic(rxCharacteristic);

    BleAdvertisingData data;
    data.appendServiceUUID(serviceUuid);
    BLE.advertise(&data);

    config.mode(SystemSleepMode::STOP)
          .ble();
}

void loop() {
    if (BLE.connected()) {
        while (Serial.available() && txLen < UART_TX_BUF_SIZE) {
            txBuf[txLen++] = Serial.read();
            Serial.write(txBuf[txLen - 1]);
        }

        if (txLen > 0) {
            txCharacteristic.setValue(txBuf, txLen);
            txLen = 0;
        } else {
            sleep();
        }
    } else {
        sleep();
    }
}
```

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
