### PR TITLE
Fixes the issue that FuelGauge doesn't work as expected after being woken up

### DIFF
--- a/system/src/system_power_manager.cpp
+++ b/system/src/system_power_manager.cpp
@@ -143,6 +143,8 @@ void PowerManager::sleep(bool s) {
       initDefault();
       update();
       gauge.wakeup();
+      // Delay for at least 500ms to make sure the fuelgauge is ready to function after woken up.
+      HAL_Delay_Milliseconds(500);
     }
   }
 }


### PR DESCRIPTION
### Problem

SoC (State of Charging) is not updating after device being woken up.

### Solution

From the FuelGauge's datasheet, we should add a delay about 500ms after the FuelGauge exiting sleep mode.

We simply add the delay in system power manager, instead in the FuelGauge library. This provides an opportunity that users can omit such a delay if they use the FuelGauge library directly and don't need to update the SoC right after the FuelGauge being woken up. @rickkas7 We should probably document this for visibility.

Reference: 
https://community.particle.io/t/sleepy-boron-soc-not-updating/55086/37

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
