### PR TITLE
[Cellular] Fixes an issue with CGI (Cellular Global Identity) not available on some devices

### DIFF
--- a/hal/network/ncp/cellular/cellular_hal.cpp
+++ b/hal/network/ncp/cellular/cellular_hal.cpp
@@ -251,8 +251,10 @@ int cellular_credentials_clear(void* reserved) {
     return 0;
 }
 
-cellular_result_t cellular_global_identity(CellularGlobalIdentity* cgi_, void* reserved_) {
-    CellularGlobalIdentity cgi;
+cellular_result_t cellular_global_identity(CellularGlobalIdentity* cgi, void* reserved) {
+    // Validate Argument(s)
+    (void)reserved;
+    CHECK_TRUE((nullptr != cgi), SYSTEM_ERROR_INVALID_ARGUMENT);
 
     // Acquire Cellular NCP Client
     const auto mgr = cellularNetworkManager();
@@ -260,21 +262,14 @@ cellular_result_t cellular_global_identity(CellularGlobalIdentity* cgi_, void* r
     const auto client = mgr->ncpClient();
     CHECK_TRUE(client, SYSTEM_ERROR_UNKNOWN);
 
-    // Validate Argument(s)
-    (void)reserved_;
-    CHECK_TRUE((nullptr != cgi_), SYSTEM_ERROR_INVALID_ARGUMENT);
-
     // Load cached data into result struct
-    CHECK(client->getCellularGlobalIdentity(&cgi));
+    CHECK(client->getCellularGlobalIdentity(cgi));
 
     // Validate cache
-    CHECK_TRUE(0 != cgi.mobile_country_code, SYSTEM_ERROR_BAD_DATA);
-    CHECK_TRUE(0 != cgi.mobile_network_code, SYSTEM_ERROR_BAD_DATA);
-    CHECK_TRUE(0xFFFF != cgi.location_area_code, SYSTEM_ERROR_BAD_DATA);
-    CHECK_TRUE(0xFFFFFFFF != cgi.cell_id, SYSTEM_ERROR_BAD_DATA);
-
-    // Update result
-    *cgi_ = cgi;
+    CHECK_TRUE(0 != cgi->mobile_country_code, SYSTEM_ERROR_BAD_DATA);
+    CHECK_TRUE(0 != cgi->mobile_network_code, SYSTEM_ERROR_BAD_DATA);
+    CHECK_TRUE(0xFFFF != cgi->location_area_code, SYSTEM_ERROR_BAD_DATA);
+    CHECK_TRUE(0xFFFFFFFF != cgi->cell_id, SYSTEM_ERROR_BAD_DATA);
 
     return SYSTEM_ERROR_NONE;
 }

--- a/hal/src/electron/cellular_hal.cpp
+++ b/hal/src/electron/cellular_hal.cpp
@@ -359,25 +359,20 @@ cellular_result_t cellular_band_available_get(MDM_BandSelect* bands, void* reser
     return 0;
 }
 
-cellular_result_t cellular_global_identity(CellularGlobalIdentity* cgi_, void* reserved_)
+cellular_result_t cellular_global_identity(CellularGlobalIdentity* cgi, void* reserved)
 {
-    CellularGlobalIdentity cgi;  // Intentionally left uninitialized
-
     // Validate Argument(s)
-    (void)reserved_;
-    CHECK_TRUE((nullptr != cgi_), SYSTEM_ERROR_INVALID_ARGUMENT);
+    (void)reserved;
+    CHECK_TRUE((nullptr != cgi), SYSTEM_ERROR_INVALID_ARGUMENT);
 
     // Load cached data into result struct
-    CHECK_TRUE(electronMDM.getCellularGlobalIdentity(cgi), SYSTEM_ERROR_AT_NOT_OK);
+    CHECK_TRUE(electronMDM.getCellularGlobalIdentity(*cgi), SYSTEM_ERROR_AT_NOT_OK);
 
     // Validate cache
-    CHECK_TRUE(0 != cgi.mobile_country_code, SYSTEM_ERROR_BAD_DATA);
-    CHECK_TRUE(0 != cgi.mobile_network_code, SYSTEM_ERROR_BAD_DATA);
-    CHECK_TRUE(0xFFFF != cgi.location_area_code, SYSTEM_ERROR_BAD_DATA);
-    CHECK_TRUE(0xFFFFFFFF != cgi.cell_id, SYSTEM_ERROR_BAD_DATA);
-
-    // Update result
-    *cgi_ = cgi;
+    CHECK_TRUE(0 != cgi->mobile_country_code, SYSTEM_ERROR_BAD_DATA);
+    CHECK_TRUE(0 != cgi->mobile_network_code, SYSTEM_ERROR_BAD_DATA);
+    CHECK_TRUE(0xFFFF != cgi->location_area_code, SYSTEM_ERROR_BAD_DATA);
+    CHECK_TRUE(0xFFFFFFFF != cgi->cell_id, SYSTEM_ERROR_BAD_DATA);
 
     return SYSTEM_ERROR_NONE;
 }


### PR DESCRIPTION
### Problem

See #2066.

The main problem is `getCellularGlobalIdentity()` function (in NCP or modem implementation) was getting a temporary intermediate on-stack structure `CellularGlobalIdentity` completely uninitialized (thus containing garbage data of whatever was potentially previously on stack). We were lucky (and are lucky with 1.5.0 release on every platform except for Electron) that its `size` field was always initialized to some large value > `sizeof(CellularGlobalIdentity)`, which made the sanity check pass correctly.

### Solution

Just pass `CellularGlobalIdentity` struct directly into the modem/NCP code and let it handle it, instead of using a temporary uninitialized on-stack variable as an intermediate.

### Steps to Test

Make sure CGI is available on all cellular platforms in vitals.

### Example App

```c++
void setup() {
    Particle.publisVitals(5s);
}

void loop() {

}
```

### References

- Closes #2066 
- [CH51209]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
