### PR TITLE
Redo: Fixes the issue that SPI default SS pin is not configured

### DIFF
--- a/hal/inc/pinmap_hal.h
+++ b/hal/inc/pinmap_hal.h
@@ -63,6 +63,8 @@ void HAL_Set_Pin_Function(pin_t pin, PinFunction pin_func);
 
 #include "pinmap_impl.h"
 
+#define HAL_Pin_Is_Valid(pin) (pin < TOTAL_PINS)
+
 #ifdef __cplusplus
 }
 #endif

--- a/hal/inc/pinmap_hal.h
+++ b/hal/inc/pinmap_hal.h
@@ -63,7 +63,7 @@ void HAL_Set_Pin_Function(pin_t pin, PinFunction pin_func);
 
 #include "pinmap_impl.h"
 
-#define HAL_Pin_Is_Valid(pin) (pin < TOTAL_PINS)
+#define HAL_Pin_Is_Valid(pin) ((pin) < TOTAL_PINS)
 
 #ifdef __cplusplus
 }

--- a/hal/src/nRF52840/spi_hal.cpp
+++ b/hal/src/nRF52840/spi_hal.cpp
@@ -299,6 +299,9 @@ void HAL_SPI_Begin_Ext(HAL_SPI_Interface spi, SPI_Mode mode, uint16_t pin, void*
             // m_spi_map[spi].ss_pin = PIN_INVALID;
         }
     } else {
+        if (pin >= TOTAL_PINS) {
+            return;
+        }
         m_spi_map[spi].ss_pin = pin;
     }
 

