### PR TITLE
[Gen 2] Fixes socket leak in UDP.begin()

### DIFF
--- a/user/tests/wiring/no_fixture/cellular.cpp
+++ b/user/tests/wiring/no_fixture/cellular.cpp
@@ -171,7 +171,7 @@ test(MDM_01_socket_writes_with_length_more_than_1023_work_correctly) {
 
     const int dataSize = 1024;
     const int bufferSize = 2048;
-    auto randData = std::make_unique<char[]>(1024);
+    auto randData = std::make_unique<char[]>(dataSize);
     assertTrue((bool)randData);
 
     Random rand;
@@ -214,7 +214,7 @@ test(MDM_01_socket_writes_with_length_more_than_1023_work_correctly) {
     int responseSize = 0;
     uint32_t mil = millis();
     while(1) {
-        while (c.available()) {
+        while (c.available() && responseSize < bufferSize) {
             responseBuf.get()[responseSize++] = c.read();
         }
         if (!c.connected())

--- a/user/tests/wiring/no_fixture/network.cpp
+++ b/user/tests/wiring/no_fixture/network.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+test(UDP_begin_does_not_leak_sockets_without_calling_stop) {
+    // Arbitrary number that is large enough to showcase the issue
+#if PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION
+    // There is a limited number of sockets available on Electrons, since we are using
+    // the internal modem TCP/IP stack. Reducing the number of iterations, because each
+    // UDP.begin() call will cause a call into the modem using AT commands.
+    // 10 should be enough to showcase the issue.
+    int maxIterations = 10;
+#else
+    int maxIterations = 1000;
+#endif // PLATFORM_ID == PLATFORM_ELECTRON
+
+    auto udp = std::make_unique<UDP>();
+    assertTrue((bool)udp);
+
+    while (--maxIterations >= 0) {
+        assertTrue(Network.ready());
+        assertTrue((bool)udp->begin(12345));
+        assertTrue((bool)socket_handle_valid(udp->socket()));
+    }
+}

--- a/wiring/src/spark_wiring_udp.cpp
+++ b/wiring/src/spark_wiring_udp.cpp
@@ -77,6 +77,8 @@ void UDP::releaseBuffer()
 
 uint8_t UDP::begin(uint16_t port, network_interface_t nif)
 {
+    stop();
+
     bool bound = 0;
     if(Network.from(nif).ready())
     {


### PR DESCRIPTION
### Problem

`UDP::begin()` can be called when already active with an open socket. It will unconditionally create open a new socket and discard its reference to the old socket while leaving it open.

If this sequence is repeated the system can run out of socket handles preventing new UDP sockets from being opened and even preventing cloud connection.

While users should call `UDP::end()` to close any open socket before a new `UDP::begin()` the implementation should defensively check for and close an open socket on `UDP::begin()`.

**NOTE: this bug only applies to Gen 2 devices**

### Solution

Call `stop()` in `begin()`.

This PR also frees up some flash space in `wiring/no_fixture` test suite for cellular platforms, as we started to overflow.

### Steps to Test

Run `wiring/no_fixture` tests on Gen 2 and Gen 3 platforms. All tests can be excluded (`E` command) except for `MDM_01_socket_writes_with_length_more_than_1023_work_correctly` on cellular platforms and `UDP_begin_does_not_leak_sockets_without_calling_stop` on all the platforms (`i` command to enable the tests selectively).

### Example App

N/A

### References

- [CH27231]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
