### PR TITLE
Validates sleep configuration before entering sleep mode

### DIFF
--- a/hal/inc/hal_dynalib_core.h
+++ b/hal/inc/hal_dynalib_core.h
@@ -80,7 +80,8 @@ DYNALIB_FN(32, hal_core, HAL_Set_Event_Callback, void(HAL_Event_Callback, void*)
 DYNALIB_FN(33, hal_core, HAL_Core_Enter_Stop_Mode_Ext, int(const uint16_t*, size_t, const InterruptMode*, size_t, long, void*))
 DYNALIB_FN(34, hal_core, HAL_Core_Execute_Standby_Mode_Ext, int(uint32_t, void*))
 
-DYNALIB_FN(35, hal_core, hal_sleep, int(const hal_sleep_config_t*, hal_wakeup_source_base_t**, void*))
+DYNALIB_FN(35, hal_core, hal_sleep_validate_config, int(const hal_sleep_config_t*, void*))
+DYNALIB_FN(36, hal_core, hal_sleep_enter, int(const hal_sleep_config_t*, hal_wakeup_source_base_t**, void*))
 
 DYNALIB_END(hal_core)
 

--- a/hal/inc/sleep_hal.h
+++ b/hal/inc/sleep_hal.h
@@ -136,6 +136,15 @@ extern "C" {
 #endif
 
 /**
+ * Check if the given sleep configuration is valid or not.
+ *
+ * @param[in]     config          Sleep configuration that specifies sleep mode, wakeup sources etc.
+ *
+ * @returns     System error code.
+ */
+int hal_sleep_validate_config(const hal_sleep_config_t* config, void* reserved);
+
+/**
  * Makes the device enter one of supported sleep modes.
  *
  * @param[in]     config          Sleep configuration that specifies sleep mode, wakeup sources etc.
@@ -144,7 +153,7 @@ extern "C" {
  *
  * @returns     System error code.
  */
-int hal_sleep(const hal_sleep_config_t* config, hal_wakeup_source_base_t** wakeup_source, void* reserved);
+int hal_sleep_enter(const hal_sleep_config_t* config, hal_wakeup_source_base_t** wakeup_source, void* reserved);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/hal/src/core/sleep_hal.cpp
+++ b/hal/src/core/sleep_hal.cpp
@@ -19,7 +19,11 @@
 #include "core_hal.h"
 #include "sleep_hal.h"
 
-int hal_sleep(const hal_sleep_config_t* config, hal_wakeup_source_base_t** wakeup_source, void* reserved) {
+int hal_sleep_validate_config(const hal_sleep_config_t* config, void* reserved) {
+    return SYSTEM_ERROR_NONE;
+}
+
+int hal_sleep_enter(const hal_sleep_config_t* config, hal_wakeup_source_base_t** wakeup_source, void* reserved) {
     CHECK_TRUE(config, SYSTEM_ERROR_INVALID_ARGUMENT);
 
     switch (config->mode) {

--- a/hal/src/gcc/sleep_hal.cpp
+++ b/hal/src/gcc/sleep_hal.cpp
@@ -19,7 +19,11 @@
 #include "core_hal.h"
 #include "sleep_hal.h"
 
-int hal_sleep(const hal_sleep_config_t* config, hal_wakeup_source_base_t** wakeup_source, void* reserved) {
+int hal_sleep_validate_config(const hal_sleep_config_t* config, void* reserved) {
+    return SYSTEM_ERROR_NONE;
+}
+
+int hal_sleep_enter(const hal_sleep_config_t* config, hal_wakeup_source_base_t** wakeup_source, void* reserved) {
     CHECK_TRUE(config, SYSTEM_ERROR_INVALID_ARGUMENT);
 
     switch (config->mode) {

--- a/hal/src/nRF52840/sleep_hal.cpp
+++ b/hal/src/nRF52840/sleep_hal.cpp
@@ -39,7 +39,7 @@ static bool isWakeupSourceSupportedGpio(hal_sleep_mode_t mode, const hal_wakeup_
 }
 
 static bool isWakeupSourceSupportedRtc(hal_sleep_mode_t mode, const hal_wakeup_source_rtc_t* rtc) {
-    if (mode == HAL_SLEEP_MODE_HIBERNATE) {
+    if (rtc->ms == 0 || mode == HAL_SLEEP_MODE_HIBERNATE) {
         return false;
     }
     return true;
@@ -162,6 +162,10 @@ int hal_sleep_validate_config(const hal_sleep_config_t* config, void* reserved) 
 
     // Checks the wakeup sources
     auto wakeupSource = config->wakeup_sources;
+    // At least one wakeup source should be configured.
+    if (!wakeupSource) {
+        return SYSTEM_ERROR_INVALID_ARGUMENT;
+    }
     while (wakeupSource) {
         if (!isWakeupSourceSupported(config->mode, wakeupSource)) {
             return SYSTEM_ERROR_NOT_SUPPORTED;

--- a/hal/src/stm32f2xx/sleep_hal.cpp
+++ b/hal/src/stm32f2xx/sleep_hal.cpp
@@ -46,6 +46,9 @@ static bool isWakeupSourceSupportedGpio(hal_sleep_mode_t mode, const hal_wakeup_
 }
 
 static bool isWakeupSourceSupportedRtc(hal_sleep_mode_t mode, const hal_wakeup_source_rtc_t* rtc) {
+    if (rtc->ms == 0) {
+        return false;
+    }
     return true;
 }
 
@@ -142,6 +145,10 @@ int hal_sleep_validate_config(const hal_sleep_config_t* config, void* reserved) 
 
     // Checks the wakeup sources
     auto wakeupSource = config->wakeup_sources;
+    // For backward compatibility, Gen2 platforms can disable WKP pin.
+    // if (!wakeupSource) {
+    //     return SYSTEM_ERROR_INVALID_ARGUMENT;
+    // }
     while (wakeupSource) {
         if (!isWakeupSourceSupported(config->mode, wakeupSource)) {
             return SYSTEM_ERROR_NOT_SUPPORTED;

--- a/hal/src/stm32f2xx/sleep_hal.cpp
+++ b/hal/src/stm32f2xx/sleep_hal.cpp
@@ -23,7 +23,51 @@
 
 using spark::Vector;
 
-static int hal_sleep_enter_stop_mode(const hal_sleep_config_t* config, hal_wakeup_source_base_t** wakeup_source) {
+static bool isWakeupSourceSupportedGpio(hal_sleep_mode_t mode, const hal_wakeup_source_gpio_t* gpio) {
+    switch(gpio->mode) {
+        case RISING:
+        case FALLING:
+        case CHANGE:
+            break;
+        default:
+            return false;
+    }
+    if (mode == HAL_SLEEP_MODE_STOP) {
+        if (gpio->pin >= TOTAL_PINS) {
+            return false;
+        }
+    } else if (mode == HAL_SLEEP_MODE_HIBERNATE) {
+        // Only the WKP pin can be used to wake up device from hibernate mode.
+        if (gpio->pin != WKP) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool isWakeupSourceSupportedRtc(hal_sleep_mode_t mode, const hal_wakeup_source_rtc_t* rtc) {
+    return true;
+}
+
+static bool isWakeupSourceSupportedNetwork(hal_sleep_mode_t mode, const hal_wakeup_source_network_t* network) {
+    if (mode == HAL_SLEEP_MODE_HIBERNATE) {
+        return false;
+    }
+    return true;
+}
+
+static bool isWakeupSourceSupported(hal_sleep_mode_t mode, const hal_wakeup_source_base_t* base) {
+    if (base->type == HAL_WAKEUP_SOURCE_TYPE_GPIO) {
+        return isWakeupSourceSupportedGpio(mode, reinterpret_cast<const hal_wakeup_source_gpio_t*>(base));
+    } else if (base->type == HAL_WAKEUP_SOURCE_TYPE_RTC) {
+        return isWakeupSourceSupportedRtc(mode, reinterpret_cast<const hal_wakeup_source_rtc_t*>(base));
+    } else if (base->type == HAL_WAKEUP_SOURCE_TYPE_NETWORK) {
+        return isWakeupSourceSupportedNetwork(mode, reinterpret_cast<const hal_wakeup_source_network_t*>(base));
+    }
+    return false;
+}
+
+static int enterStopMode(const hal_sleep_config_t* config, hal_wakeup_source_base_t** wakeup_source) {
     Vector<uint16_t> pins;
     Vector<InterruptMode> modes;
     long seconds = 0;
@@ -44,32 +88,32 @@ static int hal_sleep_enter_stop_mode(const hal_sleep_config_t* config, hal_wakeu
     }
 
     int ret = HAL_Core_Enter_Stop_Mode_Ext(pins.data(), pins.size(), modes.data(), modes.size(), seconds, nullptr);
-    if (ret < 0) {
-        return ret;
-    } 
+    CHECK(ret);
 
     // IMPORTANT: It's the caller's responsibility to free this memory.
-    if (ret == 0) {
-        hal_wakeup_source_rtc_t* rtc_wakeup = (hal_wakeup_source_rtc_t*)malloc(sizeof(hal_wakeup_source_rtc_t));
-        rtc_wakeup->base.size = sizeof(hal_wakeup_source_rtc_t);
-        rtc_wakeup->base.version = HAL_SLEEP_VERSION;
-        rtc_wakeup->base.type = HAL_WAKEUP_SOURCE_TYPE_RTC;
-        rtc_wakeup->base.next = nullptr;
-        rtc_wakeup->ms = 0;
-        *wakeup_source = reinterpret_cast<hal_wakeup_source_base_t*>(rtc_wakeup);
-    } else {
-        hal_wakeup_source_gpio_t* gpio_wakeup = (hal_wakeup_source_gpio_t*)malloc(sizeof(hal_wakeup_source_gpio_t));
-        gpio_wakeup->base.size = sizeof(hal_wakeup_source_gpio_t);
-        gpio_wakeup->base.version = HAL_SLEEP_VERSION;
-        gpio_wakeup->base.type = HAL_WAKEUP_SOURCE_TYPE_GPIO;
-        gpio_wakeup->base.next = nullptr;
-        gpio_wakeup->pin = ret;
-        *wakeup_source = reinterpret_cast<hal_wakeup_source_base_t*>(gpio_wakeup);
+    if (wakeup_source) {
+        if (ret == 0) {
+            hal_wakeup_source_rtc_t* rtc_wakeup = (hal_wakeup_source_rtc_t*)malloc(sizeof(hal_wakeup_source_rtc_t));
+            rtc_wakeup->base.size = sizeof(hal_wakeup_source_rtc_t);
+            rtc_wakeup->base.version = HAL_SLEEP_VERSION;
+            rtc_wakeup->base.type = HAL_WAKEUP_SOURCE_TYPE_RTC;
+            rtc_wakeup->base.next = nullptr;
+            rtc_wakeup->ms = 0;
+            *wakeup_source = reinterpret_cast<hal_wakeup_source_base_t*>(rtc_wakeup);
+        } else {
+            hal_wakeup_source_gpio_t* gpio_wakeup = (hal_wakeup_source_gpio_t*)malloc(sizeof(hal_wakeup_source_gpio_t));
+            gpio_wakeup->base.size = sizeof(hal_wakeup_source_gpio_t);
+            gpio_wakeup->base.version = HAL_SLEEP_VERSION;
+            gpio_wakeup->base.type = HAL_WAKEUP_SOURCE_TYPE_GPIO;
+            gpio_wakeup->base.next = nullptr;
+            gpio_wakeup->pin = ret;
+            *wakeup_source = reinterpret_cast<hal_wakeup_source_base_t*>(gpio_wakeup);
+        }
     }
     return SYSTEM_ERROR_NONE;
 }
 
-static int hal_sleep_enter_hibernate_mode(const hal_sleep_config_t* config, hal_wakeup_source_base_t** wakeup_source) {
+static int enterHibernateMode(const hal_sleep_config_t* config, hal_wakeup_source_base_t** wakeup_source) {
     long seconds = 0;
     uint32_t flags = HAL_STANDBY_MODE_FLAG_DISABLE_WKP_PIN;
 
@@ -87,24 +131,49 @@ static int hal_sleep_enter_hibernate_mode(const hal_sleep_config_t* config, hal_
     return HAL_Core_Enter_Standby_Mode(seconds, flags);
 }
 
-int hal_sleep(const hal_sleep_config_t* config, hal_wakeup_source_base_t** wakeup_source, void* reserved) {
+int hal_sleep_validate_config(const hal_sleep_config_t* config, void* reserved) {
+    // Checks the sleep mode.
+    if (config->mode == HAL_SLEEP_MODE_NONE || config->mode >= HAL_SLEEP_MODE_MAX) {
+        return SYSTEM_ERROR_INVALID_ARGUMENT;
+    }
+    if (config->mode == HAL_SLEEP_MODE_ULTRA_LOW_POWER) {
+        return SYSTEM_ERROR_NOT_SUPPORTED;
+    }
+
+    // Checks the wakeup sources
+    auto wakeupSource = config->wakeup_sources;
+    while (wakeupSource) {
+        if (!isWakeupSourceSupported(config->mode, wakeupSource)) {
+            return SYSTEM_ERROR_NOT_SUPPORTED;
+        }
+        wakeupSource = wakeupSource->next;
+    }
+
+    return SYSTEM_ERROR_NONE;
+}
+
+int hal_sleep_enter(const hal_sleep_config_t* config, hal_wakeup_source_base_t** wakeup_source, void* reserved) {
     CHECK_TRUE(config, SYSTEM_ERROR_INVALID_ARGUMENT);
 
-    int ret = SYSTEM_ERROR_NOT_SUPPORTED;
+    // Check it again just in case.
+    CHECK(hal_sleep_validate_config(config, nullptr));
+
+    int ret = SYSTEM_ERROR_NONE;
 
     switch (config->mode) {
         case HAL_SLEEP_MODE_STOP: {
-            ret = hal_sleep_enter_stop_mode(config, wakeup_source);
+            ret = enterStopMode(config, wakeup_source);
             break;
         }
         case HAL_SLEEP_MODE_ULTRA_LOW_POWER: {
             break;
         }
         case HAL_SLEEP_MODE_HIBERNATE: {
-            ret = hal_sleep_enter_hibernate_mode(config, wakeup_source);
+            ret = enterHibernateMode(config, wakeup_source);
             break;
         }
         default: {
+            ret = SYSTEM_ERROR_NOT_SUPPORTED;
             break;
         }
     }

--- a/system/inc/system_sleep.h
+++ b/system/inc/system_sleep.h
@@ -209,9 +209,11 @@ public:
         if (!valid_) {
             return valid_;
         }
-        if (sleepMode() == SystemSleepMode::NONE || wakeupSource() == nullptr) {
+        if (sleepMode() == SystemSleepMode::NONE) {
             return false;
         }
+        // Wakeup source can be nullptr herein. HAL sleep API will check
+        // if target platform supports not being woken up by any wakeup source.
         return true;
     }
 

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -280,6 +280,10 @@ static int system_sleep_network_resume(network_interface_index index) {
 int system_sleep_ext(const hal_sleep_config_t* config, hal_wakeup_source_base_t** reason, void* reserved) {
     SYSTEM_THREAD_CONTEXT_SYNC(system_sleep_ext(config, reason, reserved));
 
+    // Validates the sleep configuration previous to disconnecting network,
+    // so that the network status remains if the configuration is invalid.
+    CHECK(hal_sleep_validate_config(config, nullptr));
+
     SystemSleepConfigurationHelper configHelper(config);
     int ret;
 
@@ -342,7 +346,7 @@ int system_sleep_ext(const hal_sleep_config_t* config, hal_wakeup_source_base_t*
     system_power_management_sleep();
 
     // Now enter sleep mode
-    ret = hal_sleep(config, reason, reserved);
+    ret = hal_sleep_enter(config, reason, nullptr);
 
     // Start RGB signaling.
     led_set_update_enabled(1, nullptr); // Enable background LED updates

--- a/wiring/src/spark_wiring_system.cpp
+++ b/wiring/src/spark_wiring_system.cpp
@@ -71,7 +71,11 @@ SleepResult SystemClass::sleep(Spark_Sleep_TypeDef sleepMode, long seconds, Slee
     } else {
         SystemSleepConfiguration config;
         // For backward compatibility. This API will make device enter HIBERNATE mode.
-        config.mode(SystemSleepMode::HIBERNATE).duration(seconds * 1000);
+        config.mode(SystemSleepMode::HIBERNATE);
+
+        if (seconds > 0) {
+            config.duration(seconds * 1000);
+        }
 
         if (sleepMode == SLEEP_MODE_DEEP && (flags.value() & SYSTEM_SLEEP_FLAG_NETWORK_STANDBY)) {
 #if HAL_PLATFORM_CELLULAR
@@ -104,7 +108,11 @@ SleepResult SystemClass::sleep(Spark_Sleep_TypeDef sleepMode, long seconds, Slee
 SleepResult SystemClass::sleepPinImpl(const uint16_t* pins, size_t pins_count, const InterruptMode* modes, size_t modes_count, long seconds, SleepOptionFlags flags) {
     SystemSleepConfiguration config;
     // For backward compatibility. This API will make device enter STOP mode.
-    config.mode(SystemSleepMode::STOP).duration(seconds * 1000);
+    config.mode(SystemSleepMode::STOP);
+
+    if (seconds > 0) {
+        config.duration(seconds * 1000);
+    }
 
     for (size_t i = 0; i < pins_count; i++) {
         config.gpio(pins[i], ((i < modes_count) ? modes[i] : modes[modes_count - 1]));
@@ -127,6 +135,10 @@ SleepResult SystemClass::sleepPinImpl(const uint16_t* pins, size_t pins_count, c
 
     if (flags.value() & SYSTEM_SLEEP_FLAG_NO_WAIT) {
         config.wait(SystemSleepWait::NO_WAIT);
+    }
+
+    if (!(flags.value() & SYSTEM_SLEEP_FLAG_DISABLE_WKP_PIN)) {
+        config.gpio(WKP, RISING);
     }
 
     System.sleep(config);

--- a/wiring/src/spark_wiring_system.cpp
+++ b/wiring/src/spark_wiring_system.cpp
@@ -49,6 +49,7 @@ void SystemClass::reset(uint32_t data)
 
 SystemSleepResult SystemClass::sleep(const SystemSleepConfiguration& config) {
     if (!config.valid()) {
+        LOG(ERROR, "System sleep configuration is invalid.");
         System.systemSleepResult_ = SystemSleepResult(SYSTEM_ERROR_INVALID_ARGUMENT);
     } else {
         SystemSleepResult result;


### PR DESCRIPTION
### Problem

Device enters sleep mode without checking the sleep configuration.

### Solution

Sleep configuration that varies from platforms should be validated before entering sleep mode.

### Steps to Test

N/A

### Example App

```c
#include "application.h"

SYSTEM_MODE(MANUAL);

Serial1LogHandler log(115200, LOG_LEVEL_INFO);

/* This function is called once at start up ----------------------------------*/
void setup()
{
    LOG(INFO, "Application started");
}

/* This function loops forever -----------------------------------------------*/
void loop()
{
    delay(3000);

    LOG(INFO, "Device is going to enter sleep mode.");
    SystemSleepConfiguration config;
    config.mode(SystemSleepMode::HIBERNATE).gpio(D0, RISING).gpio(WKP, RISING);
    SystemSleepResult result = System.sleep(config);
    LOG(INFO, "Device is woken up by: %d, error: %d.", result.wakeupReason(), result.error());
    if (result.error() != SYSTEM_ERROR_NONE) {
        while(1);
    }
}
```

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
