### PR TITLE
[wiring] BLE: use 'delete' in corresponding to the 'new' keyword

### DIFF
--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -1811,7 +1811,7 @@ int BleLocalDevice::advertise(const iBeacon& beacon) const {
     BleAdvertisingData* advData = new(std::nothrow) BleAdvertisingData(beacon);
     SCOPE_GUARD ({
         if (advData) {
-            free(advData);
+            delete advData;
         }
     });
     CHECK_TRUE(advData, SYSTEM_ERROR_NO_MEMORY);


### PR DESCRIPTION

### Example App

```c
#include "Particle.h"

SYSTEM_MODE(MANUAL);

SerialLogHandler log(LOG_LEVEL_ALL);

iBeacon beacon(0, 0, "6E400001-B5A3-F393-E0A9-E50E24DCCA9E", 0);

/* This function is called once at start up ----------------------------------*/
void setup()
{
    while(!Serial.isConnected());
    delay(1000);

    static runtime_info_t heapInfo;
    if (heapInfo.size == 0) {
        heapInfo.size = sizeof(heapInfo);
    }

    HAL_Core_Runtime_Info(&heapInfo, nullptr);
    Serial.printlnf("\n\n\n=======TP1============");
    Serial.printlnf("Heapinfo: size :%d, largest_free_block_heap :%lu", heapInfo.freeheap, heapInfo.largest_free_block_heap);
    Serial.printlnf("===================\n\n\n");

    BLE.advertise(beacon);

    HAL_Core_Runtime_Info(&heapInfo, nullptr);
    Serial.printlnf("\n\n\n=======TP2============");
    Serial.printlnf("Heapinfo: size :%d, largest_free_block_heap :%lu", heapInfo.freeheap, heapInfo.largest_free_block_heap);
    Serial.printlnf("===================\n\n\n");

    BLE.advertise(beacon);

    HAL_Core_Runtime_Info(&heapInfo, nullptr);
    Serial.printlnf("\n\n\n=======TP3============");
    Serial.printlnf("Heapinfo: size :%d, largest_free_block_heap :%lu", heapInfo.freeheap, heapInfo.largest_free_block_heap);
    Serial.printlnf("===================\n\n\n");
}

void loop() {
}
```

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
