### PR TITLE
Update mbedTLS to 2.22.0

### DIFF
--- a/communication/src/dtls_message_channel.cpp
+++ b/communication/src/dtls_message_channel.cpp
@@ -120,8 +120,8 @@ SessionPersist::RestoreStatus SessionPersist::restore(mbedtls_ssl_context* conte
 		context->in_epoch = in_epoch;
 		memcpy(context->cur_out_ctr, &out_ctr, sizeof(out_ctr));
 		memcpy(context->handshake->randbytes, randbytes, sizeof(randbytes));
-		context->transform_negotiate->ciphersuite_info = mbedtls_ssl_ciphersuite_from_id(ciphersuite);
-		if (!context->transform_negotiate->ciphersuite_info)
+		const auto ciphersuiteInfo = mbedtls_ssl_ciphersuite_from_id(ciphersuite);
+		if (!ciphersuiteInfo)
 		{
 			LOG(ERROR,"unknown ciphersuite with id %d", ciphersuite);
 			return ERROR;

--- a/crypto/inc/mbedtls_config_default.h
+++ b/crypto/inc/mbedtls_config_default.h
@@ -987,6 +987,28 @@
 //#define MBEDTLS_SSL_FALLBACK_SCSV
 
 /**
+ * \def MBEDTLS_SSL_KEEP_PEER_CERTIFICATE
+ *
+ * This option controls the availability of the API mbedtls_ssl_get_peer_cert()
+ * giving access to the peer's certificate after completion of the handshake.
+ *
+ * Unless you need mbedtls_ssl_peer_cert() in your application, it is
+ * recommended to disable this option for reduced RAM usage.
+ *
+ * \note If this option is disabled, mbedtls_ssl_get_peer_cert() is still
+ *       defined, but always returns \c NULL.
+ *
+ * \note This option has no influence on the protection against the
+ *       triple handshake attack. Even if it is disabled, Mbed TLS will
+ *       still ensure that certificates do not change during renegotiation,
+ *       for exaple by keeping a hash of the peer's certificate.
+ *
+ * Comment this macro to disable storing the peer's certificate
+ * after the handshake.
+ */
+#define MBEDTLS_SSL_KEEP_PEER_CERTIFICATE
+
+/**
  * \def MBEDTLS_SSL_HW_RECORD_ACCEL
  *
  * Enable hooking functions in SSL module for hardware acceleration of

--- a/crypto/inc/mbedtls_config_photon.h
+++ b/crypto/inc/mbedtls_config_photon.h
@@ -1024,6 +1024,28 @@
 // #define MBEDTLS_SSL_FALLBACK_SCSV
 
 /**
+ * \def MBEDTLS_SSL_KEEP_PEER_CERTIFICATE
+ *
+ * This option controls the availability of the API mbedtls_ssl_get_peer_cert()
+ * giving access to the peer's certificate after completion of the handshake.
+ *
+ * Unless you need mbedtls_ssl_peer_cert() in your application, it is
+ * recommended to disable this option for reduced RAM usage.
+ *
+ * \note If this option is disabled, mbedtls_ssl_get_peer_cert() is still
+ *       defined, but always returns \c NULL.
+ *
+ * \note This option has no influence on the protection against the
+ *       triple handshake attack. Even if it is disabled, Mbed TLS will
+ *       still ensure that certificates do not change during renegotiation,
+ *       for exaple by keeping a hash of the peer's certificate.
+ *
+ * Comment this macro to disable storing the peer's certificate
+ * after the handshake.
+ */
+#define MBEDTLS_SSL_KEEP_PEER_CERTIFICATE
+
+/**
  * \def MBEDTLS_SSL_HW_RECORD_ACCEL
  *
  * Enable hooking functions in SSL module for hardware acceleration of

--- a/hal/src/nRF52840/mbedtls/ecp_alt_cc310.c
+++ b/hal/src/nRF52840/mbedtls/ecp_alt_cc310.c
@@ -436,16 +436,6 @@ int mbedtls_ecp_check_budget( const mbedtls_ecp_group *grp,
 #endif
 
 /*
- * Curve types: internal for now, might be exposed later
- */
-typedef enum
-{
-    ECP_TYPE_NONE = 0,
-    ECP_TYPE_SHORT_WEIERSTRASS,    /* y^2 = x^3 + a x + b      */
-    ECP_TYPE_MONTGOMERY,           /* y^2 = x^3 + a x^2 + x    */
-} ecp_curve_type;
-
-/*
  * List of supported curves:
  *  - internal ID
  *  - TLS NamedCurve ID (RFC 4492 sec. 5.1.1, RFC 7071 sec. 2)
@@ -840,15 +830,15 @@ const mbedtls_ecp_curve_info *mbedtls_ecp_curve_info_from_name( const char *name
 /*
  * Get the type of a curve
  */
-static inline ecp_curve_type ecp_get_type( const mbedtls_ecp_group *grp )
+mbedtls_ecp_curve_type mbedtls_ecp_get_type( const mbedtls_ecp_group *grp )
 {
     if( grp->G.X.p == NULL )
-        return( ECP_TYPE_NONE );
+        return( MBEDTLS_ECP_TYPE_NONE );
 
     if( grp->G.Y.p == NULL )
-        return( ECP_TYPE_MONTGOMERY );
+        return( MBEDTLS_ECP_TYPE_MONTGOMERY );
     else
-        return( ECP_TYPE_SHORT_WEIERSTRASS );
+        return( MBEDTLS_ECP_TYPE_SHORT_WEIERSTRASS );
 }
 
 /*
@@ -2632,11 +2622,11 @@ int mbedtls_ecp_mul_restartable( mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
 
     ret = MBEDTLS_ERR_ECP_BAD_INPUT_DATA;
 #if defined(ECP_MONTGOMERY)
-    if( ecp_get_type( grp ) == ECP_TYPE_MONTGOMERY )
+    if( mbedtls_ecp_get_type( grp ) == MBEDTLS_ECP_TYPE_MONTGOMERY )
         MBEDTLS_MPI_CHK( ecp_mul_mxz( grp, R, m, P, f_rng, p_rng ) );
 #endif
 #if defined(ECP_SHORTWEIERSTRASS)
-    if( ecp_get_type( grp ) == ECP_TYPE_SHORT_WEIERSTRASS )
+    if( mbedtls_ecp_get_type( grp ) == MBEDTLS_ECP_TYPE_SHORT_WEIERSTRASS )
     {
         CRYS_ECPKI_DomainID_t cc_id = mbedtls_to_cryptocell_group_id( grp->id );
         if ( cc_id != CRYS_ECPKI_DomainIDLast )
@@ -2775,7 +2765,7 @@ int mbedtls_ecp_muladd_restartable(
     char is_grp_capable = 0;
 #endif
 
-    if( ecp_get_type( grp ) != ECP_TYPE_SHORT_WEIERSTRASS )
+    if( mbedtls_ecp_get_type( grp ) != MBEDTLS_ECP_TYPE_SHORT_WEIERSTRASS )
         return( MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE );
 
     mbedtls_ecp_point_init( &mP );
@@ -2884,11 +2874,11 @@ int mbedtls_ecp_check_pubkey( const mbedtls_ecp_group *grp, const mbedtls_ecp_po
         return( MBEDTLS_ERR_ECP_INVALID_KEY );
 
 #if defined(ECP_MONTGOMERY)
-    if( ecp_get_type( grp ) == ECP_TYPE_MONTGOMERY )
+    if( mbedtls_ecp_get_type( grp ) == MBEDTLS_ECP_TYPE_MONTGOMERY )
         return( ecp_check_pubkey_mx( grp, pt ) );
 #endif
 #if defined(ECP_SHORTWEIERSTRASS)
-    if( ecp_get_type( grp ) == ECP_TYPE_SHORT_WEIERSTRASS )
+    if( mbedtls_ecp_get_type( grp ) == MBEDTLS_ECP_TYPE_SHORT_WEIERSTRASS )
         return( ecp_check_pubkey_sw( grp, pt ) );
 #endif
     return( MBEDTLS_ERR_ECP_BAD_INPUT_DATA );
@@ -2900,7 +2890,7 @@ int mbedtls_ecp_check_pubkey( const mbedtls_ecp_group *grp, const mbedtls_ecp_po
 int mbedtls_ecp_check_privkey( const mbedtls_ecp_group *grp, const mbedtls_mpi *d )
 {
 #if defined(ECP_MONTGOMERY)
-    if( ecp_get_type( grp ) == ECP_TYPE_MONTGOMERY )
+    if( mbedtls_ecp_get_type( grp ) == MBEDTLS_ECP_TYPE_MONTGOMERY )
     {
         /* see RFC 7748 sec. 5 para. 5 */
         if( mbedtls_mpi_get_bit( d, 0 ) != 0 ||
@@ -2916,7 +2906,7 @@ int mbedtls_ecp_check_privkey( const mbedtls_ecp_group *grp, const mbedtls_mpi *
     }
 #endif /* ECP_MONTGOMERY */
 #if defined(ECP_SHORTWEIERSTRASS)
-    if( ecp_get_type( grp ) == ECP_TYPE_SHORT_WEIERSTRASS )
+    if( mbedtls_ecp_get_type( grp ) == MBEDTLS_ECP_TYPE_SHORT_WEIERSTRASS )
     {
         /* see SEC1 3.2 */
         if( mbedtls_mpi_cmp_int( d, 1 ) < 0 ||
@@ -2942,7 +2932,7 @@ int mbedtls_ecp_gen_privkey( const mbedtls_ecp_group *grp,
     size_t n_size = ( grp->nbits + 7 ) / 8;
 
 #if defined(ECP_MONTGOMERY)
-    if( ecp_get_type( grp ) == ECP_TYPE_MONTGOMERY )
+    if( mbedtls_ecp_get_type( grp ) == MBEDTLS_ECP_TYPE_MONTGOMERY )
     {
         /* [M225] page 5 */
         size_t b;
@@ -2970,7 +2960,7 @@ int mbedtls_ecp_gen_privkey( const mbedtls_ecp_group *grp,
 #endif /* ECP_MONTGOMERY */
 
 #if defined(ECP_SHORTWEIERSTRASS)
-    if( ecp_get_type( grp ) == ECP_TYPE_SHORT_WEIERSTRASS )
+    if( mbedtls_ecp_get_type( grp ) == MBEDTLS_ECP_TYPE_SHORT_WEIERSTRASS )
     {
         /* SEC1 3.2.1: Generate d such that 1 <= n < N */
         int count = 0;
@@ -3020,7 +3010,7 @@ int mbedtls_ecp_gen_keypair_base( mbedtls_ecp_group *grp,
     int ret;
 
 #if defined(ECP_SHORTWEIERSTRASS)
-    if( ecp_get_type( grp ) == ECP_TYPE_SHORT_WEIERSTRASS )
+    if( mbedtls_ecp_get_type( grp ) == MBEDTLS_ECP_TYPE_SHORT_WEIERSTRASS )
     {
         CRYS_ECPKI_DomainID_t cc_id = mbedtls_to_cryptocell_group_id( grp->id );
         if ( cc_id != CRYS_ECPKI_DomainIDLast )

--- a/hal/src/nRF52840/mbedtls/mbedtls_config_platform.h
+++ b/hal/src/nRF52840/mbedtls/mbedtls_config_platform.h
@@ -969,6 +969,28 @@
 //#define MBEDTLS_SSL_EXTENDED_MASTER_SECRET
 
 /**
+ * \def MBEDTLS_SSL_KEEP_PEER_CERTIFICATE
+ *
+ * This option controls the availability of the API mbedtls_ssl_get_peer_cert()
+ * giving access to the peer's certificate after completion of the handshake.
+ *
+ * Unless you need mbedtls_ssl_peer_cert() in your application, it is
+ * recommended to disable this option for reduced RAM usage.
+ *
+ * \note If this option is disabled, mbedtls_ssl_get_peer_cert() is still
+ *       defined, but always returns \c NULL.
+ *
+ * \note This option has no influence on the protection against the
+ *       triple handshake attack. Even if it is disabled, Mbed TLS will
+ *       still ensure that certificates do not change during renegotiation,
+ *       for exaple by keeping a hash of the peer's certificate.
+ *
+ * Comment this macro to disable storing the peer's certificate
+ * after the handshake.
+ */
+#define MBEDTLS_SSL_KEEP_PEER_CERTIFICATE
+
+/**
  * \def MBEDTLS_SSL_FALLBACK_SCSV
  *
  * Enable support for FALLBACK_SCSV (draft-ietf-tls-downgrade-scsv-00).

--- a/hal/src/photon/crypto_compat.cpp
+++ b/hal/src/photon/crypto_compat.cpp
@@ -694,7 +694,7 @@ static int mbedtls_to_x509_all(mbedtls_x509_crt* c, x509_cert* crt, int nonalloc
     return res;
 }
 
-static int32_t x509_parse_certificate_data_impl(x509_cert* crt, const unsigned char* p, uint32_t len, uint8_t force_alloc)
+static int32_t x509_parse_certificate_data_impl(x509_cert* crt, const unsigned char* p, uint32_t len)
 {
     int32_t ret = -1;
     uint32_t total_len = 0;
@@ -713,11 +713,7 @@ static int32_t x509_parse_certificate_data_impl(x509_cert* crt, const unsigned c
                 cc = cc->next;
                 mbedtls_x509_crt_init(cc);
             }
-            if (!force_alloc) {
-                cc->raw.p = (uint8_t*)p + total_len;
-                cc->raw.len = len - total_len;
-            }
-            ret = x509_crt_parse_der_core(cc, p + total_len, len - total_len);
+            ret = mbedtls_x509_crt_parse_der_nocopy(cc, p + total_len, len - total_len);
             if (ret == 0) {
                 total_len += cc->raw.len;
             } else {
@@ -733,7 +729,7 @@ static int32_t x509_parse_certificate_data_impl(x509_cert* crt, const unsigned c
     }
 
     if (total_len > 0) {
-        ret = mbedtls_to_x509_all(c, crt, !force_alloc);
+        ret = mbedtls_to_x509_all(c, crt, 1 /* nonalloced */);
     } else {
         ret = 1;
     }
@@ -743,7 +739,7 @@ static int32_t x509_parse_certificate_data_impl(x509_cert* crt, const unsigned c
 
 int32_t x509_parse_certificate_data(x509_cert* crt, const unsigned char* p, uint32_t len)
 {
-    int ret = x509_parse_certificate_data_impl(crt, p, len, 0);
+    int ret = x509_parse_certificate_data_impl(crt, p, len);
     return ret;
 }
 
@@ -762,7 +758,7 @@ int32_t x509_parse_certificate(x509_cert* chain, const uint8_t* buf, uint32_t bu
     if (c) {
         if (x509_cert_is_pem(buf, buflen) != 0) {
             // This is probably DER
-            ret = x509_parse_certificate_data_impl(chain, buf, buflen, 0);
+            ret = x509_parse_certificate_data_impl(chain, buf, buflen);
         } else {
             // PEM
             ret = mbedtls_x509_crt_parse(c, buf, buflen);


### PR DESCRIPTION
### Problem

This PR updates mbedTLS from 2.16.2 to 2.22.0. The submodule has been updated to point to the tip of this branch: https://github.com/particle-iot/mbedtls/tree/particle-2.22.0.

For reference, below are diffs of our patchset applied to the upstream mbedTLS 2.16.2 and 2.22.0 releases respectively:

- https://github.com/ARMmbed/mbedtls/compare/mbedtls-2.16.2...particle-iot:particle
- https://github.com/ARMmbed/mbedtls/compare/mbedtls-2.22.0...particle-iot:particle-2.22.0

### Steps to Test

- Devices running this branch should connect to the cloud normally.
- UDP devices should be able to resume their sessions.
- Photon should be able to connect to a WPA Enterprise network.
- Device setup via BLE should work correctly.

### References

- [ch55085]
