### PR TITLE
[wiring]: change I2C timeout in FuelGauge and PMIC to a more manageab…

### DIFF
--- a/wiring/inc/spark_wiring_fuel.h
+++ b/wiring/inc/spark_wiring_fuel.h
@@ -75,6 +75,7 @@ public:
     bool unlock();
 
 private:
+    static constexpr system_tick_t FUELGAUGE_DEFAULT_TIMEOUT = 10; // In millisecond
 
     int readConfigRegister(byte &MSB, byte &LSB);
     int readRegister(byte startAddress, byte &MSB, byte &LSB);

--- a/wiring/inc/spark_wiring_power.h
+++ b/wiring/inc/spark_wiring_power.h
@@ -145,6 +145,7 @@ public:
 
 
 private:
+    static constexpr system_tick_t PMIC_DEFAULT_TIMEOUT = 10; // In millisecond
 
     byte readRegister(byte startAddress);
     void writeRegister(byte address, byte DATA);

--- a/wiring/src/spark_wiring_fuel.cpp
+++ b/wiring/src/spark_wiring_fuel.cpp
@@ -262,11 +262,14 @@ int FuelGauge::readConfigRegister(byte &MSB, byte &LSB) {
 
 int FuelGauge::readRegister(byte startAddress, byte &MSB, byte &LSB) {
     std::lock_guard<FuelGauge> l(*this);
-    i2c_.beginTransmission(MAX17043_ADDRESS);
+    WireTransmission config(MAX17043_ADDRESS);
+    config.timeout(FUELGAUGE_DEFAULT_TIMEOUT);
+    i2c_.beginTransmission(config);
     i2c_.write(startAddress);
     CHECK_TRUE(i2c_.endTransmission(true) == 0, SYSTEM_ERROR_TIMEOUT);
 
-    CHECK_TRUE(i2c_.requestFrom(MAX17043_ADDRESS, 2, true) == 2, SYSTEM_ERROR_TIMEOUT);
+    config.quantity(2);
+    CHECK_TRUE(i2c_.requestFrom(config) == 2, SYSTEM_ERROR_TIMEOUT);
     MSB = i2c_.read();
     LSB = i2c_.read();
 
@@ -275,7 +278,9 @@ int FuelGauge::readRegister(byte startAddress, byte &MSB, byte &LSB) {
 
 int FuelGauge::writeRegister(byte address, byte MSB, byte LSB) {
     std::lock_guard<FuelGauge> l(*this);
-    i2c_.beginTransmission(MAX17043_ADDRESS);
+    WireTransmission config(MAX17043_ADDRESS);
+    config.timeout(FUELGAUGE_DEFAULT_TIMEOUT);
+    i2c_.beginTransmission(config);
     i2c_.write(address);
     i2c_.write(MSB);
     i2c_.write(LSB);

--- a/wiring/src/spark_wiring_power.cpp
+++ b/wiring/src/spark_wiring_power.cpp
@@ -1080,11 +1080,14 @@ byte PMIC::getVersion() {
 byte PMIC::readRegister(byte startAddress) {
     std::lock_guard<PMIC> l(*this);
     byte DATA = 0;
-    pmicWireInstance()->beginTransmission(PMIC_ADDRESS);
+    WireTransmission config(PMIC_ADDRESS);
+    config.timeout(PMIC_DEFAULT_TIMEOUT);
+    pmicWireInstance()->beginTransmission(config);
     pmicWireInstance()->write(startAddress);
     pmicWireInstance()->endTransmission(true);
 
-    pmicWireInstance()->requestFrom(PMIC_ADDRESS, 1, true);
+    config.quantity(1);
+    pmicWireInstance()->requestFrom(config);
     DATA = pmicWireInstance()->read();
     return DATA;
 }
@@ -1098,7 +1101,9 @@ byte PMIC::readRegister(byte startAddress) {
  *******************************************************************************/
 void PMIC::writeRegister(byte address, byte DATA) {
     std::lock_guard<PMIC> l(*this);
-    pmicWireInstance()->beginTransmission(PMIC_ADDRESS);
+    WireTransmission config(PMIC_ADDRESS);
+    config.timeout(PMIC_DEFAULT_TIMEOUT);
+    pmicWireInstance()->beginTransmission(config);
     pmicWireInstance()->write(address);
     pmicWireInstance()->write(DATA);
     pmicWireInstance()->endTransmission(true);


### PR DESCRIPTION
### Steps to Test

1. Build and flash the following example application to B5SoM that is attached on SoM evaluation board.
2. Connect SoM evaluation board to serial monitor.
3. Short PM_SCL with GND and observe the delta time printed on serial monitor.  
4. Sample output:
```
0000494229 [app] application.cpp:25, loop(): TRACE: PMIC delta T: 557 us
0000495233 [app] application.cpp:19, loop(): TRACE: FuelGauge SoC: 81.40 %, delta T: 647 us
0000495234 [app] application.cpp:25, loop(): TRACE: PMIC delta T: 547 us
0000496364 [app] application.cpp:19, loop(): TRACE: FuelGauge SoC: 256.00 %, delta T: 122494 us
0000496487 [app] application.cpp:25, loop(): TRACE: PMIC delta T: 122085 us
0000497610 [app] application.cpp:19, loop(): TRACE: FuelGauge SoC: 256.00 %, delta T: 121994 us
0000497733 [app] application.cpp:25, loop(): TRACE: PMIC delta T: 122090 us
0000498735 [app] application.cpp:19, loop(): TRACE: FuelGauge SoC: 81.40 %, delta T: 647 us
0000498736 [app] application.cpp:25, loop(): TRACE: PMIC delta T: 555 us
0000499744 [app] application.cpp:19, loop(): TRACE: FuelGauge SoC: 81.40 %, delta T: 648 us
0000499745 [app] application.cpp:25, loop(): TRACE: PMIC delta T: 557 us
```

Normally, it only takes ~650us per reading/writing register of the FuelGauge or PMIC, so it's enough to sets the default I2C timeout to 10ms for them, instead of using the default 100ms timeout in I2C HAL. If using 100ms default timeout, the `delta T` if timeout occurred would be ~300ms.

### Example App

```c
#include "Particle.h"

SYSTEM_MODE(MANUAL);

SerialLogHandler log(115200, LOG_LEVEL_ALL);

void setup()
{
    Serial.begin(115200);
    while(!Serial.isConnected());
    LOG(TRACE, "Application started.");
}

void loop() {
    FuelGauge gauge;
    system_tick_t start = micros();
    float soc = gauge.getSoC();
    system_tick_t end = micros();
    LOG(TRACE, "FuelGauge SoC: %4.2f %%, delta T: %d us", soc, end - start);

    PMIC pmic;
    start = micros();
    pmic.getVersion();
    end = micros();
    LOG(TRACE, "PMIC delta T: %d us", end - start);

    delay(1000);
}
```

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
