### PR TITLE
Ensure NCP connection state is processed when changed by the muxer [ch48825]

### DIFF
--- a/hal/src/argon/network/esp32_ncp_client.cpp
+++ b/hal/src/argon/network/esp32_ncp_client.cpp
@@ -71,6 +71,8 @@ const auto ESP32_NCP_KEEPALIVE_MAX_MISSED = 5;
 // FIXME: for now using a very large buffer
 const auto ESP32_NCP_AT_CHANNEL_RX_BUFFER_SIZE = 4096;
 
+const auto ESP32_NCP_DEFAULT_SERIAL_BAUDRATE = 921600;
+
 const auto ESP32_NCP_AT_CHANNEL = 1;
 const auto ESP32_NCP_STA_CHANNEL = 2;
 const auto ESP32_NCP_AP_CHANNEL = 3;
@@ -102,7 +104,7 @@ int Esp32NcpClient::init(const NcpClientConfig& conf) {
 #endif
     espOff();
     // Initialize serial stream
-    std::unique_ptr<SerialStream> serial(new(std::nothrow) SerialStream(HAL_USART_SERIAL2, 921600,
+    std::unique_ptr<SerialStream> serial(new(std::nothrow) SerialStream(HAL_USART_SERIAL2, ESP32_NCP_DEFAULT_SERIAL_BAUDRATE,
             SERIAL_8N1 | SERIAL_FLOW_CONTROL_RTS_CTS));
     CHECK_TRUE(serial, SYSTEM_ERROR_NO_MEMORY);
     // Initialize muxed channel stream
@@ -451,6 +453,7 @@ int Esp32NcpClient::waitReady() {
         return 0;
     }
     muxer_.stop();
+    CHECK(serial_->setBaudRate(ESP32_NCP_DEFAULT_SERIAL_BAUDRATE));
     CHECK(initParser(serial_.get()));
     espReset();
     skipAll(serial_.get(), 1000);

--- a/hal/src/argon/network/esp32_ncp_client.cpp
+++ b/hal/src/argon/network/esp32_ncp_client.cpp
@@ -628,7 +628,6 @@ int Esp32NcpClient::muxChannelStateCb(uint8_t channel, decltype(muxer_)::Channel
         switch (channel) {
             case 0:
                 // Muxer stopped
-                self->connectionState(NcpConnectionState::DISCONNECTED);
                 self->disable();
                 break;
             case ESP32_NCP_STA_CHANNEL: {
@@ -656,11 +655,6 @@ int Esp32NcpClient::dataChannelWrite(int id, const uint8_t* data, size_t size) {
     if (err) {
         // Make sure we are going into an error state if muxer for some reason fails
         // to write into the data channel.
-        connectionState(NcpConnectionState::DISCONNECTED);
-        // disable() sets the ncpState_ to NcpState::DISABLED which prevents connectionState()
-        // from even trying to send events to the PPP client to go to a LOWER_DOWN state,
-        // and it might still not get there if connState_ is already DISCONNECTED, but order matters.
-        // Call disable() after connectionState()
         disable();
     }
 

--- a/hal/src/b5som/network/quectel_ncp_client.cpp
+++ b/hal/src/b5som/network/quectel_ncp_client.cpp
@@ -360,7 +360,20 @@ int QuectelNcpClient::updateFirmware(InputStream* file, size_t size) {
 }
 
 int QuectelNcpClient::dataChannelWrite(int id, const uint8_t* data, size_t size) {
-    return muxer_.writeChannel(QUECTEL_NCP_PPP_CHANNEL, data, size);
+    int err = muxer_.writeChannel(QUECTEL_NCP_PPP_CHANNEL, data, size);
+
+    if (err) {
+        // Make sure we are going into an error state if muxer for some reason fails
+        // to write into the data channel.
+        connectionState(NcpConnectionState::DISCONNECTED);
+        // disable() sets the ncpState_ to NcpState::DISABLED which prevents connectionState()
+        // from even trying to send events to the PPP client to go to a LOWER_DOWN state,
+        // and it might still not get there if connState_ is already DISCONNECTED, but order matters.
+        // Call disable() after connectionState()
+        disable();
+    }
+
+    return err;
 }
 
 void QuectelNcpClient::processEvents() {
@@ -922,22 +935,25 @@ int QuectelNcpClient::muxChannelStateCb(uint8_t channel, decltype(muxer_)::Chann
     // This callback is executed from the multiplexer thread, not safe to use the lock here
     // because it might get called while blocked inside some muxer function
 
+    // Also please note that connectionState() should never be called with the CONNECTED state
+    // from this callback.
+
     // We are only interested in Closed state
     if (newState == decltype(muxer_)::ChannelState::Closed) {
         switch (channel) {
-        case 0: {
-            // Muxer stopped
-            self->disable();
-            self->connState_ = NcpConnectionState::DISCONNECTED;
-            break;
-        }
-        case QUECTEL_NCP_PPP_CHANNEL: {
-            // PPP channel closed
-            if (self->connState_ != NcpConnectionState::DISCONNECTED) {
-                self->connState_ = NcpConnectionState::CONNECTING;
+            case 0: {
+                // Muxer stopped
+                self->connectionState(NcpConnectionState::DISCONNECTED);
+                self->disable();
+                break;
             }
-            break;
-        }
+            case QUECTEL_NCP_PPP_CHANNEL: {
+                // PPP channel closed
+                if (self->connState_ != NcpConnectionState::DISCONNECTED) {
+                    self->connectionState(NcpConnectionState::CONNECTING);
+                }
+                break;
+            }
         }
     }
 

--- a/hal/src/b5som/network/quectel_ncp_client.cpp
+++ b/hal/src/b5som/network/quectel_ncp_client.cpp
@@ -365,11 +365,6 @@ int QuectelNcpClient::dataChannelWrite(int id, const uint8_t* data, size_t size)
     if (err) {
         // Make sure we are going into an error state if muxer for some reason fails
         // to write into the data channel.
-        connectionState(NcpConnectionState::DISCONNECTED);
-        // disable() sets the ncpState_ to NcpState::DISABLED which prevents connectionState()
-        // from even trying to send events to the PPP client to go to a LOWER_DOWN state,
-        // and it might still not get there if connState_ is already DISCONNECTED, but order matters.
-        // Call disable() after connectionState()
         disable();
     }
 
@@ -943,13 +938,15 @@ int QuectelNcpClient::muxChannelStateCb(uint8_t channel, decltype(muxer_)::Chann
         switch (channel) {
             case 0: {
                 // Muxer stopped
-                self->connectionState(NcpConnectionState::DISCONNECTED);
                 self->disable();
                 break;
             }
             case QUECTEL_NCP_PPP_CHANNEL: {
                 // PPP channel closed
                 if (self->connState_ != NcpConnectionState::DISCONNECTED) {
+                    // It should be safe to notify the PPP netif/client about a change of state
+                    // here exactly because the muxer channel is closed and there is no
+                    // chance for a deadlock.
                     self->connectionState(NcpConnectionState::CONNECTING);
                 }
                 break;


### PR DESCRIPTION
### Problem

The loss of signal can cause the modem to draw higher currents and if the power supply is not sufficient, the modem power supply will brown out and the NCP client will become unresponsive to keep alive pings.  `[gsm0710muxer] ERROR: The other end has not replied to keep alives (TESTs) 5 times, considering muxed connection dead` can be observed in the logs when this happens.  This could be immediately after signal is lost, or approx. 5.2 minutes afterwards.  This causes the AT command & Data muxer to go through a teardown, which in turn causes the NCP client to turn off the modem, but the PPP client doesn't know about this and keeps trying to retransmit a configure-request for IPCP.  The modem will attempt to be turned on, the retransmitted configure-request will fail, and the modem initialization will immediately fail again before it turns on.

### Solution

The root cause is that the NCP connection state is changed directly in the muxer callback function, but that does not get propagated to the NCP function that handles state changes, which would send an event to the PPP client to inform it that NCP is disconnected.  This would prevent the failure loop discussed above from occurring. 

The solution is to call `connectionState()` directly from the muxer callback to ensure we process events in the NCP client when NCP state is changed from the muxer callback.  Note: we should not do this with the CONNECTED state, since that will cause the connectionState() function to call back into the `muxer_` object.  Fortunately right now this is not a requirement in the muxer callback.

Another problem area was found as well that does not seem to attribute to the fix here, but it should be noted as changed.  `disable()` was being called before connectionState(NcpConnectionState::DISCONNECTED); below. I've swapped them and added a comment.  They were also swapped in the muxer callback.

![Screen Shot 2020-03-12 at 9 40 37 PM](https://user-images.githubusercontent.com/2249224/76705995-41a89300-66b2-11ea-91c7-00500eae6d92.png)

### Steps to Test

There are multiple ways to reproduce this issue, but given that it requires a power failure it can be tricky to reproduce.  

One way, is to run the test application, wait for the device to connect initially to the tower and Particle Cloud. Disconnect the battery and run on USB power only. Ensure publishes are occurring every 5 seconds, then disconnect the antenna and wait for the device to show a similar muxer teardown error as below.  After the error, the battery should be re-attached. The device should start into the failure loop as described, and reconnecting the antenna will not recover it.

![Screen Shot 2020-03-12 at 2 46 29 PM](https://user-images.githubusercontent.com/2249224/76705918-c3e48780-66b1-11ea-9af4-7792ada2268f.png)

Another more complicated but more reliable way of reproducing the issue is to run only battery input only from a lab power supply (no USB) set to 3.6 ~ 3.8V and limit the supply current to 500mA.

### Example App

See example app referenced in ch48825, but a threaded app that publishes data every 5 seconds should be similar enough to reproduce this issue.

### References

ch48825

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] N/A Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
