### PR TITLE
Fix building of Boost on macOS

### DIFF
--- a/ci/build_boost.sh
+++ b/ci/build_boost.sh
@@ -1,4 +1,9 @@
+toolset="gcc"
+if [[ $OSTYPE == darwin* ]]; then
+  toolset="darwin"
+fi
+
 pushd $BOOST_ROOT
 ./bootstrap.sh
-./b2  --with-thread  --with-system --with-program_options --with-random --with-regex --threading=multi
+./b2  --with-thread  --with-system --with-program_options --with-random --with-regex --threading=multi toolset=$toolset
 popd

--- a/ci/install_boost.sh
+++ b/ci/install_boost.sh
@@ -5,5 +5,9 @@ export BOOST_LIBRARYDIR=$BOOST_ROOT/stage/lib
 mkdir -p $BOOST_ROOT
 test -d $BOOST_ROOT || ( echo "boost root $BOOST_ROOT not created." && exit 1)
 test -f $BOOST_ROOT/INSTALL || wget --quiet https://s3.amazonaws.com/spark-assets/boost_${BOOST_VERSION}.tar.gz -O - | tar -xz -C $BOOST_ROOT --strip-components 1
-export DYLD_LIBRARY_PATH="${BOOST_LIBRARYDIR}:$DYLD_LIBRARY_PATH"
-export LD_LIBRARY_PATH="${BOOST_LIBRARYDIR}:$LD_LIBRARY_PATH"
+
+if [[ $OSTYPE == darwin* ]]; then
+  export DYLD_LIBRARY_PATH="${BOOST_LIBRARYDIR}:$DYLD_LIBRARY_PATH"
+else
+  export LD_LIBRARY_PATH="${BOOST_LIBRARYDIR}:$LD_LIBRARY_PATH"
+fi


### PR DESCRIPTION
### Problem

On macOS, `ci/build_boost.sh` builds Boost using the system's clang compiler while Device OS for the virtual platform requires GCC and the two can't be linked together.

### Solution

Passing `toolset=darwin` to `b2` seems to resolve the problem.

### Steps to Test

On a macOS machine:

1. Remove cached Boost binaries:
```
rm -rf ~/.ci
```
2. Recompile Boost:
```
cd path/to/device_os
source ci/install_boost.sh
ci/build_boost.sh
```
3. Build Device OS:
```
cd path/to/device_os/main
make -s clean all PLATFORM=gcc TEST=app/blank
```