### PR TITLE
Clear WLAN WD so it does not interfere with Particle.connect()

### DIFF
--- a/system/src/system_network_internal.h
+++ b/system/src/system_network_internal.h
@@ -557,6 +557,8 @@ public:
             WLAN_CONNECTING = 0;
             WLAN_CONNECTED = 0;
             WLAN_DHCP_PENDING = 0;
+            CLR_WLAN_WD();
+            LOG(INFO, "Clearing WLAN WD in disconnect()");
 
             cloud_disconnect(true, false, CLOUD_DISCONNECT_REASON_NETWORK_DISCONNECT);
             const auto diag = NetworkDiagnostics::instance();

--- a/user/tests/wiring/cell_connect_after_off/application.cpp
+++ b/user/tests/wiring/cell_connect_after_off/application.cpp
@@ -1,0 +1,14 @@
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+// make clean all TEST=wiring/no_fixture PLATFORM=electron -s COMPILE_LTO=n program-dfu DEBUG_BUILD=y
+// make clean all TEST=wiring/no_fixture PLATFORM=electron -s COMPILE_LTO=n program-dfu DEBUG_BUILD=y USE_THREADING=y
+//
+ // Serial1LogHandler logHandler(115200, LOG_LEVEL_ALL, {
+  // { "comm", LOG_LEVEL_NONE }, // filter out comm messages
+  // { "system", LOG_LEVEL_INFO } // only info level for system messages
+ // });
+
+UNIT_TEST_APP();
+
+SYSTEM_THREAD(ENABLED);

--- a/user/tests/wiring/cell_connect_after_off/cellular_conn_after_off.cpp
+++ b/user/tests/wiring/cell_connect_after_off/cellular_conn_after_off.cpp
@@ -46,7 +46,7 @@ test(CELLULAR_CONN_01_conn_after_off)
     // Wait sometime for Particle.connect() to try
     delay(30000);
     // Verify that a connection attempt has been made
-    assertEqual(g_state_conn_attempt, true);
+    assertEqual(g_state_conn_attempt, 1);
 }
 
 #endif // Wiring_Cellular == 1

--- a/user/tests/wiring/cell_connect_after_off/cellular_conn_after_off.cpp
+++ b/user/tests/wiring/cell_connect_after_off/cellular_conn_after_off.cpp
@@ -1,20 +1,18 @@
-/**
- ******************************************************************************
-  Copyright (c) 2015 Particle Industries, Inc.  All rights reserved.
-
-  This library is free software; you can redistribute it and/or
-  modify it under the terms of the GNU Lesser General Public
-  License as published by the Free Software Foundation, either
-  version 3 of the License, or (at your option) any later version.
-
-  This library is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  Lesser General Public License for more details.
-
-  You should have received a copy of the GNU Lesser General Public
-  License along with this library; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
+/*
+ * Copyright (c) 2018 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
  */
 
 #include "application.h"
@@ -31,7 +29,7 @@ static void nwstatus_callback_handler(system_event_t ev, int param) {
     }
 }
 
-test(CELLULAR_CONN_01_conn-after-off)
+test(CELLULAR_CONN_01_conn_after_off)
 {
     // Connect to Particle cloud
     Particle.connect();
@@ -41,12 +39,14 @@ test(CELLULAR_CONN_01_conn-after-off)
     delay(60000);
     // Callback handler for network_status
     System.on(network_status, nwstatus_callback_handler);
+    // clear g_state_conn_attempt just-in-case
+    g_state_conn_attempt = 0;
     // Check that Particle.connect() attempts to work after the delay
     Particle.connect();
     // Wait sometime for Particle.connect() to try
     delay(30000);
     // Verify that a connection attempt has been made
-    assertEqual((g_state_conn_attempt==1), true);
+    assertEqual(g_state_conn_attempt, true);
 }
 
 #endif // Wiring_Cellular == 1

