### PR TITLE
Enable HW Flow control on Quectel modems earlier in the init process

### DIFF
--- a/hal/src/b5som/network/quectel_ncp_client.cpp
+++ b/hal/src/b5som/network/quectel_ncp_client.cpp
@@ -842,10 +842,10 @@ int QuectelNcpClient::initReady() {
     uint32_t hwVersion = HW_VERSION_UNDEFINED;
     auto ret = hal_get_device_hw_version(&hwVersion, nullptr);
     if (ret == SYSTEM_ERROR_NONE && hwVersion == HAL_VERSION_B5SOM_V003) {
-        CHECK_PARSER(parser_.execCommand("AT+IFC=0,0"));
+        CHECK_PARSER_OK(parser_.execCommand("AT+IFC=0,0"));
     } else {
         runtimeBaudrate = QUECTEL_NCP_RUNTIME_SERIAL_BAUDRATE;
-        CHECK_PARSER(parser_.execCommand("AT+IFC=2,2"));
+        CHECK_PARSER_OK(parser_.execCommand("AT+IFC=2,2"));
     }
     CHECK(changeBaudRate(runtimeBaudrate));
 


### PR DESCRIPTION
Move code to enable hardware flow control to do this earlier in the code, as soon as AT is ready.

Story details: https://app.clubhouse.io/particle/story/51153