### PR TITLE
[nrf52840] fix an issue with platform_user_ram.ld generation when path contains 'data'

### DIFF
--- a/modules/shared/nRF52840/build_linker_script.mk
+++ b/modules/shared/nRF52840/build_linker_script.mk
@@ -10,9 +10,9 @@ ifneq (,$(PREBUILD))
 # Should declare enough RAM for inermediate linker script: 89K
 USER_SRAM_LENGTH = 89K
 else
-DATA_SECTION_LEN  = $(shell $(OBJDUMP) -h --section=.data $(INTERMEDIATE_ELF) | grep .data)
+DATA_SECTION_LEN  = $(shell $(OBJDUMP) -h --section=.data $(INTERMEDIATE_ELF) | grep -E '^\s*[0-9]+\s+\.data\s+')
 DATA_SECTION_LEN := 0x$(word 3,$(DATA_SECTION_LEN))
-BSS_SECTION_LEN   = $(shell $(OBJDUMP) -h --section=.bss $(INTERMEDIATE_ELF) | grep .bss)
+BSS_SECTION_LEN   = $(shell $(OBJDUMP) -h --section=.bss $(INTERMEDIATE_ELF) | grep -E '^\s*[0-9]+\s+\.bss\s+')
 BSS_SECTION_LEN  := 0x$(word 3,$(BSS_SECTION_LEN))
 
 # Note: reserving 16 bytes for alignment just in case


### PR DESCRIPTION
### Problem

https://community.particle.io/t/workbench-local-compile-syntax-error/55841/3

### Solution

We need to be more specific in grepping the `.data` and `.bss` section description entries from `arm-none-eabi-objdump` output.

### Steps to Test

Name your application e.g. `adata`, build it. The build should succeed on all platforms: Windows, Linux, macOS.

### Example App

N/A

### References

- https://community.particle.io/t/workbench-local-compile-syntax-error/55841/3

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
