### PR TITLE
[Gen 2] Fixes SPI.beginTransaction() deadlocking

### DIFF
--- a/user/tests/wiring/no_fixture/spi.cpp
+++ b/user/tests/wiring/no_fixture/spi.cpp
@@ -79,9 +79,7 @@ test(SPI_02_SPI_DMA_Transfers_Work_Correctly)
 {
     assertTrue(tempBuf != nullptr && tempBuf1 != nullptr);
     SPI.begin();
-#if HAL_PLATFORM_SPI_HAL_THREAD_SAFETY
     SPI.beginTransaction();
-#endif // HAL_PLATFORM_SPI_HAL_THREAD_SAFETY
     uint32_t m;
 
     DMA_Completed_Flag = 0;
@@ -113,9 +111,7 @@ test(SPI_02_SPI_DMA_Transfers_Work_Correctly)
     for (uint8_t* v = tempBuf; v < tempBuf + SPI_BUF_SIZE; v++) {
         assertNotEqual(*v, 0xAA);
     }
-#if HAL_PLATFORM_SPI_HAL_THREAD_SAFETY
     SPI.endTransaction();
-#endif // HAL_PLATFORM_SPI_HAL_THREAD_SAFETY
     SPI.end();
 }
 
@@ -124,9 +120,7 @@ test(SPI_03_SPI1_DMA_Transfers_Work_Correctly)
 {
     assertTrue(tempBuf != nullptr && tempBuf1 != nullptr);
     SPI1.begin();
-#if HAL_PLATFORM_SPI_HAL_THREAD_SAFETY
     SPI1.beginTransaction();
-#endif // HAL_PLATFORM_SPI_HAL_THREAD_SAFETY
     uint32_t m;
 
     DMA_Completed_Flag = 0;
@@ -159,9 +153,7 @@ test(SPI_03_SPI1_DMA_Transfers_Work_Correctly)
         assertNotEqual(*v, 0xAA);
     }
 
-#if HAL_PLATFORM_SPI_HAL_THREAD_SAFETY
     SPI1.endTransaction();
-#endif // HAL_PLATFORM_SPI_HAL_THREAD_SAFETY
     SPI1.end();
 }
 #endif
@@ -171,9 +163,7 @@ test(SPI_04_SPI2_DMA_Transfers_Work_Correctly)
 {
     assertTrue(tempBuf != nullptr && tempBuf1 != nullptr);
     SPI2.begin();
-#if HAL_PLATFORM_SPI_HAL_THREAD_SAFETY
     SPI2.beginTransaction();
-#endif // HAL_PLATFORM_SPI_HAL_THREAD_SAFETY
     uint32_t m;
 
     DMA_Completed_Flag = 0;
@@ -206,9 +196,7 @@ test(SPI_04_SPI2_DMA_Transfers_Work_Correctly)
         assertNotEqual(*v, 0xAA);
     }
 
-#if HAL_PLATFORM_SPI_HAL_THREAD_SAFETY
     SPI2.endTransaction();
-#endif // HAL_PLATFORM_SPI_HAL_THREAD_SAFETY
     SPI2.end();
 }
 #endif
@@ -218,13 +206,8 @@ test(SPI_05_SPI_Can_Be_Locked)
 {
     SPI.begin();
     assertTrue(SPI.trylock());
-    // FIXME: platforms with HAL_PLATFORM_SPI_HAL_THREAD_SAFETY use recursive mutex
-#if !HAL_PLATFORM_SPI_HAL_THREAD_SAFETY
-    assertFalse(SPI.trylock());
-#else
     assertTrue(SPI.trylock());
     SPI.unlock();
-#endif // !HAL_PLATFORM_SPI_HAL_THREAD_SAFETY
     SPI.unlock();
     assertTrue(SPI.trylock());
     SPI.unlock();
@@ -236,13 +219,8 @@ test(SPI_06_SPI2_Can_Be_Locked)
 {
     SPI2.begin();
     assertTrue(SPI2.trylock());
-    // FIXME: platforms with HAL_PLATFORM_SPI_HAL_THREAD_SAFETY use recursive mutex
-#if !HAL_PLATFORM_SPI_HAL_THREAD_SAFETY
-    assertFalse(SPI2.trylock());
-#else
     assertTrue(SPI2.trylock());
     SPI2.unlock();
-#endif // HAL_PLATFORM_SPI_HAL_THREAD_SAFETY
     SPI2.unlock();
     assertTrue(SPI2.trylock());
     SPI2.unlock();
@@ -372,12 +350,8 @@ test(SPI_10_SPI_Begin_Transaction_Locks)
     assertTrue(SPI.trylock());
     SPI.unlock();
     SPI.beginTransaction(__SPISettings());
-#if !HAL_PLATFORM_SPI_HAL_THREAD_SAFETY
-    assertFalse(SPI.trylock());
-#else
     assertTrue(SPI.trylock());
     SPI.unlock();
-#endif // HAL_PLATFORM_SPI_HAL_THREAD_SAFETY
     SPI.endTransaction();
     assertTrue(SPI.trylock());
     SPI.unlock();
@@ -394,12 +368,8 @@ test(SPI_11_SPI1_Begin_Transaction_Locks)
     assertTrue(SPI1.trylock());
     SPI1.unlock();
     SPI1.beginTransaction(__SPISettings());
-#if !HAL_PLATFORM_SPI_HAL_THREAD_SAFETY
-    assertFalse(SPI1.trylock());
-#else
     assertTrue(SPI1.trylock());
     SPI1.unlock();
-#endif // HAL_PLATFORM_SPI_HAL_THREAD_SAFETY
     SPI1.endTransaction();
     assertTrue(SPI1.trylock());
     SPI1.unlock();
@@ -417,12 +387,8 @@ test(SPI_12_SPI2_Begin_Transaction_Locks)
     assertTrue(SPI2.trylock());
     SPI2.unlock();
     SPI2.beginTransaction(__SPISettings());
-#if !HAL_PLATFORM_SPI_HAL_THREAD_SAFETY
-    assertFalse(SPI2.trylock());
-#else
     assertTrue(SPI2.trylock());
     SPI2.unlock();
-#endif // HAL_PLATFORM_SPI_HAL_THREAD_SAFETY
     SPI2.endTransaction();
     assertTrue(SPI2.trylock());
     SPI2.unlock();

--- a/wiring/inc/spark_wiring_spi.h
+++ b/wiring/inc/spark_wiring_spi.h
@@ -153,7 +153,7 @@ private:
    *
    * Enables Gen2 platforms to synchronize access to the SPI peripheral
    */
-  Mutex _mutex;
+  RecursiveMutex _mutex;
 #endif
 
 public:


### PR DESCRIPTION
### Problem

Originally reported in https://community.particle.io/t/updating-from-deviceos-1-5-0-rc-1-rc-2-adafruit-ssd1306-lib-causes-freeze/54740/7

This is another side effect of https://github.com/particle-iot/device-os/pull/2023 and https://github.com/particle-iot/device-os/pull/1879.

The issue is caused by the usage of [`Mutex`](https://github.com/particle-iot/device-os/blob/develop/wiring/inc/spark_wiring_spi.h#L156) as a synchronization primitive on Gen 2 platforms, whereas after the changes in the PRs mentioned above, wiring is expecting a recursive mutex.

### Solution

Replace with `RecursiveMutex`.

### Steps to Test

- `wiring/no_fixture`

### Example App

N/A

### References

- https://community.particle.io/t/updating-from-deviceos-1-5-0-rc-1-rc-2-adafruit-ssd1306-lib-causes-freeze/54740/7
- [CH50091]

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
