### PR TITLE
[wiring] spi: an attempt to bring back compatibility with SPIClass

### DIFF
--- a/user/tests/wiring/api/spi.cpp
+++ b/user/tests/wiring/api/spi.cpp
@@ -1,6 +1,77 @@
 
 #include "testapi.h"
 
+// without Arduino.h we should not get a clash redefining SPISettings
+class SPISettings {};
+
+namespace api_test_namespace {
+// We should be able to define variables and types named SPI, SPI1 and SPI2
+
+struct DummyStruct {
+};
+
+DummyStruct SPI;
+DummyStruct SPI1;
+DummyStruct SPI2;
+
+
+namespace test {
+
+struct SPI {
+};
+
+struct SPI1 {
+};
+
+struct SPI2 {
+};
+
+} // test
+
+namespace proxy {
+
+void spiFuncRef(SPIClass& spi) {
+    spi.begin();
+}
+
+void spiFuncCref(const SPIClass& spi) {
+    (void)spi;
+}
+
+void spiFuncPtr(SPIClass* spi) {
+    spi->begin();
+}
+
+void spiFuncCptr(const SPIClass* spi) {
+    (void)spi;
+}
+
+} // proxy
+
+} // api_test_namespace
+
+test(spi_proxy_compatibility) {
+    using namespace api_test_namespace::proxy;
+    API_COMPILE(spiFuncRef(SPI));
+    API_COMPILE(spiFuncCref(SPI));
+    API_COMPILE(spiFuncPtr(&SPI));
+    API_COMPILE(spiFuncCptr(&SPI));
+
+#if Wiring_SPI1
+    API_COMPILE(spiFuncRef(SPI1));
+    API_COMPILE(spiFuncCref(SPI1));
+    API_COMPILE(spiFuncPtr(&SPI1));
+    API_COMPILE(spiFuncCptr(&SPI1));
+#endif // Wiring_SPI1
+
+#if Wiring_SPI2
+    API_COMPILE(spiFuncRef(SPI2));
+    API_COMPILE(spiFuncCref(SPI2));
+    API_COMPILE(spiFuncPtr(&SPI2));
+    API_COMPILE(spiFuncCptr(&SPI2));
+#endif // Wiring_SPI2
+}
+
 test(spi)
 {
     API_COMPILE(SPI.begin());
@@ -131,32 +202,3 @@ test(spi_lock)
     API_COMPILE(SPI2.unlock());
 #endif // Wiring_SPI2
 }
-
-// without Arduino.h we should not get a clash redefining SPISettings
-class SPISettings {};
-
-namespace api_test_namespace {
-// We should be able to define variables and types named SPI, SPI1 and SPI2
-
-struct DummyStruct {
-};
-
-DummyStruct SPI;
-DummyStruct SPI1;
-DummyStruct SPI2;
-
-
-namespace test {
-
-struct SPI {
-};
-
-struct SPI1 {
-};
-
-struct SPI2 {
-};
-
-} // test
-
-} // api_test_namespace

--- a/wiring/inc/spark_wiring_spi.h
+++ b/wiring/inc/spark_wiring_spi.h
@@ -162,6 +162,10 @@ public:
   SPIClass(HAL_SPI_Interface spi);
   ~SPIClass() = default;
 
+  // Prevent copying
+  SPIClass(const SPIClass&) = delete;
+  SPIClass& operator=(const SPIClass&) = delete;
+
   void begin();
   void begin(uint16_t);
   void begin(SPI_Mode mode, uint16_t ss_pin = SPI_DEFAULT_SS);

--- a/wiring/inc/spark_wiring_spi_proxy.h
+++ b/wiring/inc/spark_wiring_spi_proxy.h
@@ -102,6 +102,14 @@ public:
     void unlock() {
         return instance().unlock();
     }
+
+    operator SPIClass&() {
+        return instance();
+    }
+
+    SPIClass* operator&() {
+        return &instance();
+    }
 };
 
 } // particle


### PR DESCRIPTION
### Problem

A number of libraries rely on the internals of our wiring SPI implementation (`SPIClass`). After introducing a proxy class in #2089, we inadvertently broke them.

### Solution

As a workaround we can introduce implicit conversion operator to the proxy class to convert to `SPIClass&`, as well as `operator&` overload to be able to convert a proxy instance to `SPIClass*`. This is not ideal, but pretty much the simplest thing we can do.

### Steps to Test

- Test affected libraries/projects e.g. LIS3DH
- `wiring/api`

### Example App

N/A

### References

- https://community.particle.io/t/updating-from-deviceos-1-5-0-to-1-5-1-rc-1-sdfat-spiproxy-compile-issue/55993
- https://community.particle.io/t/electron-1-5-1-rc-1-and-assettrackerv2-error-lis3dh/56002/4?u=scruffr

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
