### PR TITLE
[hal] i2c: bus is driven low if building with JTAG/SWD enabled.

### DIFF
--- a/hal/src/electron/pinmap_defines.h
+++ b/hal/src/electron/pinmap_defines.h
@@ -23,6 +23,10 @@
 #define TOTAL_DAC_PINS 2
 #define TOTAL_ANALOG_PINS 12
 #define FIRST_ANALOG_PIN 10
+#define TOTAL_ESSENTIAL_PINS 20
+#define HAS_EXTRA_PINS 1
+#define FIRST_EXTRA_PIN 24
+#define LAST_EXTRA_PIN 35
 
 #define D0 0
 #define D1 1

--- a/hal/src/photon/pinmap_defines.h
+++ b/hal/src/photon/pinmap_defines.h
@@ -23,6 +23,8 @@
 #define TOTAL_DAC_PINS 2
 #define TOTAL_ANALOG_PINS 8
 #define FIRST_ANALOG_PIN 10
+#define TOTAL_ESSENTIAL_PINS 20
+#define HAS_EXTRA_PINS 0
 
 // Digital pins
 #define D0 0
@@ -93,6 +95,10 @@
 #define TOTAL_DAC_PINS 2
 #define TOTAL_ANALOG_PINS 13
 #define FIRST_ANALOG_PIN 10
+#define TOTAL_ESSENTIAL_PINS 20
+#define HAS_EXTRA_PINS 1
+#define FIRST_EXTRA_PIN 24
+#define LAST_EXTRA_PIN 29
 
 // Digital pins
 #define D0 0

--- a/hal/src/stm32f2xx/core_hal_stm32f2xx.c
+++ b/hal/src/stm32f2xx/core_hal_stm32f2xx.c
@@ -345,25 +345,24 @@ void HAL_Core_Config(void)
     PWR_WakeUpPinCmd(DISABLE);
 
     //Wiring pins default to inputs
