### PR TITLE
[Gen2] Replace sprintf with snprintf in modem hal

### DIFF
--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1608,7 +1608,7 @@ failure:
 void MDMParser::_setBandSelectString(MDM_BandSelect &data, char* bands, int index /*= 0*/) {
     char band[5];
     for (int x=index; x<data.count; x++) {
-        sprintf(band, "%d", data.band[x]);
+        snprintf(band, 5, "%d", data.band[x]);
         strcat(bands, band);
         if ((x+1) < data.count) strcat(bands, ",");
     }


### PR DESCRIPTION
### Problem

Compile error when building Electron after updating to gcc compiler 9.2.1
```
error: 'sprintf' may write a terminating nul past the end of the destination
```

### Solution

Use `snprintf` instead of `sprintf` to give number of bytes.

### Steps to Test

Compiling Electron on gcc 9.2.1 likely triggers this error.

### Example App

```c
void setup() {
}

void loop() {
}
```

### References

[ch55930](https://app.clubhouse.io/particle/story/55930/electron-fix-an-sprintf-error-surfacing-in-gcc-9-2-1)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
