### PR TITLE
Fix/spi macros global namespace

### DIFF
--- a/hal/src/stm32f2xx/platform_headers.h
+++ b/hal/src/stm32f2xx/platform_headers.h
@@ -22,6 +22,11 @@ extern "C" {
 #endif
 #include "usb_settings.h"
 
+// Make sure we are not polluting global namespace with these generic macro names
+#undef SPI
+#undef SPI1
+#undef SPI2
+
 #ifdef	__cplusplus
 }
 #endif

--- a/user/tests/wiring/api/spi.cpp
+++ b/user/tests/wiring/api/spi.cpp
@@ -1,6 +1,52 @@
 
 #include "testapi.h"
 
+test(spi)
+{
+    API_COMPILE(SPI.begin());
+    API_COMPILE(SPI.begin(D0));
+    API_COMPILE(SPI.begin(SPI_MODE_MASTER));
+    API_COMPILE(SPI.begin(SPI_MODE_SLAVE));
+    API_COMPILE(SPI.begin(SPI_MODE_MASTER, D0));
+    API_COMPILE(SPI.end());
+    API_COMPILE({ bool r = SPI.isEnabled(); (void)r; });
+
+#if Wiring_SPI1
+    API_COMPILE(SPI1.begin());
+    API_COMPILE(SPI1.begin(D0));
+    API_COMPILE(SPI1.begin(SPI_MODE_MASTER));
+    API_COMPILE(SPI1.begin(SPI_MODE_SLAVE));
+    API_COMPILE(SPI1.begin(SPI_MODE_MASTER, D0));
+    API_COMPILE(SPI1.end());
+    API_COMPILE({ bool r = SPI1.isEnabled(); (void)r; });
+#endif // Wiring_SPI1
+
+#if Wiring_SPI2
+    API_COMPILE(SPI2.begin());
+    API_COMPILE(SPI2.begin(D0));
+    API_COMPILE(SPI2.begin(SPI_MODE_MASTER));
+    API_COMPILE(SPI2.begin(SPI_MODE_SLAVE));
+    API_COMPILE(SPI2.begin(SPI_MODE_MASTER, D0));
+    API_COMPILE(SPI2.end());
+    API_COMPILE({ bool r = SPI2.isEnabled(); (void)r; });
+#endif // Wiring_SPI2
+}
+
+test(spi_conf) {
+    API_COMPILE(SPI.setBitOrder(MSBFIRST));
+    API_COMPILE(SPI.setDataMode(SPI_MODE0));
+
+#if Wiring_SPI1
+    API_COMPILE(SPI1.setBitOrder(MSBFIRST));
+    API_COMPILE(SPI1.setDataMode(SPI_MODE0));
+#endif // Wiring_SPI1
+
+#if Wiring_SPI2
+    API_COMPILE(SPI2.setBitOrder(MSBFIRST));
+    API_COMPILE(SPI2.setDataMode(SPI_MODE0));
+#endif // Wiring_SPI2
+}
+
 test(spi_clock)
 {
     API_COMPILE(SPI.setClockSpeed(24, MHZ));
@@ -8,14 +54,109 @@ test(spi_clock)
     API_COMPILE(SPI.setClockDivider(SPI_CLOCK_DIV2));
     API_COMPILE(SPI.setClockDividerReference(SPI_CLK_ARDUINO));
 
+#if Wiring_SPI1
+    API_COMPILE(SPI1.setClockSpeed(24, MHZ));
+    API_COMPILE(SPI1.setClockSpeed(24000000));
+    API_COMPILE(SPI1.setClockDivider(SPI_CLOCK_DIV2));
+    API_COMPILE(SPI1.setClockDividerReference(SPI_CLK_ARDUINO));
+#endif // Wiring_SPI1
+
+#if Wiring_SPI2
+    API_COMPILE(SPI2.setClockSpeed(24, MHZ));
+    API_COMPILE(SPI2.setClockSpeed(24000000));
+    API_COMPILE(SPI2.setClockDivider(SPI_CLOCK_DIV2));
+    API_COMPILE(SPI2.setClockDividerReference(SPI_CLK_ARDUINO));
+#endif // Wiring_SPI2
 }
 
 test(spi_transfer)
 {
+    API_COMPILE({ int32_t r = SPI.beginTransaction(); (void)r; });
+    API_COMPILE({ int32_t r = SPI.beginTransaction(__SPISettings(SPI_CLK_SYSTEM, SPI_MODE0, MSBFIRST)); (void)r; });
     API_COMPILE(SPI.transfer(0));
     API_COMPILE(SPI.transfer(NULL, NULL, 1, NULL));
     API_COMPILE(SPI.transferCancel());
+    API_COMPILE(SPI.endTransaction());
+
+#if Wiring_SPI1
+    API_COMPILE({ int32_t r = SPI1.beginTransaction(); (void)r; });
+    API_COMPILE({ int32_t r = SPI1.beginTransaction(__SPISettings(SPI_CLK_SYSTEM, SPI_MODE0, MSBFIRST)); (void)r; });
+    API_COMPILE(SPI1.transfer(0));
+    API_COMPILE(SPI1.transfer(NULL, NULL, 1, NULL));
+    API_COMPILE(SPI1.transferCancel());
+    API_COMPILE(SPI1.endTransaction());
+#endif // Wiring_SPI1
+
+#if Wiring_SPI2
+    API_COMPILE({ int32_t r = SPI2.beginTransaction(); (void)r; });
+    API_COMPILE({ int32_t r = SPI2.beginTransaction(__SPISettings(SPI_CLK_SYSTEM, SPI_MODE0, MSBFIRST)); (void)r; });
+    API_COMPILE(SPI2.transfer(0));
+    API_COMPILE(SPI2.transfer(NULL, NULL, 1, NULL));
+    API_COMPILE(SPI2.transferCancel());
+    API_COMPILE(SPI2.endTransaction());
+#endif // Wiring_SPI2
+}
+
+test(spi_slave)
+{
+    API_COMPILE(SPI.onSelect(nullptr));
+    API_COMPILE({ int32_t r = SPI.available(); (void)r; });
+
+#if Wiring_SPI1
+    API_COMPILE(SPI1.onSelect(nullptr));
+    API_COMPILE({ int32_t r = SPI1.available(); (void)r; });
+#endif // Wiring_SPI1
+
+#if Wiring_SPI2
+    API_COMPILE(SPI2.onSelect(nullptr));
+    API_COMPILE({ int32_t r = SPI2.available(); (void)r; });
+#endif // Wiring_SPI2
+}
+
+test(spi_lock)
+{
+    API_COMPILE({ bool r = SPI.trylock(); (void)r; });
+    API_COMPILE({ int r = SPI.lock(); (void)r; });
+    API_COMPILE(SPI.unlock());
+
+#if Wiring_SPI1
+    API_COMPILE({ bool r = SPI1.trylock(); (void)r; });
+    API_COMPILE({ int r = SPI1.lock(); (void)r; });
+    API_COMPILE(SPI1.unlock());
+#endif // Wiring_SPI1
+
+#if Wiring_SPI2
+    API_COMPILE({ bool r = SPI2.trylock(); (void)r; });
+    API_COMPILE({ int r = SPI2.lock(); (void)r; });
+    API_COMPILE(SPI2.unlock());
+#endif // Wiring_SPI2
 }
 
 // without Arduino.h we should not get a clash redefining SPISettings
 class SPISettings {};
