### PR TITLE
Fix YModem transfer

### DIFF
--- a/communication/inc/file_transfer.h
+++ b/communication/inc/file_transfer.h
@@ -61,7 +61,12 @@ namespace FileTransfer {
 
     struct Descriptor : public Chunk
     {
-        Descriptor() { size = sizeof(*this); }
+        Descriptor() :
+                Chunk(),
+                file_length(0),
+                file_address(0) {
+            size = sizeof(*this);
+        }
 
         /**
          * The length of the file data.


### PR DESCRIPTION
### Problem

This PR fixes a regression introduced in https://github.com/particle-iot/device-os/pull/2041, which relies on a wrong assumption that the `FileTransfer::Descriptor` class correctly initializes itself. This is a good example of why all class member and stack variables should be initialized explicitly at the time of their declaration, even if their initial values are overwritten later in the code.

### Steps to Test

Firmware update via YModem should succeed.