### PR TITLE
[electron] Fix "Sim not inserted" debug log when modem is not responsive

### DIFF
--- a/system/src/system_network_cellular.h
+++ b/system/src/system_network_cellular.h
@@ -133,11 +133,11 @@ public:
     bool has_credentials() override
     {
         bool rv = cellular_sim_ready(NULL);
-        LOG(INFO,"%s", (rv)?"Sim Ready":"Sim not inserted? Detecting...");
+        LOG(INFO,"%s", (rv)?"Sim Ready":"SIM/modem not responsive or SIM not inserted/requires a PIN.");
         if (!rv) {
             cellular_on(NULL);
             rv = cellular_sim_ready(NULL);
-            LOG(INFO,"%s", (rv)?"Sim Ready":"Sim not inserted.");
+            LOG(INFO,"%s", (rv)?"Sim Ready":"SIM/modem not responsive or SIM not inserted/requires a PIN.");
         }
         return rv;
     }


### PR DESCRIPTION
### Problem

Gen2 reports `SIM not inserted` or `Sim not inserted? Detecting...` when modem is not responsive. It is misleading because modem AT was not responsive and is confusing users to think that Sim is not inserted.

### Solution

Changed log message from `Sim not inserted` to `SIM/modem not responsive or SIM not inserted/requires a PIN.`

### Steps to Test

### Example App
May spoof AT not working by changing baud rate, or by connecting cell USB at the same time for testing purposes.
```c
#include "application.h"
SerialLogHandler logHandler(LOG_LEVEL_ALL);
void setup() {
}

void loop() {
}
```

### References

[ch50557](https://app.clubhouse.io/particle/story/50557/remove-sim-not-inserted-for-unresponsive-modem)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
