### PR TITLE
[wiring] Thread: fixes memory leakage due to mutex not being destroyed.

### DIFF
--- a/wiring/inc/spark_wiring_thread.h
+++ b/wiring/inc/spark_wiring_thread.h
@@ -235,6 +235,10 @@ public:
         os_mutex_create(&handle_);
     }
 
+    ~Mutex() {
+        dispose();
+    }
+
     void dispose()
     {
         if (handle_) {
@@ -262,6 +266,10 @@ public:
     RecursiveMutex() : handle_(nullptr)
     {
         os_mutex_recursive_create(&handle_);
+    }
+
+    ~RecursiveMutex() {
+        dispose();
     }
 
     void dispose()


### PR DESCRIPTION

### Problem

Memory leakage if using wiring `Mutex` or `RecursiveMutex` class.

### Solution

Add destructor which destroys the mutex if valid.

### Example App

```c
#include "Particle.h"

SYSTEM_MODE(MANUAL);
SerialLogHandler log(LOG_LEVEL_ALL);

void setup() {
}

void loop() {
    while(!Serial.isConnected());
    delay(1000);

    static runtime_info_t heapInfo;
    if (heapInfo.size == 0) {
        heapInfo.size = sizeof(heapInfo);
    }
    HAL_Core_Runtime_Info(&heapInfo, nullptr);
    Serial.printlnf("\n\n\n=======TP21============");
    Serial.printlnf("Heapinfo: size :%d, largest_free_block_heap :%lu", heapInfo.size, heapInfo.largest_free_block_heap);
    Serial.printlnf("===================\n\n\n");
    Mutex _buffer_mutex;
    HAL_Core_Runtime_Info(&heapInfo, nullptr);
    Serial.printlnf("\n\n\n=======TP22============");
    Serial.printlnf("Heapinfo: size :%d, largest_free_block_heap :%lu", heapInfo.size, heapInfo.largest_free_block_heap);
    Serial.printlnf("===================\n\n\n");
}
```

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)