### PR TITLE
[electron] cellular: compat rssi/qual for LTE devices using UCGED

### DIFF
--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -156,6 +156,9 @@ AcT toCellularAccessTechnology(int rat) {
     }
 }
 
+// see 3GPP TS 45.008 [20] subclause 8.2.4
+const char compatQualMap[] = { 49, 43, 37, 25, 19, 13, 7, 0 };
+
 } // anonymous
 
 #ifdef MDM_DEBUG
@@ -1802,6 +1805,16 @@ int MDMParser::_cbUCGED(int type, const char* buf, int len, NetStatus* status)
             } else {
                 status->rsrp = 255;
             }
+
+            // Compatibility values for old API
+            if (status->rsrp != 255) {
+                // Simply remap from [0-97] to [0-63]
+                int compatStrn = (status->rsrp * 63) / 97;
+                // -113 to -50dBm
+                status->rssi = -113 + compatStrn;
+            } else {
+                status->rssi = 0;
+            }
         }
         // RSRQ maps from dBm [-20,-3] to [0,34]
         // We are defining hard boundaries for RSRP to be between [],
@@ -1817,6 +1830,18 @@ int MDMParser::_cbUCGED(int type, const char* buf, int len, NetStatus* status)
             } else {
                 status->rsrq = 255;
             }
+
+            // Compatibility values for old API
+            if (status->rsrq != 255) {
+                // Re-map from [0-34] to [0-7]. Table in UBX-13002752 - R62 (7.2.4)
+                int compatQual = (status->rsrq < 10) ? (status->rsrq / 5) : ((std::min(status->rsrq, 30) - 10) / 4) + 2;
+                // Just in case validate that we are not going to go out of bounds
+                if (compatQual >= 0 && compatQual <= 7) {
+                    status->qual = compatQualMap[compatQual];
+                }
+            } else {
+                status->qual = 0;
+            }
         }
     }
     return WAIT;
@@ -1826,11 +1851,10 @@ int MDMParser::_cbCSQ(int type, const char* buf, int len, NetStatus* status)
 {
     if ((type == TYPE_PLUS) && status){
         int a,b;
-        char _qual[] = { 49, 43, 37, 25, 19, 13, 7, 0 }; // see 3GPP TS 45.008 [20] subclause 8.2.4
         // +CSQ: <rssi>,<qual>
         if (sscanf(buf, "\r\n+CSQ: %d,%d",&a,&b) == 2) {
             if (a != 99) status->rssi = -113 + 2*a;  // 0: -113 1: -111 ... 30: -53 dBm with 2 dBm steps
-            if ((b != 99) && (b < (int)sizeof(_qual))) status->qual = _qual[b];  //
+            if ((b != 99) && (b < (int)sizeof(compatQualMap))) status->qual = compatQualMap[b];  //
 
             switch (status->act) {
             case ACT_GSM:


### PR DESCRIPTION
### Problem

Old API rssi and qual values are not available on LTE Electrons/E Series because we've switched over to UCGED in #2033.

### Solution

Add a compatibiltiy layer, same as on Gen 3.

### Steps to Test

Use the app. On Electron LTE it should provide sane values instead of `2,0` and should be comparable to pre-1.5.0.

### Example App

```c++

SerialLogHandler dbg(LOG_LEVEL_ALL);
void setup() {
}

void loop() {
    auto sig = Cellular.RSSI();
    Log.trace("%d, %d", sig.rssi, sig.qual);
    delay(5s);
}
```

### References

- [CH51264]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
