### PR TITLE
Specify floating precision in wiring JSON library

### DIFF
--- a/user/tests/unit/json.cpp
+++ b/user/tests/unit/json.cpp
@@ -9,6 +9,7 @@
 #include <deque>
 #include <string>
 #include <cstdlib>
+#include <cfloat> // for constants
 
 namespace {
 
@@ -448,6 +449,252 @@ TEST_CASE("Writing JSON") {
             SECTION("3.40282e+38") {
                 json.value(3.40282e+38); // ~FLT_MAX
                 check(data).equals("3.40282e+38");
+            }
+            SECTION("DBL_MIN") {
+                json.value(DBL_MIN);
+                check(data).equals("2.22507e-308"); // Based on DBL_DIG significant digits for '%g' format specifier
+            }
+            SECTION("DBL_MAX") {
+                json.value(DBL_MAX);
+                check(data).equals("1.79769e+308"); // Based on DBL_DIG significant digits for '%g' format specifier
+            }
+
+
+            // Precision related tests
+
+            SECTION("0.0 precision 0") {
+                json.value(0.0, 0);
+                check(data).equals("0");
+            }
+            SECTION("0.0 precision 1") {
+                json.value(0.0, 1);
+                check(data).equals("0.0");
+            }
+            SECTION("0.0 precision 2") {
+                json.value(0.0, 2);
+                check(data).equals("0.00");
+            }
+            SECTION("0.0 precision 6") {
+                json.value(0.0, 6);
+                check(data).equals("0.000000");
+            }
+            SECTION("0.0 precision 10") {
+                json.value(0.0, 10);
+                check(data).equals("0.0000000000");
+            }
+
+            SECTION("-0.0 precision 0") {
+                json.value(-0.0, 0);
+                check(data).equals("-0");
+            }
+            SECTION("-0.0 precision 1") {
+                json.value(-0.0, 1);
+                check(data).equals("-0.0");
+            }
+            SECTION("-0.0 precision 2") {
+                json.value(-0.0, 2);
+                check(data).equals("-0.00");
+            }
+            SECTION("-0.0 precision 6") {
+                json.value(-0.0, 6);
+                check(data).equals("-0.000000");
+            }
+            SECTION("-0.0 precision 10") {
+                json.value(-0.0, 10);
+                check(data).equals("-0.0000000000");
+            }
+
+            SECTION("0.00001 precision 0") {
+                json.value(0.00001, 0);
+                check(data).equals("0"); // Round down
+            }
+            SECTION("0.00001 precision 1") {
+                json.value(0.00001, 1);
+                check(data).equals("0.0"); // Round down
+            }
+            SECTION("0.00001 precision 2") {
+                json.value(0.00001, 2);
+                check(data).equals("0.00"); // Round down
+            }
+            SECTION("0.00001 precision 3") {
+                json.value(0.00001, 3);
+                check(data).equals("0.000"); // Round down
+            }
+            SECTION("0.00001 precision 4") {
+                json.value(0.00001, 4);
+                check(data).equals("0.0000"); // Round down
+            }
+            SECTION("0.00001 precision 5") {
+                json.value(0.00001, 5);
+                check(data).equals("0.00001");
+            }
+            SECTION("0.00001 precision 6") {
+                json.value(0.00001, 6);
+                check(data).equals("0.000010");
+            }
+
+            SECTION("-0.00001 precision 0") {
+                json.value(-0.00001, 0);
+                check(data).equals("-0"); // Round down (up)
+            }
+            SECTION("-0.00001 precision 1") {
+                json.value(-0.00001, 1);
+                check(data).equals("-0.0"); // Round down (up)
+            }
+            SECTION("-0.00001 precision 2") {
+                json.value(-0.00001, 2);
+                check(data).equals("-0.00"); // Round down (up)
+            }
+            SECTION("-0.00001 precision 3") {
+                json.value(-0.00001, 3);
+                check(data).equals("-0.000"); // Round down (up)
+            }
+            SECTION("-0.00001 precision 4") {
+                json.value(-0.00001, 4);
+                check(data).equals("-0.0000"); // Round down (up)
+            }
+            SECTION("-0.00001 precision 5") {
+                json.value(-0.00001, 5);
+                check(data).equals("-0.00001");
+            }
+            SECTION("-0.00001 precision 6") {
+                json.value(-0.00001, 6);
+                check(data).equals("-0.000010");
+            }
+
+            SECTION("0.00005 precision 0") {
+                json.value(0.00005, 0);
+                check(data).equals("0"); // Round down
+            }
+            SECTION("0.00005 precision 1") {
+                json.value(0.00005, 1);
+                check(data).equals("0.0"); // Round down
+            }
+            SECTION("0.00005 precision 2") {
+                json.value(0.00005, 2);
+                check(data).equals("0.00"); // Round down
+            }
+            SECTION("0.00005 precision 3") {
+                json.value(0.00005, 3);
+                check(data).equals("0.000"); // Round down
+            }
+            SECTION("0.00005 precision 4") {
+                json.value(0.00005, 4);
+                check(data).equals("0.0001"); // Round up
+            }
+            SECTION("0.00005 precision 5") {
+                json.value(0.00005, 5);
+                check(data).equals("0.00005");
+            }
+            SECTION("0.00005 precision 6") {
+                json.value(0.00005, 6);
+                check(data).equals("0.000050");
+            }
+
+            SECTION("-0.00005 precision 0") {
+                json.value(-0.00005, 0);
+                check(data).equals("-0"); // Round down (up)
+            }
+            SECTION("-0.00005 precision 1") {
+                json.value(-0.00005, 1);
+                check(data).equals("-0.0"); // Round down (up)
+            }
+            SECTION("-0.00005 precision 2") {
+                json.value(-0.00005, 2);
+                check(data).equals("-0.00"); // Round down (up)
+            }
+            SECTION("-0.00005 precision 3") {
+                json.value(-0.00005, 3);
+                check(data).equals("-0.000"); // Round down (up)
+            }
+            SECTION("-0.00005 precision 4") {
+                json.value(-0.00005, 4);
+                check(data).equals("-0.0001"); // Round up (down)
+            }
+            SECTION("-0.00005 precision 5") {
+                json.value(-0.00005, 5);
+                check(data).equals("-0.00005");
+            }
+            SECTION("-0.00005 precision 6") {
+                json.value(-0.00005, 6);
+                check(data).equals("-0.000050");
+            }
+
+            SECTION("3.14159265358979323846 precision 0") {
+                json.value(3.14159265358979323846, 0);
+                check(data).equals("3"); // Round down
+            }
+            SECTION("3.14159265358979323846 precision 1") {
+                json.value(3.14159265358979323846, 1);
+                check(data).equals("3.1"); // Round down
+            }
+            SECTION("3.14159265358979323846 precision 2") {
+                json.value(3.14159265358979323846, 2);
+                check(data).equals("3.14"); // Round down
+            }
+            SECTION("3.14159265358979323846 precision 6") {
+                json.value(3.14159265358979323846, 6);
+                check(data).equals("3.141593"); // Round up
+            }
+            SECTION("3.14159265358979323846 precision 12") {
+                json.value(3.14159265358979323846, 12);
+                check(data).equals("3.141592653590"); // Round up
+            }
+
+            SECTION("-3.14159265358979323846 precision 0") {
+                json.value(-3.14159265358979323846, 0);
+                check(data).equals("-3"); // Round down (up)
+            }
+            SECTION("-3.14159265358979323846 precision 1") {
+                json.value(-3.14159265358979323846, 1);
+                check(data).equals("-3.1"); // Round down (up)
+            }
+            SECTION("-3.14159265358979323846 precision 2") {
+                json.value(-3.14159265358979323846, 2);
+                check(data).equals("-3.14"); // Round down (up)
+            }
+            SECTION("-3.14159265358979323846 precision 6") {
+                json.value(-3.14159265358979323846, 6);
+                check(data).equals("-3.141593"); // Round up (down)
+            }
+            SECTION("-3.14159265358979323846 precision 12") {
+                json.value(-3.14159265358979323846, 12);
+                check(data).equals("-3.141592653590"); // Round up (down)
+            }
+
+            SECTION("DBL_MIN precision 0") {
+                json.value(DBL_MIN, 0);
+                check(data).equals("0");
+            }
+            SECTION("-DBL_MIN precision 0") {
+                json.value(-DBL_MIN, 0);
+                check(data).equals("-0");
+            }
+            SECTION("DBL_MIN precision 12") {
+                json.value(DBL_MIN, 12);
+                check(data).equals("0.000000000000");
+            }
+            SECTION("-DBL_MIN precision 12") {
+                json.value(-DBL_MIN, 12);
+                check(data).equals("-0.000000000000");
+            }
+
+            SECTION("DBL_MAX precision 0") {
+                json.value(DBL_MAX, 0);
+                check(data).equals("179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368");
+            }
+            SECTION("-DBL_MAX precision 0") {
+                json.value(-DBL_MAX, 0);
+                check(data).equals("-179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368");
+            }
+
+            SECTION("DBL_MAX precision 12") {
+                json.value(DBL_MAX, 12);
+                check(data).equals("179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.000000000000");
+            }
+            SECTION("-DBL_MAX precision 12") {
+                json.value(-DBL_MAX, 12);
+                check(data).equals("-179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.000000000000");
             }
         }
     }

