### PR TITLE
[Boron] Radio unresponsive when sending large data or application desc msgs

### DIFF
--- a/hal/src/boron/network/sara_ncp_client.h
+++ b/hal/src/boron/network/sara_ncp_client.h
@@ -101,7 +101,8 @@ private:
     unsigned registrationTimeout_;
     volatile bool inFlowControl_ = false;
 
-    system_tick_t lastLargePacket_ = 0;
+    system_tick_t lastWindow_ = 0;
+    size_t bytesInWindow_ = 0;
 
     int queryAndParseAtCops(CellularSignalQuality* qual);
     int initParser(Stream* stream);


### PR DESCRIPTION
### Problem

Boron LTE-M1 cell radio becomes unresponsive (by getting stuck at an AT command) after "large" data or application describe message is sent continuously over muxer data channel

### Solution

This is a callback that writes data into muxer channel 2 (data PPP channel). Whenever we encounter a large packet, we enforce a certain number of ms to pass before transmitting anything else on this channel. After we send large packet of size 250, we drop messages(bytes) for a certain amount of time defined by UBLOX_NCP_R4_WINDOW_SIZE_MS (50ms)

### Steps to Test

Which unit/integration/application tests are applicable to this code change? (At minimum a test of some kind should be provided)

### Example App

```c
#include "Particle.h"

SerialLogHandler logHandler(Serial, LOG_LEVEL_TRACE);

SYSTEM_THREAD(ENABLED);
SYSTEM_MODE(SEMI_AUTOMATIC);

void event_handler(const char *event, const char *data)
{
}

int func_handler(String data)
{
    return 0;
}

void setup()
{
    static int dummy_int = 0;
    static String dummy_string("abc");

    waitFor(Serial.isConnected, 10000);

    Particle.function("CMD", func_handler);

    Particle.variable("HEARTBEAT", &dummy_int, INT);
    Particle.variable("HW_VER", &dummy_string,   STRING);
    Particle.variable("SELFTEST", &dummy_string, STRING);
    Particle.variable("CONFIG", &dummy_string,   STRING);
    Particle.variable("DEBUG", &dummy_string,    STRING);
    Particle.variable("ERROR", &dummy_string,    STRING);
    Particle.variable("ALARM", &dummy_string,    STRING);;

    Particle.subscribe(System.deviceID() + "/hook-response/", event_handler, MY_DEVICES);
    Particle.subscribe(System.deviceID() + "/api_get_fw/", event_handler, MY_DEVICES);
    Particle.subscribe("particle/device/name", event_handler, MY_DEVICES);
    Particle.connect();
}

void loop()
{
    static uint32_t last_sec = System.uptime();

    if(System.uptime() != last_sec)
    {
        last_sec = System.uptime();
        Log.info("heartbeat");
    }
}
```

### References

[ch53040](https://app.clubhouse.io/particle/story/53040/boron-lte-stuck-rapidly-breathing-cyan)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
