### PR TITLE
[Gen2] Fix buffer overrun in modem hal 

### DIFF
--- a/hal/shared/cellular_enums_hal.h
+++ b/hal/shared/cellular_enums_hal.h
@@ -67,7 +67,7 @@ typedef struct {
     char meid[18+1];    //!< Mobile Equipment IDentifier
     char manu[16];      //!< Manufacturer (u-blox)
     char model[16];     //!< Model Name (LISA-U200, LISA-C200 or SARA-G350)
-    char ver[16];       //!< Software Version
+    char ver[16+1];       //!< Software Version
 } DevStatus;
 //! Registration Status
 typedef enum {

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -464,7 +464,7 @@ int MDMParser::waitFinalResp(_CALLBACKPTR cb /* = NULL*/,
 
                 // GSM/UMTS Specific -------------------------------------------
                 // +UUPSDD: <profile_id>
-                if (sscanf(cmd, "UUPSDD: %s", s) == 1) {
+                if (sscanf(cmd, "UUPSDD: %31s", s) == 1) {
                     MDM_PRINTF("UUPSDD: %s matched\r\n", PROFILE);
                     if ( !strcmp(s, PROFILE) ) {
                         _ip = NOIP;
@@ -478,9 +478,9 @@ int MDMParser::waitFinalResp(_CALLBACKPTR cb /* = NULL*/,
                     // +CREG|CGREG: <n>,<stat>[,<lac>,<ci>[,AcT[,<rac>]]] // reply to AT+CREG|AT+CGREG
                     // +CREG|CGREG: <stat>[,<lac>,<ci>[,AcT[,<rac>]]]     // URC
                     b = (int)0xFFFF; c = (int)0xFFFFFFFF; d = -1;
-                    r = sscanf(cmd, "%s %*d,%d,\"%x\",\"%x\",%d",s,&a,&b,&c,&d);    // XXX: Fix for buffer overrun if applicable
+                    r = sscanf(cmd, "%31s %*d,%d,\"%x\",\"%x\",%d",s,&a,&b,&c,&d);
                     if (r <= 1)
-                        r = sscanf(cmd, "%s %d,\"%x\",\"%x\",%d",s,&a,&b,&c,&d);    // XXX: Fix for buffer overrun if applicable
+                        r = sscanf(cmd, "%31s %d,\"%x\",\"%x\",%d",s,&a,&b,&c,&d);
                     if (r >= 2) {
                         Reg *reg = !strcmp(s, "CREG:")  ? &_net.csd :
                                    !strcmp(s, "CGREG:") ? &_net.psd :
@@ -1213,7 +1213,7 @@ int MDMParser::_cbCPIN(int type, const char* buf, int len, Sim* sim)
     if (sim) {
         if (type == TYPE_PLUS){
             char s[16];
-            if (sscanf(buf, "\r\n+CPIN: %16[^\r]\r\n", s) >= 1)
+            if (sscanf(buf, "\r\n+CPIN: %15[^\r]\r\n", s) >= 1)
                 *sim = (0 == strcmp("READY", s)) ? SIM_READY : SIM_PIN;
         } else if (type == TYPE_ERROR) {
             if (strstr(buf, "+CME ERROR: SIM not inserted"))
@@ -1228,7 +1228,7 @@ int MDMParser::_cbCCID(int type, const char* buf, int len, CStringHelper* str)
     if (str && str->str && (str->size > 1) && (type == TYPE_PLUS)) {
         char format[32] = {};
         snprintf(format, sizeof(format), "\r\n+CCID: %%%u[^\r]\r\n", str->size-1);
-        if (sscanf(buf, "\r\n+CCID: %[^\r]\r\n", str->str) == 1) {
+        if (sscanf(buf, format, str->str) == 1) {
             //MDM_PRINTF("Got CCID: %s\r\n", ccid);
         }
     }
@@ -3285,7 +3285,7 @@ int MDMParser::_cbURDFILE(int type, const char* buf, int len, URDFILEparam* para
     if ((type == TYPE_PLUS) && param && param->filename && param->buf) {
         char filename[48];
         int sz;
-        if ((sscanf(buf, "\r\n+URDFILE: \"%[^\"]\",%d,", filename, &sz) == 2) &&
+        if ((sscanf(buf, "\r\n+URDFILE: \"%47[^\"]\",%d,", filename, &sz) == 2) &&
             (0 == strcmp(param->filename, filename)) &&
             (buf[len-sz-2] == '\"') && (buf[len-1] == '\"')) {
             param->len = (sz < param->sz) ? sz : param->sz;

--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -527,13 +527,25 @@ protected:
     void SMSreceived(int index);
 
 protected:
+    // String helper to prevent buffer overrun
+    struct CStringHelper {
+        CStringHelper(char* s, size_t sz)
+            : str{s},
+            size{sz} {
+        }
+        CStringHelper() = delete;
+
+        char* str;
+        size_t size;
+    };
+
     // parsing callbacks for different AT commands and their parameter arguments
-    static int _cbString(int type, const char* buf, int len, char* str);
+    static int _cbString(int type, const char* buf, int len, CStringHelper* str);
     static int _cbInt(int type, const char* buf, int len, int* val);
     // device
     static int _cbCGMM(int type, const char* buf, int len, DevStatus* s);
     static int _cbCPIN(int type, const char* buf, int len, Sim* sim);
-    static int _cbCCID(int type, const char* buf, int len, char* ccid);
+    static int _cbCCID(int type, const char* buf, int len, CStringHelper* ccid);
     // network
     static int _cbUMNOPROF(int type, const char *buf, int len, int* i);
     #define MDM_R410_EDRX_ACTS_MAX (4) //!< maximum number of AcTs for eDRX mode on SARA-R410M-02B
@@ -555,7 +567,7 @@ protected:
     static int _cbCOPS(int type, const char* buf, int len, NetStatus* status);
     static int _cbCNUM(int type, const char* buf, int len, char* num);
     static int _cbUACTIND(int type, const char* buf, int len, int* i);
-    static int _cbUDOPN(int type, const char* buf, int len, char* mccmnc);
+    static int _cbUDOPN(int type, const char* buf, int len, CStringHelper* str);
     static int _cbCGPADDR(int type, const char* buf, int len, MDM_IP* ip);
     static int _cbUCGED(int type, const char* buf, int len, NetStatus* status);
     struct CGDCONTparam { char type[8]; char apn[32]; };


### PR DESCRIPTION
### Problem

Modem software version of `DevStatus` is allocated 16 bytes overall, but the modem version itself is 16 bytes, so it is missing an additional byte for the null termination. Similarly, other functions in modem hal are to be checked for buffer size before writing into them.

### Solution

Add an extra byte in the `ver` member of the `DevStatus` struct to accommodate 16 bytes data and one null. 
Fix `_cbString` and other relevant `_cb` functions by adding a `CStringHelper` that allows passing string and string size into the callback, which can be used for size checking when writing into buffers. 

### Steps to Test

### Example App
Check that version number is logging correctly. This may _not_ be indicative of failure/success but a  basic test app that might help uncover the problem.
```c
#include "application.h"
SerialLogHandler logHandler (LOG_LEVEL_ALL);
void setup() {
}

void loop() {
}
```

### References

[ch55492](https://app.clubhouse.io/particle/story/55492/buffer-overrun-on-device-version)
Closes https://github.com/particle-iot/device-os/issues/2109

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
