### PR TITLE
Adding changes for R410M to use UCGED instead of CESQ

### DIFF
--- a/user/tests/wiring/no_fixture/cellular.cpp
+++ b/user/tests/wiring/no_fixture/cellular.cpp
@@ -157,6 +157,65 @@ test(CELLULAR_07_rssi_is_valid) {
     assertMoreOrEqual(s.rssi, -150);
 }
 
+// Collects cellular signal strength and quality and validates Accesstechnology (RAT)
+test(CELLULAR_08_sigstr_is_valid) {
+    connect_to_cloud(6*60*1000);
+    assertTrue(Particle.connected());
+    CellularSignal s;
+    bool values_in_range = false;
+    const int num_retries = 10;
+    // Checks 10 times with 500ms gap to get valid signal strength
+    for (int x = 0; x < num_retries; x++) {
+        s = Cellular.RSSI();
+        // Verify that strength and quality values are in range for the given AccessTechnology
+        switch (s.getAccessTechnology()) {
+            case NET_ACCESS_TECHNOLOGY_GSM:     // GSM strength [-111, -48] and quality [-3.70, -0.60]
+                if ((s.getStrengthValue() <= -48.0f && s.getStrengthValue() >= -111.0f)
+                    && (s.getQualityValue() <= -0.6f && s.getQualityValue() >= -3.7f)) {
+                        values_in_range = true;
+                        x = num_retries;
+                        break;
+                }
+                Serial.printlnf("StrV: %.2f, QualV: %.2f, RAT: %d", s.getStrengthValue(), s.getQualityValue(), s.getAccessTechnology());
+                break;
+            case NET_ACCESS_TECHNOLOGY_EDGE:     // EDGE strength [-111, -48] and quality [-3.70, -0.60]
+                if ((s.getStrengthValue() <= -48.0f && s.getStrengthValue() >= -111.0f)
+                    && (s.getQualityValue() <= -0.6f && s.getQualityValue() >= -3.7f)) {
+                        values_in_range = true;
+                        x = num_retries;
+                        break;
+                }
+                Serial.printlnf("StrV: %.2f, QualV: %.2f, RAT: %d", s.getStrengthValue(), s.getQualityValue(), s.getAccessTechnology());
+                break;
+            case NET_ACCESS_TECHNOLOGY_UTRAN:     // UTRAN strength [-121, -25] and quality [-24.5, 0]
+                if ((s.getStrengthValue() <= -25.0f && s.getStrengthValue() >= -121.0f)
+                    && (s.getQualityValue() <= -0.0f && s.getQualityValue() >= -25.4f)) {
+                        values_in_range = true;
+                        x = num_retries;
+                        break;
+                }
+                Serial.printlnf("StrV: %.2f, QualV: %.2f, RAT: %d", s.getStrengthValue(), s.getQualityValue(), s.getAccessTechnology());
+                break;
+            case NET_ACCESS_TECHNOLOGY_LTE:
+            case NET_ACCESS_TECHNOLOGY_LTE_CAT_M1:  // LTE CAT-M1 strength [-141, -44] and quality [-20, -3]
+            case NET_ACCESS_TECHNOLOGY_LTE_CAT_NB1:
+                if ((s.getStrengthValue() <= -44.0f && s.getStrengthValue() >= -141.0f)
+                    && (s.getQualityValue() <= -3.0f && s.getQualityValue() >= -20.0f)) {
+                        values_in_range = true;
+                        x = num_retries;
+                        break;
+                }
+                Serial.printlnf("StrV: %.2f, QualV: %.2f, RAT: %d", s.getStrengthValue(), s.getQualityValue(), s.getAccessTechnology());
+                break;
+            default:
+                break;
+        }
+        delay(500);
+    }
+    assertFalse((s.getAccessTechnology() == NET_ACCESS_TECHNOLOGY_UNKNOWN) || (s.getAccessTechnology() == NET_ACCESS_TECHNOLOGY_NONE));
+    assertTrue(values_in_range);
+}
+
 test(MDM_01_socket_writes_with_length_more_than_1023_work_correctly) {
 
 #if HAL_PLATFORM_NCP


### PR DESCRIPTION
<details>
  <summary><i>submission notes</i></summary>

```
**Important:** Please sanitize/remove any confidential info like usernames, passwords, org names, product names/ids, access tokens, client ids/secrets, or anything else you don't wish to share.

Please Read and Sign the Contributor License Agreement ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md)).

You may also delete this submission notes header if you'd like. Thank you for contributing!
```
</details>

### Problem

R410M uses CESQ to collect data, which is an unstable AT command to collect signal strength values.

### Solution

Replace CESQ with UCGED (mode 5) only on R410M. UCGED gives RSRP/RSRQ in dBm/dB and CESQ gives in index values. RSRP/RSRQ from UCGED are converted from dBm/dB to CESQ-type index values and further processed.

### Steps to Test

Manual testing required here

1. Check that correct signal strength and quality are reported by comparing the values reported by the previous Device OS and the values reported by your code for the same device in the same location.
2. Check an Boron 2/3G
3. Check the null case (no coverage)
4. Drive test

### Example App

```c
#include "Particle.h"
SerialLogHandler logHandler(LOG_LEVEL_ALL);

void setup() {
    Particle.publishVitals(30);
}

void loop() {
}
```

### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
