### PR TITLE
[wiring] SPI: fixes issue that the default SS pin is incorrect callin…

### DIFF
--- a/hal/src/nRF52840/spi_hal.cpp
+++ b/hal/src/nRF52840/spi_hal.cpp
@@ -299,6 +299,9 @@ void HAL_SPI_Begin_Ext(HAL_SPI_Interface spi, SPI_Mode mode, uint16_t pin, void*
             // m_spi_map[spi].ss_pin = PIN_INVALID;
         }
     } else {
+        if (pin >= TOTAL_PINS) {
+            return;
+        }
         m_spi_map[spi].ss_pin = pin;
     }
 

--- a/hal/src/stm32f2xx/spi_hal.c
+++ b/hal/src/stm32f2xx/spi_hal.c
@@ -289,8 +289,13 @@ void HAL_SPI_Begin(HAL_SPI_Interface spi, uint16_t pin)
 
 void HAL_SPI_Begin_Ext(HAL_SPI_Interface spi, SPI_Mode mode, uint16_t pin, void* reserved)
 {
-    if (pin == SPI_DEFAULT_SS)
+    if (pin == SPI_DEFAULT_SS) {
         pin = spiMap[spi].SPI_SS_Pin;
+    }
+
+    if (pin >= TOTAL_PINS) {
+        return;
+    }
 
     spiState[spi].SPI_SS_Pin = pin;
     Hal_Pin_Info* PIN_MAP = HAL_Pin_Map();

--- a/wiring/inc/spark_wiring_spi.h
+++ b/wiring/inc/spark_wiring_spi.h
@@ -162,7 +162,7 @@ public:
 
   void begin();
   void begin(uint16_t);
-  void begin(SPI_Mode mode, uint16_t);
+  void begin(SPI_Mode mode, uint16_t ss_pin = SPI_DEFAULT_SS);
   void end();
 
   void setBitOrder(uint8_t);

--- a/wiring/src/spark_wiring_spi.cpp
+++ b/wiring/src/spark_wiring_spi.cpp
@@ -102,11 +102,6 @@ void SPIClass::begin()
 
 void SPIClass::begin(uint16_t ss_pin)
 {
-    if (ss_pin >= TOTAL_PINS)
-    {
-        return;
-    }
-
     if (!lock())
     {
         HAL_SPI_Begin(_spi, ss_pin);
@@ -116,11 +111,6 @@ void SPIClass::begin(uint16_t ss_pin)
 
 void SPIClass::begin(SPI_Mode mode, uint16_t ss_pin)
 {
-    if (ss_pin >= TOTAL_PINS)
-    {
-        return;
-    }
-
     if (!lock())
     {
         HAL_SPI_Begin_Ext(_spi, mode, ss_pin, NULL);


### PR DESCRIPTION
### Problem

`SPI.begin(SPI_MODE_MASTER);` doesn't configure the default SS pin to be output high initially.

### Solution

Assign default parameter for the second argument of the `SPIClass::begin(SPI_Mode mode, uint16_t ss_pin = SPI_DEFAULT_SS)`.

### Steps to Test

1. Build and download the following example App.
2. Check if the default SS pin according to https://docs.particle.io/reference/device-os/firmware/electron/#begin--4 can be toggled periodically.

### Example App

```c
#include "application.h"

SYSTEM_MODE(MANUAL);

#if HAL_PLATFORM_STM32F2XX
#define SPI_DEFAULT_SS_PIN  A2
#elif PLATFORM_ID == PLATFORM_XENON || PLATFORM_ID == PLATFORM_ARGON || PLATFORM_ID == PLATFORM_BORON
#define SPI_DEFAULT_SS_PIN  A5
#endif

void setup()
{
    SPI.begin(SPI_MODE_MASTER);
}

void loop()
{
    digitalWrite(SPI_DEFAULT_SS_PIN, LOW);
    delay(3000);
    digitalWrite(SPI_DEFAULT_SS_PIN, HIGH);
    delay(3000);
}
```

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)