### PR TITLE
[Gen 3] Fixes renegotiation of options and adds IPCP packet parsing

### DIFF
--- a/hal/network/lwip/ppp_client.cpp
+++ b/hal/network/lwip/ppp_client.cpp
@@ -118,14 +118,15 @@ bool Client::prepareConnect() {
   ipcp_->init();
   ipcp_->disable();
   ipcp_->enable();
-  ipcp_->requestOption(ipcp::CONFIGURATION_OPTION_IP_ADDRESS);
-  ipcp_->requestOption(ipcp::CONFIGURATION_OPTION_PRIMARY_DNS_SERVER);
-  ipcp_->requestOption(ipcp::CONFIGURATION_OPTION_SECONDARY_DNS_SERVER);
-  ipcp_->requestOption(ipcp::CONFIGURATION_OPTION_IP_NETMASK);
-  LOCK_TCPIP_CORE();
-  if_.ip6_autoconfig_enabled = 1;
-  if_.flags |= NETIF_FLAG_MLD6;
-  UNLOCK_TCPIP_CORE();
+  ipcp_->requestOption(ipcp::CONFIGURATION_OPTION_IP_ADDRESS, CONFIGURATION_OPTION_FLAG_ACCEPT_REMOTE_ALWAYS);
+  ipcp_->requestOption(ipcp::CONFIGURATION_OPTION_PRIMARY_DNS_SERVER, CONFIGURATION_OPTION_FLAG_ACCEPT_REMOTE_ALWAYS);
+  ipcp_->requestOption(ipcp::CONFIGURATION_OPTION_SECONDARY_DNS_SERVER, CONFIGURATION_OPTION_FLAG_ACCEPT_REMOTE_ALWAYS);
+
+  // XXX: IPV6CP disabled
+  // LOCK_TCPIP_CORE();
+  // if_.ip6_autoconfig_enabled = 1;
+  // if_.flags |= NETIF_FLAG_MLD6;
+  // UNLOCK_TCPIP_CORE();
 
   // FIXME:
   static const char UBLOX_NCP_CONNECT_COMMAND[] = "ATD*99***1#\r\n";

--- a/hal/network/lwip/ppp_client.cpp
+++ b/hal/network/lwip/ppp_client.cpp
@@ -122,11 +122,12 @@ bool Client::prepareConnect() {
   ipcp_->requestOption(ipcp::CONFIGURATION_OPTION_PRIMARY_DNS_SERVER, CONFIGURATION_OPTION_FLAG_ACCEPT_REMOTE_ALWAYS);
   ipcp_->requestOption(ipcp::CONFIGURATION_OPTION_SECONDARY_DNS_SERVER, CONFIGURATION_OPTION_FLAG_ACCEPT_REMOTE_ALWAYS);
 
-  // XXX: IPV6CP disabled
-  // LOCK_TCPIP_CORE();
-  // if_.ip6_autoconfig_enabled = 1;
-  // if_.flags |= NETIF_FLAG_MLD6;
-  // UNLOCK_TCPIP_CORE();
+#if PPP_IPV6_SUPPORT
+  LOCK_TCPIP_CORE();
+  if_.ip6_autoconfig_enabled = 1;
+  if_.flags |= NETIF_FLAG_MLD6;
+  UNLOCK_TCPIP_CORE();
+#endif // PPP_IPV6_SUPPORT
 
   // FIXME:
   static const char UBLOX_NCP_CONNECT_COMMAND[] = "ATD*99***1#\r\n";

--- a/hal/network/lwip/ppp_configuration_option.h
+++ b/hal/network/lwip/ppp_configuration_option.h
@@ -22,6 +22,8 @@
 
 namespace particle { namespace net { namespace ppp {
 
+using PacketPrinter = void (*)(void *, const char *, ...);
+
 enum ConfigurationOptionState {
   CONFIGURATION_OPTION_STATE_NONE = 0,
   CONFIGURATION_OPTION_STATE_REQ  = 1,
@@ -32,7 +34,8 @@ enum ConfigurationOptionState {
 };
 
 enum ConfigurationOptionFlags {
-  CONFIGURATION_OPTION_FLAG_REQUEST = 0x01
+  CONFIGURATION_OPTION_FLAG_REQUEST = 0x01,
+  CONFIGURATION_OPTION_FLAG_ACCEPT_REMOTE_ALWAYS = 0x02
 };
 
 struct ConfigurationOption {
@@ -60,6 +63,8 @@ struct ConfigurationOption {
   virtual int sendConfigureRej(uint8_t* buf, size_t len) = 0;
   virtual int sendConfigureAck(uint8_t* buf, size_t len) = 0;
   virtual int sendConfigureNak(uint8_t* buf, size_t len) = 0;
+
+  virtual int print(const uint8_t* buf, size_t len, PacketPrinter printer, void* arg) = 0;
 
   int id = 0;
   size_t length = 0;

--- a/hal/network/lwip/ppp_ipcp.cpp
+++ b/hal/network/lwip/ppp_ipcp.cpp
@@ -50,7 +50,7 @@ Ipcp::~Ipcp() {
 }
 
 void Ipcp::enable() {
-  LOG(TRACE, "IPCP: enable %d %d %d", admState_, lowerState_, state_);
+  LOG(TRACE, "enable %d %d %d", admState_, lowerState_, state_);
   if (!admState_) {
     admState_ = true;
     if (lowerState_ && !state_) {
@@ -60,7 +60,7 @@ void Ipcp::enable() {
 }
 
 void Ipcp::disable() {
-  LOG(TRACE, "IPCP: disable %d %d %d", admState_, lowerState_, state_);
+  LOG(TRACE, "disable %d %d %d", admState_, lowerState_, state_);
   if (admState_) {
     admState_ = false;
     if (lowerState_ && state_) {
@@ -74,18 +74,18 @@ void Ipcp::setDnsEntryIndex(int idx) {
 }
 
 void Ipcp::init() {
-  LOG(TRACE, "IPCP: init");
+  LOG(TRACE, "init");
 
   fsm_init(&fsm_);
 }
 
 void Ipcp::input(uint8_t* pkt, int len) {
-  LOG(TRACE, "IPCP: input %d", len);
+  LOG(TRACE, "input %d", len);
   fsm_input(&fsm_, pkt, len);
 }
 
 void Ipcp::protocolReject() {
-  LOG(TRACE, "IPCP: Protocol-Reject");
+  LOG(TRACE, "Protocol-Reject");
   /* RFC 1661:
    * Upon reception of a Protocol-Reject, the implementation MUST stop
    * sending packets of the indicated protocol at the earliest
@@ -95,19 +95,19 @@ void Ipcp::protocolReject() {
 }
 
 void Ipcp::lowerUp() {
-  LOG(TRACE, "IPCP: lowerUp");
+  LOG(TRACE, "lowerUp");
   lowerState_= true;
   fsm_lowerup(&fsm_);
 }
 
 void Ipcp::lowerDown() {
-  LOG(TRACE, "IPCP: lowerDown");
+  LOG(TRACE, "lowerDown");
   lowerState_ = false;
   fsm_lowerdown(&fsm_);
 }
 
 void Ipcp::open() {
-  LOG(TRACE, "IPCP: open");
+  LOG(TRACE, "open");
   if (admState_) {
     fsm_open(&fsm_);
   } else {
@@ -116,14 +116,14 @@ void Ipcp::open() {
 }
 
 void Ipcp::close(const char* reason) {
-  LOG(TRACE, "ipcp:close");
+  LOG(TRACE, "lose");
   fsm_close(&fsm_, reason);
 }
 
 /* State machine callbacks */
 /* Reset our Configuration Information */
 void Ipcp::resetConfigurationInformation() {
-  LOG(TRACE, "IPCP: reset ci");
+  LOG(TRACE, "Resetting CI");
 
   const auto& conf = config_;
 
@@ -162,7 +162,6 @@ void Ipcp::resetConfigurationInformation() {
 
 /* Length of our Configuration Information */
 int Ipcp::getConfigurationInformationLength() {
-  LOG(TRACE, "IPCP: get ci length");
   size_t len = 0;
 
   forEachOption([&len](auto opt) {
@@ -173,7 +172,7 @@ int Ipcp::getConfigurationInformationLength() {
     }
   });
 
-  LOG(TRACE, "IPCP: Our CI length: %lu", len);
+  LOG(TRACE, "Our CI length: %lu", len);
   return len;
 }
 
@@ -195,8 +194,6 @@ void Ipcp::addConfigurationInformation(uint8_t* buf, int* len) {
 
 /* ACK our Configuration Information */
 int Ipcp::ackConfigurationInformation(uint8_t* buf, int len) {
-  LOG(TRACE, "IPCP: ack ci");
-
   while (len > 0) {
     uint8_t id = *buf;
     auto opt = findOption(id);
@@ -218,8 +215,6 @@ int Ipcp::ackConfigurationInformation(uint8_t* buf, int len) {
 
 /* NAK our Configuration Information */
 int Ipcp::nakConfigurationInformation(uint8_t* buf, int len, int treatAsReject) {
-  LOG(TRACE, "IPCP: nak ci");
-
   while (len > 0) {
     uint8_t id = *buf;
     auto opt = findOption(id);
@@ -241,8 +236,6 @@ int Ipcp::nakConfigurationInformation(uint8_t* buf, int len, int treatAsReject) 
 
 /* Reject our Configuration Information */
 int Ipcp::rejectConfigurationInformation(uint8_t* buf, int len) {
-  LOG(TRACE, "IPCP: reject ci");
-
   while (len > 0) {
     uint8_t id = *buf;
     auto opt = findOption(id);
@@ -264,7 +257,6 @@ int Ipcp::rejectConfigurationInformation(uint8_t* buf, int len) {
 
 /* Request peer's Configuration Information */
 int Ipcp::requestConfigurationInformation(uint8_t* buf, int* len, int rejectIfDisagree) {
-  LOG(TRACE, "IPCP: request ci");
   ConfigurationOptionState resultingState = CONFIGURATION_OPTION_STATE_ACK;
 
   int available = *len;
@@ -335,7 +327,7 @@ int Ipcp::requestConfigurationInformation(uint8_t* buf, int* len, int rejectIfDi
 
 /* Called when fsm reaches PPP_FSM_OPENED state */
 void Ipcp::up() {
-  LOG(TRACE, "IPCP: up");
+  LOG(TRACE, "up");
 
   auto ip = getNegotiatedLocalAddress();
   auto peer = getNegotiatedPeerAddress();
@@ -347,39 +339,47 @@ void Ipcp::up() {
   }
 #endif
 
-  if (!ip4_addr_isany_val(ip) && !ip4_addr_isany_val(peer)) {
-    sifup(pcb_);
-
-    auto mask = getNegotiatedNetmask();
-    netif_set_addr(pcb_->netif, &ip, &mask, &peer);
-
-    auto pdns = getNegotiatedPrimaryDns();
-    auto sdns = getNegotiatedSecondaryDns();
-    if (!ip4_addr_isany_val(pdns)) {
-      ip_addr_t tmp;
-      ip_addr_copy_from_ip4(tmp, pdns);
-      dns_setserver(dnsIndex_, &tmp);
-    }
-
-    if (!ip4_addr_isany_val(sdns)) {
-      ip_addr_t tmp;
-      ip_addr_copy_from_ip4(tmp, sdns);
-      dns_setserver(dnsIndex_ + 1, &tmp);
-    }
-
-    if (!state_) {
-      state_ = true;
-      np_up(pcb_, fsm_.protocol);
-    }
-  } else {
+  if (ip4_addr_isany_val(ip) || ip4_addr_isany_val(peer)) {
     // Teardown
     close("Failed to negotiate local or peer IP");
+    return;
+  }
+
+  auto pdns = getNegotiatedPrimaryDns();
+  auto sdns = getNegotiatedSecondaryDns();
+
+  if (ip4_addr_isany_val(pdns) && ip4_addr_isany_val(sdns)) {
+    // Teardown
+    close("Failed to negotiate DNS servers");
+    return;
+  }
+
+  sifup(pcb_);
+
+  auto mask = getNegotiatedNetmask();
+  netif_set_addr(pcb_->netif, &ip, &mask, &peer);
+
+  if (!ip4_addr_isany_val(pdns)) {
+    ip_addr_t tmp;
+    ip_addr_copy_from_ip4(tmp, pdns);
+    dns_setserver(dnsIndex_, &tmp);
+  }
+
+  if (!ip4_addr_isany_val(sdns)) {
+    ip_addr_t tmp;
+    ip_addr_copy_from_ip4(tmp, sdns);
+    dns_setserver(dnsIndex_ + 1, &tmp);
+  }
+
+  if (!state_) {
+    state_ = true;
+    np_up(pcb_, fsm_.protocol);
   }
 }
 
 /* Called when fsm leaves PPP_FSM_OPENED state */
 void Ipcp::down() {
-  LOG(TRACE, "IPCP: down");
+  LOG(TRACE, "down");
 
   sifdown(pcb_);
 
@@ -393,17 +393,17 @@ void Ipcp::down() {
 
 /* Called when we want the lower layer */
 void Ipcp::starting() {
-  LOG(TRACE, "IPCP: starting");
+  LOG(TRACE, "starting");
 }
 
 /* Called when we don't want the lower layer */
 void Ipcp::finished() {
-  LOG(TRACE, "IPCP: finished");
+  LOG(TRACE, "finished");
 }
 
 /* Called when unknown code received */
 int Ipcp::extCode(int code, int id, uint8_t* buf, int len) {
-  LOG(TRACE, "IPCP: ext code %d %d", code, id);
+  LOG(TRACE, "ext code %d %d", code, id);
   return 0;
 }
 

--- a/hal/network/lwip/ppp_ipcp.cpp
+++ b/hal/network/lwip/ppp_ipcp.cpp
@@ -116,14 +116,14 @@ void Ipcp::open() {
 }
 
 void Ipcp::close(const char* reason) {
-  LOG(TRACE, "lose");
+  LOG(TRACE, "close");
   fsm_close(&fsm_, reason);
 }
 
 /* State machine callbacks */
 /* Reset our Configuration Information */
 void Ipcp::resetConfigurationInformation() {
-  LOG(TRACE, "Resetting CI");
+  LOG(TRACE, "resetting CI");
 
   const auto& conf = config_;
 
@@ -172,7 +172,7 @@ int Ipcp::getConfigurationInformationLength() {
     }
   });
 
-  LOG(TRACE, "Our CI length: %lu", len);
+  LOG(TRACE, "iur CI length: %lu", len);
   return len;
 }
 

--- a/hal/network/lwip/ppp_ipcp_options.h
+++ b/hal/network/lwip/ppp_ipcp_options.h
@@ -69,6 +69,9 @@ struct CommonConfigurationOptionIpAddress : public ConfigurationOption {
   virtual int sendConfigureAck(uint8_t* buf, size_t len) override;
   virtual int sendConfigureNak(uint8_t* buf, size_t len) override;
 
+  virtual int print(const uint8_t* buf, size_t len, PacketPrinter printer, void* arg) override;
+  virtual const char* name() const = 0;
+
   ip4_addr_t local = {};
   ip4_addr_t peer = {};
   ip4_addr_t peerIdea = {};
@@ -78,11 +81,19 @@ struct IpAddressConfigurationOption : public CommonConfigurationOptionIpAddress 
   IpAddressConfigurationOption()
       : CommonConfigurationOptionIpAddress(CONFIGURATION_OPTION_IP_ADDRESS) {
   }
+
+  virtual const char* name() const override {
+    return "addr";
+  }
 };
 
 struct IpNetmaskConfigurationOption : public CommonConfigurationOptionIpAddress {
   IpNetmaskConfigurationOption()
       : CommonConfigurationOptionIpAddress(CONFIGURATION_OPTION_IP_NETMASK) {
+  }
+
+  virtual const char* name() const override {
+    return "netmask";
   }
 };
 
@@ -90,11 +101,19 @@ struct PrimaryDnsServerConfigurationOption : public CommonConfigurationOptionIpA
   PrimaryDnsServerConfigurationOption()
       : CommonConfigurationOptionIpAddress(CONFIGURATION_OPTION_PRIMARY_DNS_SERVER) {
   }
+
+  virtual const char* name() const override {
+    return "msdns1";
+  }
 };
 
 struct SecondaryDnsServerConfigurationOption : public CommonConfigurationOptionIpAddress {
   SecondaryDnsServerConfigurationOption()
       : CommonConfigurationOptionIpAddress(CONFIGURATION_OPTION_SECONDARY_DNS_SERVER) {
+  }
+
+  virtual const char* name() const override {
+    return "msdns2";
   }
 };
 
@@ -131,6 +150,8 @@ struct UnknownConfigurationOption : public ConfigurationOption {
   virtual int sendConfigureNak(uint8_t* buf, size_t len) override {
     return sendConfigureRej(buf, len);
   }
+
+  virtual int print(const uint8_t* buf, size_t len, PacketPrinter printer, void* arg) override;
 
   uint8_t* data = nullptr;
 };

--- a/hal/network/lwip/ppp_ncp.h
+++ b/hal/network/lwip/ppp_ncp.h
@@ -88,10 +88,10 @@ public:
     }
   }
 
-  virtual void requestOption(int id) {
+  virtual void requestOption(int id, unsigned int opts = 0) {
     auto opt = findOption(id);
     if (opt != nullptr) {
-      opt->flagsLocal |= CONFIGURATION_OPTION_FLAG_REQUEST;
+      opt->flagsLocal |= CONFIGURATION_OPTION_FLAG_REQUEST | opts;
     }
   }
 
@@ -117,6 +117,10 @@ public:
   virtual void open() = 0;
   /* Close the protocol */
   virtual void close(const char* reason) = 0;
+#if PRINTPKT_SUPPORT
+  /* Print a packet in readable form */
+  static int printPacket(const uint8_t *p, int plen, PacketPrinter printer, void* arg);
+#endif // PRINTPKT_SUPPORT
 
   /* State machine callbacks */
   /* Reset our Configuration Information */
@@ -162,7 +166,7 @@ public:
       printPacketCb,
 #endif /* PRINTPKT_SUPPORT */
 #if PPP_DATAINPUT
-      NULL,
+      nullptr,
 #endif /* PPP_DATAINPUT */
 #if PRINTPKT_SUPPORT
       protoName,
@@ -200,8 +204,6 @@ protected:
   ConfigurationOption* options_ = nullptr;
 
 private:
-
-  using PacketPrinter = void (*)(void *, const char *, ...);
 
   static Ncp* getInstance(ppp_pcb* pcb) {
     if (pcb != nullptr) {
@@ -277,9 +279,11 @@ private:
     }
   }
 
+#if PRINTPKT_SUPPORT
   static int printPacketCb(const uint8_t *p, int plen, PacketPrinter printer, void *arg) {
-    return 0;
+    return Ncp::printPacket(p, plen, printer, arg);
   }
+#endif // PRINTPKT_SUPPORT
 
   /* State machine callbacks */
   /* Reset our Configuration Information */

--- a/hal/src/b5som/network/quectel_ncp_client.cpp
+++ b/hal/src/b5som/network/quectel_ncp_client.cpp
@@ -748,6 +748,10 @@ int QuectelNcpClient::initReady() {
 
     muxerSg.dismiss();
 
+    // Make sure that we receive URCs only on AT channel, ignore response code
+    // just in case
+    CHECK_PARSER(parser_.execCommand("AT+QCFG=\"cmux/urcport\",1"));
+
     return SYSTEM_ERROR_NONE;
 }
 

--- a/hal/src/nRF52840/lwip/lwippppopts.h
+++ b/hal/src/nRF52840/lwip/lwippppopts.h
@@ -112,7 +112,11 @@
  *
  * Mandatory for debugging, it displays exchanged packet content in debug trace.
  */
+#ifndef DEBUG_BUILD
 #define PRINTPKT_SUPPORT                0
+#else
+#define PRINTPKT_SUPPORT                1
+#endif // DEBUG_BUILD
 
 /**
  * PPP_IPV4_SUPPORT==1: Enable PPP IPv4 support

--- a/hal/src/nRF52840/lwip/lwippppopts.h
+++ b/hal/src/nRF52840/lwip/lwippppopts.h
@@ -131,7 +131,7 @@
 /**
  * PPP_IPV6_SUPPORT==1: Enable PPP IPv6 support
  */
-#define PPP_IPV6_SUPPORT                (LWIP_IPV6)
+#define PPP_IPV6_SUPPORT                0
 
 /**
  * PPP_IPV6CP_OVERRIDE==1: third-party IPV6CP implementation


### PR DESCRIPTION
### Problem

1. We sometimes see that the devices establish the PPP link, however remain stuck in blinking green. This is caused by the remote side changing offered DNS servers during the negotiation (i.e. it offers one set first and then after we accept if, for some reason offers another).
2. IPCP packets are not easy to debug and are dumped raw
3. [B5 SoM] For some reason we are not receiving CREG/CGREG/CEREG URCs on muxed AT channel and they only appear in the muxed data channel, which causes us to not notice loss of carrier.

### Solution

1. All default IPCP options (IP addresses, Primary/Secondary DNS) are now overridable by the remote side. Once the PPP link is established, we now also check whether we've agreed on a set of DNS servers, and if not, teardown the link.
2. IPCP packet parsing is added.
3. [B5 SoM] Adds `AT+QCFG="cmux/urcport",1` to receive URCs only on muxed AT channel.

This PR also disables IPV6CP.

### Steps to Test

1. Force the device (b5som) into a state where it'll throw `Peer NAK'd an option unknown to us`, it should connect succesfully
2. Build monolithic DeviceOS with `DEBUG_BUILD=y`, IPCP packet dumps should be visible in the logs

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
