### PR TITLE
OTA adjustments for Argon

### DIFF
--- a/communication/inc/protocol.h
+++ b/communication/inc/protocol.h
@@ -232,11 +232,6 @@ protected:
 	}
 
 	/**
-	 * The number of missed chunks to send in a single flight.
-	 */
-	const int MISSED_CHUNKS_TO_SEND = 50;
-
-	/**
 	 * @brief Generates and sends describe message
 	 *
 	 * @param channel The message channel used to send the message

--- a/communication/inc/protocol_defs.h
+++ b/communication/inc/protocol_defs.h
@@ -70,7 +70,8 @@ const chunk_index_t NO_CHUNKS_MISSING = 65535;
 const chunk_index_t MAX_CHUNKS        = 65535;
 
 #if PLATFORM_ID == PLATFORM_ARGON
-const size_t MISSED_CHUNKS_TO_SEND = 18; // FIXME
+// FIXME: Argon doesn't seem to be able to process more than 20 chunks per flight
+const size_t MISSED_CHUNKS_TO_SEND = 18;
 #else
 const size_t MISSED_CHUNKS_TO_SEND = 40;
 #endif

--- a/communication/inc/protocol_defs.h
+++ b/communication/inc/protocol_defs.h
@@ -70,8 +70,8 @@ const chunk_index_t NO_CHUNKS_MISSING = 65535;
 const chunk_index_t MAX_CHUNKS        = 65535;
 
 #if PLATFORM_ID == PLATFORM_ARGON
-// FIXME: Argon doesn't seem to be able to process more than 20 chunks per flight
-const size_t MISSED_CHUNKS_TO_SEND = 18;
+// FIXME: Argon doesn't seem to be able to process more than 25 chunks per flight
+const size_t MISSED_CHUNKS_TO_SEND = 20;
 #else
 const size_t MISSED_CHUNKS_TO_SEND = 40;
 #endif

--- a/communication/inc/protocol_defs.h
+++ b/communication/inc/protocol_defs.h
@@ -69,7 +69,7 @@ typedef uint16_t chunk_index_t;
 const chunk_index_t NO_CHUNKS_MISSING = 65535;
 const chunk_index_t MAX_CHUNKS        = 65535;
 
-#if PLATFORM_ID == PLATFORM_ARGON
+#if PLATFORM_ID == PLATFORM_ARGON || PLATFORM_ID == PLATFORM_ASOM
 // FIXME: Argon doesn't seem to be able to process more than 25 chunks per flight
 const size_t MISSED_CHUNKS_TO_SEND = 20;
 #else

--- a/communication/inc/protocol_defs.h
+++ b/communication/inc/protocol_defs.h
@@ -4,6 +4,7 @@
 #include "system_tick_hal.h"
 
 #include "system_error.h"
+#include "platforms.h"
 
 typedef uint16_t product_id_t;
 typedef uint16_t product_firmware_version_t;
@@ -67,7 +68,13 @@ typedef uint16_t chunk_index_t;
 
 const chunk_index_t NO_CHUNKS_MISSING = 65535;
 const chunk_index_t MAX_CHUNKS        = 65535;
-const size_t MISSED_CHUNKS_TO_SEND    = 40u;
+
+#if PLATFORM_ID == PLATFORM_ARGON
+const size_t MISSED_CHUNKS_TO_SEND = 18; // FIXME
+#else
+const size_t MISSED_CHUNKS_TO_SEND = 40;
+#endif
+
 const size_t MINIMUM_CHUNK_INCREASE   = 2u;
 const size_t MAX_EVENT_TTL_SECONDS    = 16777215;
 const size_t MAX_OPTION_DELTA_LENGTH  = 12;

--- a/communication/src/chunked_transfer.cpp
+++ b/communication/src/chunked_transfer.cpp
@@ -31,7 +31,6 @@ namespace particle { namespace protocol {
 ProtocolError ChunkedTransfer::handle_update_begin(
         token_t token, Message& message, MessageChannel& channel)
 {
-    update_begin_millis = callbacks->millis();
     LOG(INFO, "Received UpdateBegin");
     uint8_t flags = 0;
     chunk_count = 0;
@@ -283,8 +282,7 @@ ProtocolError ChunkedTransfer::handle_update_done(token_t token, Message& messag
 
     if (!missing)
     {
-        const auto t = (callbacks->millis() - update_begin_millis) / 1000;
-        LOG(INFO, "Update done in %u seconds", (unsigned)t);
+        LOG(INFO, "Update done");
         reset_updating();
         callbacks->finish_firmware_update(file, UpdateFlag::SUCCESS, NULL);
     }

--- a/communication/src/chunked_transfer.cpp
+++ b/communication/src/chunked_transfer.cpp
@@ -187,6 +187,10 @@ ProtocolError ChunkedTransfer::handle_chunk(token_t token, Message& message,
             LOG(WARN, "Invalid chunk index: %u", (unsigned)chunk_index);
             return NO_ERROR;
         }
+        if (fast_ota && is_chunk_received(chunk_index)) {
+            LOG_DEBUG(TRACE, "Duplicate chunk; index: %u", (unsigned)chunk_index);
+            return NO_ERROR;
+        }
         uint32_t crc = callbacks->calculate_crc(chunk, file.chunk_size);
         uint16_t response_size = 0;
         bool crc_valid = (crc == given_crc);

--- a/communication/src/chunked_transfer.h
+++ b/communication/src/chunked_transfer.h
@@ -69,7 +69,6 @@ public:
 private:
 	uint8_t updating;
 	system_tick_t last_chunk_millis;
-	system_tick_t update_begin_millis;
 	FileTransfer::Descriptor file;
 
 	/**

--- a/communication/src/chunked_transfer.h
+++ b/communication/src/chunked_transfer.h
@@ -69,6 +69,7 @@ public:
 private:
 	uint8_t updating;
 	system_tick_t last_chunk_millis;
+	system_tick_t update_begin_millis;
 	FileTransfer::Descriptor file;
 
 	/**
@@ -140,7 +141,7 @@ public:
 
 	ProtocolError handle_update_done(token_t token, Message& message, MessageChannel& channel);
 
-	ProtocolError send_missing_chunks(MessageChannel& channel, size_t count);
+	ProtocolError send_missing_chunks(MessageChannel& channel, size_t& count);
 
 	ProtocolError idle(MessageChannel& channel);
 


### PR DESCRIPTION
### Problem

This PR introduces the following changes:

1. Reduce the maximum number of firmware chunks that can be requested by an Argon during OTA from 40 to 20. Argon doesn't seem to be able to receive more than 25 chunks from a given flight of chunks, which causes it to drop `UpdateDone` messages repeatedly.

2. Do not wait for an ACK for a `ChunkMissed` message synchronously. This causes the comms library to drop packets and blocks the system loop during OTA.

3. Rework logging in the OTA code so that it's easier to debug.

### References

- [ch48671]