### PR TITLE
Don't check and write protect the system firmware on boot

### DIFF
--- a/hal/src/stm32f2xx/core_hal_stm32f2xx.c
+++ b/hal/src/stm32f2xx/core_hal_stm32f2xx.c
@@ -383,11 +383,6 @@ void HAL_Core_Config(void)
     // fully intialize the RTOS.
     HAL_Core_Setup_override_interrupts();
 
-#if defined(MODULAR_FIRMWARE) && MODULAR_FIRMWARE
-    // write protect system module parts if not already protected
-    FLASH_WriteProtectMemory(FLASH_INTERNAL, CORE_FW_ADDRESS, USER_FIRMWARE_IMAGE_LOCATION - CORE_FW_ADDRESS, true);
-#endif /* defined(MODULAR_FIRMWARE) && MODULAR_FIRMWARE */
-
 #ifdef HAS_SERIAL_FLASH
     //Initialize Serial Flash
     sFLASH_Init();


### PR DESCRIPTION
### Problem

There is a possibility that in low power / unreliable power situations that checking if the system firmware flash pages are write protected will give the wrong result. The system firmware would attempt to write protect the system firmware flash pages, which erases the option bytes and if the device resets at that moment, sets the write protection level 1.

### Solution

Remove all code paths in device boot that might change the option bytes which contains the write protection configuration.

### Steps to Test

Flash bootloader, system firmware and user firmware over the air.

Check the write protection registers by connecting to the device with a debugger using Workbench and running `monitor flash info 0` in the Debug Console.
```
#0 : stm32f2x at 0x08000000, size 0x00100000, buswidth 0, chipwidth 0
	#  0: 0x00000000 (0x4000 16kB) protected
	#  1: 0x00004000 (0x4000 16kB) not protected
	#  2: 0x00008000 (0x4000 16kB) not protected
	#  3: 0x0000c000 (0x4000 16kB) not protected
	#  4: 0x00010000 (0x10000 64kB) not protected
	#  5: 0x00020000 (0x20000 128kB) not protected
	#  6: 0x00040000 (0x20000 128kB) not protected
	#  7: 0x00060000 (0x20000 128kB) not protected
	#  8: 0x00080000 (0x20000 128kB) not protected
	#  9: 0x000a0000 (0x20000 128kB) not protected
	# 10: 0x000c0000 (0x20000 128kB) not protected
```

This shows that only the bootloader section is write protected.

### References

A similar change was made to avoid locking the bootloader on every boot was done in https://github.com/particle-iot/device-os/pull/1578

---

### Completeness

- [x] User is totes amazing for contributing!
- [X] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [X] Problem and Solution clearly stated
- [ ] Run acceptance tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
