### PR TITLE
[stm32f2xx] platform: fix FLASH_Update() for unaligned writes

### DIFF
--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/src/flash_mal.c
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/src/flash_mal.c
@@ -900,15 +900,11 @@ int FLASH_Update(const uint8_t *pBuffer, uint32_t address, uint32_t bufferSize)
 
     if (bufferSize & 0x3) /* Not an aligned data */
     {
-        char buf[4];
-        memset(buf, 0xFF, 4);
-
-        for (index = bufferSize&3; index -->0; )
+        for (; index < bufferSize; index++)
         {
-            buf[index] = pBuffer[ (bufferSize & 0xFFFC)+index ];
+            FLASH_ProgramByte(address, pBuffer[index]);
+            ++address;
         }
-        FLASH_ProgramWord(address, *(uint32_t *)(pBuffer + index));
-
     }
 
     /* Lock the internal flash */


### PR DESCRIPTION
### Problem

#1989

### Solution

Flash the rest of the buffer using `Flash_ProgramByte`.

### Steps to Test

Gen 2 OTA/ymodem updates are not affected.

### Example App

N/A

### References

- Closes #1989 
- [CH46859]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
