### PR TITLE
Fix parsing of large AT command responses

### DIFF
--- a/hal/network/ncp/at_parser/at_response.h
+++ b/hal/network/ncp/at_parser/at_response.h
@@ -138,7 +138,7 @@ protected:
     AtResponseReader(AtResponseReader&& reader);
     virtual ~AtResponseReader();
 
-    int readLine(char* buf, size_t size, size_t offs);
+    int readLine(char** buf, size_t size, size_t offs);
     int error(int ret);
 
     AtResponseReader& operator=(AtResponseReader&& reader);


### PR DESCRIPTION
### Problem

AT command parser incorrectly handles modem responses larger than 128 bytes.

### Solution

Make sure memory reallocations are handled correctly in `AtResponseReader`.

### Steps to Test

Issue a command that typically produces a large response (e.g. `AT+COPS=?`) and make sure the entire response data is being read correctly:
```cpp
auto resp = parser_.sendCommand("AT+COPS=?");
const CString s = resp.readLine();
CHECK_PARSER_OK(resp.readResult());
LOG_PRINT(TRACE, (const char*)s);
LOG_PRINT(TRACE, "\r\n");
```

Before:
```
+COPS: (0,"MegaFon RUS","MegaFon","25002",0),(0,"MegaFon RUS","MegaFon","25002",7),(0,"Beeline","Beeline","25099",7),(0,"MegaFo��� P
```

After:
```
+COPS: (0,"MegaFon RUS","MegaFon","25002",7),(0,"MTS RUS","MTS RUS","25001",0),(0,"Beeline","Beeline","25099",0),(0,"Beeline","Beeline","25099",2),(0,"Tele2 RU","Tele2","25020",2),(0,"MTS RUS","MTS RUS","25001",2),(0,"250 11","250 11","25011",7),(0,"MegaFon RUS","MegaFon","25002",2),(0,"MegaFon RUS","MegaFon","25002",0),(0,"MTS RUS","MTS RUS","25001",7),(0,"Tele2 RU","Tele2","25020",7),(0,"Beeline","Beeline","25099",7),(0,"Tele2 RU","Tele2","25020",0),,(0-4),(0-2)
```