### PR TITLE
[b5som] hal: quectel modems don't support CHAP:<APN> in CGDCONT

### DIFF
--- a/hal/src/b5som/network/quectel_ncp_client.cpp
+++ b/hal/src/b5som/network/quectel_ncp_client.cpp
@@ -727,8 +727,7 @@ int QuectelNcpClient::configureApn(const CellularNetworkConfig& conf) {
         netConf_ = networkConfigForImsi(buf, strlen(buf));
     }
     // FIXME: for now IPv4 context only
-    auto resp = parser_.sendCommand("AT+CGDCONT=1,\"IP\",\"%s%s\"",
-            (netConf_.hasUser() && netConf_.hasPassword()) ? "CHAP:" : "",
+    auto resp = parser_.sendCommand("AT+CGDCONT=1,\"IP\",\"%s\"",
             netConf_.hasApn() ? netConf_.apn() : "");
     const int r = CHECK_PARSER(resp.readResult());
     CHECK_TRUE(r == AtResponse::OK, SYSTEM_ERROR_UNKNOWN);


### PR DESCRIPTION
### Problem

Quectel modems don't support `CHAP:` option for `AT+CGDCONT` in the form: `AT+CGDCONT=<id>,<type>,CHAP:<apn>`.

This is something that has been copied over from ublox NCP client and should be removed.

This will cause problems (i.e. inability to get cellular connectivity due to `ERROR` response from the modem) for custom credentials with username and password as well as with empty credentials and Kore SIM cards due to our IMSI-based credentials store (see `network_config_db.cpp`: `{ "204", "04", "vfd1.korem2m.com", "kore", "kore" } // Kore/Vodafone`).

```
0000078901 [ncp.at] TRACE: > AT+CGDCONT=1,"IP","CHAP:vfd1.korem2m.com"
0000078949 [ncp.at] TRACE: < ERROR
```

### Solution

Remove `CHAP:` generation for `AT+CGDCONT`.

### Steps to Test

Use Kore SIM (e.g. internal), clear the credentials, the device should not connect on `develop`, `AT+CGDCONT`` should case an error. It should connect fine with this branch.

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
