### PR TITLE
Add support for chunked transfer of USB request/reply data

### DIFF
--- a/system/inc/system_control.h
+++ b/system/inc/system_control.h
@@ -40,6 +40,7 @@ extern "C" {
 // Control request types
 typedef enum ctrl_request_type {
     CTRL_REQUEST_INVALID = 0,
+    CTRL_REQUEST_ECHO = 1,
     CTRL_REQUEST_APP_CUSTOM = 10,
     CTRL_REQUEST_DEVICE_ID = 20,
     CTRL_REQUEST_SERIAL_NUMBER = 21,
@@ -123,8 +124,7 @@ typedef enum ctrl_request_type {
     CTRL_REQUEST_MESH_LEAVE_NETWORK = 1009,
     CTRL_REQUEST_MESH_GET_NETWORK_INFO = 1010,
     CTRL_REQUEST_MESH_SCAN_NETWORKS = 1011,
-    CTRL_REQUEST_MESH_GET_NETWORK_DIAGNOSTICS = 1012,
-    CTRL_REQUEST_MESH_TEST = 1111 // FIXME
+    CTRL_REQUEST_MESH_GET_NETWORK_DIAGNOSTICS = 1012
 } ctrl_request_type;
 
 // Control request data

--- a/system/src/control/config.cpp
+++ b/system/src/control/config.cpp
@@ -247,6 +247,15 @@ int getFeature(ctrl_request* req) {
     return 0;
 }
 
+int echo(ctrl_request* req) {
+    const int ret = system_ctrl_alloc_reply_data(req, req->request_size, nullptr);
+    if (ret != 0) {
+        return ret;
+    }
+    memcpy(req->reply_data, req->request_data, req->request_size);
+    return 0;
+}
+
 #if !HAL_PLATFORM_OPENTHREAD
 
 int handleSetSecurityKeyRequest(ctrl_request* req) {

--- a/system/src/control/config.h
+++ b/system/src/control/config.h
@@ -34,6 +34,7 @@ int isDeviceSetupDone(ctrl_request* req);
 int setStartupMode(ctrl_request* req);
 int setFeature(ctrl_request* req);
 int getFeature(ctrl_request* req);
+int echo(ctrl_request* req);
 
 int handleSetClaimCodeRequest(ctrl_request* req);
 int handleIsClaimedRequest(ctrl_request* req);

--- a/system/src/control/mesh.cpp
+++ b/system/src/control/mesh.cpp
@@ -1735,15 +1735,6 @@ int getNetworkDiagnostics(ctrl_request* req) {
     return system_ctrl_alloc_reply_data(req, diagResult.written, nullptr);
 }
 
-int test(ctrl_request* req) {
-    const int ret = system_ctrl_alloc_reply_data(req, req->request_size, nullptr);
-    if (ret != 0) {
-        return ret;
-    }
-    memcpy(req->reply_data, req->request_data, req->request_size);
-    return 0;
-}
-
 } // particle::ctrl::mesh
 
 } // particle::ctrl

--- a/system/src/system_control_internal.cpp
+++ b/system/src/system_control_internal.cpp
@@ -190,6 +190,10 @@ void SystemControl::processRequest(ctrl_request* req, ControlRequestChannel* /* 
         setResult(req, control::config::setStartupMode(req));
         break;
     }
+    case CTRL_REQUEST_ECHO: {
+        setResult(req, control::config::echo(req));
+        break;
+    }
     case CTRL_REQUEST_GET_MODULE_INFO: {
         setResult(req, control::getModuleInfo(req));
         break;
@@ -453,10 +457,6 @@ void SystemControl::processRequest(ctrl_request* req, ControlRequestChannel* /* 
     }
     case CTRL_REQUEST_MESH_GET_NETWORK_DIAGNOSTICS: {
         setResult(req, ctrl::mesh::getNetworkDiagnostics(req));
-        break;
-    }
-    case CTRL_REQUEST_MESH_TEST: { // FIXME
-        setResult(req, ctrl::mesh::test(req));
         break;
     }
 #endif // HAL_PLATFORM_MESH

--- a/system/src/usb_control_request_channel.cpp
+++ b/system/src/usb_control_request_channel.cpp
@@ -298,6 +298,7 @@ bool particle::UsbControlRequestChannel::processInitRequest(HAL_USB_SetupRequest
     req->task.req = req;
     req->handler = nullptr;
     req->handlerData = nullptr;
+    req->offset = 0;
     req->result = SYSTEM_ERROR_UNKNOWN;
     req->id = ++lastReqId_;
     req->flags = 0;
@@ -395,24 +396,28 @@ bool particle::UsbControlRequestChannel::processSendRequest(HAL_USB_SetupRequest
     }
     if (!req || // Request not found
             req->state != RequestState::RECV_PAYLOAD || // Invalid request state
-            req->request_size != size) { // Unexpected size
+            req->offset + size > req->request_size) { // Unexpected size
         return false;
     }
     if (size <= MIN_WLENGTH) {
-        // Use an internal buffer provided by the HAL
+        // Use the internal buffer provided by the HAL
         if (!halReq->data) {
             return false;
         }
-        memcpy(req->request_data, halReq->data, size);
+        memcpy(req->request_data + req->offset, halReq->data, size);
     } else if (!halReq->data) {
         // Provide a buffer to the HAL
-        halReq->data = (uint8_t*)req->request_data;
+        halReq->data = (uint8_t*)req->request_data + req->offset;
         return true;
     }
-    // Invoke the request handler
-    req->task.func = invokeRequestHandler;
-    SystemISRTaskQueue.enqueue(&req->task);
-    req->state = RequestState::PENDING;
+    req->offset += size;
+    if (req->offset == req->request_size) {
+        // Invoke the request handler
+        req->task.func = invokeRequestHandler;
+        SystemISRTaskQueue.enqueue(&req->task);
+        req->offset = 0;
+        req->state = RequestState::PENDING;
+    }
     return true;
 }
 
@@ -428,19 +433,20 @@ bool particle::UsbControlRequestChannel::processRecvRequest(HAL_USB_SetupRequest
     }
     if (!req || // Request not found
             req->state != RequestState::DONE || // Invalid request state
-            req->reply_size != size || size == 0) { // Unexpected size
+            size == 0 || req->offset + size > req->reply_size) { // Unexpected size
         return false;
     }
     if (size <= MIN_WLENGTH) {
-        // Use an internal buffer provided by the HAL
+        // Use the internal buffer provided by the HAL
         if (!halReq->data) {
             return false;
         }
-        memcpy(halReq->data, req->reply_data, size);
+        memcpy(halReq->data, req->reply_data + req->offset, size);
     } else {
         // Provide a buffer to the HAL
-        halReq->data = (uint8_t*)req->reply_data;
+        halReq->data = (uint8_t*)req->reply_data + req->offset;
     }
+    req->offset += size;
     curReq_ = req;
     return true;
 }
@@ -655,10 +661,11 @@ uint8_t particle::UsbControlRequestChannel::halVendorRequestStateCallback(HAL_US
     const auto channel = static_cast<UsbControlRequestChannel*>(data);
     switch (state) {
     case HAL_USB_VENDOR_REQUEST_STATE_TX_COMPLETED: {
-        if (channel->curReq_) {
+        const auto req = channel->curReq_;
+        if (req && req->offset == req->reply_size) {
             // Set a result code that will be passed to the request completion handler
-            channel->curReq_->result = SYSTEM_ERROR_NONE;
-            channel->finishActiveRequest(channel->curReq_);
+            req->result = SYSTEM_ERROR_NONE;
+            channel->finishActiveRequest(req);
             channel->curReq_ = nullptr;
         }
         break;

--- a/system/src/usb_control_request_channel.h
+++ b/system/src/usb_control_request_channel.h
@@ -79,6 +79,7 @@ private:
         Request* next; // Next element in a list
         ctrl_completion_handler_fn handler; // Completion handler
         void* handlerData; // Completion handler data
+        size_t offset; // Offset in the request or reply data
         int result; // Result code
         uint16_t id; // Request ID
         uint8_t state; // Request state

--- a/user/tests/unit/led_service.cpp
+++ b/user/tests/unit/led_service.cpp
@@ -7,6 +7,8 @@
 
 #include "hippomocks.h"
 
+#include <functional>
+
 namespace {
 
 using namespace particle;


### PR DESCRIPTION
### Problem

libusb limits the maximum length of a control transfer's data stage to [4096 bytes](https://github.com/libusb/libusb/blob/f20f2be7825e34b5273af17fc0740c60bd352b32/libusb/os/linux_usbfs.h#L85). This causes larger USB control requests to fail.

### Solution

Implement support for chunked transfer of request/reply data by allowing the host to send multiple `SEND` and `RECV` requests for the same control request. This protocol change is backwards compatible with existing client implementations, i.e. newer versions of `particle-usb` will continue to work normally with older versions of Device OS that don't support chunked transfer.

### Steps to Test

- Run unit tests.
- Run integration tests from https://github.com/particle-iot/particle-usb/pull/19.

### References

- [ch43088]
