### PR TITLE
Replace CSQ on Gen2 with UCGED (mode 5)

### DIFF
--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -557,6 +557,7 @@ protected:
     static int _cbUACTIND(int type, const char* buf, int len, int* i);
     static int _cbUDOPN(int type, const char* buf, int len, char* mccmnc);
     static int _cbCGPADDR(int type, const char* buf, int len, MDM_IP* ip);
+    static int _cbUCGED(int type, const char* buf, int len, NetStatus* status);
     struct CGDCONTparam { char type[8]; char apn[32]; };
     static int _cbCGDCONT(int type, const char* buf, int len, CGDCONTparam* param);
     static int _cbURAT(int type, const char *buf, int len, bool *matched_default);


### PR DESCRIPTION
<details>
  <summary><i>submission notes</i></summary>

```
**Important:** Please sanitize/remove any confidential info like usernames, passwords, org names, product names/ids, access tokens, client ids/secrets, or anything else you don't wish to share.

Please Read and Sign the Contributor License Agreement ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md)).

You may also delete this submission notes header if you'd like. Thank you for contributing!
```
</details>

### Problem

Signal strength on Gen2 is collected using CSQ command. 
1. This command does not provide quality value on Gen2
2. This command is quite unreliable, meaning that is sometimes gives invalid signal strength value in an expectedly solid cell coverage location. 
u-blox recommends to use UCGED command, which is expected to work more reliably than the CSQ command. 

### Solution

Replace CSQ command with UCGED for R410M radio. UCGED gives RSRP/RSRQ in dBm/dB and CSQ gives in index values. RSRP/RSRQ from UCGED are converted from dBm/dB to CESQ-type index values and further processed. 


**Implementation:**
- Hard-bounding values for RSRP in [-200,0] and assign error value otherwise(255)
- Hard-bounding values for RSRQ in [?,0] and assign error value otherwise(255)
- Check that UCGED contains valid values for both RSRP and RSRQ string, else call it an error
- No retry algorithm on the UCGED command
- In a multiple-response UCGED command, uses the first set of values as the correct readings and ignore the rest

### Steps to Test

Manual testing required here
1. Check that correct signal strength and quality are reported by comparing the values reported by the previous Device OS and the values reported by your code for the same device in the same location.
2. Check an Electron 3G
3. Check the null case (no coverage)
4. Drive test 

### Example App

```
#include "application.h"

Serial1LogHandler logHandler (115200, LOG_LEVEL_ALL);

void setup() {
   Particle.publishVitals(30);
}

void loop() {
}
```

### References

https://app.clubhouse.io/particle/story/47681/replace-csq-on-gen2-with-ucged-mode-5


---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
