### PR TITLE
Lower priority of the network interface thread

### DIFF
--- a/hal/network/lwip/cellular/pppncpnetif.cpp
+++ b/hal/network/lwip/cellular/pppncpnetif.cpp
@@ -84,7 +84,7 @@ PppNcpNetif::~PppNcpNetif() {
 
 void PppNcpNetif::init() {
     registerHandlers();
-    SPARK_ASSERT(os_thread_create(&thread_, "pppncp", OS_THREAD_PRIORITY_NETWORK, &PppNcpNetif::loop, this, OS_THREAD_STACK_SIZE_DEFAULT) == 0);
+    SPARK_ASSERT(os_thread_create(&thread_, "pppncp", OS_THREAD_PRIORITY_DEFAULT, &PppNcpNetif::loop, this, OS_THREAD_STACK_SIZE_DEFAULT) == 0);
 }
 
 void PppNcpNetif::setCellularManager(CellularNetworkManager* celMan) {

--- a/hal/network/lwip/esp32/esp32ncpnetif.cpp
+++ b/hal/network/lwip/esp32/esp32ncpnetif.cpp
@@ -84,7 +84,7 @@ Esp32NcpNetif::~Esp32NcpNetif() {
 
 void Esp32NcpNetif::init() {
     registerHandlers();
-    SPARK_ASSERT(os_thread_create(&thread_, "esp32ncp", OS_THREAD_PRIORITY_NETWORK, &Esp32NcpNetif::loop, this, OS_THREAD_STACK_SIZE_DEFAULT) == 0);
+    SPARK_ASSERT(os_thread_create(&thread_, "esp32ncp", OS_THREAD_PRIORITY_DEFAULT, &Esp32NcpNetif::loop, this, OS_THREAD_STACK_SIZE_DEFAULT) == 0);
 }
 
 void Esp32NcpNetif::setWifiManager(particle::WifiNetworkManager* wifiMan) {


### PR DESCRIPTION
### Problem

Network interface threads on Argon and Boron (`esp32ncp` and `pppncp` respectively) are running with a higher priority than the application and system threads. Due to a limitation in the implementation of the [serial stream](https://github.com/particle-iot/device-os/blob/dd8f7b7abde56f71ea2e79cce4d68144cc5c44db/hal/src/nRF52840/serial_stream.h#L26) class, which uses busy waiting to implement event notifications, those threads may completely block the application thread from running, especially when the NCP is being turned on or off.

### Solution

This PR lowers the priority of the network interface thread on Argon and Boron. The network interface thread mostly manages the state of the network interface and processes URCs. We use a [very large](https://github.com/particle-iot/device-os/blob/dd8f7b7abde56f71ea2e79cce4d68144cc5c44db/hal/src/boron/network/sara_ncp_client.cpp#L93-L94) RX buffer for the AT command channel, so it should be okay to read URCs at a potentially lower speed than the speed at which the NCP/muxer thread can generate them.

This is more a temporary solution. Ideally, we'd want to eliminate busy waiting in the networking code entirely.

### Steps to Test

Run the example application on a Boron and make sure the application thread is not being blocked for long periods of time when the modem is being turned on and off.

### Example App

```c
#include "Particle.h"

SerialLogHandler logHandler(Serial, LOG_LEVEL_TRACE);

SYSTEM_THREAD(ENABLED);
SYSTEM_MODE(SEMI_AUTOMATIC);

void setup()
{
    Particle.connect();
}

void loop()
{
    static uint32_t last_loop = millis();
    static int cellular = true;
    static uint32_t last_cellular = millis();

    if(millis() - last_cellular > 30000)
    {
        if(cellular)
        {
            Cellular.off();
        }
        else
        {
            Particle.connect();
        }
        last_cellular = millis();
        cellular = !cellular;
    }
    if(millis() - last_loop > 10)
    {
        Log.error("*************loop took too long: %lu*****************", millis() - last_loop);
    }
    last_loop = millis();
}
```

### References

- [ch48769]
