### PR TITLE
Implement Particle.cancel()

### DIFF
--- a/system/inc/system_cloud.h
+++ b/system/inc/system_cloud.h
@@ -240,6 +240,28 @@ void spark_cloud_flag_disconnect(void);    // should be set connected since it m
  */
 bool spark_cloud_flag_auto_connect(void);
 
+/**
+ * Option flags changing the behavior of `spark_cloud_disconnect()`.
+ */
+typedef enum cloud_disconnect_flag {
+    CLOUD_DISCONNECT_GRACEFULLY = 0x01, ///< Disconnect gracefully.
+    CLOUD_DISCONNECT_DONT_CLOSE = 0x02, ///< Do not close the socket.
+    CLOUD_DISCONNECT_SYNC = 0x04 ///< Disconnect synchronously.
+} cloud_disconnect_flag;
+
+/**
+ * Parameters for `spark_cloud_disconnect()`.
+ */
+typedef struct spark_cloud_disconnect_param {
+    uint16_t size; ///< Size of this structure.
+    uint16_t flags; ///< Option flags (see `cloud_disconnect_flag`).
+} spark_cloud_disconnect_param;
+
+/**
+ * Close the cloud connection.
+ */
+int spark_cloud_disconnect(spark_cloud_disconnect_param* param);
+
 ProtocolFacade* system_cloud_protocol_instance(void);
 
 int spark_set_connection_property(unsigned property_id, unsigned data, particle::protocol::connection_properties_t* conn_prop, void* reserved);

--- a/system/inc/system_cloud.h
+++ b/system/inc/system_cloud.h
@@ -245,22 +245,17 @@ bool spark_cloud_flag_auto_connect(void);
  */
 typedef enum cloud_disconnect_flag {
     CLOUD_DISCONNECT_GRACEFULLY = 0x01, ///< Disconnect gracefully.
-    CLOUD_DISCONNECT_DONT_CLOSE = 0x02, ///< Do not close the socket.
-    CLOUD_DISCONNECT_SYNC = 0x04 ///< Disconnect synchronously.
+    CLOUD_DISCONNECT_DONT_CLOSE = 0x02 ///< Do not close the socket.
 } cloud_disconnect_flag;
 
 /**
- * Parameters for `spark_cloud_disconnect()`.
- */
-typedef struct spark_cloud_disconnect_param {
-    uint16_t size; ///< Size of this structure.
-    uint16_t flags; ///< Option flags (see `cloud_disconnect_flag`).
-} spark_cloud_disconnect_param;
-
-/**
  * Close the cloud connection.
+ *
+ * @param flags Option flags (see `cloud_disconnect_flag`).
+ * @param reserved This argument should be set to NULL.
+ * @return 0 on success or a negative result code in case of an error.
  */
-int spark_cloud_disconnect(spark_cloud_disconnect_param* param);
+int spark_cloud_disconnect(unsigned flags, void* reserved);
 
 ProtocolFacade* system_cloud_protocol_instance(void);
 

