### PR TITLE
[Argon/Boron] NCP bugfixes

### DIFF
--- a/hal/network/ncp/wifi_network_manager.cpp
+++ b/hal/network/ncp/wifi_network_manager.cpp
@@ -204,7 +204,12 @@ int WifiNetworkManager::connect(const char* ssid) {
     // Connect to the network
     bool updateConfig = false;
     auto network = &networks.at(index);
+    // Always perform a network scan for now, because ESP32 doesn't support 802.11v/k/r
+#if 0
     int r = client_->connect(network->ssid(), network->bssid(), network->security(), network->credentials());
+#else
+    int r = SYSTEM_ERROR_INTERNAL;
+#endif
     if (r < 0) {
         // Perform network scan
         Vector<WifiScanResult> scanResults;

--- a/hal/src/boron/network/sara_ncp_client.cpp
+++ b/hal/src/boron/network/sara_ncp_client.cpp
@@ -343,7 +343,16 @@ int SaraNcpClient::updateFirmware(InputStream* file, size_t size) {
 }
 
 int SaraNcpClient::dataChannelWrite(int id, const uint8_t* data, size_t size) {
-    return muxer_.writeChannel(UBLOX_NCP_PPP_CHANNEL, data, size);
+    int err = muxer_.writeChannel(UBLOX_NCP_PPP_CHANNEL, data, size);
+
+    if (err) {
+        // Make sure we are going into an error state if muxer for some reason fails
+        // to write into the data channel.
+        disable();
+        connectionState(NcpConnectionState::DISCONNECTED);
+    }
+
+    return err;
 }
 
 void SaraNcpClient::processEvents() {


### PR DESCRIPTION
### Problem

Devices may get stuck in a state where they think they are connected to the network, where in fact they are not.

### Solution

1. Bumps the `gsm0710muxer` submodule to bring in the fix that signals back to the NCP client whenever it exits with an error
2. Errors in data channel (carrying actual network packets) writes over muxer are now correctly handled

On Argon specifically we are now always performing a wifi scan before connecting, because we've learned that ESP32 doesn't support 802.11v/k/r, so with multiple access points in the area, Argons might have been connecting to a previously remembered AP which is not the best choice in its current location

### Steps to Test

N/A

### Example App

N/A

### References

- [CH39245]
- particle-iot/gsm0710muxer#4

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
