### PR TITLE
[boron] fixes SARA R4 power on sequence in light of recent baudrate c…

### DIFF
--- a/hal/src/boron/network/sara_ncp_client.h
+++ b/hal/src/boron/network/sara_ncp_client.h
@@ -141,7 +141,7 @@ private:
     int modemSetUartState(bool state) const;
     void waitForPowerOff();
     int getAppFirmwareVersion();
-    int defaultParserConfig();
+    int waitAtResponseFromPowerOn(ModemState& modemState);
 };
 
 inline AtParser* SaraNcpClient::atParser() {


### PR DESCRIPTION
### Problem

When changing the default baudrate to 460800 on LTE Borons/BSoMs we didn't account for some power on conditions in https://github.com/particle-iot/device-os/pull/2102

### Solution

Fixes that.

### Steps to Test

- Verify initialization from modem power on works on 02.00 and 02.04

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
