### PR TITLE
Implements that Gen3 platforms can be woken up by multiple pins when they are in standby mode.

### DIFF
--- a/hal/inc/interrupts_hal.h
+++ b/hal/inc/interrupts_hal.h
@@ -68,6 +68,13 @@ typedef struct HAL_InterruptCallback {
     void* data;
 } HAL_InterruptCallback;
 
+typedef struct hal_pins_interrupt_config_t {
+    uint16_t* pins;
+    uint32_t pins_count;
+    InterruptMode* modes;
+    uint32_t modes_count;
+} hal_pins_interrupt_config_t;
+
 #define HAL_INTERRUPT_EXTRA_CONFIGURATION_VERSION_1 4
 #define HAL_INTERRUPT_EXTRA_CONFIGURATION_VERSION_2 5
 #define HAL_INTERRUPT_EXTRA_CONFIGURATION_VERSION HAL_INTERRUPT_EXTRA_CONFIGURATION_VERSION_2

--- a/hal/src/nRF52840/sleep_hal.cpp
+++ b/hal/src/nRF52840/sleep_hal.cpp
@@ -64,7 +64,7 @@ static int hal_sleep_enter_stop_mode(const hal_sleep_config_t* config, hal_wakeu
         hal_wakeup_source_gpio_t* gpio_wakeup = (hal_wakeup_source_gpio_t*)malloc(sizeof(hal_wakeup_source_gpio_t));
         gpio_wakeup->base.size = sizeof(hal_wakeup_source_gpio_t);
         gpio_wakeup->base.version = HAL_SLEEP_VERSION;
-        gpio_wakeup->base.type = HAL_WAKEUP_SOURCE_TYPE_RTC;
+        gpio_wakeup->base.type = HAL_WAKEUP_SOURCE_TYPE_GPIO;
         gpio_wakeup->base.next = nullptr;
         gpio_wakeup->pin = ret;
         *wakeup_source = reinterpret_cast<hal_wakeup_source_base_t*>(gpio_wakeup);

--- a/hal/src/stm32f2xx/sleep_hal.cpp
+++ b/hal/src/stm32f2xx/sleep_hal.cpp
@@ -23,7 +23,7 @@
 
 using spark::Vector;
 
-static int hal_sleep_enter_stop_mode(const hal_sleep_config_t* config) {
+static int hal_sleep_enter_stop_mode(const hal_sleep_config_t* config, hal_wakeup_source_base_t** wakeup_source) {
     Vector<uint16_t> pins;
     Vector<InterruptMode> modes;
     long seconds = 0;
@@ -43,10 +43,33 @@ static int hal_sleep_enter_stop_mode(const hal_sleep_config_t* config) {
         wakeupSource = wakeupSource->next;
     }
 
-    return HAL_Core_Enter_Stop_Mode_Ext(pins.data(), pins.size(), modes.data(), modes.size(), seconds, nullptr);
+    int ret = HAL_Core_Enter_Stop_Mode_Ext(pins.data(), pins.size(), modes.data(), modes.size(), seconds, nullptr);
+    if (ret < 0) {
+        return ret;
+    } 
+
+    // IMPORTANT: It's the caller's responsibility to free this memory.
+    if (ret == 0) {
+        hal_wakeup_source_rtc_t* rtc_wakeup = (hal_wakeup_source_rtc_t*)malloc(sizeof(hal_wakeup_source_rtc_t));
+        rtc_wakeup->base.size = sizeof(hal_wakeup_source_rtc_t);
+        rtc_wakeup->base.version = HAL_SLEEP_VERSION;
+        rtc_wakeup->base.type = HAL_WAKEUP_SOURCE_TYPE_RTC;
+        rtc_wakeup->base.next = nullptr;
+        rtc_wakeup->ms = 0;
+        *wakeup_source = reinterpret_cast<hal_wakeup_source_base_t*>(rtc_wakeup);
+    } else {
+        hal_wakeup_source_gpio_t* gpio_wakeup = (hal_wakeup_source_gpio_t*)malloc(sizeof(hal_wakeup_source_gpio_t));
+        gpio_wakeup->base.size = sizeof(hal_wakeup_source_gpio_t);
+        gpio_wakeup->base.version = HAL_SLEEP_VERSION;
+        gpio_wakeup->base.type = HAL_WAKEUP_SOURCE_TYPE_GPIO;
+        gpio_wakeup->base.next = nullptr;
+        gpio_wakeup->pin = ret;
+        *wakeup_source = reinterpret_cast<hal_wakeup_source_base_t*>(gpio_wakeup);
+    }
+    return SYSTEM_ERROR_NONE;
 }
 
-static int hal_sleep_enter_hibernate_mode(const hal_sleep_config_t* config) {
+static int hal_sleep_enter_hibernate_mode(const hal_sleep_config_t* config, hal_wakeup_source_base_t** wakeup_source) {
     long seconds = 0;
     uint32_t flags = HAL_STANDBY_MODE_FLAG_DISABLE_WKP_PIN;
 
@@ -71,14 +94,14 @@ int hal_sleep(const hal_sleep_config_t* config, hal_wakeup_source_base_t** wakeu
 
     switch (config->mode) {
         case HAL_SLEEP_MODE_STOP: {
-            ret = hal_sleep_enter_stop_mode(config);
+            ret = hal_sleep_enter_stop_mode(config, wakeup_source);
             break;
         }
         case HAL_SLEEP_MODE_ULTRA_LOW_POWER: {
             break;
         }
         case HAL_SLEEP_MODE_HIBERNATE: {
-            ret = hal_sleep_enter_hibernate_mode(config);
+            ret = hal_sleep_enter_hibernate_mode(config, wakeup_source);
             break;
         }
         default: {

--- a/system/inc/system_sleep.h
+++ b/system/inc/system_sleep.h
@@ -135,9 +135,13 @@ public:
         return static_cast<SystemSleepMode>(config_->mode);
     }
 
-    hal_wakeup_source_base_t* wakeupSourceFeatured(hal_wakeup_source_type_t type, hal_wakeup_source_base_t* start = nullptr) const {
+    hal_wakeup_source_base_t* wakeupSourceFeatured(hal_wakeup_source_type_t type) const {
+        return wakeupSourceFeatured(type, config_->wakeup_sources);
+    }
+
+    hal_wakeup_source_base_t* wakeupSourceFeatured(hal_wakeup_source_type_t type, hal_wakeup_source_base_t* start) const {
         if (!start) {
-            start = config_->wakeup_sources;
+            return nullptr;
         }
         while (start) {
             if (start->type == type) {

--- a/wiring/src/spark_wiring_system.cpp
+++ b/wiring/src/spark_wiring_system.cpp
@@ -91,14 +91,11 @@ SleepResult SystemClass::sleep(Spark_Sleep_TypeDef sleepMode, long seconds, Slee
             config.wait(SystemSleepWait::NO_WAIT);
         }
 
-        uint32_t wakePinDisable = flags.value() & SYSTEM_SLEEP_FLAG_DISABLE_WKP_PIN;
-        uint32_t* reserved = wakePinDisable ? &wakePinDisable : nullptr;
-        SystemSleepResult result;
-        int ret = system_sleep_ext(config.halConfig(), result.halWakeupSource(), reserved);
-        result.setError(static_cast<system_error_t>(ret));
-        System.systemSleepResult_ = result;
+        if (!(flags.value() & SYSTEM_SLEEP_FLAG_DISABLE_WKP_PIN)) {
+            config.gpio(WKP, RISING);
+        }
 
-        System.toSleepResult();
+        System.sleep(config);
         return System.sleepResult_;
     }
 }


### PR DESCRIPTION
### Problem

N/A

### Solution

N/A

### Steps to Test

N/A

### Example App

```c
#include "Particle.h"

SYSTEM_MODE(MANUAL);

Serial1LogHandler log(115200, LOG_LEVEL_ALL);

void onDataReceived(const uint8_t* data, size_t len, const BlePeerDevice& peer, void* context);

const char* serviceUuid = "6E400001-B5A3-F393-E0A9-E50E24DCCA9E";
const char* rxUuid = "6E400002-B5A3-F393-E0A9-E50E24DCCA9E";

BleCharacteristic rxCharacteristic("rx",
                                   BleCharacteristicProperty::WRITE_WO_RSP,
                                   rxUuid,
                                   serviceUuid,
                                   onDataReceived, &rxCharacteristic);

SystemSleepConfiguration config;


void onDataReceived(const uint8_t* data, size_t len, const BlePeerDevice& peer, void* context) {
    System.sleep(config);
}

void setup() {
    LOG(TRACE, "Application started.");

    BLE.addCharacteristic(rxCharacteristic);

    BleAdvertisingData data;
    data.appendServiceUUID(serviceUuid);
    BLE.advertise(&data);

    config.mode(SystemSleepMode::HIBERNATE)
          .gpio(D0, RISING)
          .gpio(D3, RISING);
}

void loop() {

}
```

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)