### PR TITLE
[cellular] increase registartion timeout to 10 minutes

### DIFF
--- a/hal/src/b5som/network/quectel_ncp_client.cpp
+++ b/hal/src/b5som/network/quectel_ncp_client.cpp
@@ -100,7 +100,7 @@ const auto QUECTEL_NCP_PPP_CHANNEL = 2;
 const auto QUECTEL_NCP_SIM_SELECT_PIN = 23;
 
 const unsigned REGISTRATION_CHECK_INTERVAL = 15 * 1000;
-const unsigned REGISTRATION_TIMEOUT = 5 * 60 * 1000;
+const unsigned REGISTRATION_TIMEOUT = 10 * 60 * 1000;
 
 // Undefine hardware version
 const auto HW_VERSION_UNDEFINED = 0xFF;

--- a/hal/src/boron/network/sara_ncp_client.cpp
+++ b/hal/src/boron/network/sara_ncp_client.cpp
@@ -99,7 +99,7 @@ const auto UBLOX_NCP_PPP_CHANNEL = 2;
 const auto UBLOX_NCP_SIM_SELECT_PIN = 23;
 
 const unsigned REGISTRATION_CHECK_INTERVAL = 15 * 1000;
-const unsigned REGISTRATION_TIMEOUT = 5 * 60 * 1000;
+const unsigned REGISTRATION_TIMEOUT = 10 * 60 * 1000;
 
 using LacType = decltype(CellularGlobalIdentity::location_area_code);
 using CidType = decltype(CellularGlobalIdentity::cell_id);

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1251,7 +1251,7 @@ int MDMParser::_cbURAT(int type, const char *buf, int len, bool *matched_default
     return WAIT;
 }
 
-bool MDMParser::registerNet(const char* apn, NetStatus* status /*= NULL*/, system_tick_t timeout_ms /*= 180000*/)
+bool MDMParser::registerNet(const char* apn, NetStatus* status, system_tick_t timeout_ms)
 {
     LOCK();
     if (_init && _pwr && _dev.dev != DEV_UNKNOWN) {

--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -94,7 +94,7 @@ public:
         \param timeout_ms -1 blocking, else non blocking timeout in ms
         \return true if successful and connected to network, false otherwise
     */
-    bool registerNet(const char* apn = nullptr, NetStatus* status = NULL, system_tick_t timeout_ms = 300000);
+    bool registerNet(const char* apn = nullptr, NetStatus* status = NULL, system_tick_t timeout_ms = 10 * 60 * 1000);
 
     /** check if the network is available
         \param status an optional structure to with network information


### PR DESCRIPTION
### Problem

We have been requested by cellular providers to increase the registration timeout to 10 minutes.

### Solution

Increase it to 10.

### Steps to Test

N/A

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
