### PR TITLE
Exposed queue peek function

### DIFF
--- a/hal/inc/concurrent_hal.h
+++ b/hal/inc/concurrent_hal.h
@@ -183,6 +183,15 @@ int os_queue_put(os_queue_t queue, const void* item, system_tick_t delay, void* 
  * @return
  */
 int os_queue_take(os_queue_t queue, void* item, system_tick_t delay, void* reserved);
+
+/**
+ * Return 0 on success.
+ * @param queue
+ * @param item
+ * @param delay
+ * @return
+ */
+int os_queue_peek(os_queue_t queue, void* item, system_tick_t delay, void* reserved);
 int os_queue_destroy(os_queue_t queue, void* reserved);
 
 int os_mutex_create(os_mutex_t* mutex);

--- a/hal/inc/hal_dynalib_concurrent.h
+++ b/hal/inc/hal_dynalib_concurrent.h
@@ -70,6 +70,7 @@ DYNALIB_FN(31, hal_concurrent, os_semaphore_destroy, int(os_semaphore_t))
 DYNALIB_FN(32, hal_concurrent, os_semaphore_take, int(os_semaphore_t, system_tick_t, bool))
 DYNALIB_FN(33, hal_concurrent, os_semaphore_give, int(os_semaphore_t, bool))
 DYNALIB_FN(34, hal_concurrent, os_scheduler_get_state, os_scheduler_state_t(void*))
+DYNALIB_FN(35, hal_concurrent, os_queue_peek, int(os_queue_t, void* item, system_tick_t, void*))
 #endif // PLATFORM_THREADING
 
 DYNALIB_END(hal_concurrent)

--- a/hal/src/mesh-virtual/concurrent_hal.cpp
+++ b/hal/src/mesh-virtual/concurrent_hal.cpp
@@ -313,6 +313,11 @@ int os_queue_take(os_queue_t queue, void* item, system_tick_t delay, void*)
     return xQueueReceive(queue, item, delay)!=pdTRUE;
 }
 
+int os_queue_peek(os_queue_t queue, void* item, system_tick_t delay, void*)
+{
+    return xQueuePeek(queue, item, delay)!=pdTRUE;
+}
+
 int os_queue_destroy(os_queue_t queue, void*)
 {
     vQueueDelete(queue);

--- a/hal/src/nRF52840/concurrent_hal.cpp
+++ b/hal/src/nRF52840/concurrent_hal.cpp
@@ -364,6 +364,11 @@ int os_queue_take(os_queue_t queue, void* item, system_tick_t delay, void*)
     return xQueueReceive(static_cast<QueueHandle_t>(queue), item, delay)!=pdTRUE;
 }
 
+int os_queue_peek(os_queue_t queue, void* item, system_tick_t delay, void*)
+{
+    return xQueuePeek(static_cast<QueueHandle_t>(queue), item, delay)!=pdTRUE;
+}
+
 int os_queue_destroy(os_queue_t queue, void*)
 {
     vQueueDelete(static_cast<QueueHandle_t>(queue));

--- a/hal/src/stm32f2xx/concurrent_hal.cpp
+++ b/hal/src/stm32f2xx/concurrent_hal.cpp
@@ -364,6 +364,11 @@ int os_queue_take(os_queue_t queue, void* item, system_tick_t delay, void*)
     return xQueueReceive(static_cast<QueueHandle_t>(queue), item, delay)!=pdTRUE;
 }
 
+int os_queue_peek(os_queue_t queue, void* item, system_tick_t delay, void*)
+{
+    return xQueuePeek(static_cast<QueueHandle_t>(queue), item, delay)!=pdTRUE;
+}
+
 int os_queue_destroy(os_queue_t queue, void*)
 {
     vQueueDelete(static_cast<QueueHandle_t>(queue));

--- a/system/inc/active_object.h
+++ b/system/inc/active_object.h
@@ -385,6 +385,11 @@ protected:
     		return !os_queue_put(queue, &item, configuration.put_wait, nullptr);
     }
 
+    virtual bool peek(Item& item)
+    {
+    		return !os_queue_peek(queue, &item, configuration.put_wait, nullptr);
+    }
+
     void createQueue()
     {
         os_queue_create(&queue, sizeof(Item), configuration.queue_size, nullptr);


### PR DESCRIPTION
### Problem

Currently there is no way to check if a queue has elements available. With the help of the peek function it is possible to 1) check if the queue is empty 2) Get an item without removing it.

### Solution

Exposes the peek function of queues from FreeRTOS.

### Steps to Test

Which unit/integration/application tests are applicable to this code change? (At minimum a test of some kind should be provided)

### Example App

```c
#include "Particle.h"

SYSTEM_MODE(MANUAL);
SYSTEM_THREAD(ENABLED);

void threadFunction(void *param);

Thread thread;

// Instead of using STARTUP() another good way to initialize the queue is to use a lambda.
// setup() is too late.
os_queue_t queue = []() {
	os_queue_t q;
	// 20 is the maximum number of items in the queue.
	os_queue_create(&q, sizeof(void*), 20, 0);
	return q;
}();

system_tick_t lastThreadTime = 0;
char serialBuf[512];
size_t serialBufOffset = 0;

void setup() {
	Serial.begin(230400);
	thread = Thread("testThread", threadFunction);
}

void loop() {
	// Try to take an item from the queue. First 0 is the amount of time to wait, 0 = don't wait.
	// Second 0 is the reserved value, always 0.
	char *s = 0;
	if (os_queue_peek(queue, &s, 0, 0) == 0) {
		// We got a line of data by serial. Handle it here.
		// s is a copy of the data that must be freed when done.
		Serial.println(s);
		os_queue_take(queue, &s, 0, 0);
		Serial.println(s);
		free(s);
	}
}


void threadFunction(void *param) {
	while(true) {
		while(Serial.available()) {
			char c = Serial.read();
			if (c == '\n') {
				// null terminate
				serialBuf[serialBufOffset] = 0;

				// Make a copy of the serialBuf
				char *s = strdup(serialBuf);
				if (s) {
					if (os_queue_put(queue, (void *)&s, 0, 0)) {
						// Failed to put into queue (queue full), discard the data
						free(s);
					}
				}

				// Clear buffer
				serialBufOffset = 0;
			}
			else
			if (serialBufOffset < (sizeof(serialBuf) - 1)) {
				// Add to buffer
				serialBuf[serialBufOffset++] = c;
			}
		}

		// Delay so we're called every 1 millisecond (1000 times per second)
		os_thread_delay_until(&lastThreadTime, 1);
	}
	// You must not return from the thread function
}
```

Should output the input twice. One provided from peek and the other from take.

### References

Example taken from: https://community.particle.io/t/particle-threads-tutorial/41362

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
