### PR TITLE
[Gen 3] Modem warm bootup

### DIFF
--- a/hal/src/b5som/network/quectel_ncp_client.h
+++ b/hal/src/b5som/network/quectel_ncp_client.h
@@ -93,6 +93,13 @@ private:
         Registered    = 1,
     };
 
+    enum class ModemState {
+        Unknown = 0,
+        MuxerAtChannel = 1,
+        RuntimeBaudrate = 2,
+        DefaultBaudrate = 3
+    };
+
     RegistrationState creg_ = RegistrationState::NotRegistered;
     RegistrationState cgreg_ = RegistrationState::NotRegistered;
     RegistrationState cereg_ = RegistrationState::NotRegistered;
@@ -104,8 +111,10 @@ private:
     int queryAndParseAtCops(CellularSignalQuality* qual);
     int initParser(Stream* stream);
     int checkParser();
-    int waitReady();
-    int initReady();
+    int waitReady(bool powerOn = false);
+    int initReady(ModemState state);
+    int checkRuntimeState(ModemState& state);
+    int initMuxer();
     int waitAtResponse(unsigned int timeout, unsigned int period = 1000);
     int selectSimCard();
     int checkSimCard();

--- a/hal/src/boron/network/sara_ncp_client.cpp
+++ b/hal/src/boron/network/sara_ncp_client.cpp
@@ -91,7 +91,7 @@ inline system_tick_t millis() {
 
 const auto UBLOX_NCP_DEFAULT_SERIAL_BAUDRATE = 115200;
 const auto UBLOX_NCP_RUNTIME_SERIAL_BAUDRATE_U2 = 921600;
-const auto UBLOX_NCP_RUNTIME_SERIAL_BAUDRATE_R4 = 115200; // FIXME: 460800;
+const auto UBLOX_NCP_RUNTIME_SERIAL_BAUDRATE_R4 = 460800;
 const auto UBLOX_NCP_R4_APP_FW_VERSION_MEMORY_LEAK_ISSUE = 200;
 const auto UBLOX_NCP_R4_APP_FW_VERSION_NO_HW_FLOW_CONTROL_MIN = 200;
 const auto UBLOX_NCP_R4_APP_FW_VERSION_NO_HW_FLOW_CONTROL_MAX = 203;
@@ -1073,10 +1073,7 @@ int SaraNcpClient::initReady(ModemState state) {
                     // NOTE: ignoring AT errors just in case to accommodate for some revisions
                     // potentially not supporting anything other than 115200
 
-                    // FIXME: AT+IPR setting is persistent on SARA R4
-                    // Still using 115200 for now to avoid bricking devices until we can figure out
-                    // how to make the setting non persistent as we need to be backwards compatible
-                    // with DeviceOS versions that only talk @ 115200 to SARA R4 modems.
+                    // XXX: AT+IPR setting is persistent on SARA R4!
                     int r = changeBaudRate(UBLOX_NCP_RUNTIME_SERIAL_BAUDRATE_R4);
                     if (r != SYSTEM_ERROR_NONE && r != SYSTEM_ERROR_AT_NOT_OK) {
                         return r;

--- a/hal/src/boron/network/sara_ncp_client.h
+++ b/hal/src/boron/network/sara_ncp_client.h
@@ -89,6 +89,13 @@ private:
         Registered    = 1,
     };
 
+    enum class ModemState {
+        Unknown = 0,
+        MuxerAtChannel = 1,
+        RuntimeBaudrate = 2,
+        DefaultBaudrate = 3
+    };
+
     RegistrationState creg_ = RegistrationState::NotRegistered;
     RegistrationState cgreg_ = RegistrationState::NotRegistered;
     RegistrationState cereg_ = RegistrationState::NotRegistered;
@@ -107,10 +114,12 @@ private:
     int queryAndParseAtCops(CellularSignalQuality* qual);
     int initParser(Stream* stream);
     int checkParser();
-    int waitReady();
-    int initReady();
+    int waitReady(bool powerOn = false);
+    int initReady(ModemState state);
+    int checkRuntimeState(ModemState& state);
+    int initMuxer();
     int waitAtResponse(unsigned int timeout, unsigned int period = 1000);
-    int selectSimCard();
+    int selectSimCard(ModemState& state);
     int checkSimCard();
     int configureApn(const CellularNetworkConfig& conf);
     int registerNet();
@@ -132,6 +141,7 @@ private:
     int modemSetUartState(bool state) const;
     void waitForPowerOff();
     int getAppFirmwareVersion();
+    int defaultParserConfig();
 };
 
 inline AtParser* SaraNcpClient::atParser() {


### PR DESCRIPTION
### Problem

Gen 3 cellular devices currently always power off and power the modem back on on boot. This affects the boot/cloud connection times significantly especially on platforms where poweron/poweroff times are noticeable.

### Solution

Implement support for warm bootup!

### Steps to Test

N/A

### Example App

N/A

### References

- [CH50404]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
