### PR TITLE
[hal] sleep: allow to enter hibernate mode without specifying any wak…

### DIFF
--- a/hal/src/nRF52840/sleep_hal.cpp
+++ b/hal/src/nRF52840/sleep_hal.cpp
@@ -685,8 +685,8 @@ int hal_sleep_validate_config(const hal_sleep_config_t* config, void* reserved) 
 
     // Checks the wakeup sources
     auto wakeupSource = config->wakeup_sources;
-    // At least one wakeup source should be configured.
-    if (!wakeupSource) {
+    // At least one wakeup source should be configured for stop mode.
+    if (config->mode == HAL_SLEEP_MODE_STOP && !wakeupSource) {
         return SYSTEM_ERROR_INVALID_ARGUMENT;
     }
     while (wakeupSource) {

--- a/hal/src/stm32f2xx/sleep_hal.cpp
+++ b/hal/src/stm32f2xx/sleep_hal.cpp
@@ -292,10 +292,10 @@ int hal_sleep_validate_config(const hal_sleep_config_t* config, void* reserved) 
 
     // Checks the wakeup sources
     auto wakeupSource = config->wakeup_sources;
-    // For backward compatibility, Gen2 platforms can disable WKP pin.
-    // if (!wakeupSource) {
-    //     return SYSTEM_ERROR_INVALID_ARGUMENT;
-    // }
+    // At least one wakeup source should be configured for stop mode.
+    if (config->mode == HAL_SLEEP_MODE_STOP && !wakeupSource) {
+        return SYSTEM_ERROR_INVALID_ARGUMENT;
+    }
     while (wakeupSource) {
         CHECK(validateWakeupSource(config->mode, wakeupSource));
         wakeupSource = wakeupSource->next;


### PR DESCRIPTION

### Problem

Gen3 device cannot enter hibernate mode if not specifying any wakeup source.

### Solution

Don't check wakeup source availability in sleep HAL if hibernate mode is specified.

### Example App

```c
void setup() {
    System.sleep(SLEEP_MODE_DEEP, SLEEP_DISABLE_WKP_PIN);
    // or
    // System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::HIBERNATE));
    // Device should enter hibernate mode here. And it can only be woken up by a reset or power-cycle.
}

void loop() {
}
```
---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
