### PR TITLE
Only increment unacknowledged counter for requests, not acknowledgements

### DIFF
--- a/communication/src/coap_channel.cpp
+++ b/communication/src/coap_channel.cpp
@@ -56,10 +56,11 @@ bool CoAPMessageStore::retransmit(CoAPMessage* msg, Channel& channel, system_tic
 
 void CoAPMessageStore::message_timeout(CoAPMessage& msg, Channel& channel)
 {
-	g_unacknowledgedMessageCounter++;
 	msg.notify_timeout();
-	if (msg.is_request())
+	if (msg.is_request()) {
+		g_unacknowledgedMessageCounter++;
 		channel.command(MessageChannel::CLOSE);
+	}
 }
 
 /**


### PR DESCRIPTION
### Problem

`g_unacknowledgedMessageCounter` goes up for devices that are connected and healthy when they get a Particle.variable request from the cloud. This was seen on Electrons running Device OS 1.4.4.


Root cause:
- Cloud makes a variable request
- Response is piggybacked on ACK for original request
- In `CoAPMessageStore::send`, it checks for message type. Since it's not `CoAPType::CON`, it calls `set_expiration` which sets `transmit_count` to a large value
- Some time later, `CoAPMessageStore::process` sees that the message has expired and it deletes it from the queue and calls `message_timeout` which increments `g_unacknowledgedMessageCounter`

### Solution

`g_unacknowledgedMessageCounter` should only be incremented for confirmable messages that time out.

### Steps to Test

- Compile an application with a Particle.variable
- Call the variable
- Request device diagnostics from the Console
- `device.cloud.coap.unack` should be 0


### Completeness

- [x] User is totes amazing for contributing!
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
