### PR TITLE
[wiring] Wire.requestFrom() multiple conflicting candidates

### DIFF
--- a/user/tests/wiring/api/wiring.cpp
+++ b/user/tests/wiring/api/wiring.cpp
@@ -206,6 +206,8 @@ TwoWire& testWire(TwoWire& wire)
     API_COMPILE({ uint8_t v = wire.endTransmission(true); (void)v; });
     API_COMPILE({ size_t v = wire.requestFrom(123, 123, true); (void)v; });
     API_COMPILE({ size_t v = wire.requestFrom(123, 123); (void)v; });
+    API_COMPILE({ size_t v = wire.requestFrom((int)123, (int)123, (int)1); (void)v; });
+    API_COMPILE({ size_t v = wire.requestFrom((int)123, (int)123); (void)v; });
     API_COMPILE({ size_t v = wire.write(123); (void)v; });
     API_COMPILE({ size_t v = wire.write(nullptr, 123); (void)v; });
     API_COMPILE({ int v = wire.available(); (void)v; });

--- a/wiring/inc/spark_wiring_i2c.h
+++ b/wiring/inc/spark_wiring_i2c.h
@@ -107,8 +107,6 @@ public:
   uint8_t endTransmission(uint8_t);
   size_t requestFrom(uint8_t, size_t);
   size_t requestFrom(uint8_t, size_t, uint8_t);
-  size_t requestFrom(int, int);
-  size_t requestFrom(int, int, int);
   size_t requestFrom(const WireTransmission& transfer);
   virtual size_t write(uint8_t);
   virtual size_t write(const uint8_t *, size_t);

--- a/wiring/src/spark_wiring_i2c.cpp
+++ b/wiring/src/spark_wiring_i2c.cpp
@@ -85,16 +85,6 @@ size_t TwoWire::requestFrom(uint8_t address, size_t quantity)
   return requestFrom(address, quantity, (uint8_t)true);
 }
 
-size_t TwoWire::requestFrom(int address, int quantity)
-{
-  return requestFrom((uint8_t)address, (size_t)quantity, (uint8_t)true);
-}
-
-size_t TwoWire::requestFrom(int address, int quantity, int sendStop)
-{
-  return requestFrom((uint8_t)address, (size_t)quantity, (uint8_t)sendStop);
-}
-
 size_t TwoWire::requestFrom(const WireTransmission& transfer) {
   auto conf = transfer.halConfig();
   return HAL_I2C_Request_Data_Ex(_i2c, &conf, nullptr);


### PR DESCRIPTION
### Problem

Multiple conflicting candidates when calling Wire.requestFrom() in 1.5.0-rc.x:

```
../wiring/inc/spark_wiring_i2c.h:108:10: note: candidate: size_t TwoWire::requestFrom(uint8_t, size_t)
   size_t requestFrom(uint8_t, size_t);
          ^
../wiring/inc/spark_wiring_i2c.h:110:10: note: candidate: size_t TwoWire::requestFrom(int, int)
   size_t requestFrom(int, int);
          ^
```

### Solution

Removes unnecessary `requestFrom(int, int)` and `requestFrom(int, int, int)` overloads.

### Steps to Test

`wiring/api`

### Example App

N/A

### References

- [CH50131]
- https://community.particle.io/t/deviceos-1-5-0-rc2-causing-compile-errors-for-i2c-libraries/55099
- https://community.particle.io/t/updating-from-deviceos-1-5-0-rc-1-rc-2-adafruit-ssd1306-lib-causes-freeze/54740/14

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
