### PR TITLE
Adds internal function to modify cellular registration timeout

### DIFF
--- a/hal/inc/cellular_hal.h
+++ b/hal/inc/cellular_hal.h
@@ -143,7 +143,7 @@ bool cellular_sim_ready(void* reserved);
  * 
  * @param timeout: registration timeout in milliseconds
  */
-cellular_result_t cellular_registration_timeout_set(system_tick_t timeout, void* reserved = NULL);
+cellular_result_t cellular_registration_timeout_set(system_tick_t timeout, void* reserved);
 
 /**
  * Attempts to stop/resume the cellular modem from performing AT operations.

--- a/hal/inc/cellular_hal.h
+++ b/hal/inc/cellular_hal.h
@@ -139,6 +139,13 @@ cellular_result_t cellular_global_identity(CellularGlobalIdentity* cgi, void* re
 bool cellular_sim_ready(void* reserved);
 
 /**
+ * Change the timeout a SIM has to register on the cellular network before the modem is reset
+ * 
+ * @param timeout: registration timeout in milliseconds
+ */
+cellular_result_t cellular_registration_timeout_set(system_tick_t timeout, void* reserved = NULL);
+
+/**
  * Attempts to stop/resume the cellular modem from performing AT operations.
  * Called from another thread or ISR context.
  *

--- a/hal/inc/hal_dynalib_cellular.h
+++ b/hal/inc/hal_dynalib_cellular.h
@@ -84,6 +84,7 @@ DYNALIB_FN(36, hal_cellular, cellular_credentials_clear, int(void*))
 #endif // !HAL_PLATFORM_MESH
 
 DYNALIB_FN(BASE_CELL_IDX + 0, hal_cellular, cellular_global_identity, cellular_result_t(CellularGlobalIdentity*, void*))
+DYNALIB_FN(BASE_CELL_IDX + 1, hal_cellular, cellular_registration_timeout_set, cellular_result_t(system_tick_t, void*))
 
 DYNALIB_END(hal_cellular)
 

--- a/hal/network/ncp/cellular/cellular_hal.cpp
+++ b/hal/network/ncp/cellular/cellular_hal.cpp
@@ -276,6 +276,18 @@ cellular_result_t cellular_global_identity(CellularGlobalIdentity* cgi_, void* r
     return SYSTEM_ERROR_NONE;
 }
 
+cellular_result_t cellular_registration_timeout_set(system_tick_t timeout, void*) {
+    // Acquire Cellular NCP Client
+    const auto mgr = cellularNetworkManager();
+    CHECK_TRUE(mgr, SYSTEM_ERROR_UNKNOWN);
+    const auto client = mgr->ncpClient();
+    CHECK_TRUE(client, SYSTEM_ERROR_UNKNOWN);
+
+    CHECK(client->setRegistrationTimeout(timeout));
+
+    return SYSTEM_ERROR_NONE;
+}
+
 bool cellular_sim_ready(void* reserved) {
     return false;
 }

--- a/hal/network/ncp/cellular/cellular_hal.cpp
+++ b/hal/network/ncp/cellular/cellular_hal.cpp
@@ -276,13 +276,14 @@ cellular_result_t cellular_global_identity(CellularGlobalIdentity* cgi_, void* r
     return SYSTEM_ERROR_NONE;
 }
 
-cellular_result_t cellular_registration_timeout_set(system_tick_t timeout, void*) {
+cellular_result_t cellular_registration_timeout_set(system_tick_t timeout, void* reserved) {
     // Acquire Cellular NCP Client
     const auto mgr = cellularNetworkManager();
     CHECK_TRUE(mgr, SYSTEM_ERROR_UNKNOWN);
     const auto client = mgr->ncpClient();
     CHECK_TRUE(client, SYSTEM_ERROR_UNKNOWN);
 
+    (void)reserved;
     CHECK(client->setRegistrationTimeout(timeout));
 
     return SYSTEM_ERROR_NONE;

--- a/hal/network/ncp/cellular/cellular_ncp_client.h
+++ b/hal/network/ncp/cellular/cellular_ncp_client.h
@@ -126,6 +126,7 @@ public:
     virtual int getIccid(char* buf, size_t size) = 0;
     virtual int getImei(char* buf, size_t size) = 0;
     virtual int getSignalQuality(CellularSignalQuality* qual) = 0;
+    virtual int setRegistrationTimeout(unsigned timeout) = 0;
 };
 
 inline CellularNcpClientConfig::CellularNcpClientConfig() :

--- a/hal/src/b5som/network/quectel_ncp_client.h
+++ b/hal/src/b5som/network/quectel_ncp_client.h
@@ -63,6 +63,7 @@ public:
     virtual int getIccid(char* buf, size_t size) override;
     virtual int getImei(char* buf, size_t size) override;
     virtual int getSignalQuality(CellularSignalQuality* qual) override;
+    virtual int setRegistrationTimeout(unsigned timeout) override;
 
 private:
     AtParser parser_;

--- a/hal/src/b5som/network/quectel_ncp_client.h
+++ b/hal/src/b5som/network/quectel_ncp_client.h
@@ -90,6 +90,7 @@ private:
     RegistrationState cereg_ = RegistrationState::NotRegistered;
     system_tick_t regStartTime_;
     system_tick_t regCheckTime_;
+    unsigned registrationTimeout_;
 
     int queryAndParseAtCops(CellularSignalQuality* qual);
     int initParser(Stream* stream);

--- a/hal/src/boron/network/sara_ncp_client.h
+++ b/hal/src/boron/network/sara_ncp_client.h
@@ -63,6 +63,7 @@ public:
     virtual int getIccid(char* buf, size_t size) override;
     virtual int getImei(char* buf, size_t size) override;
     virtual int getSignalQuality(CellularSignalQuality* qual) override;
+    virtual int setRegistrationTimeout(unsigned timeout) override;
 
 private:
     AtParser parser_;
@@ -92,6 +93,7 @@ private:
     system_tick_t registeredTime_;
     system_tick_t powerOnTime_;
     bool memoryIssuePresent_ = false;
+    unsigned registrationTimeout_;
 
     int queryAndParseAtCops(CellularSignalQuality* qual);
     int initParser(Stream* stream);

--- a/hal/src/electron/cellular_hal.cpp
+++ b/hal/src/electron/cellular_hal.cpp
@@ -382,6 +382,11 @@ cellular_result_t cellular_global_identity(CellularGlobalIdentity* cgi_, void* r
     return SYSTEM_ERROR_NONE;
 }
 
+cellular_result_t cellular_registration_timeout_set(system_tick_t timeout, void*) {
+    // setting the registration timeout is not supported on the Electron/E-Series
+    return SYSTEM_ERROR_NOT_SUPPORTED;
+}
+
 cellular_result_t cellular_sms_received_handler_set(_CELLULAR_SMS_CB_MDM cb, void* data,
                                                     void* reserved)
 {

--- a/user/tests/wiring/api/cellular.cpp
+++ b/user/tests/wiring/api/cellular.cpp
@@ -144,4 +144,8 @@ test(api_cellular_lock_unlock) {
     API_COMPILE(Cellular.unlock());
 }
 
+test(api_cellular_registration_timeout_set) {
+    API_COMPILE(cellular_registration_timeout_set(60 * 60 * 1000)); // 60 minutes
+}
+
 #endif

--- a/user/tests/wiring/api/cellular.cpp
+++ b/user/tests/wiring/api/cellular.cpp
@@ -145,7 +145,7 @@ test(api_cellular_lock_unlock) {
 }
 
 test(api_cellular_registration_timeout_set) {
-    API_COMPILE(cellular_registration_timeout_set(60 * 60 * 1000)); // 60 minutes
+    API_COMPILE(cellular_registration_timeout_set(60 * 60 * 1000, nullptr)); // 60 minutes
 }
 
 #endif


### PR DESCRIPTION
### Problem

Cellular registration timeout is hardcoded to 5 minutes.  There may be instances where this needs to be specified by the user for their particular carrier/application.

### Solution

Add cellular_registration_timout_set() API to override the 5 minute default timeout.

### Example App

```c
#include "Particle.h"
SYSTEM_THREAD(ENABLED);
void setup() {
  cellular_registration_timeout_set(60 * 60 * 1000, nullptr); // 60 minutes
}
```

### References

- [CH45850]

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
