### PR TITLE
[wiring] Fixes a regression in SPI due to thread-safety additions from #1879

### DIFF
--- a/wiring/inc/spark_wiring_arduino.h
+++ b/wiring/inc/spark_wiring_arduino.h
@@ -72,4 +72,8 @@
 #define pgm_read_word_near(x) ((uint16_t)(*(x)))
 #endif
 
+#ifndef SPI_HAS_TRANSACTION
+#define SPI_HAS_TRANSACTION (1)
+#endif // SPI_HAS_TRANSACTION
+
 #endif	/* SPARK_WIRING_ARDUINO_H */

--- a/wiring/inc/spark_wiring_spi.h
+++ b/wiring/inc/spark_wiring_spi.h
@@ -262,25 +262,33 @@ public:
 
 #ifndef SPARK_WIRING_NO_SPI
 
-extern SPIClass SPI;
+namespace particle {
+namespace globals {
+
+SPIClass& instanceSpi();
+#define SPI ::particle::globals::instanceSpi()
 
 #if Wiring_SPI1
 #ifdef SPI1
 #undef SPI1
 #endif  // SPI1
 
-extern SPIClass SPI1;
+SPIClass& instanceSpi1();
+#define SPI1 ::particle::globals::instanceSpi1()
 
-#endif  // Wiring_SPI1
+#endif // Wiring_SPI1
 
 #if Wiring_SPI2
 #ifdef SPI2
 #undef SPI2
 #endif  // SPI2
 
-extern SPIClass SPI2;
+SPIClass& instanceSpi2();
+#define SPI2 ::particle::globals::instanceSpi2()
 
-#endif  // Wiring_SPI2
+#endif // Wiring_SPI2
+
+} } // particle::globals
 
 #endif  // SPARK_WIRING_NO_SPI
 

--- a/wiring/src/spark_wiring_spi.cpp
+++ b/wiring/src/spark_wiring_spi.cpp
@@ -336,14 +336,10 @@ void SPIClass::detachInterrupt()
 
 bool SPIClass::isEnabled()
 {
-    bool result = false;
-
-    if (!lock())
-    {
-        result = HAL_SPI_Is_Enabled(_spi);
-        unlock();
-    }
-    return result;
+    // XXX: pinAvailable() will call this method potentially even from
+    // interrupt context. `enabled` flag in HAL is usually just a volatile
+    // variable, so it's fine not to acquire the lock here.
+    return HAL_SPI_Is_Enabled(_spi);
 }
 
 void SPIClass::onSelect(wiring_spi_select_callback_t user_callback)

--- a/wiring_globals/src/wiring_globals_spi.cpp
+++ b/wiring_globals/src/wiring_globals_spi.cpp
@@ -6,15 +6,30 @@
 
 #ifndef SPARK_WIRING_NO_SPI
 
-SPIClass SPI(HAL_SPI_INTERFACE1);
+namespace particle {
+namespace globals {
+
+SPIClass& instanceSpi() {
+    static SPIClass instance(HAL_SPI_INTERFACE1);
+    return instance;
+}
 
 #if Wiring_SPI1
-SPIClass SPI1(HAL_SPI_INTERFACE2);
-#endif
+SPIClass& instanceSpi1() {
+    static SPIClass instance(HAL_SPI_INTERFACE2);
+    return instance;
+}
+#endif // Wiring_SPI1
 
 #if Wiring_SPI2
-SPIClass SPI2(HAL_SPI_INTERFACE3);
-#endif
+SPIClass& instanceSpi2() {
+    static SPIClass instance(HAL_SPI_INTERFACE3);
+    return instance;
+}
+
+#endif // Wiring_SPI2
+
+} } // particle::globals
 
 #endif //SPARK_WIRING_NO_SPI
 


### PR DESCRIPTION
### Problem

1. Using SPI object in global object constructors leads to a crash due to undefined initialization order of global objects
2. `pinAvailable()` calls `SPI.isEnabled()`, potentially from interrupt context.
3. #1668

### Solution

1. Use singleton-ish type of initialization for SPI objects with a function returning a reference to static object
2. Remove locking from `SPI.isEnabled()`, since in HAL it is anyway implemented with a volatile variable.
3. Adds `SPI_HAS_TRANSACTION` define

### Steps to Test

N/A

### Example App

N/A

### References

- https://community.particle.io/t/updating-from-deviceos-1-4-4-to-1-5-0-rc-1-sos-panic-1/54566
- #1879
- Closes #1668 

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