--- a/user/tests/wiring/cell_connect_after_off/cellular_conn_after_off.cpp
+++ b/user/tests/wiring/cell_connect_after_off/cellular_conn_after_off.cpp
@@ -1,0 +1,52 @@
+/**
+ ******************************************************************************
+  Copyright (c) 2015 Particle Industries, Inc.  All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation, either
+  version 3 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************
+ */
+
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+#if Wiring_Cellular == 1
+
+// Global variable to indicate a connection attempt
+volatile int g_state_conn_attempt = 0;
+
+static void nwstatus_callback_handler(system_event_t ev, int param) {
+    if (param == network_status_connecting){
+        g_state_conn_attempt = 1;
+    }
+}
+
+test(CELLULAR_CONN_01_conn-after-off)
+{
+    // Connect to Particle cloud
+    Particle.connect();
+    delay(30000);
+    // Power off the cell radio
+    Cellular.off();
+    delay(60000);
+    // Callback handler for network_status
+    System.on(network_status, nwstatus_callback_handler);
+    // Check that Particle.connect() attempts to work after the delay
+    Particle.connect();
+    // Wait sometime for Particle.connect() to try
+    delay(30000);
+    // Verify that a connection attempt has been made
+    assertEqual((g_state_conn_attempt==1), true);
+}
+
+#endif // Wiring_Cellular == 1

--- a/user/tests/wiring/cell_connect_after_off/readme.md
+++ b/user/tests/wiring/cell_connect_after_off/readme.md
@@ -1,0 +1,5 @@
+The following illustrates the problem statement:
+> Keep antenna disconnected for this test
+1. With antenna disconnected, run `Particle.connect()`
+2. Run `Cellular.off()`
+3. After 60 sec, run `Particle.connect()` again, and verify that you see cellular AT traffic to turn on the modem or connect to the network. 


### PR DESCRIPTION
…icle.connect()

<details>
  <summary><i>submission notes</i></summary>

```
**Important:** Please sanitize/remove any confidential info like usernames, passwords, org names, product names/ids, access tokens, client ids/secrets, or anything else you don't wish to share.

Please Read and Sign the Contributor License Agreement ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md)).

You may also delete this submission notes header if you'd like. Thank you for contributing!
```
</details>

### Problem

In the case when a `'first' Particle.connect()` does not connect to cloud, and `Cellular.off()` was called to power off the cell radio, `subsequent Particle.connect()` does not work. The problem is due to `WLAN Watchdog timer` not clearing when Particle.connect() fails or when cellular.off() was called. The un-cleared watchdog timer interferes with the subsequent Particle.connect().

### Solution

Clearing the watchdog timer in disconnect() clears the timer, and unblocks entering the subsequent `Particle.connect()`

### Steps to Test

Run the following sequence with removed antenna and the second Particle.connect() should work
1. `Particle.connect()` failed (remove antenna to emulate this)
2. Call `Cellular.off()`
3. `Particle.connect()` tried again - this should work

### Example App

```c
#include "Particle.h"

#define DEBUG_WAN_WD

SerialLogHandler logHandler(LOG_LEVEL_ALL);

SYSTEM_THREAD(ENABLED);
SYSTEM_MODE(SEMI_AUTOMATIC);

#define CELLULAR_INTERVAL (60000)

uint32_t t0;

void setup() {
  Particle.connect();
  t0 = millis() - 30000;
}

void loop() {
  static bool cancel = true;
  if(millis() - t0 > CELLULAR_INTERVAL)
  {
    t0 = millis();
    Log.info("Cellular %s", cancel ? "CANCEL" : "RESUME");
    if(cancel)
    {
      Log.info("calling cellular.off");
      Cellular.off();
    }
    else
    {
      //Cellular.on();
      Log.info("calling particle.connect from inside loop");
      Particle.connect();
    }
    Log.info("Cellular %s COMPLETE", cancel ? "CANCEL" : "RESUME");
    cancel = !cancel;
  }
}```

### References

https://app.clubhouse.io/particle/story/30564/cellular-off-breaks-subsequent-particle-connect-when-not-connected-to-cellular-network

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
