### PR TITLE
Removes locking in some of the SPI and I2C APIs to improve performance

### DIFF
--- a/hal/src/nRF52840/i2c_hal.cpp
+++ b/hal/src/nRF52840/i2c_hal.cpp
@@ -520,10 +520,7 @@ void HAL_I2C_Flush_Data(HAL_I2C_Interface i2c,void* reserved) {
 }
 
 bool HAL_I2C_Is_Enabled(HAL_I2C_Interface i2c,void* reserved) {
-    HAL_I2C_Acquire(i2c, NULL);
-    bool en = m_i2c_map[i2c].enabled;
-    HAL_I2C_Release(i2c, NULL);
-    return en;
+    return m_i2c_map[i2c].enabled;
 }
 
 void HAL_I2C_Set_Callback_On_Receive(HAL_I2C_Interface i2c, void (*function)(int),void* reserved) {

--- a/hal/src/nRF52840/i2c_hal.cpp
+++ b/hal/src/nRF52840/i2c_hal.cpp
@@ -71,7 +71,7 @@ typedef struct {
     uint8_t                     scl_pin;
     uint8_t                     sda_pin;
 
-    bool                        enabled;
+    volatile bool               enabled;
     volatile transfer_state_t   transfer_state;
     I2C_Mode                    mode;
     uint32_t                    speed;

--- a/hal/src/nRF52840/spi_hal.cpp
+++ b/hal/src/nRF52840/spi_hal.cpp
@@ -56,7 +56,7 @@ typedef struct {
     HAL_SPI_DMA_UserCallback            spi_dma_user_callback;
     HAL_SPI_Select_UserCallback         spi_select_user_callback;
 
-    bool                                enabled;
+    volatile bool                       enabled;
     volatile bool                       transmitting;
     volatile uint16_t                   transfer_length;
 

--- a/hal/src/nRF52840/usart_hal.cpp
+++ b/hal/src/nRF52840/usart_hal.cpp
@@ -683,7 +683,7 @@ private:
     pin_t rtsPin_;
 
     bool configured_ = false;
-    bool enabled_ = false;
+    volatile bool enabled_ = false;
 
     volatile bool transmitting_;
     volatile uint8_t receiving_;

--- a/hal/src/stm32f2xx/i2c_hal.c
+++ b/hal/src/stm32f2xx/i2c_hal.c
@@ -116,7 +116,7 @@ typedef struct STM32_I2C_Info {
     I2C_InitTypeDef I2C_InitStructure;
 
     uint32_t I2C_ClockSpeed;
-    bool I2C_Enabled;
+    volatile bool I2C_Enabled;
 
     uint8_t* rxBuffer;
     size_t rxBufferSize;

--- a/hal/src/stm32f2xx/i2c_hal.c
+++ b/hal/src/stm32f2xx/i2c_hal.c
@@ -906,10 +906,7 @@ void HAL_I2C_Flush_Data(HAL_I2C_Interface i2c, void* reserved)
 
 bool HAL_I2C_Is_Enabled(HAL_I2C_Interface i2c, void* reserved)
 {
-    HAL_I2C_Acquire(i2c, NULL);
-    bool en = i2cMap[i2c]->I2C_Enabled;
-    HAL_I2C_Release(i2c, NULL);
-    return en;
+    return i2cMap[i2c]->I2C_Enabled;
 }
 
 void HAL_I2C_Set_Callback_On_Receive(HAL_I2C_Interface i2c, void (*function)(int), void* reserved)

--- a/hal/src/stm32f2xx/spi_hal.c
+++ b/hal/src/stm32f2xx/spi_hal.c
@@ -321,7 +321,7 @@ void HAL_SPI_Begin_Ext(HAL_SPI_Interface spi, SPI_Mode mode, uint16_t pin, void*
         PIN_MAP[pin].gpio_peripheral->BSRRL = PIN_MAP[pin].gpio_pin;
         HAL_Pin_Mode(pin, OUTPUT);
     }
-    else
+    else if (mode == SPI_MODE_SLAVE)
     {
         HAL_Pin_Mode(pin, INPUT);
     }

--- a/hal/src/stm32f2xx/spi_hal.c
+++ b/hal/src/stm32f2xx/spi_hal.c
@@ -75,7 +75,7 @@ typedef struct SPI_State
     bool SPI_Bit_Order_Set;
     bool SPI_Data_Mode_Set;
     bool SPI_Clock_Divider_Set;
-    bool SPI_Enabled;
+    volatile bool SPI_Enabled;
 
     HAL_SPI_DMA_UserCallback SPI_DMA_UserCallback;
 

--- a/hal/src/stm32f2xx/usart_hal.c
+++ b/hal/src/stm32f2xx/usart_hal.c
@@ -70,7 +70,7 @@ typedef struct STM32_USART_Info {
 	Ring_Buffer* usart_tx_buffer;
 	Ring_Buffer* usart_rx_buffer;
 
-	bool usart_enabled;
+	volatile bool usart_enabled;
 	bool usart_transmitting;
 
 	uint32_t usart_config;

--- a/user/tests/wiring/no_fixture_spi/spi.cpp
+++ b/user/tests/wiring/no_fixture_spi/spi.cpp
@@ -392,116 +392,169 @@ test(SPI_10_SPI1_Begin_With_Slave_Ss_Pin)
 #endif // Wiring_SPI1
 
 // Performance tests. All SPI interfaces share the same driver. Testing on SPI only is sufficient.
-test(SPI_11_SPI_Transfer_10000_Bytes_No_Locking_Less_Than_135_Ms)
+constexpr uint32_t calculateExpectedTime(uint32_t spiClockSpeed, uint32_t spiTransferSize, float allowedOverhead) {
+    return ((((float)spiTransferSize / (spiClockSpeed / 8 /* 8 clocks per byte */)) * 1000) * allowedOverhead);
+}
+
+test(SPI_11_SPI_Transfer_1_Bytes_Per_Transmission_No_Locking)
 {
-    SPI.setClockSpeed(5, MHZ);
+    constexpr auto SPI_TRANSFER_SIZE = 10000;
+    constexpr auto SPI_TRANSFER_OVERHEAD = 7.0; // This value should be adjusted if either SPI clock or transfer size is changed.
+    constexpr auto SPI_CLOCK_SPEED_MHZ = 4;
+    constexpr auto expectedTime = calculateExpectedTime(SPI_CLOCK_SPEED_MHZ * 1000000, SPI_TRANSFER_SIZE, SPI_TRANSFER_OVERHEAD);
+
+    SPI.setClockSpeed(SPI_CLOCK_SPEED_MHZ, MHZ);
     SPI.begin();
     system_tick_t start = millis();
-    for(unsigned int i=0; i < 10000; i++)
+    for(unsigned int i = 0; i < SPI_TRANSFER_SIZE; i++)
     {
         SPI.transfer(0x55);
     }
-    Serial.printf("%d ms\r\n", millis() - start);
-    assertTrue(millis() - start < 135);
+    system_tick_t transferTime = millis() - start;
     SPI1.end();
+
+    Serial.printf("in %d ms, expected: %d\r\n", transferTime, expectedTime);
+    assertLessOrEqual(transferTime, expectedTime);
 }
 
-test(SPI_12_SPI_Transfer_10000_Bytes_Locking_Less_Than_135_Ms)
+test(SPI_12_SPI_Transfer_1_Bytes_Per_Transmission_Locking)
 {
-    SPI.setClockSpeed(5, MHZ);
+    constexpr auto SPI_TRANSFER_SIZE = 10000;
+    constexpr auto SPI_TRANSFER_OVERHEAD = 7.0; // This value should be adjusted if either SPI clock or transfer size is changed.
+    constexpr auto SPI_CLOCK_SPEED_MHZ = 4;
+    constexpr auto expectedTime = calculateExpectedTime(SPI_CLOCK_SPEED_MHZ * 1000000, SPI_TRANSFER_SIZE, SPI_TRANSFER_OVERHEAD);
+
+    SPI.setClockSpeed(SPI_CLOCK_SPEED_MHZ, MHZ);
     SPI.begin();
     SPI.beginTransaction();
     system_tick_t start = millis();
-    for(unsigned int i=0; i < 10000; i++)
+    for(unsigned int i = 0; i < SPI_TRANSFER_SIZE; i++)
     {
         SPI.transfer(0x55);
     }
     SPI.endTransaction();
-    Serial.printf("%d ms\r\n", millis() - start);
-    assertTrue(millis() - start < 135);
+    system_tick_t transferTime = millis() - start;
     SPI1.end();
+
+    Serial.printf("in %d ms, expected: %d\r\n", transferTime, expectedTime);
+    assertLessOrEqual(transferTime, expectedTime);
 }
 
-test(SPI_13_SPI_Transfer_2_Miltiply_5000_Bytes_Locking_Less_Than_135_Ms)
+test(SPI_13_SPI_Transfer_2_Bytes_Per_Transmission_Locking)
 {
-    SPI.setClockSpeed(5, MHZ);
+    constexpr auto SPI_TRANSFER_SIZE = 10000;
+    constexpr auto SPI_TRANSFER_OVERHEAD = 7.0; // This value should be adjusted if either SPI clock or transfer size is changed.
+    constexpr auto SPI_CLOCK_SPEED_MHZ = 4;
+    constexpr auto expectedTime = calculateExpectedTime(SPI_CLOCK_SPEED_MHZ * 1000000, SPI_TRANSFER_SIZE, SPI_TRANSFER_OVERHEAD);
+
+    SPI.setClockSpeed(SPI_CLOCK_SPEED_MHZ, MHZ);
     SPI.begin();
     SPI.beginTransaction();
     system_tick_t start = millis();
-    for(unsigned int i=0; i < 5000; i++)
+    for(unsigned int i = 0; i < SPI_TRANSFER_SIZE; i += 2)
     {
         SPI.transfer(0x55);
         SPI.transfer(0x55);
     }
     SPI.endTransaction();
-    Serial.printf("%d ms\r\n", millis() - start);
-    assertTrue(millis() - start < 135);
+    system_tick_t transferTime = millis() - start;
     SPI1.end();
+
+    Serial.printf("in %d ms, expected: %d\r\n", transferTime, expectedTime);
+    assertLessOrEqual(transferTime, expectedTime);
 }
 
-test(SPI_14_SPI_Transfer_10000_Bytes_DMA_No_Locking_Less_Than_140_Ms)
+test(SPI_14_SPI_Transfer_1_Bytes_Per_DMA_Transmission_No_Locking)
 {
-    SPI.setClockSpeed(5, MHZ);
+    constexpr auto SPI_TRANSFER_SIZE = 10000;
+    constexpr auto SPI_TRANSFER_OVERHEAD = 7.0; // This value should be adjusted if either SPI clock or transfer size is changed.
+    constexpr auto SPI_CLOCK_SPEED_MHZ = 4;
+    constexpr auto expectedTime = calculateExpectedTime(SPI_CLOCK_SPEED_MHZ * 1000000, SPI_TRANSFER_SIZE, SPI_TRANSFER_OVERHEAD);
+
+    SPI.setClockSpeed(SPI_CLOCK_SPEED_MHZ, MHZ);
     SPI.begin();
     system_tick_t start = millis();
     uint8_t temp = 0x55;
-    for(unsigned int i=0; i < 10000; i++)
+    for(unsigned int i = 0; i < SPI_TRANSFER_SIZE; i++)
     {
         SPI.transfer(&temp, nullptr, 1, nullptr); 
     }
-    Serial.printf("%d ms\r\n", millis() - start);
-    assertTrue(millis() - start < 140);
+    system_tick_t transferTime = millis() - start;
     SPI1.end();
+
+    Serial.printf("in %d ms, expected: %d\r\n", transferTime, expectedTime);
+    assertLessOrEqual(transferTime, expectedTime);
 }
 
-test(SPI_15_SPI_Transfer_10000_Bytes_DMA_Locking_Less_Than_140_Ms)
+test(SPI_15_SPI_Transfer_1_Bytes_Per_DMA_Transmission_Locking)
 {
-    SPI.setClockSpeed(5, MHZ);
+    constexpr auto SPI_TRANSFER_SIZE = 10000;
+    constexpr auto SPI_TRANSFER_OVERHEAD = 7.0; // This value should be adjusted if either SPI clock or transfer size is changed.
+    constexpr auto SPI_CLOCK_SPEED_MHZ = 4;
+    constexpr auto expectedTime = calculateExpectedTime(SPI_CLOCK_SPEED_MHZ * 1000000, SPI_TRANSFER_SIZE, SPI_TRANSFER_OVERHEAD);
+
+    SPI.setClockSpeed(SPI_CLOCK_SPEED_MHZ, MHZ);
     SPI.begin();
     SPI.beginTransaction();
     system_tick_t start = millis();
     uint8_t temp = 0x55;
-    for(unsigned int i=0; i < 10000; i++)
+    for(unsigned int i = 0; i < SPI_TRANSFER_SIZE; i++)
     {
         SPI.transfer(&temp, nullptr, 1, nullptr); 
     }
     SPI.endTransaction();
-    Serial.printf("%d ms\r\n", millis() - start);
-    assertTrue(millis() - start < 140);
+    system_tick_t transferTime = millis() - start;
     SPI1.end();
+
+    Serial.printf("in %d ms, expected: %d\r\n", transferTime, expectedTime);
+    assertLessOrEqual(transferTime, expectedTime);
 }
 
-test(SPI_16_SPI_Transfer_2_Multiply_5000_Bytes_DMA_Locking_Less_Than_85_Ms)
+test(SPI_16_SPI_Transfer_2_Bytes_Per_DMA_Transmission_Locking)
 {
-    SPI.setClockSpeed(5, MHZ);
+    constexpr auto SPI_TRANSFER_SIZE = 10000;
+    constexpr auto SPI_TRANSFER_OVERHEAD = 3.8; // This value should be adjusted if either SPI clock or transfer size is changed.
+    constexpr auto SPI_CLOCK_SPEED_MHZ = 4;
+    constexpr auto expectedTime = calculateExpectedTime(SPI_CLOCK_SPEED_MHZ * 1000000, SPI_TRANSFER_SIZE, SPI_TRANSFER_OVERHEAD);
+
+    SPI.setClockSpeed(SPI_CLOCK_SPEED_MHZ, MHZ);
     SPI.begin();
     SPI.beginTransaction();
     system_tick_t start = millis();
     uint8_t temp[2] = {0x55};
-    for(unsigned int i=0; i < 5000; i++)
+    for(unsigned int i = 0; i < SPI_TRANSFER_SIZE; i += 2)
     {
         SPI.transfer(&temp, nullptr, 2, nullptr); 
     }
     SPI.endTransaction();
-    Serial.printf("%d ms\r\n", millis() - start);
-    assertTrue(millis() - start < 85);
+    system_tick_t transferTime = millis() - start;
     SPI1.end();
+
+    Serial.printf("in %d ms, expected: %d\r\n", transferTime, expectedTime);
+    assertLessOrEqual(transferTime, expectedTime);
 }
 
-test(SPI_17_SPI_Transfer_10_Multiply_1000_Bytes_DMA_Locking_Less_Than_40_Ms)
+test(SPI_17_SPI_Transfer_10_Bytes_Per_DMA_Transmission_Locking)
 {
-    SPI.setClockSpeed(5, MHZ);
+    constexpr auto SPI_TRANSFER_SIZE = 10000;
+    constexpr auto SPI_TRANSFER_OVERHEAD = 1.75; // This value should be adjusted if either SPI clock or transfer size is changed.
+    constexpr auto SPI_CLOCK_SPEED_MHZ = 4;
+    constexpr auto expectedTime = calculateExpectedTime(SPI_CLOCK_SPEED_MHZ * 1000000, SPI_TRANSFER_SIZE, SPI_TRANSFER_OVERHEAD);
+
+    SPI.setClockSpeed(SPI_CLOCK_SPEED_MHZ, MHZ);
     SPI.begin();
     SPI.beginTransaction();
     system_tick_t start = millis();
-    uint8_t temp[10] = {0x55};
-    for(unsigned int i=0; i < 1000; i++)
+    uint8_t temp[2] = {0x55};
+    for(unsigned int i = 0; i < SPI_TRANSFER_SIZE; i += 10)
     {
         SPI.transfer(&temp, nullptr, 10, nullptr); 
     }
     SPI.endTransaction();
-    Serial.printf("%d ms\r\n", millis() - start);
-    assertTrue(millis() - start < 40);
+    system_tick_t transferTime = millis() - start;
     SPI1.end();
+
+    Serial.printf("in %d ms, expected: %d\r\n", transferTime, expectedTime);
+    assertLessOrEqual(transferTime, expectedTime);
 }
 

--- a/wiring/src/spark_wiring_spi.cpp
+++ b/wiring/src/spark_wiring_spi.cpp
@@ -268,30 +268,20 @@ unsigned SPIClass::setClockSpeed(unsigned value, unsigned value_scale)
 
 byte SPIClass::transfer(byte _data)
 {
-    uint16_t result = 0;
-    if (!lock())
-    {
-        result = HAL_SPI_Send_Receive_Data(_spi, _data);
-        unlock();
-    }
-    return static_cast<byte>(result);
+    return static_cast<byte>(HAL_SPI_Send_Receive_Data(_spi, _data));
 }
 
 void SPIClass::transfer(void* tx_buffer, void* rx_buffer, size_t length,
                         wiring_spi_dma_transfercomplete_callback_t user_callback)
 {
-    if (!lock())
+    HAL_SPI_DMA_Transfer(_spi, tx_buffer, rx_buffer, length, user_callback);
+    if (user_callback == NULL)
     {
-        HAL_SPI_DMA_Transfer(_spi, tx_buffer, rx_buffer, length, user_callback);
-        if (user_callback == NULL)
+        HAL_SPI_TransferStatus st;
+        do
         {
-            HAL_SPI_TransferStatus st;
-            do
-            {
-                HAL_SPI_DMA_Transfer_Status(_spi, &st);
-            } while (st.transfer_ongoing);
-        }
-        unlock();
+            HAL_SPI_DMA_Transfer_Status(_spi, &st);
+        } while (st.transfer_ongoing);
     }
 }
 


### PR DESCRIPTION

### Problem

SPI and I2C transaction becomes slow after introducing locking mechanism.

### Solution

Removes lock in some functions.

### Step to test

Build and flash the `wiring/no_fixture_spi` testing application.

#### Before removing locks
- Photon [Gen2]:
```
87 ms
Test SPI_11_SPI_Transfer_10000_Bytes_No_Locking_Less_Than_135_Ms passed.
51 ms
Test SPI_12_SPI_Transfer_10000_Bytes_Locking_Less_Than_135_Ms passed.
51 ms
Test SPI_13_SPI_Transfer_2_Miltiply_5000_Bytes_Locking_Less_Than_135_Ms passed.
175 ms
Test SPI_14_SPI_Transfer_10000_Bytes_DMA_No_Locking_Less_Than_140_Ms failed.
141 ms
Test SPI_15_SPI_Transfer_10000_Bytes_DMA_Locking_Less_Than_140_Ms failed.
85 ms
Test SPI_16_SPI_Transfer_2_Multiply_5000_Bytes_DMA_Locking_Less_Than_85_Ms failed.
34 ms
Test SPI_17_SPI_Transfer_10_Multiply_1000_Bytes_DMA_Locking_Less_Than_40_Ms passed.
```

- Argon [Gen3]:
```
219 ms
Test SPI_11_SPI_Transfer_10000_Bytes_No_Locking_Less_Than_135_Ms failed.
170 ms
Test SPI_12_SPI_Transfer_10000_Bytes_Locking_Less_Than_135_Ms failed.
170 ms
Test SPI_13_SPI_Transfer_2_Miltiply_5000_Bytes_Locking_Less_Than_135_Ms failed.
225 ms
Test SPI_14_SPI_Transfer_10000_Bytes_DMA_No_Locking_Less_Than_140_Ms failed.
173 ms
Test SPI_15_SPI_Transfer_10000_Bytes_DMA_Locking_Less_Than_140_Ms failed.
99 ms
Test SPI_16_SPI_Transfer_2_Multiply_5000_Bytes_DMA_Locking_Less_Than_85_Ms failed.
36 ms
Test SPI_17_SPI_Transfer_10_Multiply_1000_Bytes_DMA_Locking_Less_Than_40_Ms passed.
```

#### After removing locks
- Photon [Gen2]:
```
35 ms
Test SPI_11_SPI_Transfer_10000_Bytes_No_Locking_Less_Than_135_Ms passed.
35 ms
Test SPI_12_SPI_Transfer_10000_Bytes_Locking_Less_Than_135_Ms passed.
35 ms
Test SPI_13_SPI_Transfer_2_Miltiply_5000_Bytes_Locking_Less_Than_135_Ms passed.
122 ms
Test SPI_14_SPI_Transfer_10000_Bytes_DMA_No_Locking_Less_Than_140_Ms passed.
123 ms
Test SPI_15_SPI_Transfer_10000_Bytes_DMA_Locking_Less_Than_140_Ms passed.
74 ms
Test SPI_16_SPI_Transfer_2_Multiply_5000_Bytes_DMA_Locking_Less_Than_85_Ms passed.
31 ms
Test SPI_17_SPI_Transfer_10_Multiply_1000_Bytes_DMA_Locking_Less_Than_40_Ms passed.
```

- Argon [Gen3]:
```
128 ms
Test SPI_11_SPI_Transfer_10000_Bytes_No_Locking_Less_Than_135_Ms passed.
130 ms
Test SPI_12_SPI_Transfer_10000_Bytes_Locking_Less_Than_135_Ms passed.
129 ms
Test SPI_13_SPI_Transfer_2_Miltiply_5000_Bytes_Locking_Less_Than_135_Ms passed.
134 ms
Test SPI_14_SPI_Transfer_10000_Bytes_DMA_No_Locking_Less_Than_140_Ms passed.
133 ms
Test SPI_15_SPI_Transfer_10000_Bytes_DMA_Locking_Less_Than_140_Ms passed.
78 ms
Test SPI_16_SPI_Transfer_2_Multiply_5000_Bytes_DMA_Locking_Less_Than_85_Ms passed.
32 ms
Test SPI_17_SPI_Transfer_10_Multiply_1000_Bytes_DMA_Locking_Less_Than_40_Ms passed.
```

**Note: We still have significant disparity in between the Gen2 and Gen3 platforms in terms of non-DMA SPI transaction.**

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
