### PR TITLE
[Gen2] Fix sprintf compile err on gcc9

### DIFF
--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1608,7 +1608,7 @@ failure:
 void MDMParser::_setBandSelectString(MDM_BandSelect &data, char* bands, int index /*= 0*/) {
     char band[5];
     for (int x=index; x<data.count; x++) {
-        sprintf(band, "%d", data.band[x]);
+        snprintf(band, 5, "%d", data.band[x]);
         strcat(bands, band);
         if ((x+1) < data.count) strcat(bands, ",");
     }

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1606,9 +1606,9 @@ failure:
 }
 
 void MDMParser::_setBandSelectString(MDM_BandSelect &data, char* bands, int index /*= 0*/) {
-    char band[5];
+    char band[6];
     for (int x=index; x<data.count; x++) {
-        snprintf(band, 5, "%d", data.band[x]);
+        snprintf(band, sizeof(band), "%d", data.band[x]);
         strcat(bands, band);
         if ((x+1) < data.count) strcat(bands, ",");
     }
@@ -1621,7 +1621,7 @@ bool MDMParser::setBandSelect(MDM_BandSelect &data)
     if (_init && _pwr) {
         MDM_INFO("\r\n[ Modem::setBandSelect ] = = = = = = = = = =");
 
-        char bands_to_set[22] = "";
+        char bands_to_set[25] = ""; // 5 bands at 4 char each plus commas
         _setBandSelectString(data, bands_to_set, 0);
         if (strcmp(bands_to_set,"") == 0)
             goto failure;
@@ -1631,7 +1631,7 @@ bool MDMParser::setBandSelect(MDM_BandSelect &data)
         if (!getBandAvailable(band_avail))
             goto failure;
 
-        char band_defaults[22] = "";
+        char band_defaults[25] = "";
         if (band_avail.band[0] == BAND_DEFAULT)
             _setBandSelectString(band_avail, band_defaults, 1);
 
@@ -1640,7 +1640,7 @@ bool MDMParser::setBandSelect(MDM_BandSelect &data)
         if (!getBandSelect(band_sel))
             goto failure;
 
-        char bands_selected[22] = "";
+        char bands_selected[25] = "";
         _setBandSelectString(band_sel, bands_selected, 0);
 
         if (strcmp(bands_to_set, "0") == 0) {

--- a/user/tests/app/band_select/band_select.cpp
+++ b/user/tests/app/band_select/band_select.cpp
@@ -103,17 +103,17 @@ bool set_each_band_as_a_string_and_verify_is_selected(CellularBand& band_avail)
     return true;
 }
 void get_band_select_string(CellularBand &data, char* bands, int index) {
-    char band[5];
+    char band[6];
     for (int x=index; x<data.count; x++) {
-        sprintf(band, "%d", data.band[x]);
+        snprintf(band, sizeof(band), "%d", data.band[x]);
         strcat(bands, band);
         if ((x+1) < data.count) strcat(bands, ",");
     }
 }
 bool is_bands_selected_not_equal_to_default_bands(CellularBand& band_sel, CellularBand& band_avail) {
     // create default bands string
-    char band_defaults[22] = "";
-    char bands_selected[22] = "";
+    char band_defaults[25] = "";
+    char bands_selected[25] = "";
     if (band_avail.band[0] != BAND_DEFAULT) return false;
     get_band_select_string(band_avail, band_defaults, 1);
     get_band_select_string(band_sel, bands_selected, 0);


### PR DESCRIPTION
### Problem

Compile error when building Electron after updating to gcc compiler 9.2.1
```
error: 'sprintf' may write a terminating nul past the end of the destination
```

### Solution

Use `snprintf` instead of `sprintf` to give number of bytes.

### Steps to Test

Compiling Electron on gcc 9.2.1 likely triggers this error.

### Example App

```c
void setup() {
}

void loop() {
}
```

### References

[ch55930](https://app.clubhouse.io/particle/story/55930/electron-fix-an-sprintf-error-surfacing-in-gcc-9-2-1)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