--- a/hal/src/nRF52840/spi_hal.cpp
+++ b/hal/src/nRF52840/spi_hal.cpp
@@ -173,8 +173,16 @@ static void spi_init(HAL_SPI_Interface spi, SPI_Mode mode) {
         err_code = nrfx_spim_init(m_spi_map[spi].master, &spim_config, spi_master_event_handler, (void *)((int)spi));
         SPARK_ASSERT(err_code == NRF_SUCCESS);
 
-        HAL_GPIO_Write(m_spi_map[spi].ss_pin, 1);
-        HAL_Pin_Mode(m_spi_map[spi].ss_pin, OUTPUT);
+        if (HAL_Pin_Is_Valid(m_spi_map[spi].ss_pin)) {
+            hal_gpio_config_t conf = {
+                .size = sizeof(conf),
+                .version = 0,
+                .mode = OUTPUT,
+                .set_value = true,
+                .value = 1
+            };
+            HAL_Pin_Configure(m_spi_map[spi].ss_pin, &conf);
+        }
     } else {
         static const nrf_spis_mode_t nrf_spis_mode[4] = {NRF_SPIS_MODE_0, NRF_SPIS_MODE_1, NRF_SPIS_MODE_2, NRF_SPIS_MODE_3};
         nrfx_spis_config_t spis_config;
@@ -286,7 +294,9 @@ void HAL_SPI_Begin_Ext(HAL_SPI_Interface spi, SPI_Mode mode, uint16_t pin, void*
     }
 
     if (m_spi_map[spi].enabled) {
+        // Make sure we reset the enabled state
         spi_uninit(spi);
+        m_spi_map[spi].enabled = false;
     }
 
     if (pin == SPI_DEFAULT_SS) {
@@ -295,14 +305,15 @@ void HAL_SPI_Begin_Ext(HAL_SPI_Interface spi, SPI_Mode mode, uint16_t pin, void*
         } else if (spi == HAL_SPI_INTERFACE2) {
             m_spi_map[spi].ss_pin = D5;
         } else {
-            // This generates a warning with -Warray-bounds enabled
-            // m_spi_map[spi].ss_pin = PIN_INVALID;
+            m_spi_map[spi].ss_pin = PIN_INVALID;
         }
     } else {
-        if (pin >= TOTAL_PINS) {
-            return;
-        }
         m_spi_map[spi].ss_pin = pin;
+    }
+
+    if (mode == SPI_MODE_SLAVE && !HAL_Pin_Is_Valid(m_spi_map[spi].ss_pin)) {
+        // Slave mode requires a valid pin
+        return;
     }
 
     m_spi_map[spi].spi_mode = mode;

--- a/hal/src/stm32f2xx/spi_hal.c
+++ b/hal/src/stm32f2xx/spi_hal.c
@@ -293,7 +293,7 @@ void HAL_SPI_Begin_Ext(HAL_SPI_Interface spi, SPI_Mode mode, uint16_t pin, void*
         pin = spiMap[spi].SPI_SS_Pin;
     }
 
-    if (pin >= TOTAL_PINS) {
+    if (mode == SPI_MODE_SLAVE && !HAL_Pin_Is_Valid(pin)) {
         return;
     }
 
@@ -315,7 +315,7 @@ void HAL_SPI_Begin_Ext(HAL_SPI_Interface spi, SPI_Mode mode, uint16_t pin, void*
     HAL_Pin_Mode(spiMap[spi].SPI_MISO_Pin, AF_OUTPUT_PUSHPULL);
     HAL_Pin_Mode(spiMap[spi].SPI_MOSI_Pin, AF_OUTPUT_PUSHPULL);
 
-    if (mode == SPI_MODE_MASTER)
+    if (mode == SPI_MODE_MASTER && HAL_Pin_Is_Valid(pin))
     {
         // Ensure that there is no glitch on SS pin
         PIN_MAP[pin].gpio_peripheral->BSRRL = PIN_MAP[pin].gpio_pin;

--- a/hal/src/stm32f2xx/spi_hal.c
+++ b/hal/src/stm32f2xx/spi_hal.c
@@ -289,8 +289,13 @@ void HAL_SPI_Begin(HAL_SPI_Interface spi, uint16_t pin)
 
 void HAL_SPI_Begin_Ext(HAL_SPI_Interface spi, SPI_Mode mode, uint16_t pin, void* reserved)
 {
-    if (pin == SPI_DEFAULT_SS)
+    if (pin == SPI_DEFAULT_SS) {
         pin = spiMap[spi].SPI_SS_Pin;
+    }
+
+    if (pin >= TOTAL_PINS) {
+        return;
+    }
 
     spiState[spi].SPI_SS_Pin = pin;
     Hal_Pin_Info* PIN_MAP = HAL_Pin_Map();

--- a/hal/src/stm32f2xx/spi_hal.c
+++ b/hal/src/stm32f2xx/spi_hal.c
@@ -649,6 +649,9 @@ void HAL_SPI_Info(HAL_SPI_Interface spi, hal_spi_info_t* info, void* reserved)
         info->mode = spiState[spi].mode;
         info->bit_order = spiState[spi].SPI_InitStructure.SPI_FirstBit == SPI_FirstBit_MSB ? MSBFIRST : LSBFIRST;
         info->data_mode = spiState[spi].SPI_InitStructure.SPI_CPOL | spiState[spi].SPI_InitStructure.SPI_CPHA;
+        if (info->version >= HAL_SPI_INFO_VERSION_2) {
+            info->ss_pin = spiState[spi].SPI_SS_Pin;
+        }
         HAL_enable_irq(state);
     }
 }

--- a/user/tests/wiring/no_fixture_spi/application.cpp
+++ b/user/tests/wiring/no_fixture_spi/application.cpp
@@ -1,0 +1,19 @@
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+// make clean all TEST=wiring/no_fixture PLATFORM=electron -s COMPILE_LTO=n program-dfu DEBUG_BUILD=y
+// make clean all TEST=wiring/no_fixture PLATFORM=electron -s COMPILE_LTO=n program-dfu DEBUG_BUILD=y USE_THREADING=y
+//
+// Serial1LogHandler logHandler(115200, LOG_LEVEL_ALL, {
+    // { "comm", LOG_LEVEL_NONE }, // filter out comm messages
+    // { "system", LOG_LEVEL_INFO } // only info level for system messages
+// });
+
+UNIT_TEST_APP();
+
+// Enable threading if compiled with "USE_THREADING=y"
+#if PLATFORM_THREADING == 1 && USE_THREADING == 1
+SYSTEM_THREAD(ENABLED);
+#endif
+
+SYSTEM_MODE(MANUAL);

--- a/user/tests/wiring/no_fixture_spi/spi.cpp
+++ b/user/tests/wiring/no_fixture_spi/spi.cpp
@@ -1,0 +1,399 @@
+/*
+ * Copyright (c) 2019 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Particle.h"
+#include "unit-test/unit-test.h"
+
+static void querySpiInfo(HAL_SPI_Interface spi, hal_spi_info_t* info)
+{
+    memset(info, 0, sizeof(hal_spi_info_t));
+    info->version = HAL_SPI_INFO_VERSION;
+    HAL_SPI_Info(spi, info, nullptr);
+}
+
+test(SPI_1_SPI_Begin_Without_Argument)
+{
+    // Just in case
+    SPI.end();
+
+    hal_spi_info_t info = {};
+
+    SPI.begin();
+    querySpiInfo(HAL_SPI_INTERFACE1, &info);
+    assertTrue(info.enabled == true);
+    assertTrue(info.mode == SPI_MODE_MASTER);
+#if PLATFORM_ID == PLATFORM_ARGON || PLATFORM_ID == PLATFORM_BORON || PLATFORM_ID == PLATFORM_XENON
+    assertTrue(info.ss_pin == D14);
+#elif PLATFORM_ID == PLATFORM_BSOM
+    assertTrue(info.ss_pin == D8);
+#else // Photon, P1 and Electron
+    assertTrue(info.ss_pin == A2);
+#endif
+    SPI.end();
+}
+
+test(SPI_2_SPI_Begin_With_Ss_Pin)
+{
+    // Just in case
+    SPI.end();
+
+    hal_spi_info_t info = {};
+
+    SPI.begin(SPI_DEFAULT_SS);
+    querySpiInfo(HAL_SPI_INTERFACE1, &info);
+    assertTrue(info.enabled == true);
+    assertTrue(info.mode == SPI_MODE_MASTER);
+#if PLATFORM_ID == PLATFORM_ARGON || PLATFORM_ID == PLATFORM_BORON || PLATFORM_ID == PLATFORM_XENON
+    assertTrue(info.ss_pin == D14);
+#elif PLATFORM_ID == PLATFORM_BSOM
+    assertTrue(info.ss_pin == D8);
+#else // Photon, P1 and Electron
+    assertTrue(info.ss_pin == A2);
+#endif
+    SPI.end();
+
+    memset(&info, 0x00, sizeof(hal_spi_info_t));
+
+    SPI.begin(D0);
+    querySpiInfo(HAL_SPI_INTERFACE1, &info);
+    assertTrue(info.enabled == true);
+    assertTrue(info.mode == SPI_MODE_MASTER);
+    assertTrue(info.ss_pin == D0);
+    SPI.end();
+
+    memset(&info, 0x00, sizeof(hal_spi_info_t));
+
+    SPI.begin(PIN_INVALID);
+    querySpiInfo(HAL_SPI_INTERFACE1, &info);
+    assertTrue(info.enabled == true);
+    assertTrue(info.mode == SPI_MODE_MASTER);
+    assertTrue(info.ss_pin == PIN_INVALID);
+    SPI.end();
+
+    memset(&info, 0x00, sizeof(hal_spi_info_t));
+
+    SPI.begin(123);
+    querySpiInfo(HAL_SPI_INTERFACE1, &info);
+    assertTrue(info.enabled == true);
+    assertTrue(info.mode == SPI_MODE_MASTER);
+    assertTrue(info.ss_pin == 123);
+    SPI.end();
+}
+
+test(SPI_3_SPI_Begin_With_Mode)
+{
+    // Just in case
+    SPI.end();
+
+    hal_spi_info_t info = {};
+
+    SPI.begin(SPI_MODE_MASTER);
+    querySpiInfo(HAL_SPI_INTERFACE1, &info);
+    assertTrue(info.enabled == true);
+    assertTrue(info.mode == SPI_MODE_MASTER);
+#if PLATFORM_ID == PLATFORM_ARGON || PLATFORM_ID == PLATFORM_BORON || PLATFORM_ID == PLATFORM_XENON
+    assertTrue(info.ss_pin == D14);
+#elif PLATFORM_ID == PLATFORM_BSOM
+    assertTrue(info.ss_pin == D8);
+#else // Photon, P1 and Electron
+    assertTrue(info.ss_pin == A2);
+#endif
+    SPI.end();
+
+    memset(&info, 0x00, sizeof(hal_spi_info_t));
+
+    // HAL_SPI_INTERFACE1 does not support slave mode on Gen3 device
+#if HAL_PLATFORM_STM32F2XX
+    SPI.begin(SPI_MODE_SLAVE);
+    querySpiInfo(HAL_SPI_INTERFACE1, &info);
+    assertTrue(info.enabled == true);
+    assertTrue(info.mode == SPI_MODE_SLAVE);
+#if PLATFORM_ID == PLATFORM_ARGON || PLATFORM_ID == PLATFORM_BORON || PLATFORM_ID == PLATFORM_XENON
+    assertTrue(info.ss_pin == D14);
+#elif PLATFORM_ID == PLATFORM_BSOM
+    assertTrue(info.ss_pin == D8);
+#else // Photon, P1 and Electron
+    assertTrue(info.ss_pin == A2);
+#endif
+    SPI.end();
+#endif // HAL_PLATFORM_STM32F2XX
+}
+
+test(SPI_4_SPI_Begin_With_Master_Ss_Pin)
+{
+    // Just in case
+    SPI.end();
+
+    hal_spi_info_t info = {};
+
+    SPI.begin(SPI_MODE_MASTER, SPI_DEFAULT_SS);
+    querySpiInfo(HAL_SPI_INTERFACE1, &info);
+    assertTrue(info.enabled == true);
+    assertTrue(info.mode == SPI_MODE_MASTER);
+#if PLATFORM_ID == PLATFORM_ARGON || PLATFORM_ID == PLATFORM_BORON || PLATFORM_ID == PLATFORM_XENON
+    assertTrue(info.ss_pin == D14);
+#elif PLATFORM_ID == PLATFORM_BSOM
+    assertTrue(info.ss_pin == D8);
+#else // Photon, P1 and Electron
+    assertTrue(info.ss_pin == A2);
+#endif
+    SPI.end();
+
+    memset(&info, 0x00, sizeof(hal_spi_info_t));
+
+    SPI.begin(SPI_MODE_MASTER, D0);
+    querySpiInfo(HAL_SPI_INTERFACE1, &info);
+    assertTrue(info.enabled == true);
+    assertTrue(info.mode == SPI_MODE_MASTER);
+    assertTrue(info.ss_pin == D0);
+    SPI.end();
+
+    memset(&info, 0x00, sizeof(hal_spi_info_t));
+
+    SPI.begin(SPI_MODE_MASTER, PIN_INVALID);
+    querySpiInfo(HAL_SPI_INTERFACE1, &info);
+    assertTrue(info.enabled == true);
+    assertTrue(info.mode == SPI_MODE_MASTER);
+    assertTrue(info.ss_pin == PIN_INVALID);
+    SPI.end();
+
+    memset(&info, 0x00, sizeof(hal_spi_info_t));
+
+    SPI.begin(SPI_MODE_MASTER, 123);
+    querySpiInfo(HAL_SPI_INTERFACE1, &info);
+    assertTrue(info.enabled == true);
+    assertTrue(info.mode == SPI_MODE_MASTER);
+    assertTrue(info.ss_pin == 123);
+    SPI.end();
+}
+
+// HAL_SPI_INTERFACE1 does not support slave mode on Gen3 device
+#if HAL_PLATFORM_STM32F2XX
+test(SPI_5_SPI_Begin_With_Slave_Ss_Pin)
+{
+    // Just in case
+    SPI.end();
+
+    hal_spi_info_t info = {};
+
+    SPI.begin(SPI_MODE_SLAVE, SPI_DEFAULT_SS);
+    querySpiInfo(HAL_SPI_INTERFACE1, &info);
+    assertTrue(info.enabled == true);
+    assertTrue(info.mode == SPI_MODE_SLAVE);
+#if PLATFORM_ID == PLATFORM_ARGON || PLATFORM_ID == PLATFORM_BORON || PLATFORM_ID == PLATFORM_XENON
+    assertTrue(info.ss_pin == D14);
+#elif PLATFORM_ID == PLATFORM_BSOM
+    assertTrue(info.ss_pin == D8);
+#else // Photon, P1 and Electron
+    assertTrue(info.ss_pin == A2);
+#endif
+    SPI.end();
+
+    memset(&info, 0x00, sizeof(hal_spi_info_t));
+
+    SPI.begin(SPI_MODE_SLAVE, D0);
+    querySpiInfo(HAL_SPI_INTERFACE1, &info);
+    assertTrue(info.enabled == true);
+    assertTrue(info.mode == SPI_MODE_SLAVE);
+    assertTrue(info.ss_pin == D0);
+    SPI.end();
+
+    memset(&info, 0x00, sizeof(hal_spi_info_t));
+
+    SPI.begin(SPI_MODE_SLAVE, PIN_INVALID);
+    querySpiInfo(HAL_SPI_INTERFACE1, &info);
+    assertFalse(info.enabled == true);
+    SPI.end();
+
+    memset(&info, 0x00, sizeof(hal_spi_info_t));
+
+    SPI.begin(SPI_MODE_SLAVE, 123);
+    querySpiInfo(HAL_SPI_INTERFACE1, &info);
+    assertFalse(info.enabled == true);
+    SPI.end();
+}
+#endif // HAL_PLATFORM_STM32F2XX
+
+#if Wiring_SPI1
+test(SPI_6_SPI1_Begin_Without_Argument)
+{
+    // Just in case
+    SPI1.end();
+
+    hal_spi_info_t info = {};
+
+    SPI1.begin();
+    querySpiInfo(HAL_SPI_INTERFACE2, &info);
+    assertTrue(info.enabled == true);
+    assertTrue(info.mode == SPI_MODE_MASTER);
+    // D5 is the default SS pin for all platforms
+    assertTrue(info.ss_pin == D5);
+    SPI1.end();
+}
+
+test(SPI_7_SPI1_Begin_With_Ss_Pin)
+{
+    // Just in case
+    SPI1.end();
+
+    hal_spi_info_t info = {};
+
+    SPI1.begin(SPI_DEFAULT_SS);
+    querySpiInfo(HAL_SPI_INTERFACE2, &info);
+    assertTrue(info.enabled == true);
+    assertTrue(info.mode == SPI_MODE_MASTER);
+    // D5 is the default SS pin for all platforms
+    assertTrue(info.ss_pin == D5);
+    SPI1.end();
+
+    memset(&info, 0x00, sizeof(hal_spi_info_t));
+
+    SPI1.begin(D0);
+    querySpiInfo(HAL_SPI_INTERFACE2, &info);
+    assertTrue(info.enabled == true);
+    assertTrue(info.mode == SPI_MODE_MASTER);
+    assertTrue(info.ss_pin == D0);
+    SPI1.end();
+
+    memset(&info, 0x00, sizeof(hal_spi_info_t));
+
+    SPI1.begin(PIN_INVALID);
+    querySpiInfo(HAL_SPI_INTERFACE2, &info);
+    assertTrue(info.enabled == true);
+    assertTrue(info.mode == SPI_MODE_MASTER);
+    assertTrue(info.ss_pin == PIN_INVALID);
+    SPI1.end();
+
+    memset(&info, 0x00, sizeof(hal_spi_info_t));
+
+    SPI1.begin(123);
+    querySpiInfo(HAL_SPI_INTERFACE2, &info);
+    assertTrue(info.enabled == true);
+    assertTrue(info.mode == SPI_MODE_MASTER);
+    assertTrue(info.ss_pin == 123);
+    SPI1.end();
+}
+
+test(SPI_8_SPI1_Begin_With_Mode)
+{
+    // Just in case
+    SPI1.end();
+
+    hal_spi_info_t info = {};
+
+    SPI1.begin(SPI_MODE_MASTER);
+    querySpiInfo(HAL_SPI_INTERFACE2, &info);
+    assertTrue(info.enabled == true);
+    assertTrue(info.mode == SPI_MODE_MASTER);
+    // D5 is the default SS pin for all platforms
+    assertTrue(info.ss_pin == D5);
+    SPI1.end();
+
+    memset(&info, 0x00, sizeof(hal_spi_info_t));
+
+    SPI1.begin(SPI_MODE_SLAVE);
+    querySpiInfo(HAL_SPI_INTERFACE2, &info);
+    assertTrue(info.enabled == true);
+    assertTrue(info.mode == SPI_MODE_SLAVE);
+    // D5 is the default SS pin for all platforms
+    assertTrue(info.ss_pin == D5);
+    SPI1.end();
+}
+
+test(SPI_9_SPI1_Begin_With_Master_Ss_Pin)
+{
+    // Just in case
+    SPI1.end();
+
+    hal_spi_info_t info = {};
+
+    SPI1.begin(SPI_MODE_MASTER, SPI_DEFAULT_SS);
+    querySpiInfo(HAL_SPI_INTERFACE2, &info);
+    assertTrue(info.enabled == true);
+    assertTrue(info.mode == SPI_MODE_MASTER);
+    // D5 is the default SS pin for all platforms
+    assertTrue(info.ss_pin == D5);
+    SPI1.end();
+
+    memset(&info, 0x00, sizeof(hal_spi_info_t));
+
+    SPI1.begin(SPI_MODE_MASTER, D0);
+    querySpiInfo(HAL_SPI_INTERFACE2, &info);
+    assertTrue(info.enabled == true);
+    assertTrue(info.mode == SPI_MODE_MASTER);
+    assertTrue(info.ss_pin == D0);
+    SPI1.end();
+
+    memset(&info, 0x00, sizeof(hal_spi_info_t));
+
+    SPI1.begin(SPI_MODE_MASTER, PIN_INVALID);
+    querySpiInfo(HAL_SPI_INTERFACE2, &info);
+    assertTrue(info.enabled == true);
+    assertTrue(info.mode == SPI_MODE_MASTER);
+    assertTrue(info.ss_pin == PIN_INVALID);
+    SPI1.end();
+
+    memset(&info, 0x00, sizeof(hal_spi_info_t));
+
+    SPI1.begin(SPI_MODE_MASTER, 123);
+    querySpiInfo(HAL_SPI_INTERFACE2, &info);
+    assertTrue(info.enabled == true);
+    assertTrue(info.mode == SPI_MODE_MASTER);
+    assertTrue(info.ss_pin == 123);
+    SPI1.end();
+}
+
+test(SPI_10_SPI1_Begin_With_Slave_Ss_Pin)
+{
+    // Just in case
+    SPI1.end();
+
+    hal_spi_info_t info = {};
+
+    SPI1.begin(SPI_MODE_SLAVE, SPI_DEFAULT_SS);
+    querySpiInfo(HAL_SPI_INTERFACE2, &info);
+    assertTrue(info.enabled == true);
+    assertTrue(info.mode == SPI_MODE_SLAVE);
+    // D5 is the default SS pin for all platforms
+    assertTrue(info.ss_pin == D5);
+    SPI1.end();
+
+    memset(&info, 0x00, sizeof(hal_spi_info_t));
+
+    SPI1.begin(SPI_MODE_SLAVE, D0);
+    querySpiInfo(HAL_SPI_INTERFACE2, &info);
+    assertTrue(info.enabled == true);
+    assertTrue(info.mode == SPI_MODE_SLAVE);
+    assertTrue(info.ss_pin == D0);
+    SPI1.end();
+
+    memset(&info, 0x00, sizeof(hal_spi_info_t));
+
+    SPI1.begin(SPI_MODE_SLAVE, PIN_INVALID);
+    querySpiInfo(HAL_SPI_INTERFACE2, &info);
+    assertFalse(info.enabled == true);
+    SPI1.end();
+
+    memset(&info, 0x00, sizeof(hal_spi_info_t));
+
+    SPI1.begin(SPI_MODE_SLAVE, 123);
+    querySpiInfo(HAL_SPI_INTERFACE2, &info);
+    assertFalse(info.enabled == true);
+    SPI1.end();
+}
+#endif // Wiring_SPI1
+

--- a/user/tests/wiring/no_fixture_spi/spi.cpp
+++ b/user/tests/wiring/no_fixture_spi/spi.cpp
@@ -34,14 +34,14 @@ test(SPI_1_SPI_Begin_Without_Argument)
 
     SPI.begin();
     querySpiInfo(HAL_SPI_INTERFACE1, &info);
-    assertTrue(info.enabled == true);
-    assertTrue(info.mode == SPI_MODE_MASTER);
+    assertTrue(info.enabled);
+    assertEqual(info.mode, SPI_MODE_MASTER);
 #if PLATFORM_ID == PLATFORM_ARGON || PLATFORM_ID == PLATFORM_BORON || PLATFORM_ID == PLATFORM_XENON
-    assertTrue(info.ss_pin == D14);
-#elif PLATFORM_ID == PLATFORM_BSOM
-    assertTrue(info.ss_pin == D8);
+    assertEqual(info.ss_pin, D14);
+#elif PLATFORM_ID == PLATFORM_BSOM || PLATFORM_ID == PLATFORM_B5SOM
+    assertEqual(info.ss_pin, D8);
 #else // Photon, P1 and Electron
-    assertTrue(info.ss_pin == A2);
+    assertEqual(info.ss_pin, A2);
 #endif
     SPI.end();
 }
@@ -55,14 +55,14 @@ test(SPI_2_SPI_Begin_With_Ss_Pin)
 
     SPI.begin(SPI_DEFAULT_SS);
     querySpiInfo(HAL_SPI_INTERFACE1, &info);
-    assertTrue(info.enabled == true);
-    assertTrue(info.mode == SPI_MODE_MASTER);
+    assertTrue(info.enabled);
+    assertEqual(info.mode, SPI_MODE_MASTER);
 #if PLATFORM_ID == PLATFORM_ARGON || PLATFORM_ID == PLATFORM_BORON || PLATFORM_ID == PLATFORM_XENON
-    assertTrue(info.ss_pin == D14);
-#elif PLATFORM_ID == PLATFORM_BSOM
-    assertTrue(info.ss_pin == D8);
+    assertEqual(info.ss_pin, D14);
+#elif PLATFORM_ID == PLATFORM_BSOM || PLATFORM_ID == PLATFORM_B5SOM
+    assertEqual(info.ss_pin, D8);
 #else // Photon, P1 and Electron
-    assertTrue(info.ss_pin == A2);
+    assertEqual(info.ss_pin, A2);
 #endif
     SPI.end();
 
@@ -70,27 +70,27 @@ test(SPI_2_SPI_Begin_With_Ss_Pin)
 
     SPI.begin(D0);
     querySpiInfo(HAL_SPI_INTERFACE1, &info);
-    assertTrue(info.enabled == true);
-    assertTrue(info.mode == SPI_MODE_MASTER);
-    assertTrue(info.ss_pin == D0);
+    assertTrue(info.enabled);
+    assertEqual(info.mode, SPI_MODE_MASTER);
+    assertEqual(info.ss_pin, D0);
     SPI.end();
 
     memset(&info, 0x00, sizeof(hal_spi_info_t));
 
     SPI.begin(PIN_INVALID);
     querySpiInfo(HAL_SPI_INTERFACE1, &info);
-    assertTrue(info.enabled == true);
-    assertTrue(info.mode == SPI_MODE_MASTER);
-    assertTrue(info.ss_pin == PIN_INVALID);
+    assertTrue(info.enabled);
+    assertEqual(info.mode, SPI_MODE_MASTER);
+    assertEqual(info.ss_pin, PIN_INVALID);
     SPI.end();
 
     memset(&info, 0x00, sizeof(hal_spi_info_t));
 
     SPI.begin(123);
     querySpiInfo(HAL_SPI_INTERFACE1, &info);
-    assertTrue(info.enabled == true);
-    assertTrue(info.mode == SPI_MODE_MASTER);
-    assertTrue(info.ss_pin == 123);
+    assertTrue(info.enabled);
+    assertEqual(info.mode, SPI_MODE_MASTER);
+    assertEqual(info.ss_pin, 123);
     SPI.end();
 }
 
@@ -103,14 +103,14 @@ test(SPI_3_SPI_Begin_With_Mode)
 
     SPI.begin(SPI_MODE_MASTER);
     querySpiInfo(HAL_SPI_INTERFACE1, &info);
-    assertTrue(info.enabled == true);
-    assertTrue(info.mode == SPI_MODE_MASTER);
+    assertTrue(info.enabled);
+    assertEqual(info.mode, SPI_MODE_MASTER);
 #if PLATFORM_ID == PLATFORM_ARGON || PLATFORM_ID == PLATFORM_BORON || PLATFORM_ID == PLATFORM_XENON
-    assertTrue(info.ss_pin == D14);
-#elif PLATFORM_ID == PLATFORM_BSOM
-    assertTrue(info.ss_pin == D8);
+    assertEqual(info.ss_pin, D14);
+#elif PLATFORM_ID == PLATFORM_BSOM || PLATFORM_ID == PLATFORM_B5SOM
+    assertEqual(info.ss_pin,D8);
 #else // Photon, P1 and Electron
-    assertTrue(info.ss_pin == A2);
+    assertEqual(info.ss_pin, A2);
 #endif
     SPI.end();
 
@@ -120,14 +120,14 @@ test(SPI_3_SPI_Begin_With_Mode)
 #if HAL_PLATFORM_STM32F2XX
     SPI.begin(SPI_MODE_SLAVE);
     querySpiInfo(HAL_SPI_INTERFACE1, &info);
-    assertTrue(info.enabled == true);
-    assertTrue(info.mode == SPI_MODE_SLAVE);
+    assertTrue(info.enabled);
+    assertEqual(info.mode, SPI_MODE_SLAVE);
 #if PLATFORM_ID == PLATFORM_ARGON || PLATFORM_ID == PLATFORM_BORON || PLATFORM_ID == PLATFORM_XENON
-    assertTrue(info.ss_pin == D14);
-#elif PLATFORM_ID == PLATFORM_BSOM
-    assertTrue(info.ss_pin == D8);
+    assertEqual(info.ss_pin, D14);
+#elif PLATFORM_ID == PLATFORM_BSOM || PLATFORM_ID == PLATFORM_B5SOM
+    assertEqual(info.ss_pin, D8);
 #else // Photon, P1 and Electron
-    assertTrue(info.ss_pin == A2);
+    assertEqual(info.ss_pin, A2);
 #endif
     SPI.end();
 #endif // HAL_PLATFORM_STM32F2XX
@@ -142,14 +142,14 @@ test(SPI_4_SPI_Begin_With_Master_Ss_Pin)
 
     SPI.begin(SPI_MODE_MASTER, SPI_DEFAULT_SS);
     querySpiInfo(HAL_SPI_INTERFACE1, &info);
-    assertTrue(info.enabled == true);
-    assertTrue(info.mode == SPI_MODE_MASTER);
+    assertTrue(info.enabled);
+    assertEqual(info.mode, SPI_MODE_MASTER);
 #if PLATFORM_ID == PLATFORM_ARGON || PLATFORM_ID == PLATFORM_BORON || PLATFORM_ID == PLATFORM_XENON
-    assertTrue(info.ss_pin == D14);
+    assertEqual(info.ss_pin, D14);
 #elif PLATFORM_ID == PLATFORM_BSOM
-    assertTrue(info.ss_pin == D8);
+    assertEqual(info.ss_pin, D8);
 #else // Photon, P1 and Electron
-    assertTrue(info.ss_pin == A2);
+    assertEqual(info.ss_pin, A2);
 #endif
     SPI.end();
 
@@ -157,27 +157,27 @@ test(SPI_4_SPI_Begin_With_Master_Ss_Pin)
 
     SPI.begin(SPI_MODE_MASTER, D0);
     querySpiInfo(HAL_SPI_INTERFACE1, &info);
-    assertTrue(info.enabled == true);
-    assertTrue(info.mode == SPI_MODE_MASTER);
-    assertTrue(info.ss_pin == D0);
+    assertTrue(info.enabled);
+    assertEqual(info.mode, SPI_MODE_MASTER);
+    assertEqual(info.ss_pin, D0);
     SPI.end();
 
     memset(&info, 0x00, sizeof(hal_spi_info_t));
 
     SPI.begin(SPI_MODE_MASTER, PIN_INVALID);
     querySpiInfo(HAL_SPI_INTERFACE1, &info);
-    assertTrue(info.enabled == true);
-    assertTrue(info.mode == SPI_MODE_MASTER);
-    assertTrue(info.ss_pin == PIN_INVALID);
+    assertTrue(info.enabled);
+    assertEqual(info.mode, SPI_MODE_MASTER);
+    assertEqual(info.ss_pin, PIN_INVALID);
     SPI.end();
 
     memset(&info, 0x00, sizeof(hal_spi_info_t));
 
     SPI.begin(SPI_MODE_MASTER, 123);
     querySpiInfo(HAL_SPI_INTERFACE1, &info);
-    assertTrue(info.enabled == true);
-    assertTrue(info.mode == SPI_MODE_MASTER);
-    assertTrue(info.ss_pin == 123);
+    assertTrue(info.enabled);
+    assertEqual(info.mode, SPI_MODE_MASTER);
+    assertEqual(info.ss_pin, 123);
     SPI.end();
 }
 
@@ -192,38 +192,32 @@ test(SPI_5_SPI_Begin_With_Slave_Ss_Pin)
 
     SPI.begin(SPI_MODE_SLAVE, SPI_DEFAULT_SS);
     querySpiInfo(HAL_SPI_INTERFACE1, &info);
-    assertTrue(info.enabled == true);
-    assertTrue(info.mode == SPI_MODE_SLAVE);
-#if PLATFORM_ID == PLATFORM_ARGON || PLATFORM_ID == PLATFORM_BORON || PLATFORM_ID == PLATFORM_XENON
-    assertTrue(info.ss_pin == D14);
-#elif PLATFORM_ID == PLATFORM_BSOM
-    assertTrue(info.ss_pin == D8);
-#else // Photon, P1 and Electron
-    assertTrue(info.ss_pin == A2);
-#endif
+    assertTrue(info.enabled);
+    assertEqual(info.mode, SPI_MODE_SLAVE);
+    assertEqual(info.ss_pin, A2);
     SPI.end();
 
     memset(&info, 0x00, sizeof(hal_spi_info_t));
 
     SPI.begin(SPI_MODE_SLAVE, D0);
     querySpiInfo(HAL_SPI_INTERFACE1, &info);
-    assertTrue(info.enabled == true);
-    assertTrue(info.mode == SPI_MODE_SLAVE);
-    assertTrue(info.ss_pin == D0);
+    assertTrue(info.enabled);
+    assertEqual(info.mode, SPI_MODE_SLAVE);
+    assertEqual(info.ss_pin, D0);
     SPI.end();
 
     memset(&info, 0x00, sizeof(hal_spi_info_t));
 
     SPI.begin(SPI_MODE_SLAVE, PIN_INVALID);
     querySpiInfo(HAL_SPI_INTERFACE1, &info);
-    assertFalse(info.enabled == true);
+    assertFalse(info.enabled);
     SPI.end();
 
     memset(&info, 0x00, sizeof(hal_spi_info_t));
 
     SPI.begin(SPI_MODE_SLAVE, 123);
     querySpiInfo(HAL_SPI_INTERFACE1, &info);
-    assertFalse(info.enabled == true);
+    assertFalse(info.enabled);
     SPI.end();
 }
 #endif // HAL_PLATFORM_STM32F2XX
@@ -238,10 +232,10 @@ test(SPI_6_SPI1_Begin_Without_Argument)
 
     SPI1.begin();
     querySpiInfo(HAL_SPI_INTERFACE2, &info);
-    assertTrue(info.enabled == true);
-    assertTrue(info.mode == SPI_MODE_MASTER);
+    assertTrue(info.enabled);
+    assertEqual(info.mode, SPI_MODE_MASTER);
     // D5 is the default SS pin for all platforms
-    assertTrue(info.ss_pin == D5);
+    assertEqual(info.ss_pin, D5);
     SPI1.end();
 }
 
@@ -254,37 +248,37 @@ test(SPI_7_SPI1_Begin_With_Ss_Pin)
 
     SPI1.begin(SPI_DEFAULT_SS);
     querySpiInfo(HAL_SPI_INTERFACE2, &info);
-    assertTrue(info.enabled == true);
-    assertTrue(info.mode == SPI_MODE_MASTER);
+    assertTrue(info.enabled);
+    assertEqual(info.mode, SPI_MODE_MASTER);
     // D5 is the default SS pin for all platforms
-    assertTrue(info.ss_pin == D5);
+    assertEqual(info.ss_pin, D5);
     SPI1.end();
 
     memset(&info, 0x00, sizeof(hal_spi_info_t));
 
     SPI1.begin(D0);
     querySpiInfo(HAL_SPI_INTERFACE2, &info);
-    assertTrue(info.enabled == true);
-    assertTrue(info.mode == SPI_MODE_MASTER);
-    assertTrue(info.ss_pin == D0);
+    assertTrue(info.enabled);
+    assertEqual(info.mode, SPI_MODE_MASTER);
+    assertEqual(info.ss_pin, D0);
     SPI1.end();
 
     memset(&info, 0x00, sizeof(hal_spi_info_t));
 
     SPI1.begin(PIN_INVALID);
     querySpiInfo(HAL_SPI_INTERFACE2, &info);
-    assertTrue(info.enabled == true);
-    assertTrue(info.mode == SPI_MODE_MASTER);
-    assertTrue(info.ss_pin == PIN_INVALID);
+    assertTrue(info.enabled);
+    assertEqual(info.mode, SPI_MODE_MASTER);
+    assertEqual(info.ss_pin, PIN_INVALID);
     SPI1.end();
 
     memset(&info, 0x00, sizeof(hal_spi_info_t));
 
     SPI1.begin(123);
     querySpiInfo(HAL_SPI_INTERFACE2, &info);
-    assertTrue(info.enabled == true);
-    assertTrue(info.mode == SPI_MODE_MASTER);
-    assertTrue(info.ss_pin == 123);
+    assertTrue(info.enabled);
+    assertEqual(info.mode, SPI_MODE_MASTER);
+    assertEqual(info.ss_pin, 123);
     SPI1.end();
 }
 
@@ -297,20 +291,20 @@ test(SPI_8_SPI1_Begin_With_Mode)
 
     SPI1.begin(SPI_MODE_MASTER);
     querySpiInfo(HAL_SPI_INTERFACE2, &info);
-    assertTrue(info.enabled == true);
-    assertTrue(info.mode == SPI_MODE_MASTER);
+    assertTrue(info.enabled);
+    assertEqual(info.mode, SPI_MODE_MASTER);
     // D5 is the default SS pin for all platforms
-    assertTrue(info.ss_pin == D5);
+    assertEqual(info.ss_pin, D5);
     SPI1.end();
 
     memset(&info, 0x00, sizeof(hal_spi_info_t));
 
     SPI1.begin(SPI_MODE_SLAVE);
     querySpiInfo(HAL_SPI_INTERFACE2, &info);
-    assertTrue(info.enabled == true);
-    assertTrue(info.mode == SPI_MODE_SLAVE);
+    assertTrue(info.enabled);
+    assertEqual(info.mode, SPI_MODE_SLAVE);
     // D5 is the default SS pin for all platforms
-    assertTrue(info.ss_pin == D5);
+    assertEqual(info.ss_pin, D5);
     SPI1.end();
 }
 
@@ -323,37 +317,37 @@ test(SPI_9_SPI1_Begin_With_Master_Ss_Pin)
 
     SPI1.begin(SPI_MODE_MASTER, SPI_DEFAULT_SS);
     querySpiInfo(HAL_SPI_INTERFACE2, &info);
-    assertTrue(info.enabled == true);
-    assertTrue(info.mode == SPI_MODE_MASTER);
+    assertTrue(info.enabled);
+    assertEqual(info.mode, SPI_MODE_MASTER);
     // D5 is the default SS pin for all platforms
-    assertTrue(info.ss_pin == D5);
+    assertEqual(info.ss_pin, D5);
     SPI1.end();
 
     memset(&info, 0x00, sizeof(hal_spi_info_t));
 
     SPI1.begin(SPI_MODE_MASTER, D0);
     querySpiInfo(HAL_SPI_INTERFACE2, &info);
-    assertTrue(info.enabled == true);
-    assertTrue(info.mode == SPI_MODE_MASTER);
-    assertTrue(info.ss_pin == D0);
+    assertTrue(info.enabled);
+    assertEqual(info.mode, SPI_MODE_MASTER);
+    assertEqual(info.ss_pin, D0);
     SPI1.end();
 
     memset(&info, 0x00, sizeof(hal_spi_info_t));
 
     SPI1.begin(SPI_MODE_MASTER, PIN_INVALID);
     querySpiInfo(HAL_SPI_INTERFACE2, &info);
-    assertTrue(info.enabled == true);
-    assertTrue(info.mode == SPI_MODE_MASTER);
-    assertTrue(info.ss_pin == PIN_INVALID);
+    assertTrue(info.enabled);
+    assertEqual(info.mode, SPI_MODE_MASTER);
+    assertEqual(info.ss_pin, PIN_INVALID);
     SPI1.end();
 
     memset(&info, 0x00, sizeof(hal_spi_info_t));
 
     SPI1.begin(SPI_MODE_MASTER, 123);
     querySpiInfo(HAL_SPI_INTERFACE2, &info);
-    assertTrue(info.enabled == true);
-    assertTrue(info.mode == SPI_MODE_MASTER);
-    assertTrue(info.ss_pin == 123);
+    assertTrue(info.enabled);
+    assertEqual(info.mode, SPI_MODE_MASTER);
+    assertEqual(info.ss_pin, 123);
     SPI1.end();
 }
 
@@ -366,33 +360,33 @@ test(SPI_10_SPI1_Begin_With_Slave_Ss_Pin)
 
     SPI1.begin(SPI_MODE_SLAVE, SPI_DEFAULT_SS);
     querySpiInfo(HAL_SPI_INTERFACE2, &info);
-    assertTrue(info.enabled == true);
-    assertTrue(info.mode == SPI_MODE_SLAVE);
+    assertTrue(info.enabled);
+    assertEqual(info.mode, SPI_MODE_SLAVE);
     // D5 is the default SS pin for all platforms
-    assertTrue(info.ss_pin == D5);
+    assertEqual(info.ss_pin, D5);
     SPI1.end();
 
     memset(&info, 0x00, sizeof(hal_spi_info_t));
 
     SPI1.begin(SPI_MODE_SLAVE, D0);
     querySpiInfo(HAL_SPI_INTERFACE2, &info);
-    assertTrue(info.enabled == true);
-    assertTrue(info.mode == SPI_MODE_SLAVE);
-    assertTrue(info.ss_pin == D0);
+    assertTrue(info.enabled);
+    assertEqual(info.mode, SPI_MODE_SLAVE);
+    assertEqual(info.ss_pin, D0);
     SPI1.end();
 
     memset(&info, 0x00, sizeof(hal_spi_info_t));
 
     SPI1.begin(SPI_MODE_SLAVE, PIN_INVALID);
     querySpiInfo(HAL_SPI_INTERFACE2, &info);
-    assertFalse(info.enabled == true);
+    assertFalse(info.enabled);
     SPI1.end();
 
     memset(&info, 0x00, sizeof(hal_spi_info_t));
 
     SPI1.begin(SPI_MODE_SLAVE, 123);
     querySpiInfo(HAL_SPI_INTERFACE2, &info);
-    assertFalse(info.enabled == true);
+    assertFalse(info.enabled);
     SPI1.end();
 }
 #endif // Wiring_SPI1

--- a/user/tests/wiring/no_fixture_spi/test.mk
+++ b/user/tests/wiring/no_fixture_spi/test.mk
@@ -1,0 +1,18 @@
+INCLUDE_DIRS += $(SOURCE_PATH)/$(USRSRC)  # add user sources to include path
+# add C and CPP files - if USRSRC is not empty, then add a slash
+CPPSRC += $(call target_files,$(USRSRC_SLASH),*.cpp)
+CSRC += $(call target_files,$(USRSRC_SLASH),*.c)
+
+APPSOURCES=$(call target_files,$(USRSRC_SLASH),*.cpp)
+APPSOURCES+=$(call target_files,$(USRSRC_SLASH),*.c)
+ifeq ($(strip $(APPSOURCES)),)
+$(error "No sources found in $(SOURCE_PATH)/$(USRSRC)")
+endif
+
+ifeq ("${USE_THREADING}","y")
+USE_THREADING_VALUE=1
+else
+USE_THREADING_VALUE=0
+endif
+
+CFLAGS += -DUSE_THREADING=${USE_THREADING_VALUE}

--- a/wiring/inc/spark_wiring_spi.h
+++ b/wiring/inc/spark_wiring_spi.h
@@ -162,7 +162,7 @@ public:
 
   void begin();
   void begin(uint16_t);
-  void begin(SPI_Mode mode, uint16_t);
+  void begin(SPI_Mode mode, uint16_t ss_pin = SPI_DEFAULT_SS);
   void end();
 
   void setBitOrder(uint8_t);

--- a/wiring/src/spark_wiring_spi.cpp
+++ b/wiring/src/spark_wiring_spi.cpp
@@ -102,11 +102,6 @@ void SPIClass::begin()
 
 void SPIClass::begin(uint16_t ss_pin)
 {
-    if (ss_pin >= TOTAL_PINS)
-    {
-        return;
-    }
-
     if (!lock())
     {
         HAL_SPI_Begin(_spi, ss_pin);
@@ -116,11 +111,6 @@ void SPIClass::begin(uint16_t ss_pin)
 
 void SPIClass::begin(SPI_Mode mode, uint16_t ss_pin)
 {
-    if (ss_pin >= TOTAL_PINS)
-    {
-        return;
-    }
-
     if (!lock())
     {
         HAL_SPI_Begin_Ext(_spi, mode, ss_pin, NULL);


### PR DESCRIPTION
### Problem

`SPI.begin(SPI_MODE_MASTER);` doesn't configure the default SS pin to be output high initially.

### Solution

Assign default parameter for the second argument of the `SPIClass::begin(SPI_Mode mode, uint16_t ss_pin = SPI_DEFAULT_SS)`.

### Steps to Test

1. Build and download the following example App.
2. Check if the default SS pin according to https://docs.particle.io/reference/device-os/firmware/electron/#begin--4 can be toggled periodically.

### Example App

```c
#include "application.h"

SYSTEM_MODE(MANUAL);

#if HAL_PLATFORM_STM32F2XX
#define SPI_DEFAULT_SS_PIN  A2
#elif PLATFORM_ID == PLATFORM_XENON || PLATFORM_ID == PLATFORM_ARGON || PLATFORM_ID == PLATFORM_BORON
#define SPI_DEFAULT_SS_PIN  A5
#endif

void setup()
{
    SPI.begin(SPI_MODE_MASTER);
}

void loop()
{
    digitalWrite(SPI_DEFAULT_SS_PIN, LOW);
    delay(3000);
    digitalWrite(SPI_DEFAULT_SS_PIN, HIGH);
    delay(3000);
}
```

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)