### PR TITLE
Move code to wait for AT after setting run time baud

### DIFF
--- a/hal/src/b5som/network/quectel_ncp_client.cpp
+++ b/hal/src/b5som/network/quectel_ncp_client.cpp
@@ -848,6 +848,9 @@ int QuectelNcpClient::initReady() {
         CHECK_PARSER_OK(parser_.execCommand("AT+IFC=2,2"));
     }
     CHECK(changeBaudRate(runtimeBaudrate));
+    // Check that the modem is responsive at the new baudrate
+    skipAll(serial_.get(), 1000);
+    CHECK(waitAtResponse(10000));
 
     // Select either internal or external SIM card slot depending on the configuration
     CHECK(selectSimCard());
@@ -877,10 +880,6 @@ int QuectelNcpClient::initReady() {
         ncpId() == PLATFORM_NCP_QUECTEL_EG91_EX) {
         CHECK_PARSER(parser_.execCommand("AT+QDSIM=0"));
     }
-
-    // Check that the modem is responsive at the new baudrate
-    skipAll(serial_.get(), 1000);
-    CHECK(waitAtResponse(10000));
 
     // Send AT+CMUX and initialize multiplexer
     int portspeed;


### PR DESCRIPTION
### Problem

Related to [ch51153](https://app.clubhouse.io/particle/story/51153/add-at-command-at-ifc-2-2-to-enable-hw-flow-control-on-quectel-modems-during-init)

### Solution

Check for AT interface to respond after setting baud rate

### Steps to Test

Change `QUECTEL_NCP_DEFAULT_SERIAL_BAUDRATE` to a different baud rate than existing

### References

https://app.clubhouse.io/particle/story/51153/add-at-command-at-ifc-2-2-to-enable-hw-flow-control-on-quectel-modems-during-init

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
