### PR TITLE
[Gen 3] Workaround for QSPI/XIP nRF52840 hardware anomaly 215

### DIFF
--- a/hal/src/nRF52840/exflash_hal.c
+++ b/hal/src/nRF52840/exflash_hal.c
@@ -31,9 +31,11 @@
 #include "logging.h"
 #include "flash_common.h"
 #include "nrf_nvic.h"
+#include "concurrent_hal.h"
 
 enum qspi_cmds_t {
     QSPI_STD_CMD_WRSR     = 0x01,
+    QSPI_STD_CMD_WREN     = 0x06,
     QSPI_STD_CMD_RSTEN    = 0x66,
     QSPI_STD_CMD_RST      = 0x99,
     QSPI_MX25_CMD_ENSO    = 0xb1,
@@ -45,10 +47,88 @@ enum qspi_cmds_t {
 
 static const size_t MX25_OTP_SECTOR_SIZE = 4096 / 8; /* 4Kb or 512B */
 
-#define WAIT_COMPLETION() while(nrfx_qspi_mem_busy_check() != NRF_SUCCESS);
+// Mitigations for nRF52840 anomaly 215
+// [215] QSPI: Reading QSPI registers after XIP might halt CPU
+// Conditions
+// Init and start QSPI, use XIP, then write to or read any QSPI register with an offset above 0x600.
+//
+// Consequences
+// CPU halts.
+//
+// Workaround
+// Trigger QSPI TASKS_ACTIVATE after XIP is used before accessing any QSPI register with an offset above 0x600.
+//
+// Our testing showed that another side effect of this anomaly is not a lockup
+// but a failure to perform any Custom Instructions that rely on CISTR* registers
+// of QSPI peripheral, which are located above offset 0x600.
+//
+// The mitigation that we are implementing is rather simple. We need to ensure that no XIP
+// access occurs while we are performing Custom Instructions and we need to apply the workaround mentioned
+// in the anomaly description (QSPI TASKS_ACTIVATE).
+// There is a performance penalty because we are disabling RTOS thread scheduling,
+// however because we are only doing this for CINSTR, it should be minimal.
 
-static int configure_memory()
-{
+static void exflash_qspi_activate() {
+    nrf_qspi_event_clear(NRF_QSPI, NRF_QSPI_EVENT_READY);
+    nrf_qspi_task_trigger(NRF_QSPI, NRF_QSPI_TASK_ACTIVATE);
+    while (!nrf_qspi_event_check(NRF_QSPI, NRF_QSPI_EVENT_READY));
+}
+
+static nrfx_err_t exflash_qspi_wait_completion() {
+    nrfx_err_t err = NRFX_ERROR_INTERNAL;
+
+    // Certain operations like block erasure, may leave the flash
+    // in a weird state where we can't talk to it for substantial periods of time
+    // (up to ~30ms, seen in practice). According to the datasheet, the erasure for example may take up to 200ms!
+    // Ensure we have initialized comms with the external flash properly by running TASK_ACTIVATE
+    // before applying workaround to decrease the time we are staying with RTOS scheduling disabled.
+    exflash_qspi_activate();
+
+    do {
+        // Enter critical section
+        os_thread_scheduling(false, NULL);
+
+        // Run QSPI TASK_ACTIVATE task as a workaround for the anomaly 215
+        exflash_qspi_activate();
+
+        // This may block for up to 1ms (QSPI_DEF_WAIT_TIME_US * QSPI_DEF_WAIT_ATTEMPTS)
+        err = nrfx_qspi_mem_busy_check();
+
+        // Exit critical section
+        os_thread_scheduling(true, NULL);
+    } while (err == NRFX_ERROR_BUSY);
+
+    return err;
+}
+
+static nrfx_err_t exflash_qspi_cinstr_xfer(nrf_qspi_cinstr_conf_t const* p_config, void const* p_tx_buffer, void* p_rx_buffer) {
+    // Certain operations like block erasure, may leave the flash
+    // in a weird state where we can't talk to it for substantial periods of time
+    // (up to ~30ms, seen in practice). According to the datasheet, the erasure for example may take up to 200ms!
+    // Ensure we have initialized comms with the external flash properly by running TASK_ACTIVATE
+    // before applying workaround to decrease the time we are staying with RTOS scheduling disabled.
+    exflash_qspi_activate();
+
+    // Enter critical section
+    os_thread_scheduling(false, NULL);
+
+    // Run QSPI TASK_ACTIVATE task as a workaround for the anomaly 215
+    exflash_qspi_activate();
+
+    // This may block for up to 1ms (QSPI_DEF_WAIT_TIME_US * QSPI_DEF_WAIT_ATTEMPTS)
+    nrfx_err_t err = nrfx_qspi_cinstr_xfer(p_config, p_tx_buffer, p_rx_buffer);
+
+    // Exit critical section
+    os_thread_scheduling(true, NULL);
+    return err;
+}
+
+static nrfx_err_t exflash_qspi_cinstr_quick_send(uint8_t opcode, nrf_qspi_cinstr_len_t length, void const* p_tx_buffer) {
+    nrf_qspi_cinstr_conf_t config = NRFX_QSPI_DEFAULT_CINSTR(opcode, length);
+    return exflash_qspi_cinstr_xfer(&config, p_tx_buffer, NULL);
+}
+
+static int configure_memory() {
     uint8_t temporary = 0x40;
     uint32_t err_code;
     nrf_qspi_cinstr_conf_t cinstr_cfg = {
@@ -61,7 +141,7 @@ static int configure_memory()
     };
 
     // Send reset enable
-    err_code = nrfx_qspi_cinstr_xfer(&cinstr_cfg, NULL, NULL);
+    err_code = exflash_qspi_cinstr_xfer(&cinstr_cfg, NULL, NULL);
     if (err_code)
     {
         return -1;
@@ -69,7 +149,7 @@ static int configure_memory()
 
     // Send reset command
     cinstr_cfg.opcode = QSPI_STD_CMD_RST;
-    err_code = nrfx_qspi_cinstr_xfer(&cinstr_cfg, NULL, NULL);
+    err_code = exflash_qspi_cinstr_xfer(&cinstr_cfg, NULL, NULL);
     if (err_code)
     {
         return -2;
@@ -78,7 +158,7 @@ static int configure_memory()
     // Switch to qspi mode
     cinstr_cfg.opcode = QSPI_STD_CMD_WRSR;
     cinstr_cfg.length = NRF_QSPI_CINSTR_LEN_2B;
-    err_code = nrfx_qspi_cinstr_xfer(&cinstr_cfg, &temporary, NULL);
+    err_code = exflash_qspi_cinstr_xfer(&cinstr_cfg, &temporary, NULL);
     if (err_code)
     {
         return -3;
@@ -92,11 +172,11 @@ static int perform_write(uintptr_t addr, const uint8_t* data, size_t size) {
 }
 
 static int enter_secure_otp() {
-    return nrfx_qspi_cinstr_quick_send(QSPI_MX25_CMD_ENSO, 1, NULL);
+    return exflash_qspi_cinstr_quick_send(QSPI_MX25_CMD_ENSO, 1, NULL);
 }
 
 static int exit_secure_otp() {
-    return nrfx_qspi_cinstr_quick_send(QSPI_MX25_CMD_EXSO, 1, NULL);
+    return exflash_qspi_cinstr_quick_send(QSPI_MX25_CMD_EXSO, 1, NULL);
 }
 
 int hal_exflash_init(void)
@@ -181,7 +261,7 @@ int hal_exflash_write(uintptr_t addr, const uint8_t* data_buf, size_t data_size)
     hal_exflash_lock();
     int ret = hal_flash_common_write(addr, data_buf, data_size,
                                      &perform_write, &hal_flash_common_dummy_read);
-    WAIT_COMPLETION();
+    exflash_qspi_wait_completion();
     hal_exflash_unlock();
     return ret;
 }
@@ -206,8 +286,6 @@ int hal_exflash_read(uintptr_t addr, uint8_t* data_buf, size_t data_size)
             if (ret != NRF_SUCCESS) {
                 goto hal_exflash_read_done;
             }
-
-            WAIT_COMPLETION();
 
             /* Move the data if necessary */
             if (dst_aligned != data_buf || src_aligned != addr) {
@@ -245,8 +323,6 @@ int hal_exflash_read(uintptr_t addr, uint8_t* data_buf, size_t data_size)
             goto hal_exflash_read_done;
         }
 
-        WAIT_COMPLETION();
-
         const unsigned offset_front = addr - src_aligned;
 
         memcpy(data_buf, tmpbuf + offset_front, data_size);
@@ -274,7 +350,7 @@ static int erase_common(uintptr_t start_addr, size_t num_blocks, nrf_qspi_erase_
             goto erase_common_done;
         }
 
-        WAIT_COMPLETION();
+        exflash_qspi_wait_completion();
 
         start_addr += block_length;
     }
@@ -427,7 +503,7 @@ int hal_exflash_special_command(hal_exflash_special_sector_t sp, hal_exflash_com
             };
 
             /* Send sleep command */
-            ret = nrfx_qspi_cinstr_xfer(&cinstr_cfg, NULL, NULL);
+            ret = exflash_qspi_cinstr_xfer(&cinstr_cfg, NULL, NULL);
         } else if (cmd == HAL_EXFLASH_COMMAND_WAKEUP) {
             const nrf_qspi_cinstr_conf_t cinstr_cfg = {
                 .opcode    = QSPI_MX25_CMD_READ_ID,
@@ -439,7 +515,7 @@ int hal_exflash_special_command(hal_exflash_special_sector_t sp, hal_exflash_com
             };
 
             /* Wake up external flash from deep power down modeby sending read id command */
-            ret = nrfx_qspi_cinstr_xfer(&cinstr_cfg, NULL, NULL);
+            ret = exflash_qspi_cinstr_xfer(&cinstr_cfg, NULL, NULL);
         }
     } else if (sp == HAL_EXFLASH_SPECIAL_SECTOR_OTP) {
         /* OTP-specific commands */
@@ -449,7 +525,7 @@ int hal_exflash_special_command(hal_exflash_special_sector_t sp, hal_exflash_com
              * This will block the whole OTP region.
              */
             uint8_t v = 0x01;
-            ret = nrfx_qspi_cinstr_quick_send(QSPI_MX25_CMD_WRSCUR, 2, &v);
+            ret = exflash_qspi_cinstr_quick_send(QSPI_MX25_CMD_WRSCUR, 2, &v);
         }
     }
 

--- a/hal/src/nRF52840/exflash_hal.c
+++ b/hal/src/nRF52840/exflash_hal.c
@@ -85,17 +85,22 @@ static nrfx_err_t exflash_qspi_wait_completion() {
     exflash_qspi_activate();
 
     do {
+#if MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
         // Enter critical section
         os_thread_scheduling(false, NULL);
 
         // Run QSPI TASK_ACTIVATE task as a workaround for the anomaly 215
         exflash_qspi_activate();
+#endif // MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
 
         // This may block for up to 1ms (QSPI_DEF_WAIT_TIME_US * QSPI_DEF_WAIT_ATTEMPTS)
         err = nrfx_qspi_mem_busy_check();
 
+#if MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
         // Exit critical section
         os_thread_scheduling(true, NULL);
+#endif // MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
+
     } while (err == NRFX_ERROR_BUSY);
 
     return err;
@@ -109,17 +114,21 @@ static nrfx_err_t exflash_qspi_cinstr_xfer(nrf_qspi_cinstr_conf_t const* p_confi
     // before applying workaround to decrease the time we are staying with RTOS scheduling disabled.
     exflash_qspi_activate();
 
+#if MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
     // Enter critical section
     os_thread_scheduling(false, NULL);
 
     // Run QSPI TASK_ACTIVATE task as a workaround for the anomaly 215
     exflash_qspi_activate();
+#endif // MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
 
     // This may block for up to 1ms (QSPI_DEF_WAIT_TIME_US * QSPI_DEF_WAIT_ATTEMPTS)
     nrfx_err_t err = nrfx_qspi_cinstr_xfer(p_config, p_tx_buffer, p_rx_buffer);
 
+#if MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
     // Exit critical section
     os_thread_scheduling(true, NULL);
+#endif // MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
     return err;
 }
 

--- a/hal/src/nRF52840/ota_flash_hal.cpp
+++ b/hal/src/nRF52840/ota_flash_hal.cpp
@@ -110,14 +110,14 @@ int fetch_device_private_key_ex(uint8_t *key_buf, uint16_t length)
 
 int fetch_device_public_key_ex(void)
 {
-    uint8_t pubkey[DCT_DEVICE_PUBLIC_KEY_SIZE];
-    memset(pubkey, 0, sizeof(pubkey));
     bool udp = false;
 #if HAL_PLATFORM_CLOUD_UDP
     udp = HAL_Feature_Get(FEATURE_CLOUD_UDP);
 #endif
-    uint8_t privkey[DCT_DEVICE_PRIVATE_KEY_SIZE];
-    memset(privkey, 0, sizeof(privkey));
+    size_t key_size = udp ? DCT_ALT_DEVICE_PUBLIC_KEY_SIZE : DCT_DEVICE_PUBLIC_KEY_SIZE;
+    uint8_t pubkey[key_size] = {};
+
+    uint8_t privkey[DCT_DEVICE_PRIVATE_KEY_SIZE] = {};
     if (fetch_device_private_key_ex(privkey, sizeof(privkey)))
     {
         return -1;
@@ -135,15 +135,13 @@ int fetch_device_public_key_ex(void)
     }
 #endif
     int offset = udp ? DCT_ALT_DEVICE_PUBLIC_KEY_OFFSET : DCT_DEVICE_PUBLIC_KEY_OFFSET;
-    size_t key_size = udp ? DCT_ALT_DEVICE_PUBLIC_KEY_SIZE : DCT_DEVICE_PUBLIC_KEY_SIZE;
-    uint8_t flash_pub_key[DCT_DEVICE_PUBLIC_KEY_SIZE];
-    memset(flash_pub_key, 0, sizeof(flash_pub_key));
-    if (dct_read_app_data_copy(offset, flash_pub_key, DCT_DEVICE_PUBLIC_KEY_SIZE))
+    uint8_t flash_pub_key[key_size] = {};
+    if (dct_read_app_data_copy(offset, flash_pub_key, key_size))
     {
         return -2;
     }
 
-    if ((extracted_length > 0) && memcmp(pubkey, flash_pub_key, sizeof(pubkey))) {
+    if ((extracted_length > 0) && memcmp(pubkey, flash_pub_key, key_size)) {
         if (dct_write_app_data(pubkey, offset, key_size))
         {
             return -3;

--- a/hal/src/stm32f2xx/ota_flash_hal_stm32f2xx.cpp
+++ b/hal/src/stm32f2xx/ota_flash_hal_stm32f2xx.cpp
@@ -552,17 +552,19 @@ const uint8_t* fetch_device_public_key(uint8_t lock)
         return NULL;
     }
 
-    uint8_t pubkey[DCT_DEVICE_PUBLIC_KEY_SIZE];
-    memset(pubkey, 0, sizeof(pubkey));
     bool udp = false;
 #if HAL_PLATFORM_CLOUD_UDP
     udp = HAL_Feature_Get(FEATURE_CLOUD_UDP);
 #endif
+
+    size_t key_size = udp ? DCT_ALT_DEVICE_PUBLIC_KEY_SIZE : DCT_DEVICE_PUBLIC_KEY_SIZE;
+    uint8_t pubkey[key_size] = {};
+
     const uint8_t* priv = fetch_device_private_key(1);
     int extracted_length = 0;
 #if HAL_PLATFORM_CLOUD_UDP
     if (udp) {
-        extracted_length = extract_public_ec_key(pubkey, sizeof(pubkey), priv);
+        extracted_length = extract_public_ec_key(pubkey, key_size, priv);
     }
 #endif
 #if HAL_PLATFORM_CLOUD_TCP
@@ -574,9 +576,8 @@ const uint8_t* fetch_device_public_key(uint8_t lock)
     fetch_device_private_key(0);
 
     int offset = udp ? DCT_ALT_DEVICE_PUBLIC_KEY_OFFSET : DCT_DEVICE_PUBLIC_KEY_OFFSET;
-    size_t key_size = udp ? DCT_ALT_DEVICE_PUBLIC_KEY_SIZE : DCT_DEVICE_PUBLIC_KEY_SIZE;
     const uint8_t* flash_pub_key = (const uint8_t*)dct_read_app_data_lock(offset);
-    if ((extracted_length > 0) && memcmp(pubkey, flash_pub_key, sizeof(pubkey))) {
+    if ((extracted_length > 0) && memcmp(pubkey, flash_pub_key, key_size)) {
         dct_read_app_data_unlock(offset);
         dct_write_app_data(pubkey, offset, key_size);
         flash_pub_key = (const uint8_t*)dct_read_app_data_lock(offset);

--- a/user/tests/release-tests.json
+++ b/user/tests/release-tests.json
@@ -327,6 +327,12 @@
                 },
                 {
                     "enabled": true,
+                    "name": "no_fixture_stress",
+                    "path": "wiring",
+                    "use_threading": false
+                },
+                {
+                    "enabled": true,
                     "name": "ble_central",
                     "path": "wiring/ble_central_peripheral"
                 },
@@ -671,6 +677,12 @@
                     "name": "no_fixture_ble",
                     "path": "wiring",
                     "use_threading": true
+                },
+                {
+                    "enabled": true,
+                    "name": "no_fixture_stress",
+                    "path": "wiring",
+                    "use_threading": false
                 },
                 {
                     "enabled": true,
@@ -1027,6 +1039,12 @@
                 },
                 {
                     "enabled": true,
+                    "name": "no_fixture_stress",
+                    "path": "wiring",
+                    "use_threading": false
+                },
+                {
+                    "enabled": true,
                     "name": "ble_central",
                     "path": "wiring/ble_central_peripheral"
                 },
@@ -1380,6 +1398,12 @@
                 },
                 {
                     "enabled": true,
+                    "name": "no_fixture_stress",
+                    "path": "wiring",
+                    "use_threading": false
+                },
+                {
+                    "enabled": true,
                     "name": "ble_central",
                     "path": "wiring/ble_central_peripheral"
                 },
@@ -1730,6 +1754,12 @@
                     "name": "no_fixture_ble",
                     "path": "wiring",
                     "use_threading": true
+                },
+                {
+                    "enabled": true,
+                    "name": "no_fixture_stress",
+                    "path": "wiring",
+                    "use_threading": false
                 },
                 {
                     "enabled": true,
@@ -3572,6 +3602,12 @@
                 },
                 {
                     "enabled": true,
+                    "name": "no_fixture_stress",
+                    "path": "wiring",
+                    "use_threading": false
+                },
+                {
+                    "enabled": true,
                     "name": "ble_central",
                     "path": "wiring/ble_central_peripheral"
                 },
@@ -3922,6 +3958,12 @@
                     "name": "no_fixture_ble",
                     "path": "wiring",
                     "use_threading": true
+                },
+                {
+                    "enabled": true,
+                    "name": "no_fixture_stress",
+                    "path": "wiring",
+                    "use_threading": false
                 },
                 {
                     "enabled": true,

--- a/user/tests/wiring/no_fixture_stress/application.cpp
+++ b/user/tests/wiring/no_fixture_stress/application.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+SYSTEM_MODE(MANUAL);
+
+// make clean all TEST=wiring/no_fixture_long_running PLATFORM=electron -s COMPILE_LTO=n program-dfu DEBUG_BUILD=y
+// make clean all TEST=wiring/no_fixture_long_running PLATFORM=electron -s COMPILE_LTO=n program-dfu DEBUG_BUILD=y USE_THREADING=y
+//
+// Serial1LogHandler logHandler(115200, LOG_LEVEL_ALL, {
+//     { "comm", LOG_LEVEL_NONE }, // filter out comm messages
+//     { "system", LOG_LEVEL_INFO } // only info level for system messages
+// });
+
+UNIT_TEST_APP();
+
+// Enable threading if compiled with "USE_THREADING=y"
+#if PLATFORM_THREADING == 1 && USE_THREADING == 1
+SYSTEM_THREAD(ENABLED);
+#endif

--- a/user/tests/wiring/no_fixture_stress/exflash.cpp
+++ b/user/tests/wiring/no_fixture_stress/exflash.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "application.h"
+#include "unit-test/unit-test.h"
+#include "scope_guard.h"
+
+#if HAL_PLATFORM_FILESYSTEM && HAL_PLATFORM_NRF52840
+
+test(EXFLASH_00_ConcurrentXipAndQspiUsageStress) {
+    std::atomic_bool exit;
+    exit = false;
+
+    Thread* t = new Thread("test", [](void* param) -> os_thread_return_t {
+        std::atomic_bool& exit = *static_cast<std::atomic_bool*>(param);
+        constexpr size_t exflashSize = 4 * 1024 * 1024; // 4MB
+        while (!exit) {
+            for (uint32_t* addr = (uint32_t*)EXTERNAL_FLASH_XIP_BASE; !exit && addr < (uint32_t*)(EXTERNAL_FLASH_XIP_BASE + exflashSize); addr++) {
+                // We need to be doing something useful here, so that XIP accesses are not optimized out
+                uint32_t result = HAL_Core_Compute_CRC32((const uint8_t*)addr, sizeof(*addr));
+                (void)HAL_Core_Compute_CRC32((const uint8_t*)&result, sizeof(result));
+            }
+        }
+    }, (void*)&exit);
+    assertTrue(t);
+
+    SCOPE_GUARD({
+        exit = true;
+        t->join();
+        delete t;
+    });
+
+    // 30 seconds
+    constexpr system_tick_t duration = 30 * 1000;
+
+    for (system_tick_t now = millis(), begin = now; now < begin + duration; now = millis()) {
+        uint32_t val = rand();
+        uint32_t tmp;
+        EEPROM.get(0, tmp);
+
+        val = val ^ tmp;
+        EEPROM.put(0, val);
+        EEPROM.get(0, tmp);
+        assertEqual(tmp, val);
+    }
+}
+
+#endif // HAL_PLATFORM_FILESYSTEM && HAL_PLATFORM_NRF52840

--- a/user/tests/wiring/no_fixture_stress/test.mk
+++ b/user/tests/wiring/no_fixture_stress/test.mk
@@ -1,0 +1,18 @@
+INCLUDE_DIRS += $(SOURCE_PATH)/$(USRSRC)  # add user sources to include path
+# add C and CPP files - if USRSRC is not empty, then add a slash
+CPPSRC += $(call target_files,$(USRSRC_SLASH),*.cpp)
+CSRC += $(call target_files,$(USRSRC_SLASH),*.c)
+
+APPSOURCES=$(call target_files,$(USRSRC_SLASH),*.cpp)
+APPSOURCES+=$(call target_files,$(USRSRC_SLASH),*.c)
+ifeq ($(strip $(APPSOURCES)),)
+$(error "No sources found in $(SOURCE_PATH)/$(USRSRC)")
+endif
+
+ifeq ("${USE_THREADING}","y")
+USE_THREADING_VALUE=1
+else
+USE_THREADING_VALUE=0
+endif
+
+CFLAGS += -DUSE_THREADING=${USE_THREADING_VALUE}


### PR DESCRIPTION
### Problem

See #1832 

https://infocenter.nordicsemi.com/index.jsp?topic=%2Ferrata_nRF52840_Rev2%2FERR%2FnRF52840%2FRev2%2Flatest%2Fanomaly_840_215.html&anchor=anomaly_840_215

The gist of the problem is that we concurrently access the external QSPI flash through two different mechanisms: QSPI peripheral and XIP (maps the external flash into the microcontroller memory space). As outlined in the anomaly description, the access to certain QSPI registers after the access to XIP region may lead to a complete CPU lockup. In our testing it showed also that under some circumstances it's not a complete lockup, but a failure to communicate with the QSPI flash.

### Solution

The original plan was to any and all usage of XIP (currently used for OTA and module info retreival e.g. when sending a describe, validating modules, doing a particle serial inspect).

However, instead we've figured out an alternative approach in using the workarounds suggested by Nordic in conjunction with RTOS critical sections in particular pieces of external flash HAL to prevent other threads from accessing the XIP region while we are performing the operation on the QSPI peripheral.

There is a slight performance impact, however. I've added benchmarking to exflash_hal and the results while heavily writing into the filesystem are:

1. On average we'll be spending **~1.2ms** with RTOS scheduler disabled while performing certain QSPI operations (like write and erase). This should be pretty much insignificant, as the RTOS scheduler resolution is 1ms.
2. The maximum time I've seen RTOS scheduler disabled due to applied workaround was **5.7ms**, however such values were seen only during early initialization and there were no spikes seen after than with values stabilizing at **~1.2ms**

This PR also fixes issues with EC public key handling, which caused a DCT write on every boot.

### Steps to Test

`wiring/no_fixture_stress`

### Example App

N/A

### References

- Closes #1832
- [CH38816]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
