### PR TITLE
[hal] Forbid BG96 falling back to 2G network

### DIFF
--- a/hal/src/b5som/network/quectel_ncp_client.cpp
+++ b/hal/src/b5som/network/quectel_ncp_client.cpp
@@ -920,21 +920,6 @@ int QuectelNcpClient::initReady(ModemState state) {
         int r = CHECK_PARSER(parser_.execCommand("AT+COPS=2"));
         // CHECK_TRUE(r == AtResponse::OK, SYSTEM_ERROR_UNKNOWN);
 
-        if (ncpId() == PLATFORM_NCP_QUECTEL_BG96) {
-            // FIXME: Force Cat M1-only mode, do we need to do it on Quectel NCP?
-            // Scan LTE only, take effect immediately
-            CHECK_PARSER(parser_.execCommand("AT+QCFG=\"nwscanmode\",3,1"));
-            // Configure Network Category to be Searched under LTE RAT
-            // Only use LTE Cat M1, take effect immediately
-            CHECK_PARSER(parser_.execCommand("AT+QCFG=\"iotopmode\",0,1"));
-
-            // Force eDRX mode to be disabled.
-            CHECK_PARSER(parser_.execCommand("AT+CEDRXS=0"));
-
-            // Disable Power Saving Mode
-            CHECK_PARSER(parser_.execCommand("AT+CPSMS=0"));
-        }
-
         // Select (U)SIM card in slot 1, EG91 has two SIM card slots
         if (ncpId() == PLATFORM_NCP_QUECTEL_EG91_E || \
             ncpId() == PLATFORM_NCP_QUECTEL_EG91_NA || \
@@ -1134,6 +1119,21 @@ int QuectelNcpClient::registerNet() {
     r = CHECK_PARSER(parser_.execCommand(3 * 60 * 1000, "AT+COPS=0,2"));
     // Ignore response code here
     // CHECK_TRUE(r == AtResponse::OK, SYSTEM_ERROR_UNKNOWN);
+
+    if (ncpId() == PLATFORM_NCP_QUECTEL_BG96) {
+        // FIXME: Force Cat M1-only mode, do we need to do it on Quectel NCP?
+        // Scan LTE only, take effect immediately
+        CHECK_PARSER(parser_.execCommand("AT+QCFG=\"nwscanmode\",3,1"));
+        // Configure Network Category to be Searched under LTE RAT
+        // Only use LTE Cat M1, take effect immediately
+        CHECK_PARSER(parser_.execCommand("AT+QCFG=\"iotopmode\",0,1"));
+
+        // Force eDRX mode to be disabled.
+        CHECK_PARSER(parser_.execCommand("AT+CEDRXS=0"));
+
+        // Disable Power Saving Mode
+        CHECK_PARSER(parser_.execCommand("AT+CPSMS=0"));
+    }
 
     r = CHECK_PARSER(parser_.execCommand("AT+CREG?"));
     CHECK_TRUE(r == AtResponse::OK, SYSTEM_ERROR_UNKNOWN);

--- a/hal/src/b5som/network/quectel_ncp_client.cpp
+++ b/hal/src/b5som/network/quectel_ncp_client.cpp
@@ -920,6 +920,14 @@ int QuectelNcpClient::initReady(ModemState state) {
         int r = CHECK_PARSER(parser_.execCommand("AT+COPS=2"));
         // CHECK_TRUE(r == AtResponse::OK, SYSTEM_ERROR_UNKNOWN);
 
+        if (ncpId() == PLATFORM_NCP_QUECTEL_BG96) {
+            // Force eDRX mode to be disabled.
+            CHECK_PARSER(parser_.execCommand("AT+CEDRXS=0"));
+
+            // Disable Power Saving Mode
+            CHECK_PARSER(parser_.execCommand("AT+CPSMS=0"));
+        }
+
         // Select (U)SIM card in slot 1, EG91 has two SIM card slots
         if (ncpId() == PLATFORM_NCP_QUECTEL_EG91_E || \
             ncpId() == PLATFORM_NCP_QUECTEL_EG91_NA || \
@@ -1127,12 +1135,6 @@ int QuectelNcpClient::registerNet() {
         // Configure Network Category to be Searched under LTE RAT
         // Only use LTE Cat M1, take effect immediately
         CHECK_PARSER(parser_.execCommand("AT+QCFG=\"iotopmode\",0,1"));
-
-        // Force eDRX mode to be disabled.
-        CHECK_PARSER(parser_.execCommand("AT+CEDRXS=0"));
-
-        // Disable Power Saving Mode
-        CHECK_PARSER(parser_.execCommand("AT+CPSMS=0"));
     }
 
     r = CHECK_PARSER(parser_.execCommand("AT+CREG?"));


### PR DESCRIPTION
### Problem

BG96 falls back to 2G network even if we force it to connect to Cat-M1. We found that `AT+COPS=0` will reset `AT+QCFG="nwscanmode"` from `3 LTE only` to `0 Automatic`

```
AT+QCFG="nwscanmode",3,1
OK

AT+COPS=0
OK

AT+QCFG="nwscanmode"
+QCFG: "nwscanmode",0
OK
```

### Solution

Set `nwscanmode` configuration after `AT+COPS=0` 

### Steps to Test

Check `nwscanmode` configuration after connecting to the Particle Cloud.

### Example App

```c
#include "application.h"

Serial1LogHandler logHandler(115200, LOG_LEVEL_ALL, {
    {"app", LOG_LEVEL_ALL},
    {"ncp.at", LOG_LEVEL_ALL},
    {"hal.ble", LOG_LEVEL_WARN},
    {"system.listen.ble", LOG_LEVEL_WARN},
    {"sys.power", LOG_LEVEL_WARN}
});

static int lines;
static int handler(int type, const char* buf, int len, int* lines) {
    Log.info("data: %s", buf);
    return WAIT;
}

void setup() {

}

void loop(void) {
    Cellular.command(handler, &lines, 60, "AT+QCFG=\"nwscanmode\"");
    delay(3000);
}

```

### References

[CH54311]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
