### PR TITLE
Fix CGI for Quectel modems

### DIFF
--- a/hal/src/b5som/network/quectel_ncp_client.cpp
+++ b/hal/src/b5som/network/quectel_ncp_client.cpp
@@ -38,6 +38,7 @@
 #include "spark_wiring_vector.h"
 
 #include <algorithm>
+#include <limits>
 
 #undef LOG_COMPILE_TIME_LEVEL
 #define LOG_COMPILE_TIME_LEVEL LOG_LEVEL_ALL
@@ -152,90 +153,97 @@ int QuectelNcpClient::initParser(Stream* stream) {
     auto parserConf = AtParserConfig().stream(stream).commandTerminator(AtCommandTerminator::CRLF);
     parser_.destroy();
     CHECK(parser_.init(std::move(parserConf)));
-    CHECK(parser_.addUrcHandler("+CREG",
-                                [](AtResponseReader* reader, const char* prefix, void* data) -> int {
-                                    const auto self = (QuectelNcpClient*)data;
-                                    int val[4] = {-1,-1,-1,-1};
-                                    char atResponse[64] = {0};
-                                    // Take a copy of AT response for multi-pass scanning
-                                    CHECK_PARSER_URC(reader->readLine(atResponse, sizeof(atResponse)));
-                                    // Parse response ignoring mode (replicate URC response)
-                                    int r = ::sscanf(atResponse, "+CREG: %*d,%d,\"%x\",\"%x\",%d", &val[0], &val[1], &val[2], &val[3]);
-                                    // Reparse URC as direct response
-                                    if (0 >= r) {
-                                        r = CHECK_PARSER_URC(
-                                            ::sscanf(atResponse, "+CREG: %d,\"%x\",\"%x\",%d", &val[0], &val[1], &val[2], &val[3]));
-                                    }
-                                    CHECK_TRUE(r >= 1, SYSTEM_ERROR_AT_RESPONSE_UNEXPECTED);
-                                    // Home network or roaming
-                                    if (val[0] == 1 || val[0] == 5) {
-                                        self->creg_ = RegistrationState::Registered;
-                                    } else {
-                                        self->creg_ = RegistrationState::NotRegistered;
-                                    }
-                                    self->checkRegistrationState();
-                                    // Cellular Global Identity (partial)
-                                    self->cgi_.location_area_code = static_cast<uint16_t>(val[1]);
-                                    self->cgi_.cell_id = val[2];
-                                    return SYSTEM_ERROR_NONE;
-                                },
-                                this));
-    CHECK(parser_.addUrcHandler("+CGREG",
-                                [](AtResponseReader* reader, const char* prefix, void* data) -> int {
-                                    const auto self = (QuectelNcpClient*)data;
-                                    int val[4] = {-1,-1,-1,-1};
-                                    char atResponse[64] = {0};
-                                    // Take a copy of AT response for multi-pass scanning
-                                    CHECK_PARSER_URC(reader->readLine(atResponse, sizeof(atResponse)));
-                                    // Parse response ignoring mode (replicate URC response)
-                                    int r = ::sscanf(atResponse, "+CGREG: %*d,%d,\"%x\",\"%x\",%d,\"%*x\"", &val[0], &val[1], &val[2], &val[3]);
-                                    // Reparse URC as direct response
-                                    if (0 >= r) {
-                                        r = CHECK_PARSER_URC(
-                                            ::sscanf(atResponse, "+CGREG: %d,\"%x\",\"%x\",%d,\"%*x\"", &val[0], &val[1], &val[2], &val[3]));
-                                    }
-                                    CHECK_TRUE(r >= 1, SYSTEM_ERROR_AT_RESPONSE_UNEXPECTED);
-                                    // Home network or roaming
-                                    if (val[0] == 1 || val[0] == 5) {
-                                        self->cgreg_ = RegistrationState::Registered;
-                                    } else {
-                                        self->cgreg_ = RegistrationState::NotRegistered;
-                                    }
-                                    self->checkRegistrationState();
-                                    // Cellular Global Identity (partial)
-                                    self->cgi_.location_area_code = val[1];
-                                    self->cgi_.cell_id = val[2];
-                                    return SYSTEM_ERROR_NONE;
-                                },
-                                this));
-    CHECK(parser_.addUrcHandler("+CEREG",
-                                [](AtResponseReader* reader, const char* prefix, void* data) -> int {
-                                    const auto self = (QuectelNcpClient*)data;
-                                    int val[4] = {-1,-1,-1,-1};
-                                    char atResponse[64] = {0};
-                                    // Take a copy of AT response for multi-pass scanning
-                                    CHECK_PARSER_URC(reader->readLine(atResponse, sizeof(atResponse)));
-                                    // Parse response ignoring mode (replicate URC response)
-                                    int r = ::sscanf(atResponse, "+CEREG: %*d,%d,\"%x\",\"%x\",%d", &val[0], &val[1], &val[2], &val[3]);
-                                    // Reparse URC as direct response
-                                    if (0 >= r) {
-                                        r = CHECK_PARSER_URC(
-                                            ::sscanf(atResponse, "+CEREG: %d,\"%x\",\"%x\",%d", &val[0], &val[1], &val[2], &val[3]));
-                                    }
-                                    CHECK_TRUE(r >= 1, SYSTEM_ERROR_AT_RESPONSE_UNEXPECTED);
-                                    // Home network or roaming
-                                    if (val[0] == 1 || val[0] == 5) {
-                                        self->cereg_ = RegistrationState::Registered;
-                                    } else {
-                                        self->cereg_ = RegistrationState::NotRegistered;
-                                    }
-                                    self->checkRegistrationState();
-                                    // Cellular Global Identity (partial)
-                                    self->cgi_.location_area_code = val[1];
-                                    self->cgi_.cell_id = val[2];
-                                    return SYSTEM_ERROR_NONE;
-                                },
-                                this));
+
+    // NOTE: These URC handlers need to take care of both the URCs and direct responses to the commands.
+    // See CH28408
+
+    using LacType = decltype(CellularGlobalIdentity::location_area_code);
+    using CidType = decltype(CellularGlobalIdentity::cell_id);
+
+    //+CREG: <n>,<stat>[,<lac>,<ci>[,<Act>]]
+    //+CREG: <stat>[,<lac>,<ci>[,<Act>]]
+    CHECK(parser_.addUrcHandler("+CREG", [](AtResponseReader* reader, const char* prefix, void* data) -> int {
+        const auto self = (QuectelNcpClient*)data;
+        unsigned int val[4] = {};
+        char atResponse[64] = {};
+        // Take a copy of AT response for multi-pass scanning
+        CHECK_PARSER_URC(reader->readLine(atResponse, sizeof(atResponse)));
+        // Parse response ignoring mode (replicate URC response)
+        int r = ::sscanf(atResponse, "+CREG: %*u,%u,\"%x\",\"%x\",%u", &val[0], &val[1], &val[2], &val[3]);
+        // Reparse URC as direct response
+        if (0 >= r) {
+            r = CHECK_PARSER_URC(
+                ::sscanf(atResponse, "+CREG: %u,\"%x\",\"%x\",%u", &val[0], &val[1], &val[2], &val[3]));
+        }
+        CHECK_TRUE(r >= 1, SYSTEM_ERROR_AT_RESPONSE_UNEXPECTED);
+        // Home network or roaming
+        if (val[0] == 1 || val[0] == 5) {
+            self->creg_ = RegistrationState::Registered;
+        } else {
+            self->creg_ = RegistrationState::NotRegistered;
+        }
+        self->checkRegistrationState();
+        // Cellular Global Identity (partial)
+        self->cgi_.location_area_code = r >= 2 ? static_cast<LacType>(val[1]) : std::numeric_limits<LacType>::max();
+        self->cgi_.cell_id = r >= 3 ? static_cast<CidType>(val[2]) : std::numeric_limits<CidType>::max();
+        return SYSTEM_ERROR_NONE;
+    }, this));
+    //+CGREG: <n>,<stat>[,<lac>,<ci>[,<Act>]]
+    //+CGREG: <stat>[,<lac>,<ci>[,<Act>]]
+    CHECK(parser_.addUrcHandler("+CGREG", [](AtResponseReader* reader, const char* prefix, void* data) -> int {
+        const auto self = (QuectelNcpClient*)data;
+        unsigned int val[4] = {};
+        char atResponse[64] = {};
+        // Take a copy of AT response for multi-pass scanning
+        CHECK_PARSER_URC(reader->readLine(atResponse, sizeof(atResponse)));
+        // Parse response ignoring mode (replicate URC response)
+        int r = ::sscanf(atResponse, "+CGREG: %*u,%u,\"%x\",\"%x\",%u", &val[0], &val[1], &val[2], &val[3]);
+        // Reparse URC as direct response
+        if (0 >= r) {
+            r = CHECK_PARSER_URC(
+                ::sscanf(atResponse, "+CGREG: %u,\"%x\",\"%x\",%u", &val[0], &val[1], &val[2], &val[3]));
+        }
+        CHECK_TRUE(r >= 1, SYSTEM_ERROR_AT_RESPONSE_UNEXPECTED);
+        // Home network or roaming
+        if (val[0] == 1 || val[0] == 5) {
+            self->cgreg_ = RegistrationState::Registered;
+        } else {
+            self->cgreg_ = RegistrationState::NotRegistered;
+        }
+        self->checkRegistrationState();
+        // Cellular Global Identity (partial)
+        self->cgi_.location_area_code = r >= 2 ? static_cast<LacType>(val[1]) : std::numeric_limits<LacType>::max();
+        self->cgi_.cell_id = r >= 3 ? static_cast<CidType>(val[2]) : std::numeric_limits<CidType>::max();
+        return SYSTEM_ERROR_NONE;
+    }, this));
+    //+CEREG: <n>,<stat>[,<tac>,<ci>[,<Act>]]
+    //+CEREG: <stat>[,<tac>,<ci>[,<Act>]]
+    CHECK(parser_.addUrcHandler("+CEREG", [](AtResponseReader* reader, const char* prefix, void* data) -> int {
+        const auto self = (QuectelNcpClient*)data;
+        unsigned int val[4] = {};
+        char atResponse[64] = {};
+        // Take a copy of AT response for multi-pass scanning
+        CHECK_PARSER_URC(reader->readLine(atResponse, sizeof(atResponse)));
+        // Parse response ignoring mode (replicate URC response)
+        int r = ::sscanf(atResponse, "+CEREG: %*u,%u,\"%x\",\"%x\",%u", &val[0], &val[1], &val[2], &val[3]);
+        // Reparse URC as direct response
+        if (0 >= r) {
+            r = CHECK_PARSER_URC(
+                ::sscanf(atResponse, "+CEREG: %u,\"%x\",\"%x\",%u", &val[0], &val[1], &val[2], &val[3]));
+        }
+        CHECK_TRUE(r >= 1, SYSTEM_ERROR_AT_RESPONSE_UNEXPECTED);
+        // Home network or roaming
+        if (val[0] == 1 || val[0] == 5) {
+            self->cereg_ = RegistrationState::Registered;
+        } else {
+            self->cereg_ = RegistrationState::NotRegistered;
+        }
+        self->checkRegistrationState();
+        // Cellular Global Identity (partial)
+        self->cgi_.location_area_code = r >= 2 ? static_cast<LacType>(val[1]) : std::numeric_limits<LacType>::max();
+        self->cgi_.cell_id = r >= 3 ? static_cast<CidType>(val[2]) : std::numeric_limits<CidType>::max();
+        return SYSTEM_ERROR_NONE;
+    }, this));
     return SYSTEM_ERROR_NONE;
 }
 


### PR DESCRIPTION
<details>
  <summary><i>submission notes</i></summary>

```
**Important:** Please sanitize/remove any confidential info like usernames, passwords, org names, product names/ids, access tokens, client ids/secrets, or anything else you don't wish to share.

Please Read and Sign the Contributor License Agreement ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md)).

You may also delete this submission notes header if you'd like. Thank you for contributing!
```
</details>

### Problem

Quectel modems do not correctly report CGI data.

`quectel_ncp_client.cpp` appears to have been copied before CGI data was finished.

This results in not setting the flags TWO_DIGIT_MNC flag value, and the lac and ci are reported from uninitialized values.

### Solution

Copy the latest Gen3 implementation from `sara_ncp_client.cpp`.

### Steps to Test

Create a sample application on new b5som hardware

### Example App

```c
void setup() {
  Particle.publishVitals(15);
}

void loop() {

}
```

### References

[ch46950](https://app.clubhouse.io/particle/story/46950/quectel-modems-do-not-correctly-report-cgi-data)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
