### PR TITLE
Add a new member to differentiate internal and wiring setSecurity

### DIFF
--- a/hal/src/photon/softap.cpp
+++ b/hal/src/photon/softap.cpp
@@ -635,7 +635,7 @@ protected:
             case 4:
             // sec
             // Why are we receiving WICED-specific security type here?
-            credentials.setSecurity((WLanSecurityType)toSecurityType((wiced_security_t)atoi(str)));
+            credentials.setSecurity((spark::SecurityType)toSecurityType((wiced_security_t)atoi(str)));
             break;
             case 5:
             // eap

--- a/system/src/system_setup.cpp
+++ b/system/src/system_setup.cpp
@@ -498,7 +498,7 @@ void WiFiSetupConsole::handle(char c)
 
         credentials.setSsid(ssid);
         credentials.setPassword(password);
-        credentials.setSecurity(security_);
+        credentials.setSecurity((spark::SecurityType)security_);
         credentials.setCipher(cipher_);
 
         // dry run

--- a/user/tests/wiring/api/wifi.cpp
+++ b/user/tests/wiring/api/wifi.cpp
@@ -88,6 +88,12 @@ test(api_wifi_set_credentials)
     (void)ok; // avoid unused warning
 }
 
+test(api_wifi_set_security)
+{
+    WiFiCredentials credentials;
+    credentials.setSecurity(WPA2);
+}
+
 test(api_wifi_setStaticIP)
 {
     IPAddress myAddress(192,168,1,100);

--- a/wiring/inc/spark_wiring_wifi_credentials.h
+++ b/wiring/inc/spark_wiring_wifi_credentials.h
@@ -59,17 +59,17 @@ enum SecurityType {
 class WiFiCredentials {
 public:
     WiFiCredentials(SecurityType security = UNSEC) {
-        setSecurity((WLanSecurityType)security);
+        setSecurity(security);
     }
 
     WiFiCredentials(const char* ssid, SecurityType security = UNSEC) {
-        setSecurity((WLanSecurityType)security);
+        setSecurity(security);
         setSsid(ssid);
     }
 
     virtual ~WiFiCredentials() {}
 
-    virtual WiFiCredentials& setSecurity(WLanSecurityType security) {
+    virtual WiFiCredentials& setSecurity(SecurityType security) {
         creds_.security = (WLanSecurityType)security;
         return *this;
     }


### PR DESCRIPTION
</details>

### Problem

As per documentation,` setSecurity()` should be given a value belonging to `SecurityType` enum, but currently it expects a `WLANSecurityType` in the code, and hence results in compile error for `WLAN.setSecurity(WPA2)`

### Solution

Currently, the argument for `setSecurity()` is `WLANSecurityType` which throws the compile error. Changing the argument to `SecurityType` fixes it but breaks other internal code that passes `WLANSecurityType` to the `setSecurity()`. Hence, changed the `setSecurity()`'s argument to `SecurityType` for wiring and added another member `setWlanSecurity()` for internal use. 

### Steps to Test

### The following should compile successfully on Wifi platforms

```c
#include "application.h"

void setup() {
  WiFiCredentials credentials;
  credentials.setSecurity(WPA2);
}

void loop() {
}
```

### References

- [ch50408](https://app.clubhouse.io/particle/story/50408/incompatibility-between-wlansecuritytype-and-securitytype)
- https://github.com/particle-iot/device-os/issues/1562

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