--- a/system/inc/system_dynalib_cloud.h
+++ b/system/inc/system_dynalib_cloud.h
@@ -51,7 +51,7 @@ DYNALIB_FN(13, system_cloud, spark_sync_time_last, system_tick_t(time_t*, void*)
 DYNALIB_FN(14, system_cloud, spark_set_connection_property, int(unsigned, unsigned, particle::protocol::connection_properties_t*, void*))
 DYNALIB_FN(15, system_cloud, spark_set_random_seed_from_cloud_handler, int(void (*handler)(unsigned int), void*))
 DYNALIB_FN(16, system_cloud, spark_publish_vitals, int(system_tick_t, void*))
-DYNALIB_FN(17, system_cloud, spark_cloud_disconnect, int(spark_cloud_disconnect_param*))
+DYNALIB_FN(17, system_cloud, spark_cloud_disconnect, int(unsigned, void*))
 
 DYNALIB_END(system_cloud)
 

--- a/system/inc/system_dynalib_cloud.h
+++ b/system/inc/system_dynalib_cloud.h
@@ -51,6 +51,7 @@ DYNALIB_FN(13, system_cloud, spark_sync_time_last, system_tick_t(time_t*, void*)
 DYNALIB_FN(14, system_cloud, spark_set_connection_property, int(unsigned, unsigned, particle::protocol::connection_properties_t*, void*))
 DYNALIB_FN(15, system_cloud, spark_set_random_seed_from_cloud_handler, int(void (*handler)(unsigned int), void*))
 DYNALIB_FN(16, system_cloud, spark_publish_vitals, int(system_tick_t, void*))
+DYNALIB_FN(17, system_cloud, spark_cloud_disconnect, int(spark_cloud_disconnect_param*))
 
 DYNALIB_END(system_cloud)
 

--- a/system/inc/system_threading.h
+++ b/system/inc/system_threading.h
@@ -114,10 +114,6 @@ FFL(F const &func)
     SYSTEM_THREAD_CONTEXT_ASYNC(fn); \
     fn;
 
-#define SYSTEM_THREAD_CONTEXT_ASYNC_CALL_RESULT(fn, result) \
-    SYSTEM_THREAD_CONTEXT_ASYNC_RESULT(fn, result); \
-    return fn;
-
 #define SYSTEM_THREAD_CONTEXT_SYNC_CALL(fn) \
     SYSTEM_THREAD_CONTEXT_SYNC(fn); \
     fn;

--- a/system/inc/system_threading.h
+++ b/system/inc/system_threading.h
@@ -114,6 +114,10 @@ FFL(F const &func)
     SYSTEM_THREAD_CONTEXT_ASYNC(fn); \
     fn;
 
+#define SYSTEM_THREAD_CONTEXT_ASYNC_CALL_RESULT(fn, result) \
+    SYSTEM_THREAD_CONTEXT_ASYNC_RESULT(fn, result); \
+    return fn;
+
 #define SYSTEM_THREAD_CONTEXT_SYNC_CALL(fn) \
     SYSTEM_THREAD_CONTEXT_SYNC(fn); \
     fn;

--- a/system/src/system_cloud.cpp
+++ b/system/src/system_cloud.cpp
@@ -61,6 +61,13 @@ VitalsPublisher<Timer> _vitals;
 VitalsPublisher<particle::NullTimer> _vitals;
 #endif // PLATFORM_THREADING
 
+int spark_cloud_disconnect_impl(unsigned flags) {
+    cloud_disconnect(!(flags & CLOUD_DISCONNECT_DONT_CLOSE), // closeSocket
+            flags & CLOUD_DISCONNECT_GRACEFULLY, // graceful
+            CLOUD_DISCONNECT_REASON_USER);
+    return 0;
+}
+
 } // namespace
 
 #ifndef SPARK_NO_CLOUD
@@ -258,4 +265,13 @@ int spark_set_random_seed_from_cloud_handler(void (*handler)(unsigned int), void
 #endif // SPARK_NO_CLOUD
 
     return 0;
+}
+
+int spark_cloud_disconnect(spark_cloud_disconnect_param* param) {
+    const unsigned flags = param ? param->flags : 0;
+    if (flags & CLOUD_DISCONNECT_SYNC) {
+        SYSTEM_THREAD_CONTEXT_SYNC_CALL_RESULT(spark_cloud_disconnect_impl(flags));
+    } else {
+        SYSTEM_THREAD_CONTEXT_ASYNC_CALL_RESULT(spark_cloud_disconnect_impl(flags), 0);
+    }
 }

--- a/system/src/system_cloud.cpp
+++ b/system/src/system_cloud.cpp
@@ -61,13 +61,6 @@ VitalsPublisher<Timer> _vitals;
 VitalsPublisher<particle::NullTimer> _vitals;
 #endif // PLATFORM_THREADING
 
-int spark_cloud_disconnect_impl(unsigned flags) {
-    cloud_disconnect(!(flags & CLOUD_DISCONNECT_DONT_CLOSE), // closeSocket
-            flags & CLOUD_DISCONNECT_GRACEFULLY, // graceful
-            CLOUD_DISCONNECT_REASON_USER);
-    return 0;
-}
-
 } // namespace
 
 #ifndef SPARK_NO_CLOUD