--- a/wiring/inc/spark_wiring_json.h
+++ b/wiring/inc/spark_wiring_json.h
@@ -175,6 +175,7 @@ public:
     JSONWriter& value(bool val);
     JSONWriter& value(int val);
     JSONWriter& value(unsigned val);
+    JSONWriter& value(double val, int precision);
     JSONWriter& value(double val);
     JSONWriter& value(const char *val);
     JSONWriter& value(const char *val, size_t size);

--- a/wiring/src/spark_wiring_json.cpp
+++ b/wiring/src/spark_wiring_json.cpp
@@ -462,6 +462,13 @@ spark::JSONWriter& spark::JSONWriter::value(unsigned val) {
     return *this;
 }
 
+spark::JSONWriter& spark::JSONWriter::value(double val, int precision) {
+    writeSeparator();
+    printf("%.*lf", precision, val);
+    state_ = NEXT;
+    return *this;
+}
+
 spark::JSONWriter& spark::JSONWriter::value(double val) {
     writeSeparator();
     printf("%g", val);


### PR DESCRIPTION
### Problem

The wiring JSON library based on JSMN has a limitation to display double floating point numbers in limited default precision. The current `JSONWriter& value(double val)` method calls the `printf("%g", val)` statement that relies on the '%g' formatting specifier. This specifier adjusts precision based on overall significant digits versus digits to the right of the decimal point. As a result, significant decimal digits important to the application may be removed automatically.

```c
Serial.printlnf("%g", M_PI * 1301.0); // 6 (FLT_DIG) significant digits total
Serial.printlnf("%lf", M_PI * 1301.0); // 6 (FLT_DIG) digits right of the decimal point
Serial.printlnf("%.*lf", 12, M_PI * 1301.0); // 12 digits right of the decimal point
```
Outputs:
`4087.21`
`4087.212042`
`4087.212042320321`

### Solution

Added an extra method in the JSONWriter class that takes a specific precision as an argument and format the double float to string output with the given precision, `JSONWriter& value(double val, int precision)`

### Steps to Test

56 new test cases were added to user/tests/unit/json.cpp which check the functionality of this feature.  The user/tests/unit unit test framework was run to verify results.

### Example App

```c
#include <cmath> // for constants
#define JSON_BUFFER_SIZE (512) // characters

void setup() {
  Serial.begin(9600);
  while(!Serial.isConnected());

  delay(1000);

  char buffer[JSON_BUFFER_SIZE] = { 0 };
  JSONBufferWriter json(buffer, ARRAY_SIZE(buffer));

  json.beginObject();
  json.name("pi").value(M_PI, 12); // Up to DBL_DIG in <cfloat>
  json.endObject();

  Serial.println(buffer);
}

void loop() {
}
```
This outputs pi to 12 decimal places
`{"pi":3.141592653590}`

### References

ch48771

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