+
+namespace api_test_namespace {
+// We should be able to define variables and types named SPI, SPI1 and SPI2
+
+struct DummyStruct {
+};
+
+DummyStruct SPI;
+DummyStruct SPI1;
+DummyStruct SPI2;
+
+
+namespace test {
+
+struct SPI {
+};
+
+struct SPI1 {
+};
+
+struct SPI2 {
+};
+
+} // test
+
+} // api_test_namespace

--- a/user/tests/wiring/api/system.cpp
+++ b/user/tests/wiring/api/system.cpp
@@ -390,8 +390,8 @@ test(system_power_management) {
 
     API_COMPILE(System.setPowerConfiguration(conf));
 
-    API_COMPILE({ auto source = System.powerSource() == POWER_SOURCE_VIN; });
-    API_COMPILE({ auto state = System.batteryState() == BATTERY_STATE_CHARGING; });
-    API_COMPILE({ auto charge = System.batteryCharge(); });
+    API_COMPILE({ auto source = System.powerSource() == POWER_SOURCE_VIN; (void)source; });
+    API_COMPILE({ auto state = System.batteryState() == BATTERY_STATE_CHARGING; (void)state; });
+    API_COMPILE({ auto charge = System.batteryCharge(); (void)charge; });
 }
 #endif // HAL_PLATFORM_POWER_MANAGEMENT

