### PR TITLE
Map AccessTechnology correctly on SARA R410M

### DIFF
--- a/hal/network/ncp/cellular/cellular_hal.cpp
+++ b/hal/network/ncp/cellular/cellular_hal.cpp
@@ -96,9 +96,9 @@ hal_net_access_tech_t fromCellularAccessTechnology(CellularAccessTechnology rat)
         return NET_ACCESS_TECHNOLOGY_UTRAN;
     case CellularAccessTechnology::LTE:
         return NET_ACCESS_TECHNOLOGY_LTE;
-    case CellularAccessTechnology::EC_GSM_IOT:
+    case CellularAccessTechnology::LTE_CAT_M1:
         return NET_ACCESS_TECHNOLOGY_LTE_CAT_M1;
-    case CellularAccessTechnology::E_UTRAN:
+    case CellularAccessTechnology::LTE_NB_IOT:
         return NET_ACCESS_TECHNOLOGY_LTE_CAT_NB1;
     default:
         return NET_ACCESS_TECHNOLOGY_UNKNOWN;

--- a/hal/network/ncp/cellular/cellular_ncp_client.h
+++ b/hal/network/ncp/cellular/cellular_ncp_client.h
@@ -75,8 +75,8 @@ enum class CellularAccessTechnology {
     UTRAN_HSUPA = 5,
     UTRAN_HSDPA_HSUPA = 6,
     LTE = 7,
-    EC_GSM_IOT = 8,
-    E_UTRAN = 9
+    LTE_CAT_M1 = 8,
+    LTE_NB_IOT = 9
 };
 
 enum class CellularStrengthUnits {
@@ -187,8 +187,8 @@ inline CellularStrengthUnits CellularSignalQuality::strengthUnits() const {
             return CellularStrengthUnits::RSCP;
         }
         case CellularAccessTechnology::LTE:
-        case CellularAccessTechnology::EC_GSM_IOT:
-        case CellularAccessTechnology::E_UTRAN: {
+        case CellularAccessTechnology::LTE_CAT_M1:
+        case CellularAccessTechnology::LTE_NB_IOT: {
             return CellularStrengthUnits::RSRP;
         }
         default: {
@@ -228,8 +228,8 @@ inline CellularQualityUnits CellularSignalQuality::qualityUnits() const {
             return CellularQualityUnits::ECN0;
         }
         case CellularAccessTechnology::LTE:
-        case CellularAccessTechnology::EC_GSM_IOT:
-        case CellularAccessTechnology::E_UTRAN: {
+        case CellularAccessTechnology::LTE_CAT_M1:
+        case CellularAccessTechnology::LTE_NB_IOT: {
             return CellularQualityUnits::RSRQ;
         }
         default: {

--- a/hal/shared/cellular_enums_hal.h
+++ b/hal/shared/cellular_enums_hal.h
@@ -99,8 +99,8 @@ typedef enum {
     UBLOX_SARA_RAT_UTRAN_HSUPA       = 5,
     UBLOX_SARA_RAT_UTRAN_HSDPA_HSUPA = 6,
     UBLOX_SARA_RAT_LTE               = 7,
-    UBLOX_SARA_RAT_EC_GSM_IOT        = 8,
-    UBLOX_SARA_RAT_E_UTRAN           = 9
+    UBLOX_SARA_RAT_LTE_CAT_M1        = 8,
+    UBLOX_SARA_RAT_LTE_NB_IOT        = 9
 } UbloxSaraCellularAccessTechnology;
 //! Ublox UMNOPROF settings
 typedef enum {

--- a/hal/src/b5som/network/quectel_ncp_client.cpp
+++ b/hal/src/b5som/network/quectel_ncp_client.cpp
@@ -284,8 +284,8 @@ int QuectelNcpClient::initParser(Stream* stream) {
             auto rat = r >= 4 ? static_cast<CellularAccessTechnology>(val[3]) : self->act_;
             switch (rat) {
                 case CellularAccessTechnology::LTE:
-                case CellularAccessTechnology::EC_GSM_IOT:
-                case CellularAccessTechnology::E_UTRAN: {
+                case CellularAccessTechnology::LTE_CAT_M1:
+                case CellularAccessTechnology::LTE_NB_IOT: {
                     self->cgi_.location_area_code = static_cast<LacType>(val[1]);
                     self->cgi_.cell_id = static_cast<CidType>(val[2]);
                     break;
@@ -523,8 +523,8 @@ int QuectelNcpClient::queryAndParseAtCops(CellularSignalQuality* qual) {
         case CellularAccessTechnology::UTRAN_HSUPA:
         case CellularAccessTechnology::UTRAN_HSDPA_HSUPA:
         case CellularAccessTechnology::LTE:
-        case CellularAccessTechnology::EC_GSM_IOT:
-        case CellularAccessTechnology::E_UTRAN: {
+        case CellularAccessTechnology::LTE_CAT_M1:
+        case CellularAccessTechnology::LTE_NB_IOT: {
             break;
         }
         default: {
@@ -595,8 +595,8 @@ int QuectelNcpClient::getSignalQuality(CellularSignalQuality* qual) {
         {"WCDMA", CellularAccessTechnology::UTRAN},
         {"TDSCDMA", CellularAccessTechnology::UTRAN},
         {"LTE", CellularAccessTechnology::LTE},
-        {"CAT-M1", CellularAccessTechnology::EC_GSM_IOT},
-        {"CAT-NB1", CellularAccessTechnology::E_UTRAN}
+        {"CAT-M1", CellularAccessTechnology::LTE_CAT_M1},
+        {"CAT-NB1", CellularAccessTechnology::LTE_NB_IOT}
     };
 
     int vals[5] = {};
@@ -652,8 +652,8 @@ int QuectelNcpClient::getSignalQuality(CellularSignalQuality* qual) {
                     break;
                 }
                 case CellularAccessTechnology::LTE:
-                case CellularAccessTechnology::EC_GSM_IOT:
-                case CellularAccessTechnology::E_UTRAN: {
+                case CellularAccessTechnology::LTE_CAT_M1:
+                case CellularAccessTechnology::LTE_NB_IOT: {
                     if (qcsqVals >= 5) {
                         const int min_rsrq_mul_by_100 = -1950;
                         const int max_rsrq_mul_by_100 = -300;

--- a/hal/src/boron/network/sara_ncp_client.cpp
+++ b/hal/src/boron/network/sara_ncp_client.cpp
@@ -40,6 +40,7 @@
 #include <algorithm>
 #include <limits>
 #include <lwip/memp.h>
+#include "enumclass.h"
 
 #undef LOG_COMPILE_TIME_LEVEL
 #define LOG_COMPILE_TIME_LEVEL LOG_LEVEL_ALL
@@ -270,8 +271,8 @@ int SaraNcpClient::initParser(Stream* stream) {
             auto rat = r >= 4 ? static_cast<CellularAccessTechnology>(val[3]) : self->act_;
             switch (rat) {
                 case CellularAccessTechnology::LTE:
-                case CellularAccessTechnology::EC_GSM_IOT:
-                case CellularAccessTechnology::E_UTRAN: {
+                case CellularAccessTechnology::LTE_CAT_M1:
+                case CellularAccessTechnology::LTE_NB_IOT: {
                     self->cgi_.location_area_code = static_cast<LacType>(val[1]);
                     self->cgi_.cell_id = static_cast<CidType>(val[2]);
                     break;
@@ -494,6 +495,12 @@ int SaraNcpClient::queryAndParseAtCops(CellularSignalQuality* qual) {
     cgi_.mobile_country_code = static_cast<uint16_t>(::atoi(mobileCountryCode));
     cgi_.mobile_network_code = static_cast<uint16_t>(::atoi(mobileNetworkCode));
 
+    if (ncpId() == PLATFORM_NCP_SARA_R410) {
+        if (act == particle::to_underlying(CellularAccessTechnology::LTE)) {
+            act = particle::to_underlying(CellularAccessTechnology::LTE_CAT_M1);
+        }
+    }
+
     switch (static_cast<CellularAccessTechnology>(act)) {
         case CellularAccessTechnology::NONE:
         case CellularAccessTechnology::GSM:
@@ -504,8 +511,8 @@ int SaraNcpClient::queryAndParseAtCops(CellularSignalQuality* qual) {
         case CellularAccessTechnology::UTRAN_HSUPA:
         case CellularAccessTechnology::UTRAN_HSDPA_HSUPA:
         case CellularAccessTechnology::LTE:
-        case CellularAccessTechnology::EC_GSM_IOT:
-        case CellularAccessTechnology::E_UTRAN: {
+        case CellularAccessTechnology::LTE_CAT_M1:
+        case CellularAccessTechnology::LTE_NB_IOT: {
             break;
         }
         default: {

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -147,9 +147,9 @@ AcT toCellularAccessTechnology(int rat) {
             return ACT_UTRAN;
         case UBLOX_SARA_RAT_LTE:
             return ACT_LTE;
-        case UBLOX_SARA_RAT_EC_GSM_IOT:
+        case UBLOX_SARA_RAT_LTE_CAT_M1:
             return ACT_LTE_CAT_M1;
-        case UBLOX_SARA_RAT_E_UTRAN:
+        case UBLOX_SARA_RAT_LTE_NB_IOT:
             return ACT_LTE_CAT_NB1;
         default:
             return ACT_UNKNOWN;
@@ -1484,6 +1484,12 @@ bool MDMParser::getSignalStrength(NetStatus &status)
         // RSSI() API's have a RAT for conversion lookup purposes.
         if (_dev.dev == DEV_SARA_G350) {
             _net.act = ACT_GSM;
+        }
+
+        // R410M modems report AcT as LTE and LTE-M1 when connecting
+        // on LTE-M1. If AcT is reported as LTE, change it to report LTE-M1
+        if (_dev.dev == DEV_SARA_R410 && _net.act == ACT_LTE) {
+            _net.act = ACT_LTE_CAT_M1;
         }
 
         // AT command used to collect signal stregnth is different for R410M radio


### PR DESCRIPTION
- Access technology on R410M modems on Boron LTE is sometimes registered as `7` and sometimes registered as `8`. Hence, mapping them correctly for the R410M platform, by considering both `7` and `8` as Cat-m1 RAT.
- Rename access technology related enums to be more understandable.

Story details: https://app.clubhouse.io/particle/story/49272