### PR TITLE
Invalidate value of '0' for RSRP and RSRQ on B5SoM

### DIFF
--- a/hal/src/b5som/network/quectel_ncp_client.cpp
+++ b/hal/src/b5som/network/quectel_ncp_client.cpp
@@ -645,7 +645,7 @@ int QuectelNcpClient::getSignalQuality(CellularSignalQuality* qual) {
 
                         if (rsrp < -140 && rsrp >= -200) {
                             qual->strength(0);
-                        } else if (rsrp >= -44 && rsrp <= 0) {
+                        } else if (rsrp >= -44 && rsrp < 0) {
                             qual->strength(97);
                         } else if (rsrp >= -140 && rsrp < -44) {
                             qual->strength(rsrp + 141);
@@ -656,7 +656,7 @@ int QuectelNcpClient::getSignalQuality(CellularSignalQuality* qual) {
 
                         if (rsrq_mul_100 < min_rsrq_mul_by_100 && rsrq_mul_100 >= -2000) {
                             qual->quality(0);
-                        } else if (rsrq_mul_100 >= max_rsrq_mul_by_100 && rsrq_mul_100 <=0) {
+                        } else if (rsrq_mul_100 >= max_rsrq_mul_by_100 && rsrq_mul_100 < 0) {
                             qual->quality(34);
                         } else if (rsrq_mul_100 >= min_rsrq_mul_by_100 && rsrq_mul_100 < max_rsrq_mul_by_100) {
                             qual->quality((rsrq_mul_100 + 2000) / 50);


### PR DESCRIPTION
<details>
  <summary><i>submission notes</i></summary>

```
**Important:** Please sanitize/remove any confidential info like usernames, passwords, org names, product names/ids, access tokens, client ids/secrets, or anything else you don't wish to share.

Please Read and Sign the Contributor License Agreement ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md)).

You may also delete this submission notes header if you'd like. Thank you for contributing!
```
</details>

### Problem

Quectel BG96 does not give valid values in QCSQ command to calculate signal stregnth immediately after power up. There is a known delay associated with this modem to give a valid value. If the code checks this AT command before it's ready, we get `0` for RSRP and RSRQ. Currently, we are translating `0` as -44 dBm (best signal strength), so it is misleading. 

### Solution

Invalidate `0` for RSRP and RSRQ. If a value of `0` is read on RSRP and/or RSRQ, then it is treated as an ERROR.

### Steps to Test

### Example App

```c
void setup() {
  Particle.publishVitals(2s);
}

void loop() {
}
```

### References

- [ch52017](https://app.clubhouse.io/particle/story/52017/b5-som-signal-strength-quality-suddenly-reported-as-100)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
