### PR TITLE
[Gen 3] Logging modem AT commands and data TX/RX by default on modular Boron/B SoM [ch33624]

### DIFF
--- a/hal/network/lwip/ppp_client.cpp
+++ b/hal/network/lwip/ppp_client.cpp
@@ -31,6 +31,10 @@ extern "C" {
 #include "system_error.h"
 #include "lwiplock.h"
 
+#undef LOG_COMPILE_TIME_LEVEL
+#define LOG_COMPILE_TIME_LEVEL LOG_LEVEL_ALL
+LOG_SOURCE_CATEGORY("net.ppp.client");
+
 using namespace particle::net::ppp;
 
 std::once_flag Client::once_;
@@ -168,6 +172,7 @@ int Client::input(const uint8_t* data, size_t size) {
       case STATE_CONNECTING:
       case STATE_DISCONNECTING:
       case STATE_CONNECTED: {
+        LOG(TRACE, "RX: %lu", size);
         err_t err = pppos_input_tcpip(pcb_, (u8_t*)data, size);
         if (err) {
           return SYSTEM_ERROR_INTERNAL;
@@ -355,7 +360,7 @@ uint32_t Client::outputCb(ppp_pcb* pcb, uint8_t* data, uint32_t len, void* ctx) 
 }
 
 uint32_t Client::output(const uint8_t* data, size_t len) {
-  LOG_DEBUG(TRACE, "Outputing %lu bytes", len);
+  LOG(TRACE, "TX: %lu", len);
 
   if (oCb_) {
     auto r = oCb_(data, len, oCbCtx_);

--- a/hal/network/ncp/at_parser/at_parser_impl.cpp
+++ b/hal/network/ncp/at_parser/at_parser_impl.cpp
@@ -30,7 +30,9 @@
 #include <cctype>
 #include <cassert>
 
-LOG_SOURCE_CATEGORY("ncp.at")
+#undef LOG_COMPILE_TIME_LEVEL
+#define LOG_COMPILE_TIME_LEVEL LOG_LEVEL_ALL
+LOG_SOURCE_CATEGORY("ncp.at");
 
 namespace particle {
 

--- a/hal/src/boron/network/sara_ncp_client.cpp
+++ b/hal/src/boron/network/sara_ncp_client.cpp
@@ -39,6 +39,9 @@
 
 #include <algorithm>
 
+#undef LOG_COMPILE_TIME_LEVEL
+#define LOG_COMPILE_TIME_LEVEL LOG_LEVEL_ALL
+
 #define CHECK_PARSER(_expr) \
         ({ \
             const auto _r = _expr; \


### PR DESCRIPTION
### Problem

As a user of a Gen 3 device, I would like the logging of modem AT commands and data TX/RX to be included in firmware by default on modular Boron/B SoM.

Unfortunately there is not enough space in modular firmware to enable all logging for Boron/B SoM, which is why it's only enabled for monolithic firmware.

### Solution

Enable a minimal subset of logs for Boron/B SoM by default in modular firmware:
- AT commands and URCs
- PPP Client TX and RX bytes

### Steps to Test

Local Build outputting logs on TX (Serial1):
`device-os/modular $ make clean all -s PLATFORM=boron COMPILE_LTO=n APP=tinker-serial1-debugging program-dfu`

### Example App

```c
// Build as modular app
// Outputting logs on USB (Serial)
SerialLogHandler logHandler(LOG_LEVEL_ALL);

void setup() {
}
void loop() {
}
```

### References

ch33624

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
