### PR TITLE
[test] unit: fixes Print tests failing

### DIFF
--- a/test/unit_tests/wiring/print.cpp
+++ b/test/unit_tests/wiring/print.cpp
@@ -12,6 +12,10 @@ enum TestEnum {
 
 class PrintTest : public Print {
 public:
+    PrintTest()
+            : data_{},
+              size_{0} {
+    }
     static constexpr const size_t MAX_DATA_BUFFER_SIZE = 200;
     size_t write(const uint8_t* buffer, size_t size) override {
         if (size_ + size >= MAX_DATA_BUFFER_SIZE) {


### PR DESCRIPTION
### Problem

`wiring_Print tests for all types` test suite may fail with Segmentation Fault.

### Solution

Add a constructor to `PrintTest`, make sure the member variables are properly initialized.

### Steps to Test

Run the unit-tests.

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