-    for (pin_t pin = 0; pin <= 19; pin++) {
+    for (pin_t pin = 0; pin < TOTAL_ESSENTIAL_PINS; pin++) {
 #if defined(USE_SWD_JTAG) || defined(USE_SWD)
-        if (pin >= 3 && pin <= 7) {
+        if (pin >= D3 && pin <= D7) { // JTAG pins
             continue;
         }
 #endif
         HAL_Pin_Mode(pin, INPUT);
     }
-#if PLATFORM_ID==8 // Additional pins for P1
-    for (pin_t pin = 24; pin <= 29; pin++) {
+
+#if HAS_EXTRA_PINS
+    for (pin_t pin = FIRST_EXTRA_PIN; pin <= LAST_EXTRA_PIN; pin++) {
         HAL_Pin_Mode(pin, INPUT);
-    }
-    if (isWiFiPowersaveClockDisabled()) {
-        HAL_Pin_Mode(30, INPUT); // Wi-Fi Powersave clock is disabled, default to INPUT
     }
 #endif
-#if PLATFORM_ID==10 // Additional pins for Electron
-    for (pin_t pin = 24; pin <= 35; pin++) {
-        HAL_Pin_Mode(pin, INPUT);
+
+#if PLATFORM_ID==8
+    if (isWiFiPowersaveClockDisabled()) {
+        HAL_Pin_Mode(30, INPUT); // Wi-Fi Powersave clock is disabled, default to INPUT
     }
 #endif
 

--- a/hal/src/stm32f2xx/core_hal_stm32f2xx.c
+++ b/hal/src/stm32f2xx/core_hal_stm32f2xx.c
@@ -57,7 +57,7 @@
 #include "hal_event.h"
 #include "system_error.h"
 
-#if PLATFORM_ID==PLATFORM_P1
+#if PLATFORM_ID == PLATFORM_P1
 #include "wwd_management.h"
 #include "wlan_hal.h"
 #endif
@@ -360,7 +360,7 @@ void HAL_Core_Config(void)
     }
 #endif
 
-#if PLATFORM_ID==8
+#if PLATFORM_ID == PLATFORM_P1
     if (isWiFiPowersaveClockDisabled()) {
         HAL_Pin_Mode(30, INPUT); // Wi-Fi Powersave clock is disabled, default to INPUT
     }
@@ -964,7 +964,7 @@ void TIM8_TRG_COM_TIM14_irq(void)
 
 void TIM8_CC_irq(void)
 {
-#if PLATFORM_ID == 10 // Electron
+#if PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION // Electron
     if(NULL != HAL_TIM8_Handler)
     {
         HAL_TIM8_Handler();
@@ -1190,7 +1190,7 @@ int HAL_Feature_Set(HAL_Feature feature, bool enabled)
             return Write_Feature_Flag(FEATURE_FLAG_RESET_INFO, enabled, NULL);
         }
 
-#if PLATFORM_ID==PLATFORM_P1
+#if PLATFORM_ID == PLATFORM_P1
         case FEATURE_WIFI_POWERSAVE_CLOCK:
         {
             wwd_set_wlan_sleep_clock_enabled(enabled);
@@ -1351,10 +1351,10 @@ static inline uint32_t Tim_Peripheral_To_Af(TIM_TypeDef* tim) {
             return GPIO_AF_TIM4;
         case (uint32_t)TIM5:
             return GPIO_AF_TIM5;
-#if PLATFORM_ID == 10
+#if PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION
         case (uint32_t)TIM8:
             return GPIO_AF_TIM8;
-#endif // PLATFORM_ID == 10
+#endif // PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION
     }
 
     return 0;

--- a/hal/src/stm32f2xx/core_hal_stm32f2xx.c
+++ b/hal/src/stm32f2xx/core_hal_stm32f2xx.c
@@ -345,20 +345,26 @@ void HAL_Core_Config(void)
     PWR_WakeUpPinCmd(DISABLE);
 
     //Wiring pins default to inputs
-#if !defined(USE_SWD_JTAG) && !defined(USE_SWD)
-    for (pin_t pin=0; pin<=19; pin++)
+    for (pin_t pin = 0; pin <= 19; pin++) {
+#if defined(USE_SWD_JTAG) || defined(USE_SWD)
+        if (pin >= 3 && pin <= 7) {
+            continue;
+        }
+#endif
         HAL_Pin_Mode(pin, INPUT);
+    }
 #if PLATFORM_ID==8 // Additional pins for P1
-    for (pin_t pin=24; pin<=29; pin++)
+    for (pin_t pin = 24; pin <= 29; pin++) {
         HAL_Pin_Mode(pin, INPUT);
+    }
     if (isWiFiPowersaveClockDisabled()) {
         HAL_Pin_Mode(30, INPUT); // Wi-Fi Powersave clock is disabled, default to INPUT
     }
 #endif
 #if PLATFORM_ID==10 // Additional pins for Electron
-    for (pin_t pin=24; pin<=35; pin++)
+    for (pin_t pin = 24; pin <= 35; pin++) {
         HAL_Pin_Mode(pin, INPUT);
-#endif
+    }
 #endif
 
     HAL_Core_Config_systick_configuration();

--- a/hal/src/stm32f2xx/i2c_hal.c
+++ b/hal/src/stm32f2xx/i2c_hal.c
@@ -237,6 +237,8 @@ int HAL_I2C_Init(HAL_I2C_Interface i2c, const HAL_I2C_Config* config)
     if(i2c == HAL_I2C_INTERFACE1)
     {
         i2cMap[i2c] = &I2C_MAP[I2C1_D0_D1];
+        HAL_Pin_Mode(i2cMap[i2c]->I2C_SDA_Pin, INPUT);
+        HAL_Pin_Mode(i2cMap[i2c]->I2C_SCL_Pin, INPUT);
     }
 #if PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION // Electron
     if(i2c == HAL_I2C_INTERFACE2 || i2c == HAL_I2C_INTERFACE1)

--- a/hal/src/stm32f2xx/i2c_hal.c
+++ b/hal/src/stm32f2xx/i2c_hal.c
@@ -237,8 +237,6 @@ int HAL_I2C_Init(HAL_I2C_Interface i2c, const HAL_I2C_Config* config)
     if(i2c == HAL_I2C_INTERFACE1)
     {
         i2cMap[i2c] = &I2C_MAP[I2C1_D0_D1];
-        HAL_Pin_Mode(i2cMap[i2c]->I2C_SDA_Pin, INPUT);
-        HAL_Pin_Mode(i2cMap[i2c]->I2C_SCL_Pin, INPUT);
     }
 #if PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION // Electron
     if(i2c == HAL_I2C_INTERFACE2 || i2c == HAL_I2C_INTERFACE1)


### PR DESCRIPTION

### Problem

I2C bus is driven LOW after `Wire.begin()` when building with JTAG/SWD enabled on Electron.

### Solution

Initialize I2C pins to be float input.
### Example App

```c
#include "Particle.h"

SYSTEM_THREAD(ENABLED);
SYSTEM_MODE(SEMI_AUTOMATIC);

void setup() {
    Wire.begin();
}

void loop() {
}
```

### Steps to test

1. Build modular firmware with JTAG/SWD enabled:
`make PLATFORM=electron DEBUG_BUILD=y USE_SWD_JTAG=y`

2. Flash system firmware and the above application.
3. Use logic analyser to monitor the SDA(D0) and SCL(D1) and see if both pins go to high level or not.

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