--- a/user/tests/wiring/no_fixture/spi.cpp
+++ b/user/tests/wiring/no_fixture/spi.cpp
@@ -24,7 +24,7 @@ static __SPISettings spiSettingsFromSpiInfo(hal_spi_info_t* info)
   return __SPISettings(info->clock, info->bit_order, info->data_mode);
 }
 
-static bool spiSettingsApplyCheck(SPIClass& spi, const __SPISettings& settings, HAL_SPI_Interface interface = HAL_SPI_INTERFACE1)
+static bool spiSettingsApplyCheck(auto& spi, const __SPISettings& settings, HAL_SPI_Interface interface = HAL_SPI_INTERFACE1)
 {
     hal_spi_info_t info;
     spi.beginTransaction(settings);

--- a/wiring/inc/spark_wiring_spi.h
+++ b/wiring/inc/spark_wiring_spi.h
@@ -135,6 +135,8 @@ private:
 };
 }
 
+// NOTE: when modifying this class (method signatures, adding/removing methods)
+// make sure to update spark_wiring_spi_proxy.h and wiring/api SPI tests to reflect these changes.
 class SPIClass {
 private:
   HAL_SPI_Interface _spi;
@@ -158,7 +160,7 @@ private:
 
 public:
   SPIClass(HAL_SPI_Interface spi);
-  virtual ~SPIClass() {};
+  ~SPIClass() = default;
 
   void begin();
   void begin(uint16_t);
@@ -262,33 +264,42 @@ public:
 
 #ifndef SPARK_WIRING_NO_SPI
 
+#include "spark_wiring_spi_proxy.h"
+
 namespace particle {
 namespace globals {
 
-SPIClass& instanceSpi();
-#define SPI ::particle::globals::instanceSpi()
+extern ::particle::SpiProxy<HAL_SPI_INTERFACE1> SPI;
 
 #if Wiring_SPI1
 #ifdef SPI1
 #undef SPI1
-#endif  // SPI1
+#endif // SPI1
 
-SPIClass& instanceSpi1();
-#define SPI1 ::particle::globals::instanceSpi1()
+extern ::particle::SpiProxy<HAL_SPI_INTERFACE2> SPI1;
 
 #endif // Wiring_SPI1
 
 #if Wiring_SPI2
 #ifdef SPI2
 #undef SPI2
-#endif  // SPI2
+#endif // SPI2
 
-SPIClass& instanceSpi2();
-#define SPI2 ::particle::globals::instanceSpi2()
+extern ::particle::SpiProxy<HAL_SPI_INTERFACE3> SPI2;
 
 #endif // Wiring_SPI2
 
 } } // particle::globals
+
+using particle::globals::SPI;
+
+#if Wiring_SPI1
+using particle::globals::SPI1;
+#endif // Wiring_SPI1
+
+#if Wiring_SPI2
+using particle::globals::SPI2;
+#endif // Wiring_SPI1
 
 #endif  // SPARK_WIRING_NO_SPI
 

--- a/wiring/inc/spark_wiring_spi_proxy.h
+++ b/wiring/inc/spark_wiring_spi_proxy.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2020 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace particle {
+
+template <HAL_SPI_Interface Interface>
+class SpiProxy {
+public:
+    static SPIClass& instance() {
+        static SPIClass instance(Interface);
+        return instance;
+    }
+
+    void begin() {
+        instance().begin();
+    }
+    void begin(uint16_t ss_pin) {
+        instance().begin(ss_pin);
+    }
+    void begin(SPI_Mode mode, uint16_t ss_pin = SPI_DEFAULT_SS) {
+        instance().begin(mode, ss_pin);
+    }
+    void end() {
+        instance().end();
+    }
+    void setBitOrder(uint8_t order) {
+        instance().setBitOrder(order);
+    }
+    void setDataMode(uint8_t mode) {
+        instance().setDataMode(mode);
+    }
+    static void usingInterrupt(uint8_t arg) {
+        instance().usingInterrupt(arg);
+    }
+    int32_t beginTransaction() {
+        return instance().beginTransaction();
+    }
+    int32_t beginTransaction(const particle::__SPISettings& settings) {
+        return instance().beginTransaction(settings);
+    }
+    void endTransaction() {
+        instance().endTransaction();
+    }
+    void setClockDividerReference(unsigned value, unsigned scale=HZ) {
+        instance().setClockDividerReference(value, scale);
+    }
+    void setClockDivider(uint8_t divider) {
+        instance().setClockDivider(divider);
+    }
+    unsigned setClockSpeed(unsigned value, unsigned scale=HZ) {
+        return instance().setClockSpeed(value, scale);
+    }
+    static void computeClockDivider(unsigned reference, unsigned targetSpeed, uint8_t& divider, unsigned& clock) {
+        instance().computeClockDivider(reference, targetSpeed, divider, clock);
+    }
+    byte transfer(byte data) {
+        return instance().transfer(data);
+    }
+    void transfer(void* tx_buffer, void* rx_buffer, size_t length, wiring_spi_dma_transfercomplete_callback_t user_callback) {
+        instance().transfer(tx_buffer, rx_buffer, length, user_callback);
+    }
+    void attachInterrupt() {
+        instance().attachInterrupt();
+    }
+    void detachInterrupt() {
+        instance().detachInterrupt();
+    }
+    bool isEnabled(void) {
+        return instance().isEnabled();
+    }
+    void onSelect(wiring_spi_select_callback_t user_callback) {
+        instance().onSelect(user_callback);
+    }
+    void transferCancel() {
+        instance().transferCancel();
+    }
+    int32_t available() {
+        return instance().available();
+    }
+    bool trylock() {
+        return instance().trylock();
+    }
+    int lock() {
+        return instance().lock();
+    }
+    void unlock() {
+        return instance().unlock();
+    }
+};
+
+} // particle

--- a/wiring_globals/src/wiring_globals_spi.cpp
+++ b/wiring_globals/src/wiring_globals_spi.cpp
@@ -9,27 +9,16 @@
 namespace particle {
 namespace globals {
 
-SPIClass& instanceSpi() {
-    static SPIClass instance(HAL_SPI_INTERFACE1);
-    return instance;
-}
+::particle::SpiProxy<HAL_SPI_INTERFACE1> SPI;
 
 #if Wiring_SPI1
-SPIClass& instanceSpi1() {
-    static SPIClass instance(HAL_SPI_INTERFACE2);
-    return instance;
-}
+::particle::SpiProxy<HAL_SPI_INTERFACE2> SPI1;
 #endif // Wiring_SPI1
 
 #if Wiring_SPI2
-SPIClass& instanceSpi2() {
-    static SPIClass instance(HAL_SPI_INTERFACE3);
-    return instance;
-}
-
+::particle::SpiProxy<HAL_SPI_INTERFACE3> SPI2;
 #endif // Wiring_SPI2
 
 } } // particle::globals
 
 #endif //SPARK_WIRING_NO_SPI
-


### PR DESCRIPTION
### Problem

`SPI`, `SPI1` and `SPI2` are defines in wiring. Such generic macro names pollute the global namespace and easily cause issue e.g. #2077

### Solution

Add a proxy class that would delegate the calls to actual wiring SPI objects, while still maintaining singleton-like static initialization of them.

This PR also updates SPI API tests, as they have not been complete.

### Steps to Test

- `wiring/api`
- `wiring/no_fixture`
- `wiring/no_fixture_spi`
- #2077 should work

### Example App

N/A

### References

- Closes #2077

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
