### PR TITLE
[Gen 3] Boron 2G/3G fixes

### DIFF
--- a/hal/src/boron/network/sara_ncp_client.cpp
+++ b/hal/src/boron/network/sara_ncp_client.cpp
@@ -83,7 +83,7 @@ inline system_tick_t millis() {
 }
 
 const auto UBLOX_NCP_DEFAULT_SERIAL_BAUDRATE = 115200;
-const auto UBLOX_NCP_RUNTIME_SERIAL_BAUDRATE_U2 = 921600;
+const auto UBLOX_NCP_RUNTIME_SERIAL_BAUDRATE_U2 = 115200;
 
 const auto UBLOX_NCP_MAX_MUXER_FRAME_SIZE = 1509;
 const auto UBLOX_NCP_KEEPALIVE_PERIOD = 5000; // milliseconds
@@ -1011,8 +1011,9 @@ int SaraNcpClient::registerNet() {
     connectionState(NcpConnectionState::CONNECTING);
     registeredTime_ = 0;
 
-    // NOTE: up to 3 mins
-    r = CHECK_PARSER(parser_.execCommand(3 * 60 * 1000, "AT+COPS=0,2"));
+    // NOTE: up to 3 mins (FIXME: there seems to be a bug where this timeout of 3 minutes
+    //       is not being respected by u-blox modems.  Setting to 5 for now.)
+    r = CHECK_PARSER(parser_.execCommand(5 * 60 * 1000, "AT+COPS=0,2"));
     // Ignore response code here
     // CHECK_TRUE(r == AtResponse::OK, SYSTEM_ERROR_AT_NOT_OK);
 


### PR DESCRIPTION
### Problem

Boron 2G/3G devices are having a hard time connecting to the cellular tower due to a few issues:
- AT+COPS=0 command is taking longer than the specified 3 minutes to resolve, if this times out initialization can fail early, and the cycle will repeat.
- The AT interface has been noted to not respond directly after the baudrate change command AT+IPR=921600 which causes a similar response.
- The observed status here is "blinking green"

### Solution

- We are working with u-blox and Kore to gain insight on why COPS=0 is taking so long to resolve, but while we are digging in to pinpoint the source of the problem we will increase the timeout from 3 minutes to 5 minutes to help it complete successfully.
- The baudrate was changed to 115200 to avoid the issue seen with no response.  When other issues are resolved, we can revisit this and bump it back up to a higher value after more testing.

### Steps to Test

- Manual testing in certain locations required.  These issues don't present themselves everywhere.  But these can be tested with the tinker-serial-debugging app.

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] N/A - Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
