### PR TITLE
Increase the size of the ARP queue

### DIFF
--- a/hal/src/nRF52840/lwip/lwipopts.h
+++ b/hal/src/nRF52840/lwip/lwipopts.h
@@ -385,7 +385,7 @@ void sys_unlock_tcpip_core(void);
  *  unresolved address by other network layers. Defaults to 3, 0 means disabled.
  *  Old packets are dropped, new packets are queued.
  */
-#define ARP_QUEUE_LEN                   3
+#define ARP_QUEUE_LEN                   6
 
 /**
  * ETHARP_SUPPORT_VLAN==1: support receiving and sending ethernet packets with


### PR DESCRIPTION
### Problem

The size of the ARP queue for pending network packets is limited to 3 on Argon. This results in the loss and subsequent retransmission of one of the four handshake packets sent when the session is resumed.

### Solution

Increase the size of the ARP queue.

### References

- [ch51720]