### PR TITLE
[Gen3] Hide wifi wiring API that are not supported

### DIFF
--- a/user/tests/wiring/api/wifi.cpp
+++ b/user/tests/wiring/api/wifi.cpp
@@ -94,6 +94,7 @@ test(api_wifi_set_security)
     credentials.setSecurity(WPA2);
 }
 
+#if !HAL_PLATFORM_NCP
 test(api_wifi_setStaticIP)
 {
     IPAddress myAddress(192,168,1,100);
@@ -106,6 +107,7 @@ test(api_wifi_setStaticIP)
     WiFi.useStaticIP();
     WiFi.useDynamicIP();
 }
+#endif //!HAL_PLATFORM_NCP
 
 test(api_wifi_scan_buffer)
 {
@@ -202,6 +204,7 @@ test(api_wifi_get_credentials)
     }
 }
 
+#if !HAL_PLATFORM_NCP
 test(api_wifi_hostname)
 {
     String hostname;
@@ -210,5 +213,6 @@ test(api_wifi_hostname)
     API_COMPILE(WiFi.setHostname(hostname));
     API_COMPILE(WiFi.setHostname(shostname));
 }
+#endif //!HAL_PLATFORM_NCP
 
 #endif

--- a/user/tests/wiring/no_fixture/wifi.cpp
+++ b/user/tests/wiring/no_fixture/wifi.cpp
@@ -181,6 +181,7 @@ test(WIFI_07_restore_connection)
 
 #if PLATFORM_ID == 6 || PLATFORM_ID == 8
 
+#if !HAL_PLATFORM_NCP
 test(WIFI_08_reset_hostname)
 {
     assertEqual(WiFi.setHostname(NULL), 0);
@@ -204,6 +205,7 @@ test(WIFI_11_restore_default_hostname)
 {
     assertEqual(WiFi.setHostname(NULL), 0);
 }
+#endif //!HAL_PLATFORM_NCP
 
 #endif // PLATFORM_ID == 6 || PLATFORM_ID == 8
 

--- a/wiring/inc/spark_wiring_wifi.h
+++ b/wiring/inc/spark_wiring_wifi.h
@@ -238,6 +238,7 @@ public:
     }
 #endif // !HAL_USE_INET_HAL_POSIX
 
+#if !HAL_PLATFORM_NCP
     void setStaticIP(const IPAddress& host, const IPAddress& netmask,
         const IPAddress& gateway, const IPAddress& dns)
     {
@@ -248,6 +249,7 @@ public:
     {
         setIPAddressSource(STATIC_IP);
     }
+#endif //!HAL_PLATFORM_NCP
 
     void useDynamicIP()
     {
@@ -267,6 +269,7 @@ public:
 
     int getCredentials(WiFiAccessPoint* results, size_t result_count);
 
+#if !HAL_PLATFORM_NCP
     String hostname()
     {
         const size_t maxHostname = 64;
@@ -284,6 +287,8 @@ public:
     {
         return network_set_hostname(*this, 0, hostname, nullptr);
     }
+#endif //!HAL_PLATFORM_NCP
+
 };
 
 extern WiFiClass WiFi;


### PR DESCRIPTION
### Problem

Wifi wiring calls that are either unimplemented or unsupported might cause confusion to customers who are trying to use them (may be because they are likely supported on different platforms)

### Solution

Throw compile time errors for unimplemented or unsupported wifi wiring calls on Gen3

### Steps to Test

### Example App

The following code should throw a compile error when built on Gen3 - Argon, for example
such as 
```
filename.cpp:6:28: error: 'class spark::WiFiClass' has no member named 'hostname'; did you mean 'setHostname'?
```

```c
#include "application.h"

void setup() {
    String hostname = WiFi.hostname();
    Serial.printlnf("Wifi hostname is %s" ,hostname);
}

void loop() {
}
```

### References

[ch51761](https://app.clubhouse.io/particle/story/51761/hide-wifi-hostname-on-gen-3)
[ch51357](https://app.clubhouse.io/particle/story/51357/wifi-hostname-is-unimplemented-in-gen-3)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
