### PR TITLE
prevent expansion of `EXTRA_CFLAGS` build env var

### DIFF
--- a/user/build.mk
+++ b/user/build.mk
@@ -77,7 +77,7 @@ CFLAGS += -DSPARK_PLATFORM_NET=$(PLATFORM_NET)
 BUILTINS_EXCLUDE = malloc free realloc
 CFLAGS += $(addprefix -fno-builtin-,$(BUILTINS_EXCLUDE))
 
-CFLAGS += $(EXTRA_CFLAGS)
+CFLAGS += $(value EXTRA_CFLAGS)
 
 # Use application source info regardless of release/debug build
 CFLAGS += -DLOG_INCLUDE_SOURCE_INFO=1


### PR DESCRIPTION
### Problem

special shell variables are expanded when the `EXTRA_CFLAGS` build env var is processed by the build system resulting in build failures.

```sh
$echo $EXTRA_CFLAGS
-DFOO="$"
```

...then build

```sh
cd "${DEVICE_OS_PATH}/main" && make all program-dfu
#snipping out log noise...
/bin/sh: -c: line 0: unexpected EOF while looking for matching `"'
/bin/sh: -c: line 1: syntax error: unexpected end of file
```

### Solution

don't expand the `EXTRA_CFLAGS` variable when setting `CFLAGS`

https://www.gnu.org/software/make/manual/html_node/Value-Function.html

### Steps to Test

build an app which [reads in a custom symbol](https://docs.particle.io/support/particle-tools-faq/local-build/#defining-custom-symbols) set via `EXTRA_CFLAGS` and reports the value as a cloud variable then build:

```
EXTRA_CFLAGS='-DFOO="$"' cd "${DEVICE_OS_PATH}/main" && make all program-dfu
```

...once your device comes back online, check the variable using the cli

```sh
particle variable get <device> foo
```

undo the change and retry the steps above to see the failure state

### Example App

```c
#define __STRINGIFY(x) #x
#define STRINGIFY(x) __STRINGIFY(x)

String foo = STRINGIFY(FOO);

void setup() {
  Particle.variable("name", &foo, STRING);
}

void loop() {

}
```

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
