### PR TITLE
[hal] usb serial: return -1 instead of 0 when there's no data to read

### DIFF
--- a/hal/src/nRF52840/usb_hal.cpp
+++ b/hal/src/nRF52840/usb_hal.cpp
@@ -81,6 +81,10 @@ int32_t HAL_USB_USART_Available_Data_For_Write(HAL_USB_USART_Serial serial) {
 }
 
 int32_t HAL_USB_USART_Receive_Data(HAL_USB_USART_Serial serial, uint8_t peek) {
+    if (usb_uart_available_rx_data() == 0) {
+        return -1;
+    }
+
     if (peek) {
         return usb_uart_peek_rx_data(0);
     } else {


### PR DESCRIPTION
### Problem
The `USBSerial::read` method returns 0 instead of returning an invalid character to signal that there are no characters to read. It makes it impossible to make the difference between the 0 character and there being no characters to read from the serial port. 

This causes problems with functions that expect this method to return -1 whenever there are no characters left to read. This is the case of `Serial::readStringUntil`.

### Solution
To solve the problem, I've added a check before reading a byte from the serial port to see whether there is one to read. If there isn't, it returns -1, otherwise the function works just like it did before.

### Steps to Test
System info:
* Firmware: built from this pull request
* Device: Particle Boron

Steps:
* Upload the following code to the device:
```c
#include <Particle.h>

SYSTEM_THREAD(ENABLED);
SYSTEM_MODE(MANUAL);

void setup() {
    Serial.begin(9600);
}

void loop() {
    Serial.print(Serial.read());
    Serial.print(", ");
    delay(100);
}
```
* Connect to the Boron's serial port using a serial port monitor
* Send characters to the Boron through its' Serial port
* When you aren't pressing any key, you should see -1 being printed
* When you are pressing a key, you should see the ASCII code of the character sent being printed

### Example App

```c
#include <Particle.h>

SYSTEM_THREAD(ENABLED);
SYSTEM_MODE(MANUAL);

void setup() {
    Serial.begin(9600);
}

void loop() {
    if (Serial.available() != 0) {
        String s = Serial.readStringUntil('\n');
        Serial.println(s);
    }
}
```

This app shows that `Serial.readStringUntil` can now return strings with more than a single character, because it isn't inserting a bunch of `0` everywhere in the string when there are no characters to read.

### References
Here's the issue that this PR resolves: #2032

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