@@ -267,11 +260,10 @@ int spark_set_random_seed_from_cloud_handler(void (*handler)(unsigned int), void
     return 0;
 }
 
-int spark_cloud_disconnect(spark_cloud_disconnect_param* param) {
-    const unsigned flags = param ? param->flags : 0;
-    if (flags & CLOUD_DISCONNECT_SYNC) {
-        SYSTEM_THREAD_CONTEXT_SYNC_CALL_RESULT(spark_cloud_disconnect_impl(flags));
-    } else {
-        SYSTEM_THREAD_CONTEXT_ASYNC_CALL_RESULT(spark_cloud_disconnect_impl(flags), 0);
-    }
+int spark_cloud_disconnect(unsigned flags, void* reserved) {
+    SYSTEM_THREAD_CONTEXT_ASYNC_RESULT(spark_cloud_disconnect(flags, reserved), 0);
+    cloud_disconnect(!(flags & CLOUD_DISCONNECT_DONT_CLOSE), // closeSocket
+            flags & CLOUD_DISCONNECT_GRACEFULLY, // graceful
+            CLOUD_DISCONNECT_REASON_USER);
+    return 0;
 }

--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -375,6 +375,14 @@ class CloudClass {
     inline static void keepAlive(std::chrono::seconds s) { keepAlive(s.count()); }
 #endif
 
+    /**
+     * Synchronously cancel all pending cloud operations and disconnect from the cloud.
+     *
+     * Calling this method resets the auto-connection flag. The system will not attempt to reconnect
+     * to the cloud until `Particle.connect()` is called.
+     */
+    static void cancel();
+
 private:
 
     static bool register_function(cloud_function_t fn, void* data, const char* funcKey);

--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -380,8 +380,10 @@ class CloudClass {
      *
      * Calling this method resets the auto-connection flag. The system will not attempt to reconnect
      * to the cloud until `Particle.connect()` is called.
+     *
+     * @note This method is experimental and is subject to change in future releases of Device OS.
      */
-    static void cancel();
+    static void _cancel();
 
 private:
 

--- a/wiring/src/spark_wiring_cloud.cpp
+++ b/wiring/src/spark_wiring_cloud.cpp
@@ -76,3 +76,9 @@ Future<bool> CloudClass::publish_event(const char *eventName, const char *eventD
 int CloudClass::publishVitals(system_tick_t period_s_) {
     return spark_publish_vitals(period_s_, nullptr);
 }
+
+void CloudClass::cancel() {
+    spark_cloud_flag_disconnect();
+    spark_cloud_disconnect(0, nullptr);
+    waitUntil(Particle.disconnected);
+}

--- a/wiring/src/spark_wiring_cloud.cpp
+++ b/wiring/src/spark_wiring_cloud.cpp
@@ -77,7 +77,7 @@ int CloudClass::publishVitals(system_tick_t period_s_) {
     return spark_publish_vitals(period_s_, nullptr);
 }
 
-void CloudClass::cancel() {
+void CloudClass::_cancel() {
     spark_cloud_flag_disconnect();
     spark_cloud_disconnect(0, nullptr);
     waitUntil(Particle.disconnected);


### PR DESCRIPTION
### Problem

This PR implements a method called `Particle.cancel()` which closes the cloud connection synchronously, without waiting for any unacknowledged messages.

### Steps to Test

_TBD_

### References

- [ch42232]
