### PR TITLE
Particle.process() is a no-op when called from a custom thread.

### DIFF
--- a/system/src/system_cloud.cpp
+++ b/system/src/system_cloud.cpp
@@ -240,15 +240,17 @@ void spark_process(void)
 {
 	// application thread will pump application messages
 #if PLATFORM_THREADING
-    if (system_thread_get_state(NULL) && APPLICATION_THREAD_CURRENT())
-    {
-        ApplicationThread.process();
-        return;
+    if (APPLICATION_THREAD_CURRENT()) {
+        if (system_thread_get_state(NULL)) {
+            ApplicationThread.process();
+        } else {
+            Spark_Idle_Events(true);
+        }
     }
-#endif // PLATFORM_THREADING
-
+#else
     // run the background processing loop, and specifically also pump cloud events
     Spark_Idle_Events(true);
+#endif // PLATFORM_THREADING
 }
 
 String spark_deviceID(void)


### PR DESCRIPTION
…a custom thread

<details>
  <summary><i>submission notes</i></summary>

```
**Important:** Please sanitize/remove any confidential info like usernames, passwords, org names, product names/ids, access tokens, client ids/secrets, or anything else you don't wish to share.

Please Read and Sign the Contributor License Agreement ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md)).

You may also delete this submission notes header if you'd like. Thank you for contributing!
```
</details>

### Problem

If `Particle.process()` is called from custom thread, it runs `Spark_idle_events()`
(It's not safe is that Particle.process (and the underlying spark function) also handle things like serial event handlers, subscription handlers, function handlers, and (in 1.5.0 and later) variable queries. These are all expected to only be called from the loop context, otherwise you'd need thread safe constructs around them and in the loop code.)

### Solution

Particle.process() should be a no-op when called from a custom thread.

### Steps to Test

#### Test App that attempts to run Particle.process() from custom thread

```c
#include "application.h"

SYSTEM_THREAD(ENABLED);
void fn() {
    while (true) {
        Particle.process();
    }
}

void setup() {
    Thread* th = new Thread("name", fn, OS_THREAD_PRIORITY_DEFAULT);
}
void loop() {
}
```

### References

[ch38445](https://app.clubhouse.io/particle/story/38445/particle-process-should-be-a-no-op-when-called-from-a-custom-thread)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
