### PR TITLE
[Gen3] Frees up some flash space

### DIFF
--- a/hal/src/nRF52840/ble_hal.cpp
+++ b/hal/src/nRF52840/ble_hal.cpp
@@ -16,12 +16,13 @@
  */
 
 #include "logging.h"
-LOG_SOURCE_CATEGORY("hal.ble")
+LOG_SOURCE_CATEGORY("hal.ble");
 
 #include "ble_hal.h"
 
 #if HAL_PLATFORM_BLE
-#define LOG_CHECKED_ERRORS 1
+// Uncomment to enable more error logs
+// #define LOG_CHECKED_ERRORS 1
 
 /* Headers included from nRF5_SDK/components/softdevice/s140/headers */
 #include "ble.h"

--- a/hal/src/nRF52840/mbedtls/mbedtls_config_platform.h
+++ b/hal/src/nRF52840/mbedtls/mbedtls_config_platform.h
@@ -1698,7 +1698,8 @@
  *
  * This module provides debugging functions.
  */
-#define MBEDTLS_DEBUG_C
+// Disabled to reduce flash usage
+// #define MBEDTLS_DEBUG_C
 
 /**
  * \def MBEDTLS_DEBUG_COMPILE_TIME_LEVEL


### PR DESCRIPTION
### Problem

We've run out of flash space (again) on some Gen 3 platforms.

### Solution

This PR:
1. Disables logging of checked errors in BLE HAL
2. Disable mbedtls debug logs

Both of these things together free up about 20-30k.

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
