### PR TITLE
Implement sleep function for UART peripheral.

### DIFF
--- a/hal/inc/hal_dynalib_usart.h
+++ b/hal/inc/hal_dynalib_usart.h
@@ -22,7 +22,7 @@
  */
 
 #ifndef HAL_DYNALIB_USART_H
-#define	HAL_DYNALIB_USART_H
+#define HAL_DYNALIB_USART_H
 
 #include "dynalib.h"
 #include "hal_platform.h"
@@ -86,5 +86,5 @@ DYNALIB_END(hal_usart)
 #undef BASE_IDX
 #undef BASE_IDX2
 
-#endif	/* HAL_DYNALIB_USART_H */
+#endif /* HAL_DYNALIB_USART_H */
 

--- a/hal/inc/hal_dynalib_usart.h
+++ b/hal/inc/hal_dynalib_usart.h
@@ -54,17 +54,17 @@ DYNALIB_FN(5, hal_usart, USB_USART_LineCoding_BitRate_Handler, void(void(*)(uint
 #define BASE_IDX 0
 #endif
 
-DYNALIB_FN(BASE_IDX + 0, hal_usart, HAL_USART_Init, void(HAL_USART_Serial, Ring_Buffer*, Ring_Buffer*))
-DYNALIB_FN(BASE_IDX + 1, hal_usart, HAL_USART_Begin, void(HAL_USART_Serial, uint32_t))
-DYNALIB_FN(BASE_IDX + 2, hal_usart, HAL_USART_End, void(HAL_USART_Serial))
-DYNALIB_FN(BASE_IDX + 3, hal_usart, HAL_USART_Write_Data, uint32_t(HAL_USART_Serial, uint8_t))
-DYNALIB_FN(BASE_IDX + 4, hal_usart, HAL_USART_Available_Data, int32_t(HAL_USART_Serial))
-DYNALIB_FN(BASE_IDX + 5, hal_usart, HAL_USART_Read_Data, int32_t(HAL_USART_Serial))
-DYNALIB_FN(BASE_IDX + 6, hal_usart, HAL_USART_Peek_Data, int32_t(HAL_USART_Serial))
-DYNALIB_FN(BASE_IDX + 7, hal_usart, HAL_USART_Flush_Data, void(HAL_USART_Serial))
-DYNALIB_FN(BASE_IDX + 8, hal_usart, HAL_USART_Is_Enabled, bool(HAL_USART_Serial))
-DYNALIB_FN(BASE_IDX + 9, hal_usart, HAL_USART_Half_Duplex, void(HAL_USART_Serial, bool))
-DYNALIB_FN(BASE_IDX + 10, hal_usart, HAL_USART_Available_Data_For_Write, int32_t(HAL_USART_Serial))
+DYNALIB_FN(BASE_IDX + 0, hal_usart, hal_usart_init, void(HAL_USART_Serial, Ring_Buffer*, Ring_Buffer*))
+DYNALIB_FN(BASE_IDX + 1, hal_usart, hal_usart_begin, void(HAL_USART_Serial, uint32_t))
+DYNALIB_FN(BASE_IDX + 2, hal_usart, hal_usart_end, void(HAL_USART_Serial))
+DYNALIB_FN(BASE_IDX + 3, hal_usart, hal_usart_write, uint32_t(HAL_USART_Serial, uint8_t))
+DYNALIB_FN(BASE_IDX + 4, hal_usart, hal_usart_available, int32_t(HAL_USART_Serial))
+DYNALIB_FN(BASE_IDX + 5, hal_usart, hal_usart_read, int32_t(HAL_USART_Serial))
+DYNALIB_FN(BASE_IDX + 6, hal_usart, hal_usart_peek, int32_t(HAL_USART_Serial))
+DYNALIB_FN(BASE_IDX + 7, hal_usart, hal_usart_flush, void(HAL_USART_Serial))
+DYNALIB_FN(BASE_IDX + 8, hal_usart, hal_usart_is_enabled, bool(HAL_USART_Serial))
+DYNALIB_FN(BASE_IDX + 9, hal_usart, hal_usart_half_duplex, void(HAL_USART_Serial, bool))
+DYNALIB_FN(BASE_IDX + 10, hal_usart, hal_usart_available_data_for_write, int32_t(HAL_USART_Serial))
 
 #if defined (USB_CDC_ENABLE) && !HAL_PLATFORM_NRF52840
 DYNALIB_FN(BASE_IDX + 11, hal_usart, USB_USART_Available_Data_For_Write, int32_t(void))
@@ -74,10 +74,11 @@ DYNALIB_FN(BASE_IDX + 12, hal_usart, USB_USART_Flush_Data, void(void))
 #define BASE_IDX2 (BASE_IDX+11)
 #endif
 
-DYNALIB_FN(BASE_IDX2 + 0, hal_usart, HAL_USART_BeginConfig, void(HAL_USART_Serial serial, uint32_t baud, uint32_t config, void *ptr))
-DYNALIB_FN(BASE_IDX2 + 1, hal_usart, HAL_USART_Write_NineBitData, uint32_t(HAL_USART_Serial serial, uint16_t data))
-DYNALIB_FN(BASE_IDX2 + 2, hal_usart, HAL_USART_Send_Break, void(HAL_USART_Serial, void*))
-DYNALIB_FN(BASE_IDX2 + 3, hal_usart, HAL_USART_Break_Detected, uint8_t(HAL_USART_Serial))
+DYNALIB_FN(BASE_IDX2 + 0, hal_usart, hal_usart_begin_config, void(HAL_USART_Serial serial, uint32_t baud, uint32_t config, void *ptr))
+DYNALIB_FN(BASE_IDX2 + 1, hal_usart, hal_usart_write_nine_bits, uint32_t(HAL_USART_Serial serial, uint16_t data))
+DYNALIB_FN(BASE_IDX2 + 2, hal_usart, hal_usart_send_break, void(HAL_USART_Serial, void*))
+DYNALIB_FN(BASE_IDX2 + 3, hal_usart, hal_usart_break_detected, uint8_t(HAL_USART_Serial))
+DYNALIB_FN(BASE_IDX2 + 4, hal_usart, hal_usart_sleep, int(HAL_USART_Serial serial, bool, void*))
 
 
 DYNALIB_END(hal_usart)

--- a/hal/inc/hal_dynalib_usart.h
+++ b/hal/inc/hal_dynalib_usart.h
@@ -54,17 +54,17 @@ DYNALIB_FN(5, hal_usart, USB_USART_LineCoding_BitRate_Handler, void(void(*)(uint
 #define BASE_IDX 0
 #endif
 
-DYNALIB_FN(BASE_IDX + 0, hal_usart, hal_usart_init, void(HAL_USART_Serial, Ring_Buffer*, Ring_Buffer*))
-DYNALIB_FN(BASE_IDX + 1, hal_usart, hal_usart_begin, void(HAL_USART_Serial, uint32_t))
-DYNALIB_FN(BASE_IDX + 2, hal_usart, hal_usart_end, void(HAL_USART_Serial))
-DYNALIB_FN(BASE_IDX + 3, hal_usart, hal_usart_write, uint32_t(HAL_USART_Serial, uint8_t))
-DYNALIB_FN(BASE_IDX + 4, hal_usart, hal_usart_available, int32_t(HAL_USART_Serial))
-DYNALIB_FN(BASE_IDX + 5, hal_usart, hal_usart_read, int32_t(HAL_USART_Serial))
-DYNALIB_FN(BASE_IDX + 6, hal_usart, hal_usart_peek, int32_t(HAL_USART_Serial))
-DYNALIB_FN(BASE_IDX + 7, hal_usart, hal_usart_flush, void(HAL_USART_Serial))
-DYNALIB_FN(BASE_IDX + 8, hal_usart, hal_usart_is_enabled, bool(HAL_USART_Serial))
-DYNALIB_FN(BASE_IDX + 9, hal_usart, hal_usart_half_duplex, void(HAL_USART_Serial, bool))
-DYNALIB_FN(BASE_IDX + 10, hal_usart, hal_usart_available_data_for_write, int32_t(HAL_USART_Serial))
+DYNALIB_FN(BASE_IDX + 0, hal_usart, hal_usart_init, void(hal_usart_interface_t, hal_usart_ring_buffer_t*, hal_usart_ring_buffer_t*))
+DYNALIB_FN(BASE_IDX + 1, hal_usart, hal_usart_begin, void(hal_usart_interface_t, uint32_t))
+DYNALIB_FN(BASE_IDX + 2, hal_usart, hal_usart_end, void(hal_usart_interface_t))
+DYNALIB_FN(BASE_IDX + 3, hal_usart, hal_usart_write, uint32_t(hal_usart_interface_t, uint8_t))
+DYNALIB_FN(BASE_IDX + 4, hal_usart, hal_usart_available, int32_t(hal_usart_interface_t))
+DYNALIB_FN(BASE_IDX + 5, hal_usart, hal_usart_read, int32_t(hal_usart_interface_t))
+DYNALIB_FN(BASE_IDX + 6, hal_usart, hal_usart_peek, int32_t(hal_usart_interface_t))
+DYNALIB_FN(BASE_IDX + 7, hal_usart, hal_usart_flush, void(hal_usart_interface_t))
+DYNALIB_FN(BASE_IDX + 8, hal_usart, hal_usart_is_enabled, bool(hal_usart_interface_t))
+DYNALIB_FN(BASE_IDX + 9, hal_usart, hal_usart_half_duplex, void(hal_usart_interface_t, bool))
+DYNALIB_FN(BASE_IDX + 10, hal_usart, hal_usart_available_data_for_write, int32_t(hal_usart_interface_t))
 
 #if defined (USB_CDC_ENABLE) && !HAL_PLATFORM_NRF52840
 DYNALIB_FN(BASE_IDX + 11, hal_usart, USB_USART_Available_Data_For_Write, int32_t(void))
@@ -74,11 +74,11 @@ DYNALIB_FN(BASE_IDX + 12, hal_usart, USB_USART_Flush_Data, void(void))
 #define BASE_IDX2 (BASE_IDX+11)
 #endif
 
-DYNALIB_FN(BASE_IDX2 + 0, hal_usart, hal_usart_begin_config, void(HAL_USART_Serial serial, uint32_t baud, uint32_t config, void *ptr))
-DYNALIB_FN(BASE_IDX2 + 1, hal_usart, hal_usart_write_nine_bits, uint32_t(HAL_USART_Serial serial, uint16_t data))
-DYNALIB_FN(BASE_IDX2 + 2, hal_usart, hal_usart_send_break, void(HAL_USART_Serial, void*))
-DYNALIB_FN(BASE_IDX2 + 3, hal_usart, hal_usart_break_detected, uint8_t(HAL_USART_Serial))
-DYNALIB_FN(BASE_IDX2 + 4, hal_usart, hal_usart_sleep, int(HAL_USART_Serial serial, bool, void*))
+DYNALIB_FN(BASE_IDX2 + 0, hal_usart, hal_usart_begin_config, void(hal_usart_interface_t serial, uint32_t baud, uint32_t config, void *ptr))
+DYNALIB_FN(BASE_IDX2 + 1, hal_usart, hal_usart_write_nine_bits, uint32_t(hal_usart_interface_t serial, uint16_t data))
+DYNALIB_FN(BASE_IDX2 + 2, hal_usart, hal_usart_send_break, void(hal_usart_interface_t, void*))
+DYNALIB_FN(BASE_IDX2 + 3, hal_usart, hal_usart_break_detected, uint8_t(hal_usart_interface_t))
+DYNALIB_FN(BASE_IDX2 + 4, hal_usart, hal_usart_sleep, int(hal_usart_interface_t serial, bool, void*))
 
 
 DYNALIB_END(hal_usart)

--- a/hal/inc/usart_hal.h
+++ b/hal/inc/usart_hal.h
@@ -36,9 +36,9 @@
 
 /* Exported defines ----------------------------------------------------------*/
 #if PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION // Electron
-    #define TOTAL_USARTS		5
+    #define TOTAL_USARTS        5
 #else
-    #define TOTAL_USARTS		2
+    #define TOTAL_USARTS        2
 #endif
 
 #define SERIAL_BUFFER_SIZE      64

--- a/hal/inc/usart_hal.h
+++ b/hal/inc/usart_hal.h
@@ -134,6 +134,13 @@ typedef enum hal_usart_interface_t {
 } hal_usart_interface_t;
 typedef hal_usart_interface_t HAL_USART_Serial; // For backwards compatibility
 
+typedef enum hal_usart_state_t {
+    HAL_USART_STATE_UNKNOWN,
+    HAL_USART_STATE_ENABLED,
+    HAL_USART_STATE_DISABLED,
+    HAL_USART_STATE_SUSPENDED
+} hal_usart_state_t;
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/hal/inc/usart_hal.h
+++ b/hal/inc/usart_hal.h
@@ -35,7 +35,7 @@
 // #include "pinmap_hal.h"
 
 /* Exported defines ----------------------------------------------------------*/
-#if PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION // Electron
+#if PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION
     #define TOTAL_USARTS        5
 #else
     #define TOTAL_USARTS        2
@@ -116,56 +116,58 @@
 #define SERIAL_TX_PULL_UP             ((uint32_t)0x8000)
 
 /* Exported types ------------------------------------------------------------*/
-typedef struct Ring_Buffer {
+typedef struct hal_usart_ring_buffer_t {
     uint16_t buffer[SERIAL_BUFFER_SIZE];
     volatile uint16_t head;
     volatile uint16_t tail;
-} Ring_Buffer;
+} hal_usart_ring_buffer_t;
+typedef hal_usart_ring_buffer_t Ring_Buffer; // For backwards compatibility
 
-typedef enum HAL_USART_Serial {
+typedef enum hal_usart_interface_t {
     HAL_USART_SERIAL1 = 0,    //maps to USART_TX_RX
     HAL_USART_SERIAL2 = 1     //maps to USART_RGBG_RGBB
 #if PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION // Electron
-    ,HAL_USART_SERIAL3 = 2    //maps to USART_TXD_UC_RXD_UC
-    ,HAL_USART_SERIAL4 = 3    //maps to USART_C3_C2
-    ,HAL_USART_SERIAL5 = 4    //maps to USART_C1_C0
+   ,HAL_USART_SERIAL3 = 2    //maps to USART_TXD_UC_RXD_UC
+   ,HAL_USART_SERIAL4 = 3    //maps to USART_C3_C2
+   ,HAL_USART_SERIAL5 = 4    //maps to USART_C1_C0
 #endif
-} HAL_USART_Serial;
-
+} hal_usart_interface_t;
+typedef hal_usart_interface_t HAL_USART_Serial; // For backwards compatibility
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-typedef struct HAL_USART_Buffer_Config {
+typedef struct hal_usart_buffer_config_t {
     uint16_t size;
     void* rx_buffer;
     uint16_t rx_buffer_size;
     void* tx_buffer;
     uint16_t tx_buffer_size;
-} HAL_USART_Buffer_Config;
+} hal_usart_buffer_config_t;
+typedef hal_usart_buffer_config_t HAL_USART_Buffer_Config; // For backwards compatibility
 
-int      hal_usart_init_ex(HAL_USART_Serial serial, const HAL_USART_Buffer_Config* config, void*);
-void     hal_usart_init(HAL_USART_Serial serial, Ring_Buffer *rx_buffer, Ring_Buffer *tx_buffer);
-void     hal_usart_begin(HAL_USART_Serial serial, uint32_t baud);
-void     hal_usart_begin_config(HAL_USART_Serial serial, uint32_t baud, uint32_t config, void*);
-void     hal_usart_end(HAL_USART_Serial serial);
-uint32_t hal_usart_write(HAL_USART_Serial serial, uint8_t data);
-int32_t  hal_usart_available_data_for_write(HAL_USART_Serial serial);
-int32_t  hal_usart_available(HAL_USART_Serial serial);
-int32_t  hal_usart_read(HAL_USART_Serial serial);
-int32_t  hal_usart_peek(HAL_USART_Serial serial);
-void     hal_usart_flush(HAL_USART_Serial serial);
-bool     hal_usart_is_enabled(HAL_USART_Serial serial);
-void     hal_usart_half_duplex(HAL_USART_Serial serial, bool enable);
-uint32_t hal_usart_write_nine_bits(HAL_USART_Serial serial, uint16_t data);
-void     hal_usart_send_break(HAL_USART_Serial serial, void* reserved);
-uint8_t  hal_usart_break_detected(HAL_USART_Serial serial);
-int      hal_usart_sleep(HAL_USART_Serial serial, bool sleep, void* reserved);
+int hal_usart_init_ex(hal_usart_interface_t serial, const hal_usart_buffer_config_t* config, void*);
+void hal_usart_init(hal_usart_interface_t serial, hal_usart_ring_buffer_t *rx_buffer, hal_usart_ring_buffer_t *tx_buffer);
+void hal_usart_begin(hal_usart_interface_t serial, uint32_t baud);
+void hal_usart_begin_config(hal_usart_interface_t serial, uint32_t baud, uint32_t config, void*);
+void hal_usart_end(hal_usart_interface_t serial);
+uint32_t hal_usart_write(hal_usart_interface_t serial, uint8_t data);
+int32_t hal_usart_available_data_for_write(hal_usart_interface_t serial);
+int32_t hal_usart_available(hal_usart_interface_t serial);
+int32_t hal_usart_read(hal_usart_interface_t serial);
+int32_t hal_usart_peek(hal_usart_interface_t serial);
+void hal_usart_flush(hal_usart_interface_t serial);
+bool hal_usart_is_enabled(hal_usart_interface_t serial);
+void hal_usart_half_duplex(hal_usart_interface_t serial, bool enable);
+uint32_t hal_usart_write_nine_bits(hal_usart_interface_t serial, uint16_t data);
+void hal_usart_send_break(hal_usart_interface_t serial, void* reserved);
+uint8_t hal_usart_break_detected(hal_usart_interface_t serial);
+int hal_usart_sleep(hal_usart_interface_t serial, bool sleep, void* reserved);
 
-ssize_t  hal_usart_write_buffer(HAL_USART_Serial serial, const void* buffer, size_t size, size_t elementSize);
-ssize_t  hal_usart_read_buffer(HAL_USART_Serial serial, void* buffer, size_t size, size_t elementSize);
-ssize_t  hal_usart_peak_buffer(HAL_USART_Serial serial, void* buffer, size_t size, size_t elementSize);
+ssize_t hal_usart_write_buffer(hal_usart_interface_t serial, const void* buffer, size_t size, size_t elementSize);
+ssize_t hal_usart_read_buffer(hal_usart_interface_t serial, void* buffer, size_t size, size_t elementSize);
+ssize_t hal_usart_peak_buffer(hal_usart_interface_t serial, void* buffer, size_t size, size_t elementSize);
 
 #ifdef __cplusplus
 }

--- a/hal/inc/usart_hal.h
+++ b/hal/inc/usart_hal.h
@@ -127,9 +127,9 @@ typedef enum hal_usart_interface_t {
     HAL_USART_SERIAL1 = 0,    //maps to USART_TX_RX
     HAL_USART_SERIAL2 = 1     //maps to USART_RGBG_RGBB
 #if PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION // Electron
-   ,HAL_USART_SERIAL3 = 2    //maps to USART_TXD_UC_RXD_UC
-   ,HAL_USART_SERIAL4 = 3    //maps to USART_C3_C2
-   ,HAL_USART_SERIAL5 = 4    //maps to USART_C1_C0
+   ,HAL_USART_SERIAL3 = 2     //maps to USART_TXD_UC_RXD_UC
+   ,HAL_USART_SERIAL4 = 3     //maps to USART_C3_C2
+   ,HAL_USART_SERIAL5 = 4     //maps to USART_C1_C0
 #endif
 } hal_usart_interface_t;
 typedef hal_usart_interface_t HAL_USART_Serial; // For backwards compatibility

--- a/hal/inc/usart_hal.h
+++ b/hal/inc/usart_hal.h
@@ -1,26 +1,25 @@
-/**
- ******************************************************************************
+/******************************************************************************
  * @file    usart_hal.h
  * @author  Satish Nair, Brett Walach
  * @version V1.0.0
  * @date    12-Sept-2014
  * @brief
- ******************************************************************************
-  Copyright (c) 2013-2015 Particle Industries, Inc.  All rights reserved.
-
-  This library is free software; you can redistribute it and/or
-  modify it under the terms of the GNU Lesser General Public
-  License as published by the Free Software Foundation, either
-  version 3 of the License, or (at your option) any later version.
-
-  This library is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  Lesser General Public License for more details.
-
-  You should have received a copy of the GNU Lesser General Public
-  License along with this library; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
+ ******************************************************************************/
+/*
+ * Copyright (c) 2020 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHAN'TABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
@@ -37,10 +36,11 @@
 
 /* Exported defines ----------------------------------------------------------*/
 #if PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION // Electron
-	#define TOTAL_USARTS		5
+    #define TOTAL_USARTS		5
 #else
-	#define TOTAL_USARTS		2
+    #define TOTAL_USARTS		2
 #endif
+
 #define SERIAL_BUFFER_SIZE      64
 
 // Pre-defined USART configurations
@@ -115,63 +115,57 @@
 
 #define SERIAL_TX_PULL_UP             ((uint32_t)0x8000)
 
-
 /* Exported types ------------------------------------------------------------*/
-typedef struct Ring_Buffer
-{
-  uint16_t buffer[SERIAL_BUFFER_SIZE];
-  volatile uint16_t head;
-  volatile uint16_t tail;
+typedef struct Ring_Buffer {
+    uint16_t buffer[SERIAL_BUFFER_SIZE];
+    volatile uint16_t head;
+    volatile uint16_t tail;
 } Ring_Buffer;
 
 typedef enum HAL_USART_Serial {
-  HAL_USART_SERIAL1 = 0,    //maps to USART_TX_RX
-  HAL_USART_SERIAL2 = 1     //maps to USART_RGBG_RGBB
+    HAL_USART_SERIAL1 = 0,    //maps to USART_TX_RX
+    HAL_USART_SERIAL2 = 1     //maps to USART_RGBG_RGBB
 #if PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION // Electron
-  ,HAL_USART_SERIAL3 = 2    //maps to USART_TXD_UC_RXD_UC
-  ,HAL_USART_SERIAL4 = 3    //maps to USART_C3_C2
-  ,HAL_USART_SERIAL5 = 4    //maps to USART_C1_C0
+    ,HAL_USART_SERIAL3 = 2    //maps to USART_TXD_UC_RXD_UC
+    ,HAL_USART_SERIAL4 = 3    //maps to USART_C3_C2
+    ,HAL_USART_SERIAL5 = 4    //maps to USART_C1_C0
 #endif
 } HAL_USART_Serial;
 
-/* Exported constants --------------------------------------------------------*/
-
-/* Exported macros -----------------------------------------------------------*/
-
-/* Exported functions --------------------------------------------------------*/
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef struct HAL_USART_Buffer_Config {
-  uint16_t size;
-  void* rx_buffer;
-  uint16_t rx_buffer_size;
-  void* tx_buffer;
-  uint16_t tx_buffer_size;
+    uint16_t size;
+    void* rx_buffer;
+    uint16_t rx_buffer_size;
+    void* tx_buffer;
+    uint16_t tx_buffer_size;
 } HAL_USART_Buffer_Config;
 
-int HAL_USART_Init_Ex(HAL_USART_Serial serial, const HAL_USART_Buffer_Config* config, void*);
-void HAL_USART_Init(HAL_USART_Serial serial, Ring_Buffer *rx_buffer, Ring_Buffer *tx_buffer);
-void HAL_USART_Begin(HAL_USART_Serial serial, uint32_t baud);
-void HAL_USART_End(HAL_USART_Serial serial);
-uint32_t HAL_USART_Write_Data(HAL_USART_Serial serial, uint8_t data);
-int32_t HAL_USART_Available_Data_For_Write(HAL_USART_Serial serial);
-int32_t HAL_USART_Available_Data(HAL_USART_Serial serial);
-int32_t HAL_USART_Read_Data(HAL_USART_Serial serial);
-int32_t HAL_USART_Peek_Data(HAL_USART_Serial serial);
-void HAL_USART_Flush_Data(HAL_USART_Serial serial);
-bool HAL_USART_Is_Enabled(HAL_USART_Serial serial);
-void HAL_USART_Half_Duplex(HAL_USART_Serial serial, bool Enable);
-void HAL_USART_BeginConfig(HAL_USART_Serial serial, uint32_t baud, uint32_t config, void*);
-uint32_t HAL_USART_Write_NineBitData(HAL_USART_Serial serial, uint16_t data);
-void HAL_USART_Send_Break(HAL_USART_Serial serial, void* reserved);
-uint8_t HAL_USART_Break_Detected(HAL_USART_Serial serial);
+int      hal_usart_init_ex(HAL_USART_Serial serial, const HAL_USART_Buffer_Config* config, void*);
+void     hal_usart_init(HAL_USART_Serial serial, Ring_Buffer *rx_buffer, Ring_Buffer *tx_buffer);
+void     hal_usart_begin(HAL_USART_Serial serial, uint32_t baud);
+void     hal_usart_begin_config(HAL_USART_Serial serial, uint32_t baud, uint32_t config, void*);
+void     hal_usart_end(HAL_USART_Serial serial);
+uint32_t hal_usart_write(HAL_USART_Serial serial, uint8_t data);
+int32_t  hal_usart_available_data_for_write(HAL_USART_Serial serial);
+int32_t  hal_usart_available(HAL_USART_Serial serial);
+int32_t  hal_usart_read(HAL_USART_Serial serial);
+int32_t  hal_usart_peek(HAL_USART_Serial serial);
+void     hal_usart_flush(HAL_USART_Serial serial);
+bool     hal_usart_is_enabled(HAL_USART_Serial serial);
+void     hal_usart_half_duplex(HAL_USART_Serial serial, bool enable);
+uint32_t hal_usart_write_nine_bits(HAL_USART_Serial serial, uint16_t data);
+void     hal_usart_send_break(HAL_USART_Serial serial, void* reserved);
+uint8_t  hal_usart_break_detected(HAL_USART_Serial serial);
+int      hal_usart_sleep(HAL_USART_Serial serial, bool sleep, void* reserved);
 
-ssize_t HAL_USART_Write(HAL_USART_Serial serial, const void* buffer, size_t size, size_t elementSize);
-ssize_t HAL_USART_Read(HAL_USART_Serial serial, void* buffer, size_t size, size_t elementSize);
-ssize_t HAL_USART_Peek(HAL_USART_Serial serial, void* buffer, size_t size, size_t elementSize);
+ssize_t  hal_usart_write_buffer(HAL_USART_Serial serial, const void* buffer, size_t size, size_t elementSize);
+ssize_t  hal_usart_read_buffer(HAL_USART_Serial serial, void* buffer, size_t size, size_t elementSize);
+ssize_t  hal_usart_peak_buffer(HAL_USART_Serial serial, void* buffer, size_t size, size_t elementSize);
 
 #ifdef __cplusplus
 }

--- a/hal/inc/usart_hal_private.h
+++ b/hal/inc/usart_hal_private.h
@@ -34,10 +34,10 @@ typedef enum HAL_USART_Pvt_Events {
     HAL_USART_PVT_EVENT_MAX = HAL_USART_PVT_EVENT_WRITABLE
 } HAL_USART_Pvt_Events;
 
-int hal_usart_pvt_get_event_group_handle(HAL_USART_Serial serial, EventGroupHandle_t* handle);
-int hal_usart_pvt_enable_event(HAL_USART_Serial serial, HAL_USART_Pvt_Events events);
-int hal_usart_pvt_disable_event(HAL_USART_Serial serial, HAL_USART_Pvt_Events events);
-int hal_usart_pvt_wait_event(HAL_USART_Serial serial, uint32_t events, system_tick_t timeout);
+int hal_usart_pvt_get_event_group_handle(hal_usart_interface_t serial, EventGroupHandle_t* handle);
+int hal_usart_pvt_enable_event(hal_usart_interface_t serial, HAL_USART_Pvt_Events events);
+int hal_usart_pvt_disable_event(hal_usart_interface_t serial, HAL_USART_Pvt_Events events);
+int hal_usart_pvt_wait_event(hal_usart_interface_t serial, uint32_t events, system_tick_t timeout);
 
 #ifdef __cplusplus
 }

--- a/hal/inc/usart_hal_private.h
+++ b/hal/inc/usart_hal_private.h
@@ -34,10 +34,10 @@ typedef enum HAL_USART_Pvt_Events {
     HAL_USART_PVT_EVENT_MAX = HAL_USART_PVT_EVENT_WRITABLE
 } HAL_USART_Pvt_Events;
 
-int HAL_USART_Pvt_Get_Event_Group_Handle(HAL_USART_Serial serial, EventGroupHandle_t* handle);
-int HAL_USART_Pvt_Enable_Event(HAL_USART_Serial serial, HAL_USART_Pvt_Events events);
-int HAL_USART_Pvt_Disable_Event(HAL_USART_Serial serial, HAL_USART_Pvt_Events events);
-int HAL_USART_Pvt_Wait_Event(HAL_USART_Serial serial, uint32_t events, system_tick_t timeout);
+int hal_usart_pvt_get_event_group_handle(HAL_USART_Serial serial, EventGroupHandle_t* handle);
+int hal_usart_pvt_enable_event(HAL_USART_Serial serial, HAL_USART_Pvt_Events events);
+int hal_usart_pvt_disable_event(HAL_USART_Serial serial, HAL_USART_Pvt_Events events);
+int hal_usart_pvt_wait_event(HAL_USART_Serial serial, uint32_t events, system_tick_t timeout);
 
 #ifdef __cplusplus
 }

--- a/hal/src/electron/modem/electronserialpipe_hal.cpp
+++ b/hal/src/electron/modem/electronserialpipe_hal.cpp
@@ -42,7 +42,7 @@ ElectronSerialPipe::~ElectronSerialPipe(void)
 
 void ElectronSerialPipe::begin(unsigned baud, bool hwFlowCtrl)
 {
-    //HAL_USART_Begin(HAL_USART_SERIAL3, baud);
+    //hal_usart_begin(HAL_USART_SERIAL3, baud);
     //USART_DeInit(USART3);
     end();
 
@@ -92,17 +92,17 @@ void ElectronSerialPipe::begin(unsigned baud, bool hwFlowCtrl)
     // - Hardware flow control disabled for Serial1/2/4/5
     // - Hardware flow control enabled (RTS and CTS signals) for Serial3
     // - Receive and transmit enabled
-    USART_InitTypeDef USART_InitStructure = {};
-    USART_InitStructure.USART_BaudRate = baud;
-    USART_InitStructure.USART_WordLength = USART_WordLength_8b;
-    USART_InitStructure.USART_StopBits = USART_StopBits_1;
-    USART_InitStructure.USART_Parity = USART_Parity_No;
-    USART_InitStructure.USART_Mode = USART_Mode_Rx | USART_Mode_Tx;
-    USART_InitStructure.USART_HardwareFlowControl = hwFlowCtrl ? USART_HardwareFlowControl_RTS_CTS :
+    USART_InitTypeDef usartInitStructure = {};
+    usartInitStructure.USART_BaudRate = baud;
+    usartInitStructure.USART_WordLength = USART_WordLength_8b;
+    usartInitStructure.USART_StopBits = USART_StopBits_1;
+    usartInitStructure.USART_Parity = USART_Parity_No;
+    usartInitStructure.USART_Mode = USART_Mode_Rx | USART_Mode_Tx;
+    usartInitStructure.USART_HardwareFlowControl = hwFlowCtrl ? USART_HardwareFlowControl_RTS_CTS :
             USART_HardwareFlowControl_None;
 
     // Configure USART
-    USART_Init(USART3, &USART_InitStructure);
+    USART_Init(USART3, &usartInitStructure);
 
     // Enable the USART
     USART_Cmd(USART3, ENABLE);

--- a/hal/src/gcc/usart_hal.cpp
+++ b/hal/src/gcc/usart_hal.cpp
@@ -3,7 +3,7 @@
 #include "socket_hal.h"
 
 struct Usart {
-    virtual void init(Ring_Buffer *rx_buffer, Ring_Buffer *tx_buffer)=0;
+    virtual void init(hal_usart_ring_buffer_t *rx_buffer, hal_usart_ring_buffer_t *tx_buffer)=0;
     virtual void begin(uint32_t baud)=0;
     virtual void end()=0;
     virtual int32_t available()=0;
@@ -21,8 +21,8 @@ const sock_handle_t SOCKET_INVALID = sock_handle_t(-1);
 class SocketUsartBase : public Usart
 {
     private:
-        Ring_Buffer* rx;
-        Ring_Buffer* tx;
+        hal_usart_ring_buffer_t* rx;
+        hal_usart_ring_buffer_t* tx;
 
     protected:
         sock_handle_t socket;
@@ -68,7 +68,7 @@ class SocketUsartBase : public Usart
 
 
     public:
-        virtual void init(Ring_Buffer *rx_buffer, Ring_Buffer *tx_buffer) override
+        virtual void init(hal_usart_ring_buffer_t *rx_buffer, hal_usart_ring_buffer_t *tx_buffer) override
         {
             this->rx = rx_buffer;
             this->tx = tx_buffer;
@@ -178,74 +178,74 @@ static SocketUsartClient usart2 = SocketUsartClient();
 
 }
 
-void hal_usart_init(HAL_USART_Serial serial, Ring_Buffer *rx_buffer, Ring_Buffer *tx_buffer)
+void hal_usart_init(hal_usart_interface_t serial, hal_usart_ring_buffer_t *rx_buffer, hal_usart_ring_buffer_t *tx_buffer)
 {
     usartMap(serial).init(rx_buffer, tx_buffer);
 }
 
-void hal_usart_begin(HAL_USART_Serial serial, uint32_t baud)
+void hal_usart_begin(hal_usart_interface_t serial, uint32_t baud)
 {
     //usartMap(serial).begin(baud);
 }
 
-void hal_usart_end(HAL_USART_Serial serial)
+void hal_usart_end(hal_usart_interface_t serial)
 {
     //usartMap(serial).end();
 }
 
-int32_t hal_usart_available_data_for_write(HAL_USART_Serial serial)
+int32_t hal_usart_available_data_for_write(hal_usart_interface_t serial)
 {
     return usartMap(serial).availableForWrite();
 }
 
-uint32_t hal_usart_write(HAL_USART_Serial serial, uint8_t data)
+uint32_t hal_usart_write(hal_usart_interface_t serial, uint8_t data)
 {
     return usartMap(serial).write(data);
 }
 
-int32_t hal_usart_available(HAL_USART_Serial serial)
+int32_t hal_usart_available(hal_usart_interface_t serial)
 {
     return usartMap(serial).available();
 }
 
-int32_t hal_usart_read(HAL_USART_Serial serial)
+int32_t hal_usart_read(hal_usart_interface_t serial)
 {
     return usartMap(serial).read();
 }
 
-int32_t hal_usart_peek(HAL_USART_Serial serial)
+int32_t hal_usart_peek(hal_usart_interface_t serial)
 {
     return usartMap(serial).peek();
 }
 
-void hal_usart_flush(HAL_USART_Serial serial)
+void hal_usart_flush(hal_usart_interface_t serial)
 {
     usartMap(serial).flush();
 }
 
-bool hal_usart_is_enabled(HAL_USART_Serial serial)
+bool hal_usart_is_enabled(hal_usart_interface_t serial)
 {
     return usartMap(serial).enabled();
 }
 
-void hal_usart_half_duplex(HAL_USART_Serial serial, bool Enable)
+void hal_usart_half_duplex(hal_usart_interface_t serial, bool Enable)
 {
 }
 
-void hal_usart_begin_config(HAL_USART_Serial serial, uint32_t baud, uint32_t config, void *ptr)
+void hal_usart_begin_config(hal_usart_interface_t serial, uint32_t baud, uint32_t config, void *ptr)
 {
 }
 
-uint32_t hal_usart_write_nine_bits(HAL_USART_Serial serial, uint16_t data)
+uint32_t hal_usart_write_nine_bits(hal_usart_interface_t serial, uint16_t data)
 {
     return usartMap(serial).write((uint8_t) data);
 }
 
-void hal_usart_send_break(HAL_USART_Serial serial, void* reserved)
+void hal_usart_send_break(hal_usart_interface_t serial, void* reserved)
 {
 }
 
-uint8_t hal_usart_break_detected(HAL_USART_Serial serial)
+uint8_t hal_usart_break_detected(hal_usart_interface_t serial)
 {
   return 0;
 }

--- a/hal/src/gcc/usart_hal.cpp
+++ b/hal/src/gcc/usart_hal.cpp
@@ -247,5 +247,10 @@ void hal_usart_send_break(hal_usart_interface_t serial, void* reserved)
 
 uint8_t hal_usart_break_detected(hal_usart_interface_t serial)
 {
-  return 0;
+    return 0;
+}
+
+int hal_usart_sleep(hal_usart_interface_t serial, bool sleep, void* reserved)
+{
+    return 0;
 }

--- a/hal/src/gcc/usart_hal.cpp
+++ b/hal/src/gcc/usart_hal.cpp
@@ -178,74 +178,74 @@ static SocketUsartClient usart2 = SocketUsartClient();
 
 }
 
-void HAL_USART_Init(HAL_USART_Serial serial, Ring_Buffer *rx_buffer, Ring_Buffer *tx_buffer)
+void hal_usart_init(HAL_USART_Serial serial, Ring_Buffer *rx_buffer, Ring_Buffer *tx_buffer)
 {
     usartMap(serial).init(rx_buffer, tx_buffer);
 }
 
-void HAL_USART_Begin(HAL_USART_Serial serial, uint32_t baud)
+void hal_usart_begin(HAL_USART_Serial serial, uint32_t baud)
 {
     //usartMap(serial).begin(baud);
 }
 
-void HAL_USART_End(HAL_USART_Serial serial)
+void hal_usart_end(HAL_USART_Serial serial)
 {
     //usartMap(serial).end();
 }
 
-int32_t HAL_USART_Available_Data_For_Write(HAL_USART_Serial serial)
+int32_t hal_usart_available_data_for_write(HAL_USART_Serial serial)
 {
     return usartMap(serial).availableForWrite();
 }
 
-uint32_t HAL_USART_Write_Data(HAL_USART_Serial serial, uint8_t data)
+uint32_t hal_usart_write(HAL_USART_Serial serial, uint8_t data)
 {
     return usartMap(serial).write(data);
 }
 
-int32_t HAL_USART_Available_Data(HAL_USART_Serial serial)
+int32_t hal_usart_available(HAL_USART_Serial serial)
 {
     return usartMap(serial).available();
 }
 
-int32_t HAL_USART_Read_Data(HAL_USART_Serial serial)
+int32_t hal_usart_read(HAL_USART_Serial serial)
 {
     return usartMap(serial).read();
 }
 
-int32_t HAL_USART_Peek_Data(HAL_USART_Serial serial)
+int32_t hal_usart_peek(HAL_USART_Serial serial)
 {
     return usartMap(serial).peek();
 }
 
-void HAL_USART_Flush_Data(HAL_USART_Serial serial)
+void hal_usart_flush(HAL_USART_Serial serial)
 {
     usartMap(serial).flush();
 }
 
-bool HAL_USART_Is_Enabled(HAL_USART_Serial serial)
+bool hal_usart_is_enabled(HAL_USART_Serial serial)
 {
     return usartMap(serial).enabled();
 }
 
-void HAL_USART_Half_Duplex(HAL_USART_Serial serial, bool Enable)
+void hal_usart_half_duplex(HAL_USART_Serial serial, bool Enable)
 {
 }
 
-void HAL_USART_BeginConfig(HAL_USART_Serial serial, uint32_t baud, uint32_t config, void *ptr)
+void hal_usart_begin_config(HAL_USART_Serial serial, uint32_t baud, uint32_t config, void *ptr)
 {
 }
 
-uint32_t HAL_USART_Write_NineBitData(HAL_USART_Serial serial, uint16_t data)
+uint32_t hal_usart_write_nine_bits(HAL_USART_Serial serial, uint16_t data)
 {
     return usartMap(serial).write((uint8_t) data);
 }
 
-void HAL_USART_Send_Break(HAL_USART_Serial serial, void* reserved)
+void hal_usart_send_break(HAL_USART_Serial serial, void* reserved)
 {
 }
 
-uint8_t HAL_USART_Break_Detected(HAL_USART_Serial serial)
+uint8_t hal_usart_break_detected(HAL_USART_Serial serial)
 {
   return 0;
 }

--- a/hal/src/nRF52840/i2c_hal.cpp
+++ b/hal/src/nRF52840/i2c_hal.cpp
@@ -378,7 +378,7 @@ void hal_i2c_begin(hal_i2c_interface_t i2c, hal_i2c_mode_t mode, uint8_t address
      * We cannot enable both of them at the same time.
      */
     if (i2c == HAL_I2C_INTERFACE3) {
-        if (HAL_USART_Is_Enabled(HAL_USART_SERIAL1)) {
+        if (hal_usart_is_enabled(HAL_USART_SERIAL1)) {
             // Unfortunately we cannot return an error code here
             return;
         }

--- a/hal/src/nRF52840/serial_stream.cpp
+++ b/hal/src/nRF52840/serial_stream.cpp
@@ -31,7 +31,7 @@ const auto SERIAL_STREAM_BUFFER_SIZE_TX = 2048;
 
 namespace particle {
 
-SerialStream::SerialStream(HAL_USART_Serial serial, uint32_t baudrate, uint32_t config,
+SerialStream::SerialStream(hal_usart_interface_t serial, uint32_t baudrate, uint32_t config,
         size_t rxBufferSize, size_t txBufferSize)
         : serial_(serial),
           config_(config),
@@ -51,7 +51,7 @@ SerialStream::SerialStream(HAL_USART_Serial serial, uint32_t baudrate, uint32_t 
     SPARK_ASSERT(rxBuffer_);
     SPARK_ASSERT(txBuffer_);
 
-    HAL_USART_Buffer_Config c = {};
+    hal_usart_buffer_config_t c = {};
     c.size = sizeof(c);
     c.rx_buffer = (uint8_t*)rxBuffer_.get();
     c.tx_buffer = (uint8_t*)txBuffer_.get();

--- a/hal/src/nRF52840/serial_stream.cpp
+++ b/hal/src/nRF52840/serial_stream.cpp
@@ -57,13 +57,13 @@ SerialStream::SerialStream(HAL_USART_Serial serial, uint32_t baudrate, uint32_t 
     c.tx_buffer = (uint8_t*)txBuffer_.get();
     c.rx_buffer_size = rxBufferSize;
     c.tx_buffer_size = txBufferSize;
-    HAL_USART_Init_Ex(serial_, &c, nullptr);
-    HAL_USART_BeginConfig(serial_, baudrate, config, 0);
+    hal_usart_init_ex(serial_, &c, nullptr);
+    hal_usart_begin_config(serial_, baudrate, config, 0);
     phyOn_ = true;
 }
 
 SerialStream::~SerialStream() {
-    HAL_USART_End(serial_);
+    hal_usart_end(serial_);
 }
 
 int SerialStream::read(char* data, size_t size) {
@@ -73,7 +73,7 @@ int SerialStream::read(char* data, size_t size) {
     if (size == 0) {
         return 0;
     }
-    auto r = HAL_USART_Read(serial_, data, size, sizeof(char));
+    auto r = hal_usart_read_buffer(serial_, data, size, sizeof(char));
     if (r == SYSTEM_ERROR_NO_MEMORY) {
         return 0;
     }
@@ -87,7 +87,7 @@ int SerialStream::peek(char* data, size_t size) {
     if (size == 0) {
         return 0;
     }
-    auto r = HAL_USART_Peek(serial_, data, size, sizeof(char));
+    auto r = hal_usart_peak_buffer(serial_, data, size, sizeof(char));
     if (r == SYSTEM_ERROR_NO_MEMORY) {
         return 0;
     }
@@ -105,7 +105,7 @@ int SerialStream::write(const char* data, size_t size) {
     if (size == 0) {
         return 0;
     }
-    auto r = HAL_USART_Write(serial_, data, size, sizeof(char));
+    auto r = hal_usart_write_buffer(serial_, data, size, sizeof(char));
     if (r == SYSTEM_ERROR_NO_MEMORY) {
         return 0;
     }
@@ -116,7 +116,7 @@ int SerialStream::flush() {
     if (!phyOn_ || !enabled_) {
         return SYSTEM_ERROR_INVALID_STATE;
     }
-    HAL_USART_Flush_Data(serial_);
+    hal_usart_flush(serial_);
     return 0;
 }
 
@@ -124,14 +124,14 @@ int SerialStream::availForRead() {
     if (!phyOn_ || !enabled_) {
         return SYSTEM_ERROR_INVALID_STATE;
     }
-    return HAL_USART_Available_Data(serial_);
+    return hal_usart_available(serial_);
 }
 
 int SerialStream::availForWrite() {
     if (!phyOn_ || !enabled_) {
         return SYSTEM_ERROR_INVALID_STATE;
     }
-    return HAL_USART_Available_Data_For_Write(serial_);
+    return hal_usart_available_data_for_write(serial_);
 }
 
 int SerialStream::waitEvent(unsigned flags, unsigned timeout) {
@@ -144,26 +144,26 @@ int SerialStream::waitEvent(unsigned flags, unsigned timeout) {
 
     // NOTE: non-Stream events may be passed here
 
-    return HAL_USART_Pvt_Wait_Event(serial_, flags, timeout);
+    return hal_usart_pvt_wait_event(serial_, flags, timeout);
 }
 
 int SerialStream::setBaudRate(unsigned int baudrate) {
     if (!phyOn_ || !enabled_) {
         return SYSTEM_ERROR_INVALID_STATE;
     }
-    HAL_USART_End(serial_);
-    HAL_USART_BeginConfig(serial_, baudrate, config_, 0);
+    hal_usart_end(serial_);
+    hal_usart_begin_config(serial_, baudrate, config_, 0);
     return 0;
 }
 
 int SerialStream::on(bool on) {
     if (on) {
         CHECK_FALSE(phyOn_, SYSTEM_ERROR_NONE);
-        HAL_USART_BeginConfig(serial_, baudrate_, config_, 0);
+        hal_usart_begin_config(serial_, baudrate_, config_, 0);
         phyOn_ = true;
     } else {
         CHECK_TRUE(phyOn_, SYSTEM_ERROR_NONE);
-        HAL_USART_End(serial_);
+        hal_usart_end(serial_);
         phyOn_ = false;
     }
     return SYSTEM_ERROR_NONE;
@@ -171,7 +171,7 @@ int SerialStream::on(bool on) {
 
 EventGroupHandle_t SerialStream::eventGroup() {
     EventGroupHandle_t ev = nullptr;
-    HAL_USART_Pvt_Get_Event_Group_Handle(serial_, &ev);
+    hal_usart_pvt_get_event_group_handle(serial_, &ev);
     return ev;
 }
 

--- a/hal/src/nRF52840/serial_stream.h
+++ b/hal/src/nRF52840/serial_stream.h
@@ -27,7 +27,7 @@ namespace particle {
 
 class SerialStream: public Stream {
 public:
-    SerialStream(HAL_USART_Serial serial, uint32_t baudrate, uint32_t config,
+    SerialStream(hal_usart_interface_t serial, uint32_t baudrate, uint32_t config,
             size_t rxBufferSize = 0, size_t txBufferSize = 0);
     ~SerialStream();
 
@@ -51,7 +51,7 @@ public:
     EventGroupHandle_t eventGroup();
 
 private:
-    HAL_USART_Serial serial_;
+    hal_usart_interface_t serial_;
     std::unique_ptr<char[]> rxBuffer_;
     std::unique_ptr<char[]> txBuffer_;
     uint32_t config_;

--- a/hal/src/nRF52840/sleep_hal.cpp
+++ b/hal/src/nRF52840/sleep_hal.cpp
@@ -137,8 +137,8 @@ static int enterStopMode(const hal_sleep_config_t* config, hal_wakeup_source_bas
 
     // Flush all USARTs
     for (int usart = 0; usart < TOTAL_USARTS; usart++) {
-        if (hal_usart_is_enabled(static_cast<HAL_USART_Serial>(usart))) {
-            hal_usart_flush(static_cast<HAL_USART_Serial>(usart));
+        if (hal_usart_is_enabled(static_cast<hal_usart_interface_t>(usart))) {
+            hal_usart_flush(static_cast<hal_usart_interface_t>(usart));
         }
     }
 

--- a/hal/src/nRF52840/sleep_hal.cpp
+++ b/hal/src/nRF52840/sleep_hal.cpp
@@ -137,8 +137,8 @@ static int enterStopMode(const hal_sleep_config_t* config, hal_wakeup_source_bas
 
     // Flush all USARTs
     for (int usart = 0; usart < TOTAL_USARTS; usart++) {
-        if (HAL_USART_Is_Enabled(static_cast<HAL_USART_Serial>(usart))) {
-            HAL_USART_Flush_Data(static_cast<HAL_USART_Serial>(usart));
+        if (hal_usart_is_enabled(static_cast<HAL_USART_Serial>(usart))) {
+            hal_usart_flush(static_cast<HAL_USART_Serial>(usart));
         }
     }
 

--- a/hal/src/nRF52840/usart_hal.cpp
+++ b/hal/src/nRF52840/usart_hal.cpp
@@ -289,6 +289,7 @@ public:
         enabled_ = false;
         transmitting_ = false;
         receiving_ = 0;
+        rxBuffer_.reset();
         txBuffer_.reset();
 
         return SYSTEM_ERROR_NONE;

--- a/hal/src/nRF52840/usart_hal.cpp
+++ b/hal/src/nRF52840/usart_hal.cpp
@@ -260,7 +260,7 @@ public:
     }
 
     int suspend() {
-        CHECK_TRUE(isEnabled(), SYSTEM_ERROR_NONE);
+        CHECK_TRUE(isEnabled(), SYSTEM_ERROR_INVALID_STATE);
 
         flush();
 
@@ -294,7 +294,7 @@ public:
 
     int restore() {
         AtomicSection lk;
-        CHECK_TRUE(state_ == HAL_USART_STATE_SUSPENDED, SYSTEM_ERROR_NONE);
+        CHECK_TRUE(state_ == HAL_USART_STATE_SUSPENDED, SYSTEM_ERROR_INVALID_STATE);
         return begin(config_);
     }
 

--- a/hal/src/nRF52840/usart_hal.cpp
+++ b/hal/src/nRF52840/usart_hal.cpp
@@ -627,6 +627,7 @@ private:
                       NRF_UARTE_INT_TXSTOPPED_MASK |
                       NRF_UARTE_INT_ENDTX_MASK);
         NRFX_IRQ_DISABLE(nrfx_get_irq_number((void*)uarte_));
+        NRFX_IRQ_PENDING_CLEAR(nrfx_get_irq_number((void*)uarte_));
     }
 
     void enableTimer() {

--- a/hal/src/stm32f2xx/sleep_hal.cpp
+++ b/hal/src/stm32f2xx/sleep_hal.cpp
@@ -85,8 +85,8 @@ static int enterStopMode(const hal_sleep_config_t* config, hal_wakeup_source_bas
 
     // Flush all USARTs
     for (int usart = 0; usart < TOTAL_USARTS; usart++) {
-        if (HAL_USART_Is_Enabled(static_cast<HAL_USART_Serial>(usart))) {
-            HAL_USART_Flush_Data(static_cast<HAL_USART_Serial>(usart));
+        if (hal_usart_is_enabled(static_cast<HAL_USART_Serial>(usart))) {
+            hal_usart_flush(static_cast<HAL_USART_Serial>(usart));
         }
     }
 

--- a/hal/src/stm32f2xx/sleep_hal.cpp
+++ b/hal/src/stm32f2xx/sleep_hal.cpp
@@ -85,8 +85,8 @@ static int enterStopMode(const hal_sleep_config_t* config, hal_wakeup_source_bas
 
     // Flush all USARTs
     for (int usart = 0; usart < TOTAL_USARTS; usart++) {
-        if (hal_usart_is_enabled(static_cast<HAL_USART_Serial>(usart))) {
-            hal_usart_flush(static_cast<HAL_USART_Serial>(usart));
+        if (hal_usart_is_enabled(static_cast<hal_usart_interface_t>(usart))) {
+            hal_usart_flush(static_cast<hal_usart_interface_t>(usart));
         }
     }
 

--- a/hal/src/stm32f2xx/usart_hal.c
+++ b/hal/src/stm32f2xx/usart_hal.c
@@ -34,7 +34,7 @@
 #include "system_error.h"
 
 /* Private typedef -----------------------------------------------------------*/
-typedef enum usart_ports {
+typedef enum usart_ports_t {
     USART_TX_RX = 0,
     USART_RGBG_RGBB = 1
 #if PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION
@@ -42,52 +42,52 @@ typedef enum usart_ports {
     ,USART_C3_C2 = 3
     ,USART_C1_C0 = 4
 #endif // PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION
-} usart_ports;
+} usart_ports_t;
 
 /* Private macro -------------------------------------------------------------*/
 #define USE_USART3_HARDWARE_FLOW_CONTROL_RTS_CTS 0  //Enabling this => 1 is not working at present
 
-typedef struct usart_config {
+typedef struct usart_config_t {
     uint32_t baud_rate;
     uint32_t config;
-} usart_config;
+} usart_config_t;
 
 /* Private variables ---------------------------------------------------------*/
-typedef struct stm32_usart_info {
-    USART_TypeDef* usart_peripheral;
+typedef struct stm32_usart_info_t {
+    USART_TypeDef* peripheral;
 
-    __IO uint32_t* usart_apbReg;
-    uint32_t usart_clock_en;
+    __IO uint32_t* apb_reg;
+    uint32_t clock_enabled;
 
-    int32_t usart_int_n;
+    int32_t int_n;
 
-    uint16_t usart_tx_pin;
-    uint16_t usart_rx_pin;
+    uint16_t tx_pin;
+    uint16_t rx_pin;
 
-    uint8_t usart_tx_pinsource;
-    uint8_t usart_rx_pinsource;
+    uint8_t tx_pinsource;
+    uint8_t rx_pinsource;
 
-    uint8_t usart_af_map;
+    uint8_t af_map;
 
-    uint8_t usart_cts_pin;
-    uint8_t usart_rts_pin;
+    uint8_t cts_pin;
+    uint8_t rts_pin;
 
     // Buffer pointers. These need to be global for IRQ handler access
-    Ring_Buffer* usart_tx_buffer;
-    Ring_Buffer* usart_rx_buffer;
+    hal_usart_ring_buffer_t* tx_buffer;
+    hal_usart_ring_buffer_t* rx_buffer;
 
-    bool usart_configured;
-    volatile bool usart_enabled;
-    volatile bool usart_suspended;
-    bool usart_transmitting;
+    bool configured;
+    volatile bool enabled;
+    volatile bool suspended;
+    bool transmitting;
 
-    usart_config conf;
-} stm32_usart_info;
+    usart_config_t conf;
+} stm32_usart_info_t;
 
 /*
  * USART mapping
  */
-stm32_usart_info USART_MAP[TOTAL_USARTS] = {
+stm32_usart_info_t USART_MAP[TOTAL_USARTS] = {
     /*
      * USART_peripheral (USARTx/UARTx; not using others)
      * clock control register (APBxENR)
@@ -105,21 +105,21 @@ stm32_usart_info USART_MAP[TOTAL_USARTS] = {
      * <usart enabled> used internally and does not appear below
      * <usart transmitting> used internally and does not appear below
      */
-    { USART1,  &RCC->APB2ENR, RCC_APB2Periph_USART1, USART1_IRQn, TX,     RX,     GPIO_PinSource9,  GPIO_PinSource10, GPIO_AF_USART1 }, // USART 1
-    { USART2,  &RCC->APB1ENR, RCC_APB1Periph_USART2, USART2_IRQn, RGBG,   RGBB,   GPIO_PinSource2,  GPIO_PinSource3,  GPIO_AF_USART2, A7,     RGBR } // USART 2
+    { USART1, &RCC->APB2ENR, RCC_APB2Periph_USART1, USART1_IRQn, TX,     RX,     GPIO_PinSource9,  GPIO_PinSource10, GPIO_AF_USART1 }, // USART 1
+    { USART2, &RCC->APB1ENR, RCC_APB1Periph_USART2, USART2_IRQn, RGBG,   RGBB,   GPIO_PinSource2,  GPIO_PinSource3,  GPIO_AF_USART2, A7,     RGBR } // USART 2
 #if PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION
-    ,{ USART3, &RCC->APB1ENR, RCC_APB1Periph_USART3, USART3_IRQn, TXD_UC, RXD_UC, GPIO_PinSource10, GPIO_PinSource11, GPIO_AF_USART3, CTS_UC, RTS_UC } // USART 3
-    ,{ UART4,  &RCC->APB1ENR, RCC_APB1Periph_UART4,  UART4_IRQn,  C3,     C2,     GPIO_PinSource10, GPIO_PinSource11, GPIO_AF_UART4 } // UART 4
-    ,{ UART5,  &RCC->APB1ENR, RCC_APB1Periph_UART5,  UART5_IRQn,  C1,     C0,     GPIO_PinSource12, GPIO_PinSource2,  GPIO_AF_UART5 } // UART 5
+   ,{ USART3, &RCC->APB1ENR, RCC_APB1Periph_USART3, USART3_IRQn, TXD_UC, RXD_UC, GPIO_PinSource10, GPIO_PinSource11, GPIO_AF_USART3, CTS_UC, RTS_UC } // USART 3
+   ,{ UART4,  &RCC->APB1ENR, RCC_APB1Periph_UART4,  UART4_IRQn,  C3,     C2,     GPIO_PinSource10, GPIO_PinSource11, GPIO_AF_UART4 } // UART 4
+   ,{ UART5,  &RCC->APB1ENR, RCC_APB1Periph_UART5,  UART5_IRQn,  C1,     C0,     GPIO_PinSource12, GPIO_PinSource2,  GPIO_AF_UART5 } // UART 5
 #endif // PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION
 };
 
 static USART_InitTypeDef usartInitStructure;
-static stm32_usart_info *usartMap[TOTAL_USARTS]; // pointer to USART_MAP[] containing USART peripheral register locations (etc)
+static stm32_usart_info_t *usartMap[TOTAL_USARTS]; // pointer to USART_MAP[] containing USART peripheral register locations (etc)
 
 /* Private function prototypes -----------------------------------------------*/
-inline void storeChar(uint16_t c, Ring_Buffer *buffer) __attribute__((always_inline));
-inline void storeChar(uint16_t c, Ring_Buffer *buffer) {
+inline void storeChar(uint16_t c, hal_usart_ring_buffer_t *buffer) __attribute__((always_inline));
+inline void storeChar(uint16_t c, hal_usart_ring_buffer_t *buffer) {
     unsigned i = (unsigned int)(buffer->head + 1) % SERIAL_BUFFER_SIZE;
 
     if (i != buffer->tail) {
@@ -131,9 +131,9 @@ inline void storeChar(uint16_t c, Ring_Buffer *buffer) {
 static uint8_t calculateWordLength(uint32_t config, uint8_t noparity);
 static uint32_t calculateDataBitsMask(uint32_t config);
 static uint8_t validateConfig(uint32_t config);
-static void configureTransmitReceive(HAL_USART_Serial serial, uint8_t transmit, uint8_t receive);
-static void configurePinsMode(HAL_USART_Serial serial, uint32_t config);
-static void usartEndImpl(HAL_USART_Serial serial, bool cache);
+static void configureTransmitReceive(hal_usart_interface_t serial, uint8_t transmit, uint8_t receive);
+static void configurePinsMode(hal_usart_interface_t serial, uint32_t config);
+static void usartEndImpl(hal_usart_interface_t serial, bool cache);
 
 uint8_t calculateWordLength(uint32_t config, uint8_t noparity) {
     // STM32F2 USARTs support only 8-bit or 9-bit communication, however
@@ -204,7 +204,7 @@ uint8_t validateConfig(uint32_t config) {
     return 1;
 }
 
-void configureTransmitReceive(HAL_USART_Serial serial, uint8_t transmit, uint8_t receive) {
+void configureTransmitReceive(hal_usart_interface_t serial, uint8_t transmit, uint8_t receive) {
     uint32_t toset = 0;
     if (transmit) {
         toset |= ((uint32_t)USART_CR1_TE);
@@ -212,23 +212,23 @@ void configureTransmitReceive(HAL_USART_Serial serial, uint8_t transmit, uint8_t
     if (receive) {
         toset |= ((uint32_t)USART_CR1_RE);
     }
-    uint32_t tmp = usartMap[serial]->usart_peripheral->CR1;
+    uint32_t tmp = usartMap[serial]->peripheral->CR1;
     if ((tmp & ((uint32_t)(USART_CR1_TE | USART_CR1_RE))) != toset) {
         tmp &= ~((uint32_t)(USART_CR1_TE | USART_CR1_RE));
         tmp |= toset;
-        usartMap[serial]->usart_peripheral->CR1 = tmp;
+        usartMap[serial]->peripheral->CR1 = tmp;
     }
 }
 
-void configurePinsMode(HAL_USART_Serial serial, uint32_t config) {
+void configurePinsMode(hal_usart_interface_t serial, uint32_t config) {
     if ((config & SERIAL_HALF_DUPLEX) == 0) {
         // Full duplex with push-pull
-        HAL_Pin_Mode(usartMap[serial]->usart_rx_pin, AF_OUTPUT_PUSHPULL);
-        HAL_Pin_Mode(usartMap[serial]->usart_tx_pin, AF_OUTPUT_PUSHPULL);
+        HAL_Pin_Mode(usartMap[serial]->rx_pin, AF_OUTPUT_PUSHPULL);
+        HAL_Pin_Mode(usartMap[serial]->tx_pin, AF_OUTPUT_PUSHPULL);
     } else if ((config & SERIAL_OPEN_DRAIN)) {
         // Half-duplex with open drain
-        HAL_Pin_Mode(usartMap[serial]->usart_rx_pin, INPUT);
-        HAL_Pin_Mode(usartMap[serial]->usart_tx_pin, AF_OUTPUT_DRAIN);
+        HAL_Pin_Mode(usartMap[serial]->rx_pin, INPUT);
+        HAL_Pin_Mode(usartMap[serial]->tx_pin, AF_OUTPUT_DRAIN);
     } else {
         // Half-duplex with push-pull
         /* RM0033 24.3.10:
@@ -236,13 +236,13 @@ void configurePinsMode(HAL_USART_Serial serial, uint32_t config) {
          * I/O in idle or in reception. It means that the I/O must be configured so that TX is
          * configured as floating input (or output high open-drain) when not driven by the USART
          */
-        HAL_Pin_Mode(usartMap[serial]->usart_rx_pin, INPUT);
-        HAL_Pin_Mode(usartMap[serial]->usart_tx_pin, AF_OUTPUT_PUSHPULL);
+        HAL_Pin_Mode(usartMap[serial]->rx_pin, INPUT);
+        HAL_Pin_Mode(usartMap[serial]->tx_pin, AF_OUTPUT_PUSHPULL);
         if (config & SERIAL_TX_PULL_UP) {
             // We ought to allow enabling pull-up or pull-down through HAL somehow
             Hal_Pin_Info* PIN_MAP = HAL_Pin_Map();
-            pin_t gpio_pin = PIN_MAP[usartMap[serial]->usart_tx_pin].gpio_pin;
-            GPIO_TypeDef *gpio_port = PIN_MAP[usartMap[serial]->usart_tx_pin].gpio_peripheral;
+            pin_t gpio_pin = PIN_MAP[usartMap[serial]->tx_pin].gpio_pin;
+            GPIO_TypeDef *gpio_port = PIN_MAP[usartMap[serial]->tx_pin].gpio_peripheral;
             GPIO_InitTypeDef GPIO_InitStructure = {0};
             GPIO_InitStructure.GPIO_Pin = gpio_pin;
             GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF;
@@ -254,54 +254,54 @@ void configurePinsMode(HAL_USART_Serial serial, uint32_t config) {
     }
 }
 
-void usartEndImpl(HAL_USART_Serial serial, bool cache) {
+void usartEndImpl(hal_usart_interface_t serial, bool cache) {
     // Wait for transmission of outgoing data
-    while (usartMap[serial]->usart_tx_buffer->head != usartMap[serial]->usart_tx_buffer->tail);
+    while (usartMap[serial]->tx_buffer->head != usartMap[serial]->tx_buffer->tail);
 
     // Disable the USART
-    USART_Cmd(usartMap[serial]->usart_peripheral, DISABLE);
+    USART_Cmd(usartMap[serial]->peripheral, DISABLE);
 
     // Switch pins to INPUT
-    HAL_Pin_Mode(usartMap[serial]->usart_rx_pin, INPUT);
-    HAL_Pin_Mode(usartMap[serial]->usart_tx_pin, INPUT);
+    HAL_Pin_Mode(usartMap[serial]->rx_pin, INPUT);
+    HAL_Pin_Mode(usartMap[serial]->tx_pin, INPUT);
 
     // Disable LIN mode
-    USART_LINCmd(usartMap[serial]->usart_peripheral, DISABLE);
+    USART_LINCmd(usartMap[serial]->peripheral, DISABLE);
 
     // Deinitialise USART
-    USART_DeInit(usartMap[serial]->usart_peripheral);
+    USART_DeInit(usartMap[serial]->peripheral);
 
     // Disable USART Receive and Transmit interrupts
-    USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_RXNE, DISABLE);
-    USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TXE, DISABLE);
+    USART_ITConfig(usartMap[serial]->peripheral, USART_IT_RXNE, DISABLE);
+    USART_ITConfig(usartMap[serial]->peripheral, USART_IT_TXE, DISABLE);
 
     NVIC_InitTypeDef NVIC_InitStructure;
 
     // Disable the USART Interrupt
-    NVIC_InitStructure.NVIC_IRQChannel = usartMap[serial]->usart_int_n;
+    NVIC_InitStructure.NVIC_IRQChannel = usartMap[serial]->int_n;
     NVIC_InitStructure.NVIC_IRQChannelCmd = DISABLE;
 
     NVIC_Init(&NVIC_InitStructure);
 
     // Disable USART Clock
-    *usartMap[serial]->usart_apbReg &= ~usartMap[serial]->usart_clock_en;
+    *usartMap[serial]->apb_reg &= ~usartMap[serial]->clock_enabled;
 
     if (!cache) {
         // clear any received data
-        usartMap[serial]->usart_rx_buffer->head = usartMap[serial]->usart_rx_buffer->tail;
+        usartMap[serial]->rx_buffer->head = usartMap[serial]->rx_buffer->tail;
         // Undo any pin re-mapping done for this USART
         // ...
-        memset(usartMap[serial]->usart_rx_buffer, 0, sizeof(Ring_Buffer));
+        memset(usartMap[serial]->rx_buffer, 0, sizeof(hal_usart_ring_buffer_t));
     }
 
-    memset(usartMap[serial]->usart_tx_buffer, 0, sizeof(Ring_Buffer));
+    memset(usartMap[serial]->tx_buffer, 0, sizeof(hal_usart_ring_buffer_t));
 
-    usartMap[serial]->usart_enabled = false;
-    usartMap[serial]->usart_transmitting = false;
+    usartMap[serial]->enabled = false;
+    usartMap[serial]->transmitting = false;
 }
 
-void hal_usart_init(HAL_USART_Serial serial, Ring_Buffer *rx_buffer, Ring_Buffer *tx_buffer) {
-    usartMap[serial]->usart_configured = false;
+void hal_usart_init(hal_usart_interface_t serial, hal_usart_ring_buffer_t *rx_buffer, hal_usart_ring_buffer_t *tx_buffer) {
+    usartMap[serial]->configured = false;
 
     if (serial == HAL_USART_SERIAL1) {
         usartMap[serial] = &USART_MAP[USART_TX_RX];
@@ -318,52 +318,52 @@ void hal_usart_init(HAL_USART_Serial serial, Ring_Buffer *rx_buffer, Ring_Buffer
     }
 #endif // PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION
 
-    usartMap[serial]->usart_rx_buffer = rx_buffer;
-    usartMap[serial]->usart_tx_buffer = tx_buffer;
+    usartMap[serial]->rx_buffer = rx_buffer;
+    usartMap[serial]->tx_buffer = tx_buffer;
 
-    memset(usartMap[serial]->usart_rx_buffer, 0, sizeof(Ring_Buffer));
-    memset(usartMap[serial]->usart_tx_buffer, 0, sizeof(Ring_Buffer));
+    memset(usartMap[serial]->rx_buffer, 0, sizeof(hal_usart_ring_buffer_t));
+    memset(usartMap[serial]->tx_buffer, 0, sizeof(hal_usart_ring_buffer_t));
 
-    usartMap[serial]->usart_enabled = false;
-    usartMap[serial]->usart_transmitting = false;
+    usartMap[serial]->enabled = false;
+    usartMap[serial]->transmitting = false;
 
-    usartMap[serial]->usart_configured = true;
+    usartMap[serial]->configured = true;
 }
 
-void hal_usart_begin(HAL_USART_Serial serial, uint32_t baud) {
+void hal_usart_begin(hal_usart_interface_t serial, uint32_t baud) {
     hal_usart_begin_config(serial, baud, 0, 0); // Default serial configuration is 8N1
 }
 
-void hal_usart_begin_config(HAL_USART_Serial serial, uint32_t baud, uint32_t config, void *ptr) {
-    if (!usartMap[serial]->usart_configured) {
+void hal_usart_begin_config(hal_usart_interface_t serial, uint32_t baud, uint32_t config, void *ptr) {
+    if (!usartMap[serial]->configured) {
         return;
     }
     // Verify UART configuration, exit if it's invalid.
     if (!validateConfig(config)) {
-        usartMap[serial]->usart_enabled = false;
+        usartMap[serial]->enabled = false;
         return;
     }
 
-    usartMap[serial]->usart_suspended = false;
+    usartMap[serial]->suspended = false;
 
-    USART_DeInit(usartMap[serial]->usart_peripheral);
+    USART_DeInit(usartMap[serial]->peripheral);
 
-    usartMap[serial]->usart_enabled = false;
+    usartMap[serial]->enabled = false;
 
     configurePinsMode(serial, config);
 
     // Enable USART Clock
-    *usartMap[serial]->usart_apbReg |=  usartMap[serial]->usart_clock_en;
+    *usartMap[serial]->apb_reg |=  usartMap[serial]->clock_enabled;
 
     // Connect USART pins to AFx
     Hal_Pin_Info* PIN_MAP = HAL_Pin_Map();
-    GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_rx_pin].gpio_peripheral, usartMap[serial]->usart_rx_pinsource, usartMap[serial]->usart_af_map);
-    GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_tx_pin].gpio_peripheral, usartMap[serial]->usart_tx_pinsource, usartMap[serial]->usart_af_map);
+    GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->rx_pin].gpio_peripheral, usartMap[serial]->rx_pinsource, usartMap[serial]->af_map);
+    GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->tx_pin].gpio_peripheral, usartMap[serial]->tx_pinsource, usartMap[serial]->af_map);
 
     // NVIC Configuration
     NVIC_InitTypeDef NVIC_InitStructure;
     // Enable the USART Interrupt
-    NVIC_InitStructure.NVIC_IRQChannel = usartMap[serial]->usart_int_n;
+    NVIC_InitStructure.NVIC_IRQChannel = usartMap[serial]->int_n;
     NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 7;
     NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
     NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
@@ -423,20 +423,20 @@ void hal_usart_begin_config(HAL_USART_Serial serial, uint32_t baud, uint32_t con
 
     switch (usartInitStructure.USART_HardwareFlowControl) {
         case USART_HardwareFlowControl_CTS: {
-            HAL_Pin_Mode(usartMap[serial]->usart_cts_pin, AF_OUTPUT_PUSHPULL);
-            GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_cts_pin].gpio_peripheral, PIN_MAP[usartMap[serial]->usart_cts_pin].gpio_pin_source, usartMap[serial]->usart_af_map);
+            HAL_Pin_Mode(usartMap[serial]->cts_pin, AF_OUTPUT_PUSHPULL);
+            GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->cts_pin].gpio_peripheral, PIN_MAP[usartMap[serial]->cts_pin].gpio_pin_source, usartMap[serial]->af_map);
             break;
         }
         case USART_HardwareFlowControl_RTS: {
-            HAL_Pin_Mode(usartMap[serial]->usart_rts_pin, AF_OUTPUT_PUSHPULL);
-            GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_rts_pin].gpio_peripheral, PIN_MAP[usartMap[serial]->usart_rts_pin].gpio_pin_source, usartMap[serial]->usart_af_map);
+            HAL_Pin_Mode(usartMap[serial]->rts_pin, AF_OUTPUT_PUSHPULL);
+            GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->rts_pin].gpio_peripheral, PIN_MAP[usartMap[serial]->rts_pin].gpio_pin_source, usartMap[serial]->af_map);
             break;
         }
         case USART_HardwareFlowControl_RTS_CTS: {
-            HAL_Pin_Mode(usartMap[serial]->usart_cts_pin, AF_OUTPUT_PUSHPULL);
-            HAL_Pin_Mode(usartMap[serial]->usart_rts_pin, AF_OUTPUT_PUSHPULL);
-            GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_cts_pin].gpio_peripheral, PIN_MAP[usartMap[serial]->usart_cts_pin].gpio_pin_source, usartMap[serial]->usart_af_map);
-            GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_rts_pin].gpio_peripheral, PIN_MAP[usartMap[serial]->usart_rts_pin].gpio_pin_source, usartMap[serial]->usart_af_map);
+            HAL_Pin_Mode(usartMap[serial]->cts_pin, AF_OUTPUT_PUSHPULL);
+            HAL_Pin_Mode(usartMap[serial]->rts_pin, AF_OUTPUT_PUSHPULL);
+            GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->cts_pin].gpio_peripheral, PIN_MAP[usartMap[serial]->cts_pin].gpio_pin_source, usartMap[serial]->af_map);
+            GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->rts_pin].gpio_peripheral, PIN_MAP[usartMap[serial]->rts_pin].gpio_pin_source, usartMap[serial]->af_map);
             break;
         }
         case USART_HardwareFlowControl_None:
@@ -503,21 +503,21 @@ void hal_usart_begin_config(HAL_USART_Serial serial, uint32_t baud, uint32_t con
     }
 
     // Disable LIN mode just in case
-    USART_LINCmd(usartMap[serial]->usart_peripheral, DISABLE);
+    USART_LINCmd(usartMap[serial]->peripheral, DISABLE);
 
     // Configure USART
-    USART_Init(usartMap[serial]->usart_peripheral, &usartInitStructure);
+    USART_Init(usartMap[serial]->peripheral, &usartInitStructure);
 
     // LIN configuration
     if (config & LIN_MODE) {
         // Enable break detection
         switch (config & LIN_BREAK_BITS) {
             case LIN_BREAK_10B: {
-                USART_LINBreakDetectLengthConfig(usartMap[serial]->usart_peripheral, USART_LINBreakDetectLength_10b);
+                USART_LINBreakDetectLengthConfig(usartMap[serial]->peripheral, USART_LINBreakDetectLength_10b);
                 break;
             }
             case LIN_BREAK_11B: {
-                USART_LINBreakDetectLengthConfig(usartMap[serial]->usart_peripheral, USART_LINBreakDetectLength_11b);
+                USART_LINBreakDetectLengthConfig(usartMap[serial]->peripheral, USART_LINBreakDetectLength_11b);
                 break;
             }
             default: {
@@ -532,118 +532,118 @@ void hal_usart_begin_config(HAL_USART_Serial serial, uint32_t baud, uint32_t con
         hal_usart_half_duplex(serial, ENABLE);
     }
 
-    USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TC, DISABLE);
+    USART_ITConfig(usartMap[serial]->peripheral, USART_IT_TC, DISABLE);
 
     // Enable the USART
-    USART_Cmd(usartMap[serial]->usart_peripheral, ENABLE);
+    USART_Cmd(usartMap[serial]->peripheral, ENABLE);
 
     if (config & LIN_MODE) {
-        USART_LINCmd(usartMap[serial]->usart_peripheral, ENABLE);
+        USART_LINCmd(usartMap[serial]->peripheral, ENABLE);
     }
 
-    usartMap[serial]->usart_enabled = true;
-    usartMap[serial]->usart_transmitting = false;
+    usartMap[serial]->enabled = true;
+    usartMap[serial]->transmitting = false;
 
     // Enable USART Receive and Transmit interrupts
-    USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TXE, ENABLE);
-    USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_RXNE, ENABLE);
+    USART_ITConfig(usartMap[serial]->peripheral, USART_IT_TXE, ENABLE);
+    USART_ITConfig(usartMap[serial]->peripheral, USART_IT_RXNE, ENABLE);
 }
 
-void hal_usart_end(HAL_USART_Serial serial) {
-    usartMap[serial]->usart_suspended = true;
+void hal_usart_end(hal_usart_interface_t serial) {
+    usartMap[serial]->suspended = true;
     usartEndImpl(serial, false);
 }
 
-uint32_t hal_usart_write(HAL_USART_Serial serial, uint8_t data) {
+uint32_t hal_usart_write(hal_usart_interface_t serial, uint8_t data) {
     return hal_usart_write_nine_bits(serial, data);
 }
 
-uint32_t hal_usart_write_nine_bits(HAL_USART_Serial serial, uint16_t data) {
+uint32_t hal_usart_write_nine_bits(hal_usart_interface_t serial, uint16_t data) {
     // Remove any bits exceeding data bits configured
     data &= calculateDataBitsMask(usartMap[serial]->conf.config);
     // interrupts are off and data in queue;
-    if ((USART_GetITStatus(usartMap[serial]->usart_peripheral, USART_IT_TXE) == RESET)
-        && usartMap[serial]->usart_tx_buffer->head != usartMap[serial]->usart_tx_buffer->tail) {
+    if ((USART_GetITStatus(usartMap[serial]->peripheral, USART_IT_TXE) == RESET)
+        && usartMap[serial]->tx_buffer->head != usartMap[serial]->tx_buffer->tail) {
         // Get him busy
-        USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TXE, ENABLE);
+        USART_ITConfig(usartMap[serial]->peripheral, USART_IT_TXE, ENABLE);
     }
 
-    unsigned i = (usartMap[serial]->usart_tx_buffer->head + 1) % SERIAL_BUFFER_SIZE;
+    unsigned i = (usartMap[serial]->tx_buffer->head + 1) % SERIAL_BUFFER_SIZE;
 
     // If the output buffer is full, there's nothing for it other than to
     // wait for the interrupt handler to empty it a bit
     // no space so or Called Off Panic with interrupt off get the message out!
     // make space Enter Polled IO mode
-    while (i == usartMap[serial]->usart_tx_buffer->tail || ((__get_PRIMASK() & 1) && usartMap[serial]->usart_tx_buffer->head != usartMap[serial]->usart_tx_buffer->tail) ) {
+    while (i == usartMap[serial]->tx_buffer->tail || ((__get_PRIMASK() & 1) && usartMap[serial]->tx_buffer->head != usartMap[serial]->tx_buffer->tail) ) {
         // Interrupts are on but they are not being serviced because this was called from a higher
         // Priority interrupt
-        if (USART_GetITStatus(usartMap[serial]->usart_peripheral, USART_IT_TXE) && USART_GetFlagStatus(usartMap[serial]->usart_peripheral, USART_FLAG_TXE)) {
+        if (USART_GetITStatus(usartMap[serial]->peripheral, USART_IT_TXE) && USART_GetFlagStatus(usartMap[serial]->peripheral, USART_FLAG_TXE)) {
             // protect for good measure
-            USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TXE, DISABLE);
+            USART_ITConfig(usartMap[serial]->peripheral, USART_IT_TXE, DISABLE);
             // Write out a byte
-            USART_SendData(usartMap[serial]->usart_peripheral,  usartMap[serial]->usart_tx_buffer->buffer[usartMap[serial]->usart_tx_buffer->tail++]);
-            usartMap[serial]->usart_tx_buffer->tail %= SERIAL_BUFFER_SIZE;
+            USART_SendData(usartMap[serial]->peripheral,  usartMap[serial]->tx_buffer->buffer[usartMap[serial]->tx_buffer->tail++]);
+            usartMap[serial]->tx_buffer->tail %= SERIAL_BUFFER_SIZE;
             // unprotect
-            USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TXE, ENABLE);
+            USART_ITConfig(usartMap[serial]->peripheral, USART_IT_TXE, ENABLE);
         }
     }
 
-    usartMap[serial]->usart_tx_buffer->buffer[usartMap[serial]->usart_tx_buffer->head] = data;
-    usartMap[serial]->usart_tx_buffer->head = i;
-    usartMap[serial]->usart_transmitting = true;
-    USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TXE, ENABLE);
+    usartMap[serial]->tx_buffer->buffer[usartMap[serial]->tx_buffer->head] = data;
+    usartMap[serial]->tx_buffer->head = i;
+    usartMap[serial]->transmitting = true;
+    USART_ITConfig(usartMap[serial]->peripheral, USART_IT_TXE, ENABLE);
 
     return 1;
 }
 
-int32_t hal_usart_available(HAL_USART_Serial serial) {
-    return (unsigned int)(SERIAL_BUFFER_SIZE + usartMap[serial]->usart_rx_buffer->head - usartMap[serial]->usart_rx_buffer->tail) % SERIAL_BUFFER_SIZE;
+int32_t hal_usart_available(hal_usart_interface_t serial) {
+    return (unsigned int)(SERIAL_BUFFER_SIZE + usartMap[serial]->rx_buffer->head - usartMap[serial]->rx_buffer->tail) % SERIAL_BUFFER_SIZE;
 }
 
-int32_t hal_usart_available_data_for_write(HAL_USART_Serial serial) {
-    int32_t tail = usartMap[serial]->usart_tx_buffer->tail;
-    int32_t available = SERIAL_BUFFER_SIZE - (usartMap[serial]->usart_tx_buffer->head >= tail ?
-                                              usartMap[serial]->usart_tx_buffer->head - tail :
-                                              (SERIAL_BUFFER_SIZE + usartMap[serial]->usart_tx_buffer->head - tail) - 1);
+int32_t hal_usart_available_data_for_write(hal_usart_interface_t serial) {
+    int32_t tail = usartMap[serial]->tx_buffer->tail;
+    int32_t available = SERIAL_BUFFER_SIZE - (usartMap[serial]->tx_buffer->head >= tail ?
+                                              usartMap[serial]->tx_buffer->head - tail :
+                                              (SERIAL_BUFFER_SIZE + usartMap[serial]->tx_buffer->head - tail) - 1);
 
     return available;
 }
 
 
-int32_t hal_usart_read(HAL_USART_Serial serial) {
+int32_t hal_usart_read(hal_usart_interface_t serial) {
     // if the head isn't ahead of the tail, we don't have any characters
-    if (usartMap[serial]->usart_rx_buffer->head == usartMap[serial]->usart_rx_buffer->tail) {
+    if (usartMap[serial]->rx_buffer->head == usartMap[serial]->rx_buffer->tail) {
         return -1;
     } else {
-        uint16_t c = usartMap[serial]->usart_rx_buffer->buffer[usartMap[serial]->usart_rx_buffer->tail];
-        usartMap[serial]->usart_rx_buffer->tail = (unsigned int)(usartMap[serial]->usart_rx_buffer->tail + 1) % SERIAL_BUFFER_SIZE;
+        uint16_t c = usartMap[serial]->rx_buffer->buffer[usartMap[serial]->rx_buffer->tail];
+        usartMap[serial]->rx_buffer->tail = (unsigned int)(usartMap[serial]->rx_buffer->tail + 1) % SERIAL_BUFFER_SIZE;
         return c;
     }
 }
 
-int32_t hal_usart_peek(HAL_USART_Serial serial) {
-    if (usartMap[serial]->usart_rx_buffer->head == usartMap[serial]->usart_rx_buffer->tail) {
+int32_t hal_usart_peek(hal_usart_interface_t serial) {
+    if (usartMap[serial]->rx_buffer->head == usartMap[serial]->rx_buffer->tail) {
         return -1;
     } else {
-        return usartMap[serial]->usart_rx_buffer->buffer[usartMap[serial]->usart_rx_buffer->tail];
+        return usartMap[serial]->rx_buffer->buffer[usartMap[serial]->rx_buffer->tail];
     }
 }
 
-void hal_usart_flush(HAL_USART_Serial serial) {
+void hal_usart_flush(hal_usart_interface_t serial) {
     // Loop until USART DR register is empty
-    while ( usartMap[serial]->usart_tx_buffer->head != usartMap[serial]->usart_tx_buffer->tail );
+    while ( usartMap[serial]->tx_buffer->head != usartMap[serial]->tx_buffer->tail );
     // Loop until last frame transmission complete
-    while (usartMap[serial]->usart_transmitting && (USART_GetFlagStatus(usartMap[serial]->usart_peripheral, USART_FLAG_TC) == RESET));
-    usartMap[serial]->usart_transmitting = false;
+    while (usartMap[serial]->transmitting && (USART_GetFlagStatus(usartMap[serial]->peripheral, USART_FLAG_TC) == RESET));
+    usartMap[serial]->transmitting = false;
 }
 
-bool hal_usart_is_enabled(HAL_USART_Serial serial) {
-    return usartMap[serial]->usart_enabled;
+bool hal_usart_is_enabled(hal_usart_interface_t serial) {
+    return usartMap[serial]->enabled;
 }
 
-void hal_usart_half_duplex(HAL_USART_Serial serial, bool enable) {
+void hal_usart_half_duplex(hal_usart_interface_t serial, bool enable) {
     if (hal_usart_is_enabled(serial)) {
-        USART_Cmd(usartMap[serial]->usart_peripheral, DISABLE);
+        USART_Cmd(usartMap[serial]->peripheral, DISABLE);
     }
 
     if (enable) {
@@ -654,28 +654,28 @@ void hal_usart_half_duplex(HAL_USART_Serial serial, bool enable) {
     configurePinsMode(serial, usartMap[serial]->conf.config);
 
     // These bits need to be cleared according to the reference manual
-    usartMap[serial]->usart_peripheral->CR2 &= ~(USART_CR2_LINEN | USART_CR2_CLKEN);
-    usartMap[serial]->usart_peripheral->CR3 &= ~(USART_CR3_IREN | USART_CR3_SCEN);
-    USART_HalfDuplexCmd(usartMap[serial]->usart_peripheral, enable ? ENABLE : DISABLE);
+    usartMap[serial]->peripheral->CR2 &= ~(USART_CR2_LINEN | USART_CR2_CLKEN);
+    usartMap[serial]->peripheral->CR3 &= ~(USART_CR3_IREN | USART_CR3_SCEN);
+    USART_HalfDuplexCmd(usartMap[serial]->peripheral, enable ? ENABLE : DISABLE);
 
 
     if (hal_usart_is_enabled(serial)) {
-        USART_Cmd(usartMap[serial]->usart_peripheral, ENABLE);
+        USART_Cmd(usartMap[serial]->peripheral, ENABLE);
     }
 }
 
-void hal_usart_send_break(HAL_USART_Serial serial, void* reserved) {
+void hal_usart_send_break(hal_usart_interface_t serial, void* reserved) {
     int32_t state = HAL_disable_irq();
-    while((usartMap[serial]->usart_peripheral->CR1 & USART_CR1_SBK) == SET);
-    USART_SendBreak(usartMap[serial]->usart_peripheral);
-    while((usartMap[serial]->usart_peripheral->CR1 & USART_CR1_SBK) == SET);
+    while((usartMap[serial]->peripheral->CR1 & USART_CR1_SBK) == SET);
+    USART_SendBreak(usartMap[serial]->peripheral);
+    while((usartMap[serial]->peripheral->CR1 & USART_CR1_SBK) == SET);
     HAL_enable_irq(state);
 }
 
-uint8_t hal_usart_break_detected(HAL_USART_Serial serial) {
-    if (USART_GetFlagStatus(usartMap[serial]->usart_peripheral, USART_FLAG_LBD)) {
+uint8_t hal_usart_break_detected(hal_usart_interface_t serial) {
+    if (USART_GetFlagStatus(usartMap[serial]->peripheral, USART_FLAG_LBD)) {
         // Clear LBD flag
-        USART_ClearFlag(usartMap[serial]->usart_peripheral, USART_FLAG_LBD);
+        USART_ClearFlag(usartMap[serial]->peripheral, USART_FLAG_LBD);
         return 1;
     }
     return 0;
@@ -683,58 +683,58 @@ uint8_t hal_usart_break_detected(HAL_USART_Serial serial) {
 
 // Shared Interrupt Handler for USART2/Serial1 and USART1/Serial2
 // WARNING: This function MUST remain reentrance compliant -- no local static variables etc.
-static void usartIntHandler(HAL_USART_Serial serial) {
-    if (USART_GetITStatus(usartMap[serial]->usart_peripheral, USART_IT_RXNE) != RESET) {
+static void usartIntHandler(hal_usart_interface_t serial) {
+    if (USART_GetITStatus(usartMap[serial]->peripheral, USART_IT_RXNE) != RESET) {
         // Read byte from the receive data register
-        uint16_t c = USART_ReceiveData(usartMap[serial]->usart_peripheral);
+        uint16_t c = USART_ReceiveData(usartMap[serial]->peripheral);
         // Remove parity bits from data
         c &= calculateDataBitsMask(usartMap[serial]->conf.config);
-        storeChar(c, usartMap[serial]->usart_rx_buffer);
+        storeChar(c, usartMap[serial]->rx_buffer);
     }
 
     uint8_t noecho = (usartMap[serial]->conf.config & (SERIAL_HALF_DUPLEX | SERIAL_HALF_DUPLEX_NO_ECHO)) == (SERIAL_HALF_DUPLEX | SERIAL_HALF_DUPLEX_NO_ECHO);
 
-    if (USART_GetITStatus(usartMap[serial]->usart_peripheral, USART_IT_TC) != RESET) {
+    if (USART_GetITStatus(usartMap[serial]->peripheral, USART_IT_TC) != RESET) {
         if (noecho) {
-            USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TC, DISABLE);
+            USART_ITConfig(usartMap[serial]->peripheral, USART_IT_TC, DISABLE);
             configureTransmitReceive(serial, 0, 1);
         }
     }
 
-    if (USART_GetITStatus(usartMap[serial]->usart_peripheral, USART_IT_TXE) != RESET) {
+    if (USART_GetITStatus(usartMap[serial]->peripheral, USART_IT_TXE) != RESET) {
         // Write byte to the transmit data register
-        if (usartMap[serial]->usart_tx_buffer->head == usartMap[serial]->usart_tx_buffer->tail) {
+        if (usartMap[serial]->tx_buffer->head == usartMap[serial]->tx_buffer->tail) {
             // Buffer empty, so disable the USART Transmit interrupt
-            USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TXE, DISABLE);
+            USART_ITConfig(usartMap[serial]->peripheral, USART_IT_TXE, DISABLE);
             if (noecho) {
-                USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TC, ENABLE);
+                USART_ITConfig(usartMap[serial]->peripheral, USART_IT_TC, ENABLE);
             }
         } else {
             if (noecho) {
                 configureTransmitReceive(serial, 1, 0);
             }
             // There is more data in the output buffer. Send the next byte
-            USART_SendData(usartMap[serial]->usart_peripheral, usartMap[serial]->usart_tx_buffer->buffer[usartMap[serial]->usart_tx_buffer->tail++]);
-            usartMap[serial]->usart_tx_buffer->tail %= SERIAL_BUFFER_SIZE;
+            USART_SendData(usartMap[serial]->peripheral, usartMap[serial]->tx_buffer->buffer[usartMap[serial]->tx_buffer->tail++]);
+            usartMap[serial]->tx_buffer->tail %= SERIAL_BUFFER_SIZE;
         }
     }
 
-    if (USART_GetFlagStatus(usartMap[serial]->usart_peripheral, USART_FLAG_ORE) != RESET) {
+    if (USART_GetFlagStatus(usartMap[serial]->peripheral, USART_FLAG_ORE) != RESET) {
         // If Overrun flag is still set, clear it
-        (void)USART_ReceiveData(usartMap[serial]->usart_peripheral);
+        (void)USART_ReceiveData(usartMap[serial]->peripheral);
     }
 }
 
-int hal_usart_sleep(HAL_USART_Serial serial, bool sleep, void* reserved) {
+int hal_usart_sleep(hal_usart_interface_t serial, bool sleep, void* reserved) {
     if (sleep) {
-        CHECK_TRUE(usartMap[serial]->usart_enabled, SYSTEM_ERROR_NONE);
-        CHECK_FALSE(usartMap[serial]->usart_suspended, SYSTEM_ERROR_NONE);
-        usartMap[serial]->usart_suspended = true;
+        CHECK_TRUE(usartMap[serial]->enabled, SYSTEM_ERROR_NONE);
+        CHECK_FALSE(usartMap[serial]->suspended, SYSTEM_ERROR_NONE);
+        usartMap[serial]->suspended = true;
         hal_usart_flush(serial);
         usartEndImpl(serial, true);
     } else {
-        CHECK_TRUE(usartMap[serial]->usart_configured, SYSTEM_ERROR_INVALID_STATE);
-        CHECK_TRUE(usartMap[serial]->usart_suspended, SYSTEM_ERROR_NONE);
+        CHECK_TRUE(usartMap[serial]->configured, SYSTEM_ERROR_INVALID_STATE);
+        CHECK_TRUE(usartMap[serial]->suspended, SYSTEM_ERROR_NONE);
         hal_usart_begin_config(serial, usartMap[serial]->conf.baud_rate, usartMap[serial]->conf.config, NULL);
     }
     return SYSTEM_ERROR_NONE;

--- a/hal/src/stm32f2xx/usart_hal.c
+++ b/hal/src/stm32f2xx/usart_hal.c
@@ -48,8 +48,8 @@ typedef enum usart_ports {
 #define USE_USART3_HARDWARE_FLOW_CONTROL_RTS_CTS 0  //Enabling this => 1 is not working at present
 
 typedef struct usart_config {
-	uint32_t baud_rate;
-	uint32_t config;
+    uint32_t baud_rate;
+    uint32_t config;
 } usart_config;
 
 /* Private variables ---------------------------------------------------------*/
@@ -76,9 +76,9 @@ typedef struct stm32_usart_info {
     Ring_Buffer* usart_tx_buffer;
     Ring_Buffer* usart_rx_buffer;
 
-	bool usart_configured;
+    bool usart_configured;
     volatile bool usart_enabled;
-	volatile bool usart_suspended;
+    volatile bool usart_suspended;
     bool usart_transmitting;
 
     usart_config conf;
@@ -88,7 +88,7 @@ typedef struct stm32_usart_info {
  * USART mapping
  */
 stm32_usart_info USART_MAP[TOTAL_USARTS] = {
-	/*
+    /*
      * USART_peripheral (USARTx/UARTx; not using others)
      * clock control register (APBxENR)
      * clock enable bit value (RCC_APBxPeriph_USARTx/RCC_APBxPeriph_UARTx)
@@ -144,24 +144,24 @@ uint8_t calculateWordLength(uint32_t config, uint8_t noparity) {
         case SERIAL_DATA_BITS_7: {
             wlen += 7;
             break;
-		}
+        }
         case SERIAL_DATA_BITS_8: {
             wlen += 8;
             break;
-		}
+        }
         case SERIAL_DATA_BITS_9: {
             wlen += 9;
             break;
-		}
+        }
     }
 
     if ((config & SERIAL_PARITY) && !noparity) {
         wlen++;
-	}
+    }
 
     if (wlen > 9 || wlen < (noparity ? 7 : 8)) {
         wlen = 0;
-	}
+    }
 
     return wlen;
 }
@@ -174,30 +174,30 @@ uint8_t validateConfig(uint32_t config) {
     // Total word length should be either 8 or 9 bits
     if (calculateWordLength(config, 0) == 0) {
         return 0;
-	}
+    }
     // Either No, Even or Odd parity
     if ((config & SERIAL_PARITY) == (SERIAL_PARITY_EVEN | SERIAL_PARITY_ODD)) {
         return 0;
-	}
+    }
     if ((config & SERIAL_HALF_DUPLEX) && (config & LIN_MODE)) {
         return 0;
-	}
+    }
 
     if (config & LIN_MODE) {
         // Either Master or Slave mode
         // Break detection can still be enabled in both Master and Slave modes
         if ((config & LIN_MODE_MASTER) && (config & LIN_MODE_SLAVE)) {
             return 0;
-		}
+        }
         switch (config & LIN_BREAK_BITS) {
             case LIN_BREAK_13B:
             case LIN_BREAK_10B:
             case LIN_BREAK_11B: {
                 break;
-			}
+            }
             default: {
                 return 0;
-			}
+            }
         }
     }
 
@@ -286,13 +286,13 @@ void usartEndImpl(HAL_USART_Serial serial, bool cache) {
     // Disable USART Clock
     *usartMap[serial]->usart_apbReg &= ~usartMap[serial]->usart_clock_en;
 
-	if (!cache) {
-		// clear any received data
-		usartMap[serial]->usart_rx_buffer->head = usartMap[serial]->usart_rx_buffer->tail;
-		// Undo any pin re-mapping done for this USART
-		// ...
-		memset(usartMap[serial]->usart_rx_buffer, 0, sizeof(Ring_Buffer));
-	}
+    if (!cache) {
+        // clear any received data
+        usartMap[serial]->usart_rx_buffer->head = usartMap[serial]->usart_rx_buffer->tail;
+        // Undo any pin re-mapping done for this USART
+        // ...
+        memset(usartMap[serial]->usart_rx_buffer, 0, sizeof(Ring_Buffer));
+    }
 
     memset(usartMap[serial]->usart_tx_buffer, 0, sizeof(Ring_Buffer));
 
@@ -301,7 +301,7 @@ void usartEndImpl(HAL_USART_Serial serial, bool cache) {
 }
 
 void hal_usart_init(HAL_USART_Serial serial, Ring_Buffer *rx_buffer, Ring_Buffer *tx_buffer) {
-	usartMap[serial]->usart_configured = false;
+    usartMap[serial]->usart_configured = false;
 
     if (serial == HAL_USART_SERIAL1) {
         usartMap[serial] = &USART_MAP[USART_TX_RX];
@@ -327,7 +327,7 @@ void hal_usart_init(HAL_USART_Serial serial, Ring_Buffer *rx_buffer, Ring_Buffer
     usartMap[serial]->usart_enabled = false;
     usartMap[serial]->usart_transmitting = false;
 
-	usartMap[serial]->usart_configured = true;
+    usartMap[serial]->usart_configured = true;
 }
 
 void hal_usart_begin(HAL_USART_Serial serial, uint32_t baud) {
@@ -335,16 +335,16 @@ void hal_usart_begin(HAL_USART_Serial serial, uint32_t baud) {
 }
 
 void hal_usart_begin_config(HAL_USART_Serial serial, uint32_t baud, uint32_t config, void *ptr) {
-	if (!usartMap[serial]->usart_configured) {
-		return;
-	}
+    if (!usartMap[serial]->usart_configured) {
+        return;
+    }
     // Verify UART configuration, exit if it's invalid.
     if (!validateConfig(config)) {
         usartMap[serial]->usart_enabled = false;
         return;
     }
 
-	usartMap[serial]->usart_suspended = false;
+    usartMap[serial]->usart_suspended = false;
 
     USART_DeInit(usartMap[serial]->usart_peripheral);
 
@@ -387,20 +387,20 @@ void hal_usart_begin_config(HAL_USART_Serial serial, uint32_t baud, uint32_t con
         case SERIAL_FLOW_CONTROL_CTS: {
             usartInitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_CTS;
             break;
-		}
+        }
         case SERIAL_FLOW_CONTROL_RTS: {
             usartInitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_RTS;
             break;
-		}
+        }
         case SERIAL_FLOW_CONTROL_RTS_CTS: {
             usartInitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_RTS_CTS;
             break;
-		}
+        }
         case SERIAL_FLOW_CONTROL_NONE:
         default: {
             usartInitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
             break;
-		}
+        }
     }
 
     if (serial == HAL_USART_SERIAL1) {
@@ -426,23 +426,23 @@ void hal_usart_begin_config(HAL_USART_Serial serial, uint32_t baud, uint32_t con
             HAL_Pin_Mode(usartMap[serial]->usart_cts_pin, AF_OUTPUT_PUSHPULL);
             GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_cts_pin].gpio_peripheral, PIN_MAP[usartMap[serial]->usart_cts_pin].gpio_pin_source, usartMap[serial]->usart_af_map);
             break;
-		}
+        }
         case USART_HardwareFlowControl_RTS: {
             HAL_Pin_Mode(usartMap[serial]->usart_rts_pin, AF_OUTPUT_PUSHPULL);
             GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_rts_pin].gpio_peripheral, PIN_MAP[usartMap[serial]->usart_rts_pin].gpio_pin_source, usartMap[serial]->usart_af_map);
             break;
-		}
+        }
         case USART_HardwareFlowControl_RTS_CTS: {
             HAL_Pin_Mode(usartMap[serial]->usart_cts_pin, AF_OUTPUT_PUSHPULL);
             HAL_Pin_Mode(usartMap[serial]->usart_rts_pin, AF_OUTPUT_PUSHPULL);
             GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_cts_pin].gpio_peripheral, PIN_MAP[usartMap[serial]->usart_cts_pin].gpio_pin_source, usartMap[serial]->usart_af_map);
             GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_rts_pin].gpio_peripheral, PIN_MAP[usartMap[serial]->usart_rts_pin].gpio_pin_source, usartMap[serial]->usart_af_map);
             break;
-		}
+        }
         case USART_HardwareFlowControl_None:
         default: {
             break;
-		}
+        }
     }
 
     // Stop bit configuration.
@@ -450,22 +450,22 @@ void hal_usart_begin_config(HAL_USART_Serial serial, uint32_t baud, uint32_t con
         case SERIAL_STOP_BITS_1: { // 1 stop bit
             usartInitStructure.USART_StopBits = USART_StopBits_1;
             break;
-		}
+        }
         case SERIAL_STOP_BITS_2: { // 2 stop bits
             usartInitStructure.USART_StopBits = USART_StopBits_2;
             break;
-		}
+        }
         case SERIAL_STOP_BITS_0_5: { // 0.5 stop bits
             usartInitStructure.USART_StopBits = USART_StopBits_0_5;
             break;
-		}
+        }
         case SERIAL_STOP_BITS_1_5: { // 1.5 stop bits
             usartInitStructure.USART_StopBits = USART_StopBits_1_5;
             break;
-		}
-		default: {
-			break;
-		}
+        }
+        default: {
+            break;
+        }
     }
 
     // Data bits configuration
@@ -473,14 +473,14 @@ void hal_usart_begin_config(HAL_USART_Serial serial, uint32_t baud, uint32_t con
         case 8: {
             usartInitStructure.USART_WordLength = USART_WordLength_8b;
             break;
-		}
+        }
         case 9: {
             usartInitStructure.USART_WordLength = USART_WordLength_9b;
             break;
-		}
-		default: {
-			break;
-		}
+        }
+        default: {
+            break;
+        }
     }
 
     // Parity configuration
@@ -488,18 +488,18 @@ void hal_usart_begin_config(HAL_USART_Serial serial, uint32_t baud, uint32_t con
         case SERIAL_PARITY_NO: {
             usartInitStructure.USART_Parity = USART_Parity_No;
             break;
-		}
+        }
         case SERIAL_PARITY_EVEN: {
             usartInitStructure.USART_Parity = USART_Parity_Even;
             break;
-		}
+        }
         case SERIAL_PARITY_ODD: {
             usartInitStructure.USART_Parity = USART_Parity_Odd;
             break;
-		}
-		default: {
-			break;
-		}
+        }
+        default: {
+            break;
+        }
     }
 
     // Disable LIN mode just in case
@@ -515,18 +515,18 @@ void hal_usart_begin_config(HAL_USART_Serial serial, uint32_t baud, uint32_t con
             case LIN_BREAK_10B: {
                 USART_LINBreakDetectLengthConfig(usartMap[serial]->usart_peripheral, USART_LINBreakDetectLength_10b);
                 break;
-			}
+            }
             case LIN_BREAK_11B: {
                 USART_LINBreakDetectLengthConfig(usartMap[serial]->usart_peripheral, USART_LINBreakDetectLength_11b);
                 break;
-			}
-			default: {
-				break;
-			}
+            }
+            default: {
+                break;
+            }
         }
     }
 
-	usartMap[serial]->conf.baud_rate = baud;
+    usartMap[serial]->conf.baud_rate = baud;
     usartMap[serial]->conf.config = config;
     if (config & SERIAL_HALF_DUPLEX) {
         hal_usart_half_duplex(serial, ENABLE);
@@ -550,7 +550,7 @@ void hal_usart_begin_config(HAL_USART_Serial serial, uint32_t baud, uint32_t con
 }
 
 void hal_usart_end(HAL_USART_Serial serial) {
-	usartMap[serial]->usart_suspended = true;
+    usartMap[serial]->usart_suspended = true;
     usartEndImpl(serial, false);
 }
 
@@ -726,18 +726,18 @@ static void usartIntHandler(HAL_USART_Serial serial) {
 }
 
 int hal_usart_sleep(HAL_USART_Serial serial, bool sleep, void* reserved) {
-	if (sleep) {
+    if (sleep) {
         CHECK_TRUE(usartMap[serial]->usart_enabled, SYSTEM_ERROR_NONE);
         CHECK_FALSE(usartMap[serial]->usart_suspended, SYSTEM_ERROR_NONE);
-		usartMap[serial]->usart_suspended = true;
-		hal_usart_flush(serial);
-		usartEndImpl(serial, true);
-	} else {
-		CHECK_TRUE(usartMap[serial]->usart_configured, SYSTEM_ERROR_INVALID_STATE);
-		CHECK_TRUE(usartMap[serial]->usart_suspended, SYSTEM_ERROR_NONE);
-		hal_usart_begin_config(serial, usartMap[serial]->conf.baud_rate, usartMap[serial]->conf.config, NULL);
-	}
-	return SYSTEM_ERROR_NONE;
+        usartMap[serial]->usart_suspended = true;
+        hal_usart_flush(serial);
+        usartEndImpl(serial, true);
+    } else {
+        CHECK_TRUE(usartMap[serial]->usart_configured, SYSTEM_ERROR_INVALID_STATE);
+        CHECK_TRUE(usartMap[serial]->usart_suspended, SYSTEM_ERROR_NONE);
+        hal_usart_begin_config(serial, usartMap[serial]->conf.baud_rate, usartMap[serial]->conf.config, NULL);
+    }
+    return SYSTEM_ERROR_NONE;
 }
 
 // Serial1 interrupt handler

--- a/hal/src/stm32f2xx/usart_hal.c
+++ b/hal/src/stm32f2xx/usart_hal.c
@@ -262,8 +262,8 @@ void usartEndImpl(hal_usart_interface_t serial, bool cache) {
     USART_Cmd(usartMap[serial]->peripheral, DISABLE);
 
     // Switch pins to INPUT
-    HAL_Pin_Mode(usartMap[serial]->rx_pin, INPUT);
-    HAL_Pin_Mode(usartMap[serial]->tx_pin, INPUT);
+    HAL_Pin_Mode(usartMap[serial]->usart_rx_pin, INPUT);
+    HAL_Pin_Mode(usartMap[serial]->usart_tx_pin, INPUT_PULLUP);
 
     // Disable LIN mode
     USART_LINCmd(usartMap[serial]->peripheral, DISABLE);
@@ -550,7 +550,7 @@ void hal_usart_begin_config(hal_usart_interface_t serial, uint32_t baud, uint32_
 }
 
 void hal_usart_end(hal_usart_interface_t serial) {
-    usartMap[serial]->suspended = true;
+    usartMap[serial]->usart_suspended = false;
     usartEndImpl(serial, false);
 }
 

--- a/hal/src/stm32f2xx/usart_hal.c
+++ b/hal/src/stm32f2xx/usart_hal.c
@@ -736,7 +736,7 @@ static void usartIntHandler(hal_usart_interface_t serial) {
 
 int hal_usart_sleep(hal_usart_interface_t serial, bool sleep, void* reserved) {
     if (sleep) {
-        CHECK_TRUE(usartMap[serial]->state == HAL_USART_STATE_ENABLED, SYSTEM_ERROR_NONE);
+        CHECK_TRUE(usartMap[serial]->state == HAL_USART_STATE_ENABLED, SYSTEM_ERROR_INVALID_STATE);
         hal_usart_flush(serial);
         usartEndImpl(serial);
         // Switch pins to INPUT
@@ -764,7 +764,7 @@ int hal_usart_sleep(hal_usart_interface_t serial, bool sleep, void* reserved) {
         usartMap[serial]->state = HAL_USART_STATE_SUSPENDED;
         usartMap[serial]->transmitting = false;
     } else {
-        CHECK_TRUE(usartMap[serial]->state == HAL_USART_STATE_SUSPENDED, SYSTEM_ERROR_NONE);
+        CHECK_TRUE(usartMap[serial]->state == HAL_USART_STATE_SUSPENDED, SYSTEM_ERROR_INVALID_STATE);
         hal_usart_begin_config(serial, usartMap[serial]->conf.baud_rate, usartMap[serial]->conf.config, NULL);
     }
     return SYSTEM_ERROR_NONE;

--- a/hal/src/stm32f2xx/usart_hal.c
+++ b/hal/src/stm32f2xx/usart_hal.c
@@ -1,26 +1,25 @@
-/**
- ******************************************************************************
+/******************************************************************************
  * @file    usart_hal.c
  * @author  Satish Nair, Brett Walach
  * @version V1.0.0
  * @date    17-Dec-2014
  * @brief
- ******************************************************************************
-  Copyright (c) 2013-2015 Particle Industries, Inc.  All rights reserved.
-
-  This library is free software; you can redistribute it and/or
-  modify it under the terms of the GNU Lesser General Public
-  License as published by the Free Software Foundation, either
-  version 3 of the License, or (at your option) any later version.
-
-  This library is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  Lesser General Public License for more details.
-
-  You should have received a copy of the GNU Lesser General Public
-  License along with this library; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
+ ******************************************************************************/
+/*
+ * Copyright (c) 2020 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHAN'TABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
  */
 
 /* Includes ------------------------------------------------------------------*/
@@ -31,687 +30,714 @@
 #include "stm32f2xx.h"
 #include <string.h>
 #include "interrupts_hal.h"
+#include "check.h"
+#include "system_error.h"
 
 /* Private typedef -----------------------------------------------------------*/
-typedef enum USART_Num_Def {
-	USART_TX_RX = 0,
-	USART_RGBG_RGBB = 1
-#if PLATFORM_ID == 10 // Electron
-	,USART_TXD_UC_RXD_UC = 2
-	,USART_C3_C2 = 3
-	,USART_C1_C0 = 4
-#endif
-} USART_Num_Def;
+typedef enum usart_ports {
+    USART_TX_RX = 0,
+    USART_RGBG_RGBB = 1
+#if PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION
+    ,USART_TXD_UC_RXD_UC = 2
+    ,USART_C3_C2 = 3
+    ,USART_C1_C0 = 4
+#endif // PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION
+} usart_ports;
 
 /* Private macro -------------------------------------------------------------*/
 #define USE_USART3_HARDWARE_FLOW_CONTROL_RTS_CTS 0  //Enabling this => 1 is not working at present
 
+typedef struct usart_config {
+	uint32_t baud_rate;
+	uint32_t config;
+} usart_config;
+
 /* Private variables ---------------------------------------------------------*/
-typedef struct STM32_USART_Info {
-	USART_TypeDef* usart_peripheral;
+typedef struct stm32_usart_info {
+    USART_TypeDef* usart_peripheral;
 
-	__IO uint32_t* usart_apbReg;
-	uint32_t usart_clock_en;
+    __IO uint32_t* usart_apbReg;
+    uint32_t usart_clock_en;
 
-	int32_t usart_int_n;
+    int32_t usart_int_n;
 
-	uint16_t usart_tx_pin;
-	uint16_t usart_rx_pin;
+    uint16_t usart_tx_pin;
+    uint16_t usart_rx_pin;
 
-	uint8_t usart_tx_pinsource;
-	uint8_t usart_rx_pinsource;
+    uint8_t usart_tx_pinsource;
+    uint8_t usart_rx_pinsource;
 
-	uint8_t usart_af_map;
+    uint8_t usart_af_map;
 
-	uint8_t usart_cts_pin;
-	uint8_t usart_rts_pin;
+    uint8_t usart_cts_pin;
+    uint8_t usart_rts_pin;
 
-	// Buffer pointers. These need to be global for IRQ handler access
-	Ring_Buffer* usart_tx_buffer;
-	Ring_Buffer* usart_rx_buffer;
+    // Buffer pointers. These need to be global for IRQ handler access
+    Ring_Buffer* usart_tx_buffer;
+    Ring_Buffer* usart_rx_buffer;
 
-	volatile bool usart_enabled;
-	bool usart_transmitting;
+	bool usart_configured;
+    volatile bool usart_enabled;
+	volatile bool usart_suspended;
+    bool usart_transmitting;
 
-	uint32_t usart_config;
-} STM32_USART_Info;
+    usart_config conf;
+} stm32_usart_info;
 
 /*
  * USART mapping
  */
-STM32_USART_Info USART_MAP[TOTAL_USARTS] =
-{
-		/*
-		 * USART_peripheral (USARTx/UARTx; not using others)
-		 * clock control register (APBxENR)
-		 * clock enable bit value (RCC_APBxPeriph_USARTx/RCC_APBxPeriph_UARTx)
-		 * interrupt number (USARTx_IRQn/UARTx_IRQn)
-		 * TX pin
-		 * RX pin
-		 * TX pin source
-		 * RX pin source
-		 * GPIO AF map (GPIO_AF_USARTx/GPIO_AF_UARTx)
-		 * CTS pin
-		 * RTS pin
-		 * <tx_buffer pointer> used internally and does not appear below
-		 * <rx_buffer pointer> used internally and does not appear below
-		 * <usart enabled> used internally and does not appear below
-		 * <usart transmitting> used internally and does not appear below
-		 */
-		{ USART1, &RCC->APB2ENR, RCC_APB2Periph_USART1, USART1_IRQn, TX, RX, GPIO_PinSource9, GPIO_PinSource10, GPIO_AF_USART1 }, // USART 1
-		{ USART2, &RCC->APB1ENR, RCC_APB1Periph_USART2, USART2_IRQn, RGBG, RGBB, GPIO_PinSource2, GPIO_PinSource3, GPIO_AF_USART2, A7, RGBR } // USART 2
-#if PLATFORM_ID == 10 // Electron
-		,{ USART3, &RCC->APB1ENR, RCC_APB1Periph_USART3, USART3_IRQn, TXD_UC, RXD_UC, GPIO_PinSource10, GPIO_PinSource11, GPIO_AF_USART3, CTS_UC, RTS_UC } // USART 3
-		,{ UART4, &RCC->APB1ENR, RCC_APB1Periph_UART4, UART4_IRQn, C3, C2, GPIO_PinSource10, GPIO_PinSource11, GPIO_AF_UART4 } // UART 4
-		,{ UART5, &RCC->APB1ENR, RCC_APB1Periph_UART5, UART5_IRQn, C1, C0, GPIO_PinSource12, GPIO_PinSource2, GPIO_AF_UART5 } // UART 5
-#endif
+stm32_usart_info USART_MAP[TOTAL_USARTS] = {
+	/*
+     * USART_peripheral (USARTx/UARTx; not using others)
+     * clock control register (APBxENR)
+     * clock enable bit value (RCC_APBxPeriph_USARTx/RCC_APBxPeriph_UARTx)
+     * interrupt number (USARTx_IRQn/UARTx_IRQn)
+     * TX pin
+     * RX pin
+     * TX pin source
+     * RX pin source
+     * GPIO AF map (GPIO_AF_USARTx/GPIO_AF_UARTx)
+     * CTS pin
+     * RTS pin
+     * <tx_buffer pointer> used internally and does not appear below
+     * <rx_buffer pointer> used internally and does not appear below
+     * <usart enabled> used internally and does not appear below
+     * <usart transmitting> used internally and does not appear below
+     */
+    { USART1,  &RCC->APB2ENR, RCC_APB2Periph_USART1, USART1_IRQn, TX,     RX,     GPIO_PinSource9,  GPIO_PinSource10, GPIO_AF_USART1 }, // USART 1
+    { USART2,  &RCC->APB1ENR, RCC_APB1Periph_USART2, USART2_IRQn, RGBG,   RGBB,   GPIO_PinSource2,  GPIO_PinSource3,  GPIO_AF_USART2, A7,     RGBR } // USART 2
+#if PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION
+    ,{ USART3, &RCC->APB1ENR, RCC_APB1Periph_USART3, USART3_IRQn, TXD_UC, RXD_UC, GPIO_PinSource10, GPIO_PinSource11, GPIO_AF_USART3, CTS_UC, RTS_UC } // USART 3
+    ,{ UART4,  &RCC->APB1ENR, RCC_APB1Periph_UART4,  UART4_IRQn,  C3,     C2,     GPIO_PinSource10, GPIO_PinSource11, GPIO_AF_UART4 } // UART 4
+    ,{ UART5,  &RCC->APB1ENR, RCC_APB1Periph_UART5,  UART5_IRQn,  C1,     C0,     GPIO_PinSource12, GPIO_PinSource2,  GPIO_AF_UART5 } // UART 5
+#endif // PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION
 };
 
-static USART_InitTypeDef USART_InitStructure;
-static STM32_USART_Info *usartMap[TOTAL_USARTS]; // pointer to USART_MAP[] containing USART peripheral register locations (etc)
-
-/* Extern variables ----------------------------------------------------------*/
+static USART_InitTypeDef usartInitStructure;
+static stm32_usart_info *usartMap[TOTAL_USARTS]; // pointer to USART_MAP[] containing USART peripheral register locations (etc)
 
 /* Private function prototypes -----------------------------------------------*/
+inline void storeChar(uint16_t c, Ring_Buffer *buffer) __attribute__((always_inline));
+inline void storeChar(uint16_t c, Ring_Buffer *buffer) {
+    unsigned i = (unsigned int)(buffer->head + 1) % SERIAL_BUFFER_SIZE;
 
-inline void store_char(uint16_t c, Ring_Buffer *buffer) __attribute__((always_inline));
-inline void store_char(uint16_t c, Ring_Buffer *buffer)
-{
-	unsigned i = (unsigned int)(buffer->head + 1) % SERIAL_BUFFER_SIZE;
-
-	if (i != buffer->tail)
-	{
-		buffer->buffer[buffer->head] = c;
-		buffer->head = i;
-	}
+    if (i != buffer->tail) {
+        buffer->buffer[buffer->head] = c;
+        buffer->head = i;
+    }
 }
 
-static uint8_t HAL_USART_Calculate_Word_Length(uint32_t config, uint8_t noparity);
-static uint32_t HAL_USART_Calculate_Data_Bits_Mask(uint32_t config);
-static uint8_t HAL_USART_Validate_Config(uint32_t config);
-static void HAL_USART_Configure_Transmit_Receive(HAL_USART_Serial serial, uint8_t transmit, uint8_t receive);
-static void HAL_USART_Configure_Pin_Modes(HAL_USART_Serial serial, uint32_t config);
+static uint8_t calculateWordLength(uint32_t config, uint8_t noparity);
+static uint32_t calculateDataBitsMask(uint32_t config);
+static uint8_t validateConfig(uint32_t config);
+static void configureTransmitReceive(HAL_USART_Serial serial, uint8_t transmit, uint8_t receive);
+static void configurePinsMode(HAL_USART_Serial serial, uint32_t config);
+static void usartEndImpl(HAL_USART_Serial serial, bool cache);
 
-uint8_t HAL_USART_Calculate_Word_Length(uint32_t config, uint8_t noparity)
-{
-	// STM32F2 USARTs support only 8-bit or 9-bit communication, however
-	// the parity bit is included in the total word length, so for 8E1 mode
-	// the total word length would be 9 bits.
-	uint8_t wlen = 0;
-	switch (config & SERIAL_DATA_BITS) {
-		case SERIAL_DATA_BITS_7:
-			wlen += 7;
-			break;
-		case SERIAL_DATA_BITS_8:
-			wlen += 8;
-			break;
-		case SERIAL_DATA_BITS_9:
-			wlen += 9;
-			break;
-	}
-
-	if ((config & SERIAL_PARITY) && !noparity)
-		wlen++;
-
-	if (wlen > 9 || wlen < (noparity ? 7 : 8))
-		wlen = 0;
-
-	return wlen;
-}
-
-uint32_t HAL_USART_Calculate_Data_Bits_Mask(uint32_t config)
-{
-	return (1 << HAL_USART_Calculate_Word_Length(config, 1)) - 1;
-}
-
-uint8_t HAL_USART_Validate_Config(uint32_t config)
-{
-	// Total word length should be either 8 or 9 bits
-	if (HAL_USART_Calculate_Word_Length(config, 0) == 0)
-		return 0;
-
-	// Either No, Even or Odd parity
-	if ((config & SERIAL_PARITY) == (SERIAL_PARITY_EVEN | SERIAL_PARITY_ODD))
-		return 0;
-
-	if ((config & SERIAL_HALF_DUPLEX) && (config & LIN_MODE))
-		return 0;
-
-	if (config & LIN_MODE)
-	{
-		// Either Master or Slave mode
-		// Break detection can still be enabled in both Master and Slave modes
-		if ((config & LIN_MODE_MASTER) && (config & LIN_MODE_SLAVE))
-			return 0;
-		switch (config & LIN_BREAK_BITS)
-		{
-			case LIN_BREAK_13B:
-			case LIN_BREAK_10B:
-			case LIN_BREAK_11B:
-				break;
-			default:
-				return 0;
+uint8_t calculateWordLength(uint32_t config, uint8_t noparity) {
+    // STM32F2 USARTs support only 8-bit or 9-bit communication, however
+    // the parity bit is included in the total word length, so for 8E1 mode
+    // the total word length would be 9 bits.
+    uint8_t wlen = 0;
+    switch (config & SERIAL_DATA_BITS) {
+        case SERIAL_DATA_BITS_7: {
+            wlen += 7;
+            break;
 		}
-	}
-
-	return 1;
-}
-
-void HAL_USART_Configure_Transmit_Receive(HAL_USART_Serial serial, uint8_t transmit, uint8_t receive)
-{
-	uint32_t toset = 0;
-	if (transmit) {
-		toset |= ((uint32_t)USART_CR1_TE);
-	}
-	if (receive) {
-		toset |= ((uint32_t)USART_CR1_RE);
-	}
-	uint32_t tmp = usartMap[serial]->usart_peripheral->CR1;
-	if ((tmp & ((uint32_t)(USART_CR1_TE | USART_CR1_RE))) != toset) {
-		tmp &= ~((uint32_t)(USART_CR1_TE | USART_CR1_RE));
-		tmp |= toset;
-		usartMap[serial]->usart_peripheral->CR1 = tmp;
-	}
-}
-
-void HAL_USART_Configure_Pin_Modes(HAL_USART_Serial serial, uint32_t config)
-{
-	if ((config & SERIAL_HALF_DUPLEX) == 0) {
-		// Full duplex with push-pull
-		HAL_Pin_Mode(usartMap[serial]->usart_rx_pin, AF_OUTPUT_PUSHPULL);
-		HAL_Pin_Mode(usartMap[serial]->usart_tx_pin, AF_OUTPUT_PUSHPULL);
-	} else if ((config & SERIAL_OPEN_DRAIN)) {
-		// Half-duplex with open drain
-		HAL_Pin_Mode(usartMap[serial]->usart_rx_pin, INPUT);
-		HAL_Pin_Mode(usartMap[serial]->usart_tx_pin, AF_OUTPUT_DRAIN);
-	} else {
-		// Half-duplex with push-pull
-		/* RM0033 24.3.10:
-		 * The TX pin is always released when no data is transmitted. Thus, it acts as a standard
-		 * I/O in idle or in reception. It means that the I/O must be configured so that TX is
-		 * configured as floating input (or output high open-drain) when not driven by the USART
-		 */
-		HAL_Pin_Mode(usartMap[serial]->usart_rx_pin, INPUT);
-		HAL_Pin_Mode(usartMap[serial]->usart_tx_pin, AF_OUTPUT_PUSHPULL);
-		if (config & SERIAL_TX_PULL_UP) {
-			// We ought to allow enabling pull-up or pull-down through HAL somehow
-			Hal_Pin_Info* PIN_MAP = HAL_Pin_Map();
-			pin_t gpio_pin = PIN_MAP[usartMap[serial]->usart_tx_pin].gpio_pin;
-			GPIO_TypeDef *gpio_port = PIN_MAP[usartMap[serial]->usart_tx_pin].gpio_peripheral;
-			GPIO_InitTypeDef GPIO_InitStructure = {0};
-			GPIO_InitStructure.GPIO_Pin = gpio_pin;
-			GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF;
-			GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
-			GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
-			GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_UP;
-			GPIO_Init(gpio_port, &GPIO_InitStructure);
+        case SERIAL_DATA_BITS_8: {
+            wlen += 8;
+            break;
 		}
+        case SERIAL_DATA_BITS_9: {
+            wlen += 9;
+            break;
+		}
+    }
+
+    if ((config & SERIAL_PARITY) && !noparity) {
+        wlen++;
 	}
+
+    if (wlen > 9 || wlen < (noparity ? 7 : 8)) {
+        wlen = 0;
+	}
+
+    return wlen;
 }
 
-void HAL_USART_Init(HAL_USART_Serial serial, Ring_Buffer *rx_buffer, Ring_Buffer *tx_buffer)
-{
-	if(serial == HAL_USART_SERIAL1)
-	{
-		usartMap[serial] = &USART_MAP[USART_TX_RX];
-	}
-	else if(serial == HAL_USART_SERIAL2)
-	{
-		usartMap[serial] = &USART_MAP[USART_RGBG_RGBB];
-	}
-#if PLATFORM_ID == 10 // Electron
-	else if(serial == HAL_USART_SERIAL3)
-	{
-		usartMap[serial] = &USART_MAP[USART_TXD_UC_RXD_UC];
-	}
-	else if(serial == HAL_USART_SERIAL4)
-	{
-		usartMap[serial] = &USART_MAP[USART_C3_C2];
-	}
-	else if(serial == HAL_USART_SERIAL5)
-	{
-		usartMap[serial] = &USART_MAP[USART_C1_C0];
-	}
-#endif
-
-	usartMap[serial]->usart_rx_buffer = rx_buffer;
-	usartMap[serial]->usart_tx_buffer = tx_buffer;
-
-	memset(usartMap[serial]->usart_rx_buffer, 0, sizeof(Ring_Buffer));
-	memset(usartMap[serial]->usart_tx_buffer, 0, sizeof(Ring_Buffer));
-
-	usartMap[serial]->usart_enabled = false;
-	usartMap[serial]->usart_transmitting = false;
+uint32_t calculateDataBitsMask(uint32_t config) {
+    return (1 << calculateWordLength(config, 1)) - 1;
 }
 
-void HAL_USART_Begin(HAL_USART_Serial serial, uint32_t baud)
-{
-	HAL_USART_BeginConfig(serial, baud, 0, 0); // Default serial configuration is 8N1
+uint8_t validateConfig(uint32_t config) {
+    // Total word length should be either 8 or 9 bits
+    if (calculateWordLength(config, 0) == 0) {
+        return 0;
+	}
+    // Either No, Even or Odd parity
+    if ((config & SERIAL_PARITY) == (SERIAL_PARITY_EVEN | SERIAL_PARITY_ODD)) {
+        return 0;
+	}
+    if ((config & SERIAL_HALF_DUPLEX) && (config & LIN_MODE)) {
+        return 0;
+	}
+
+    if (config & LIN_MODE) {
+        // Either Master or Slave mode
+        // Break detection can still be enabled in both Master and Slave modes
+        if ((config & LIN_MODE_MASTER) && (config & LIN_MODE_SLAVE)) {
+            return 0;
+		}
+        switch (config & LIN_BREAK_BITS) {
+            case LIN_BREAK_13B:
+            case LIN_BREAK_10B:
+            case LIN_BREAK_11B: {
+                break;
+			}
+            default: {
+                return 0;
+			}
+        }
+    }
+
+    return 1;
 }
 
-void HAL_USART_BeginConfig(HAL_USART_Serial serial, uint32_t baud, uint32_t config, void *ptr)
-{
-	// Verify UART configuration, exit if it's invalid.
-	if (!HAL_USART_Validate_Config(config)) {
-		usartMap[serial]->usart_enabled = false;
+void configureTransmitReceive(HAL_USART_Serial serial, uint8_t transmit, uint8_t receive) {
+    uint32_t toset = 0;
+    if (transmit) {
+        toset |= ((uint32_t)USART_CR1_TE);
+    }
+    if (receive) {
+        toset |= ((uint32_t)USART_CR1_RE);
+    }
+    uint32_t tmp = usartMap[serial]->usart_peripheral->CR1;
+    if ((tmp & ((uint32_t)(USART_CR1_TE | USART_CR1_RE))) != toset) {
+        tmp &= ~((uint32_t)(USART_CR1_TE | USART_CR1_RE));
+        tmp |= toset;
+        usartMap[serial]->usart_peripheral->CR1 = tmp;
+    }
+}
+
+void configurePinsMode(HAL_USART_Serial serial, uint32_t config) {
+    if ((config & SERIAL_HALF_DUPLEX) == 0) {
+        // Full duplex with push-pull
+        HAL_Pin_Mode(usartMap[serial]->usart_rx_pin, AF_OUTPUT_PUSHPULL);
+        HAL_Pin_Mode(usartMap[serial]->usart_tx_pin, AF_OUTPUT_PUSHPULL);
+    } else if ((config & SERIAL_OPEN_DRAIN)) {
+        // Half-duplex with open drain
+        HAL_Pin_Mode(usartMap[serial]->usart_rx_pin, INPUT);
+        HAL_Pin_Mode(usartMap[serial]->usart_tx_pin, AF_OUTPUT_DRAIN);
+    } else {
+        // Half-duplex with push-pull
+        /* RM0033 24.3.10:
+         * The TX pin is always released when no data is transmitted. Thus, it acts as a standard
+         * I/O in idle or in reception. It means that the I/O must be configured so that TX is
+         * configured as floating input (or output high open-drain) when not driven by the USART
+         */
+        HAL_Pin_Mode(usartMap[serial]->usart_rx_pin, INPUT);
+        HAL_Pin_Mode(usartMap[serial]->usart_tx_pin, AF_OUTPUT_PUSHPULL);
+        if (config & SERIAL_TX_PULL_UP) {
+            // We ought to allow enabling pull-up or pull-down through HAL somehow
+            Hal_Pin_Info* PIN_MAP = HAL_Pin_Map();
+            pin_t gpio_pin = PIN_MAP[usartMap[serial]->usart_tx_pin].gpio_pin;
+            GPIO_TypeDef *gpio_port = PIN_MAP[usartMap[serial]->usart_tx_pin].gpio_peripheral;
+            GPIO_InitTypeDef GPIO_InitStructure = {0};
+            GPIO_InitStructure.GPIO_Pin = gpio_pin;
+            GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF;
+            GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
+            GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
+            GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_UP;
+            GPIO_Init(gpio_port, &GPIO_InitStructure);
+        }
+    }
+}
+
+void usartEndImpl(HAL_USART_Serial serial, bool cache) {
+    // Wait for transmission of outgoing data
+    while (usartMap[serial]->usart_tx_buffer->head != usartMap[serial]->usart_tx_buffer->tail);
+
+    // Disable the USART
+    USART_Cmd(usartMap[serial]->usart_peripheral, DISABLE);
+
+    // Switch pins to INPUT
+    HAL_Pin_Mode(usartMap[serial]->usart_rx_pin, INPUT);
+    HAL_Pin_Mode(usartMap[serial]->usart_tx_pin, INPUT);
+
+    // Disable LIN mode
+    USART_LINCmd(usartMap[serial]->usart_peripheral, DISABLE);
+
+    // Deinitialise USART
+    USART_DeInit(usartMap[serial]->usart_peripheral);
+
+    // Disable USART Receive and Transmit interrupts
+    USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_RXNE, DISABLE);
+    USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TXE, DISABLE);
+
+    NVIC_InitTypeDef NVIC_InitStructure;
+
+    // Disable the USART Interrupt
+    NVIC_InitStructure.NVIC_IRQChannel = usartMap[serial]->usart_int_n;
+    NVIC_InitStructure.NVIC_IRQChannelCmd = DISABLE;
+
+    NVIC_Init(&NVIC_InitStructure);
+
+    // Disable USART Clock
+    *usartMap[serial]->usart_apbReg &= ~usartMap[serial]->usart_clock_en;
+
+	if (!cache) {
+		// clear any received data
+		usartMap[serial]->usart_rx_buffer->head = usartMap[serial]->usart_rx_buffer->tail;
+		// Undo any pin re-mapping done for this USART
+		// ...
+		memset(usartMap[serial]->usart_rx_buffer, 0, sizeof(Ring_Buffer));
+	}
+
+    memset(usartMap[serial]->usart_tx_buffer, 0, sizeof(Ring_Buffer));
+
+    usartMap[serial]->usart_enabled = false;
+    usartMap[serial]->usart_transmitting = false;
+}
+
+void hal_usart_init(HAL_USART_Serial serial, Ring_Buffer *rx_buffer, Ring_Buffer *tx_buffer) {
+	usartMap[serial]->usart_configured = false;
+
+    if (serial == HAL_USART_SERIAL1) {
+        usartMap[serial] = &USART_MAP[USART_TX_RX];
+    } else if (serial == HAL_USART_SERIAL2) {
+        usartMap[serial] = &USART_MAP[USART_RGBG_RGBB];
+    }
+#if PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION
+    else if (serial == HAL_USART_SERIAL3) {
+        usartMap[serial] = &USART_MAP[USART_TXD_UC_RXD_UC];
+    } else if (serial == HAL_USART_SERIAL4) {
+        usartMap[serial] = &USART_MAP[USART_C3_C2];
+    } else if (serial == HAL_USART_SERIAL5) {
+        usartMap[serial] = &USART_MAP[USART_C1_C0];
+    }
+#endif // PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION
+
+    usartMap[serial]->usart_rx_buffer = rx_buffer;
+    usartMap[serial]->usart_tx_buffer = tx_buffer;
+
+    memset(usartMap[serial]->usart_rx_buffer, 0, sizeof(Ring_Buffer));
+    memset(usartMap[serial]->usart_tx_buffer, 0, sizeof(Ring_Buffer));
+
+    usartMap[serial]->usart_enabled = false;
+    usartMap[serial]->usart_transmitting = false;
+
+	usartMap[serial]->usart_configured = true;
+}
+
+void hal_usart_begin(HAL_USART_Serial serial, uint32_t baud) {
+    hal_usart_begin_config(serial, baud, 0, 0); // Default serial configuration is 8N1
+}
+
+void hal_usart_begin_config(HAL_USART_Serial serial, uint32_t baud, uint32_t config, void *ptr) {
+	if (!usartMap[serial]->usart_configured) {
 		return;
 	}
+    // Verify UART configuration, exit if it's invalid.
+    if (!validateConfig(config)) {
+        usartMap[serial]->usart_enabled = false;
+        return;
+    }
 
-	USART_DeInit(usartMap[serial]->usart_peripheral);
+	usartMap[serial]->usart_suspended = false;
 
-	usartMap[serial]->usart_enabled = false;
+    USART_DeInit(usartMap[serial]->usart_peripheral);
 
-	HAL_USART_Configure_Pin_Modes(serial, config);
+    usartMap[serial]->usart_enabled = false;
 
-	// Enable USART Clock
-	*usartMap[serial]->usart_apbReg |=  usartMap[serial]->usart_clock_en;
+    configurePinsMode(serial, config);
 
-	// Connect USART pins to AFx
-	Hal_Pin_Info* PIN_MAP = HAL_Pin_Map();
-	GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_rx_pin].gpio_peripheral, usartMap[serial]->usart_rx_pinsource, usartMap[serial]->usart_af_map);
-	GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_tx_pin].gpio_peripheral, usartMap[serial]->usart_tx_pinsource, usartMap[serial]->usart_af_map);
+    // Enable USART Clock
+    *usartMap[serial]->usart_apbReg |=  usartMap[serial]->usart_clock_en;
 
-	// NVIC Configuration
-	NVIC_InitTypeDef NVIC_InitStructure;
-	// Enable the USART Interrupt
-	NVIC_InitStructure.NVIC_IRQChannel = usartMap[serial]->usart_int_n;
-	NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 7;
-	NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
-	NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-	NVIC_Init(&NVIC_InitStructure);
+    // Connect USART pins to AFx
+    Hal_Pin_Info* PIN_MAP = HAL_Pin_Map();
+    GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_rx_pin].gpio_peripheral, usartMap[serial]->usart_rx_pinsource, usartMap[serial]->usart_af_map);
+    GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_tx_pin].gpio_peripheral, usartMap[serial]->usart_tx_pinsource, usartMap[serial]->usart_af_map);
 
-	// USART default configuration
-	// USART configured as follow:
-	// - BaudRate = (set baudRate as 9600 baud)
-	// - Word Length = 8 Bits
-	// - One Stop Bit
-	// - No parity
-	// - Hardware flow control disabled for Serial1/2/4/5
-	// - Hardware flow control enabled (RTS and CTS signals) for Serial3
-	// - Receive and transmit enabled
-	// USART configuration
-	USART_InitStructure.USART_BaudRate = baud;
-	USART_InitStructure.USART_Mode = USART_Mode_Rx | USART_Mode_Tx;
+    // NVIC Configuration
+    NVIC_InitTypeDef NVIC_InitStructure;
+    // Enable the USART Interrupt
+    NVIC_InitStructure.NVIC_IRQChannel = usartMap[serial]->usart_int_n;
+    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 7;
+    NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
+    NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
+    NVIC_Init(&NVIC_InitStructure);
 
-	// Flow control configuration
-	switch (config & SERIAL_FLOW_CONTROL) {
-		case SERIAL_FLOW_CONTROL_CTS:
-			USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_CTS;
-			break;
-		case SERIAL_FLOW_CONTROL_RTS:
-			USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_RTS;
-			break;
-		case SERIAL_FLOW_CONTROL_RTS_CTS:
-			USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_RTS_CTS;
-			break;
-		case SERIAL_FLOW_CONTROL_NONE:
-		default:
-			USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
-			break;
-	}
+    // USART default configuration
+    // USART configured as follow:
+    // - BaudRate = (set baudRate as 9600 baud)
+    // - Word Length = 8 Bits
+    // - One Stop Bit
+    // - No parity
+    // - Hardware flow control disabled for Serial1/2/4/5
+    // - Hardware flow control enabled (RTS and CTS signals) for Serial3
+    // - Receive and transmit enabled
+    // USART configuration
+    usartInitStructure.USART_BaudRate = baud;
+    usartInitStructure.USART_Mode = USART_Mode_Rx | USART_Mode_Tx;
 
-	if (serial == HAL_USART_SERIAL1) {
-		// USART1 supports hardware flow control, but RTS and CTS pins are not exposed
-		USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
-	}
+    // Flow control configuration
+    switch (config & SERIAL_FLOW_CONTROL) {
+        case SERIAL_FLOW_CONTROL_CTS: {
+            usartInitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_CTS;
+            break;
+		}
+        case SERIAL_FLOW_CONTROL_RTS: {
+            usartInitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_RTS;
+            break;
+		}
+        case SERIAL_FLOW_CONTROL_RTS_CTS: {
+            usartInitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_RTS_CTS;
+            break;
+		}
+        case SERIAL_FLOW_CONTROL_NONE:
+        default: {
+            usartInitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
+            break;
+		}
+    }
 
-#if PLATFORM_ID == 10 // Electron
-	if (serial == HAL_USART_SERIAL4 || serial == HAL_USART_SERIAL5) {
-		// UART4 and UART5 do not support hardware flow control
-		USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
-	}
-#endif // PLATFORM_ID == 10
+    if (serial == HAL_USART_SERIAL1) {
+        // USART1 supports hardware flow control, but RTS and CTS pins are not exposed
+        usartInitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
+    }
+
+#if PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION
+    if (serial == HAL_USART_SERIAL4 || serial == HAL_USART_SERIAL5) {
+        // UART4 and UART5 do not support hardware flow control
+        usartInitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
+    }
+#endif // PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION
 
 #if USE_USART3_HARDWARE_FLOW_CONTROL_RTS_CTS    // Electron
-	if (serial == HAL_USART_SERIAL3)
-	{
-		USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_RTS_CTS;
-	}
+    if (serial == HAL_USART_SERIAL3) {
+        usartInitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_RTS_CTS;
+    }
 #endif
 
-	switch (USART_InitStructure.USART_HardwareFlowControl) {
-		case USART_HardwareFlowControl_CTS:
-			HAL_Pin_Mode(usartMap[serial]->usart_cts_pin, AF_OUTPUT_PUSHPULL);
-			GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_cts_pin].gpio_peripheral, PIN_MAP[usartMap[serial]->usart_cts_pin].gpio_pin_source, usartMap[serial]->usart_af_map);
-			break;
-		case USART_HardwareFlowControl_RTS:
-			HAL_Pin_Mode(usartMap[serial]->usart_rts_pin, AF_OUTPUT_PUSHPULL);
-			GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_rts_pin].gpio_peripheral, PIN_MAP[usartMap[serial]->usart_rts_pin].gpio_pin_source, usartMap[serial]->usart_af_map);
-			break;
-		case USART_HardwareFlowControl_RTS_CTS:
-			HAL_Pin_Mode(usartMap[serial]->usart_cts_pin, AF_OUTPUT_PUSHPULL);
-			HAL_Pin_Mode(usartMap[serial]->usart_rts_pin, AF_OUTPUT_PUSHPULL);
-			GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_cts_pin].gpio_peripheral, PIN_MAP[usartMap[serial]->usart_cts_pin].gpio_pin_source, usartMap[serial]->usart_af_map);
-			GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_rts_pin].gpio_peripheral, PIN_MAP[usartMap[serial]->usart_rts_pin].gpio_pin_source, usartMap[serial]->usart_af_map);
-			break;
-		case USART_HardwareFlowControl_None:
-		default:
-			break;
-	}
-
-	// Stop bit configuration.
-	switch (config & SERIAL_STOP_BITS) {
-		case SERIAL_STOP_BITS_1: // 1 stop bit
-			USART_InitStructure.USART_StopBits = USART_StopBits_1;
-			break;
-		case SERIAL_STOP_BITS_2: // 2 stop bits
-			USART_InitStructure.USART_StopBits = USART_StopBits_2;
-			break;
-		case SERIAL_STOP_BITS_0_5: // 0.5 stop bits
-			USART_InitStructure.USART_StopBits = USART_StopBits_0_5;
-			break;
-		case SERIAL_STOP_BITS_1_5: // 1.5 stop bits
-			USART_InitStructure.USART_StopBits = USART_StopBits_1_5;
-			break;
-	}
-
-	// Data bits configuration
-	switch (HAL_USART_Calculate_Word_Length(config, 0)) {
-		case 8:
-			USART_InitStructure.USART_WordLength = USART_WordLength_8b;
-			break;
-		case 9:
-			USART_InitStructure.USART_WordLength = USART_WordLength_9b;
-			break;
-	}
-
-	// Parity configuration
-	switch (config & SERIAL_PARITY) {
-		case SERIAL_PARITY_NO:
-			USART_InitStructure.USART_Parity = USART_Parity_No;
-			break;
-		case SERIAL_PARITY_EVEN:
-			USART_InitStructure.USART_Parity = USART_Parity_Even;
-			break;
-		case SERIAL_PARITY_ODD:
-			USART_InitStructure.USART_Parity = USART_Parity_Odd;
-			break;
-	}
-
-	// Disable LIN mode just in case
-	USART_LINCmd(usartMap[serial]->usart_peripheral, DISABLE);
-
-	// Configure USART
-	USART_Init(usartMap[serial]->usart_peripheral, &USART_InitStructure);
-
-	// LIN configuration
-	if (config & LIN_MODE) {
-		// Enable break detection
-		switch(config & LIN_BREAK_BITS) {
-			case LIN_BREAK_10B:
-				USART_LINBreakDetectLengthConfig(usartMap[serial]->usart_peripheral, USART_LINBreakDetectLength_10b);
-				break;
-			case LIN_BREAK_11B:
-				USART_LINBreakDetectLengthConfig(usartMap[serial]->usart_peripheral, USART_LINBreakDetectLength_11b);
-				break;
+    switch (usartInitStructure.USART_HardwareFlowControl) {
+        case USART_HardwareFlowControl_CTS: {
+            HAL_Pin_Mode(usartMap[serial]->usart_cts_pin, AF_OUTPUT_PUSHPULL);
+            GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_cts_pin].gpio_peripheral, PIN_MAP[usartMap[serial]->usart_cts_pin].gpio_pin_source, usartMap[serial]->usart_af_map);
+            break;
 		}
-	}
-
-	usartMap[serial]->usart_config = config;
-	if (config & SERIAL_HALF_DUPLEX) {
-		HAL_USART_Half_Duplex(serial, ENABLE);
-	}
-
-	USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TC, DISABLE);
-
-	// Enable the USART
-	USART_Cmd(usartMap[serial]->usart_peripheral, ENABLE);
-
-	if (config & LIN_MODE) {
-		USART_LINCmd(usartMap[serial]->usart_peripheral, ENABLE);
-	}
-
-	usartMap[serial]->usart_enabled = true;
-	usartMap[serial]->usart_transmitting = false;
-
-	// Enable USART Receive and Transmit interrupts
-	USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TXE, ENABLE);
-	USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_RXNE, ENABLE);
-}
-
-void HAL_USART_End(HAL_USART_Serial serial)
-{
-	// Wait for transmission of outgoing data
-	while (usartMap[serial]->usart_tx_buffer->head != usartMap[serial]->usart_tx_buffer->tail);
-
-	// Disable the USART
-	USART_Cmd(usartMap[serial]->usart_peripheral, DISABLE);
-
-	// Switch pins to INPUT
-	HAL_Pin_Mode(usartMap[serial]->usart_rx_pin, INPUT);
-	HAL_Pin_Mode(usartMap[serial]->usart_tx_pin, INPUT);
-
-	// Disable LIN mode
-	USART_LINCmd(usartMap[serial]->usart_peripheral, DISABLE);
-
-	// Deinitialise USART
-	USART_DeInit(usartMap[serial]->usart_peripheral);
-
-	// Disable USART Receive and Transmit interrupts
-	USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_RXNE, DISABLE);
-	USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TXE, DISABLE);
-
-	NVIC_InitTypeDef NVIC_InitStructure;
-
-	// Disable the USART Interrupt
-	NVIC_InitStructure.NVIC_IRQChannel = usartMap[serial]->usart_int_n;
-	NVIC_InitStructure.NVIC_IRQChannelCmd = DISABLE;
-
-	NVIC_Init(&NVIC_InitStructure);
-
-	// Disable USART Clock
-	*usartMap[serial]->usart_apbReg &= ~usartMap[serial]->usart_clock_en;
-
-	// clear any received data
-	usartMap[serial]->usart_rx_buffer->head = usartMap[serial]->usart_rx_buffer->tail;
-
-	// Undo any pin re-mapping done for this USART
-	// ...
-
-	memset(usartMap[serial]->usart_rx_buffer, 0, sizeof(Ring_Buffer));
-	memset(usartMap[serial]->usart_tx_buffer, 0, sizeof(Ring_Buffer));
-
-	usartMap[serial]->usart_enabled = false;
-	usartMap[serial]->usart_transmitting = false;
-}
-
-uint32_t HAL_USART_Write_Data(HAL_USART_Serial serial, uint8_t data)
-{
-	return HAL_USART_Write_NineBitData(serial, data);
-}
-
-uint32_t HAL_USART_Write_NineBitData(HAL_USART_Serial serial, uint16_t data)
-{
-	// Remove any bits exceeding data bits configured
-	data &= HAL_USART_Calculate_Data_Bits_Mask(usartMap[serial]->usart_config);
-	// interrupts are off and data in queue;
-	if ((USART_GetITStatus(usartMap[serial]->usart_peripheral, USART_IT_TXE) == RESET)
-		&& usartMap[serial]->usart_tx_buffer->head != usartMap[serial]->usart_tx_buffer->tail) {
-		// Get him busy
-		USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TXE, ENABLE);
-	}
-
-	unsigned i = (usartMap[serial]->usart_tx_buffer->head + 1) % SERIAL_BUFFER_SIZE;
-
-	// If the output buffer is full, there's nothing for it other than to
-	// wait for the interrupt handler to empty it a bit
-	//         no space so       or  Called Off Panic with interrupt off get the message out!
-	//         make space                     Enter Polled IO mode
-	while (i == usartMap[serial]->usart_tx_buffer->tail || ((__get_PRIMASK() & 1) && usartMap[serial]->usart_tx_buffer->head != usartMap[serial]->usart_tx_buffer->tail) ) {
-		// Interrupts are on but they are not being serviced because this was called from a higher
-		// Priority interrupt
-
-		if (USART_GetITStatus(usartMap[serial]->usart_peripheral, USART_IT_TXE) && USART_GetFlagStatus(usartMap[serial]->usart_peripheral, USART_FLAG_TXE))
-		{
-		  // protect for good measure
-			USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TXE, DISABLE);
-		  // Write out a byte
-			USART_SendData(usartMap[serial]->usart_peripheral,  usartMap[serial]->usart_tx_buffer->buffer[usartMap[serial]->usart_tx_buffer->tail++]);
-			usartMap[serial]->usart_tx_buffer->tail %= SERIAL_BUFFER_SIZE;
-		  // unprotect
-			USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TXE, ENABLE);
+        case USART_HardwareFlowControl_RTS: {
+            HAL_Pin_Mode(usartMap[serial]->usart_rts_pin, AF_OUTPUT_PUSHPULL);
+            GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_rts_pin].gpio_peripheral, PIN_MAP[usartMap[serial]->usart_rts_pin].gpio_pin_source, usartMap[serial]->usart_af_map);
+            break;
 		}
-	}
+        case USART_HardwareFlowControl_RTS_CTS: {
+            HAL_Pin_Mode(usartMap[serial]->usart_cts_pin, AF_OUTPUT_PUSHPULL);
+            HAL_Pin_Mode(usartMap[serial]->usart_rts_pin, AF_OUTPUT_PUSHPULL);
+            GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_cts_pin].gpio_peripheral, PIN_MAP[usartMap[serial]->usart_cts_pin].gpio_pin_source, usartMap[serial]->usart_af_map);
+            GPIO_PinAFConfig(PIN_MAP[usartMap[serial]->usart_rts_pin].gpio_peripheral, PIN_MAP[usartMap[serial]->usart_rts_pin].gpio_pin_source, usartMap[serial]->usart_af_map);
+            break;
+		}
+        case USART_HardwareFlowControl_None:
+        default: {
+            break;
+		}
+    }
 
-	usartMap[serial]->usart_tx_buffer->buffer[usartMap[serial]->usart_tx_buffer->head] = data;
-	usartMap[serial]->usart_tx_buffer->head = i;
-	usartMap[serial]->usart_transmitting = true;
-	USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TXE, ENABLE);
+    // Stop bit configuration.
+    switch (config & SERIAL_STOP_BITS) {
+        case SERIAL_STOP_BITS_1: { // 1 stop bit
+            usartInitStructure.USART_StopBits = USART_StopBits_1;
+            break;
+		}
+        case SERIAL_STOP_BITS_2: { // 2 stop bits
+            usartInitStructure.USART_StopBits = USART_StopBits_2;
+            break;
+		}
+        case SERIAL_STOP_BITS_0_5: { // 0.5 stop bits
+            usartInitStructure.USART_StopBits = USART_StopBits_0_5;
+            break;
+		}
+        case SERIAL_STOP_BITS_1_5: { // 1.5 stop bits
+            usartInitStructure.USART_StopBits = USART_StopBits_1_5;
+            break;
+		}
+		default: {
+			break;
+		}
+    }
 
-	return 1;
+    // Data bits configuration
+    switch (calculateWordLength(config, 0)) {
+        case 8: {
+            usartInitStructure.USART_WordLength = USART_WordLength_8b;
+            break;
+		}
+        case 9: {
+            usartInitStructure.USART_WordLength = USART_WordLength_9b;
+            break;
+		}
+		default: {
+			break;
+		}
+    }
+
+    // Parity configuration
+    switch (config & SERIAL_PARITY) {
+        case SERIAL_PARITY_NO: {
+            usartInitStructure.USART_Parity = USART_Parity_No;
+            break;
+		}
+        case SERIAL_PARITY_EVEN: {
+            usartInitStructure.USART_Parity = USART_Parity_Even;
+            break;
+		}
+        case SERIAL_PARITY_ODD: {
+            usartInitStructure.USART_Parity = USART_Parity_Odd;
+            break;
+		}
+		default: {
+			break;
+		}
+    }
+
+    // Disable LIN mode just in case
+    USART_LINCmd(usartMap[serial]->usart_peripheral, DISABLE);
+
+    // Configure USART
+    USART_Init(usartMap[serial]->usart_peripheral, &usartInitStructure);
+
+    // LIN configuration
+    if (config & LIN_MODE) {
+        // Enable break detection
+        switch (config & LIN_BREAK_BITS) {
+            case LIN_BREAK_10B: {
+                USART_LINBreakDetectLengthConfig(usartMap[serial]->usart_peripheral, USART_LINBreakDetectLength_10b);
+                break;
+			}
+            case LIN_BREAK_11B: {
+                USART_LINBreakDetectLengthConfig(usartMap[serial]->usart_peripheral, USART_LINBreakDetectLength_11b);
+                break;
+			}
+			default: {
+				break;
+			}
+        }
+    }
+
+	usartMap[serial]->conf.baud_rate = baud;
+    usartMap[serial]->conf.config = config;
+    if (config & SERIAL_HALF_DUPLEX) {
+        hal_usart_half_duplex(serial, ENABLE);
+    }
+
+    USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TC, DISABLE);
+
+    // Enable the USART
+    USART_Cmd(usartMap[serial]->usart_peripheral, ENABLE);
+
+    if (config & LIN_MODE) {
+        USART_LINCmd(usartMap[serial]->usart_peripheral, ENABLE);
+    }
+
+    usartMap[serial]->usart_enabled = true;
+    usartMap[serial]->usart_transmitting = false;
+
+    // Enable USART Receive and Transmit interrupts
+    USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TXE, ENABLE);
+    USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_RXNE, ENABLE);
 }
 
-int32_t HAL_USART_Available_Data(HAL_USART_Serial serial)
-{
-	return (unsigned int)(SERIAL_BUFFER_SIZE + usartMap[serial]->usart_rx_buffer->head - usartMap[serial]->usart_rx_buffer->tail) % SERIAL_BUFFER_SIZE;
+void hal_usart_end(HAL_USART_Serial serial) {
+	usartMap[serial]->usart_suspended = true;
+    usartEndImpl(serial, false);
 }
 
-int32_t HAL_USART_Available_Data_For_Write(HAL_USART_Serial serial)
-{
-	int32_t tail = usartMap[serial]->usart_tx_buffer->tail;
-	int32_t available = SERIAL_BUFFER_SIZE - (usartMap[serial]->usart_tx_buffer->head >= tail ?
-		usartMap[serial]->usart_tx_buffer->head - tail :
-		(SERIAL_BUFFER_SIZE + usartMap[serial]->usart_tx_buffer->head - tail) - 1);
+uint32_t hal_usart_write(HAL_USART_Serial serial, uint8_t data) {
+    return hal_usart_write_nine_bits(serial, data);
+}
 
-	return available;
+uint32_t hal_usart_write_nine_bits(HAL_USART_Serial serial, uint16_t data) {
+    // Remove any bits exceeding data bits configured
+    data &= calculateDataBitsMask(usartMap[serial]->conf.config);
+    // interrupts are off and data in queue;
+    if ((USART_GetITStatus(usartMap[serial]->usart_peripheral, USART_IT_TXE) == RESET)
+        && usartMap[serial]->usart_tx_buffer->head != usartMap[serial]->usart_tx_buffer->tail) {
+        // Get him busy
+        USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TXE, ENABLE);
+    }
+
+    unsigned i = (usartMap[serial]->usart_tx_buffer->head + 1) % SERIAL_BUFFER_SIZE;
+
+    // If the output buffer is full, there's nothing for it other than to
+    // wait for the interrupt handler to empty it a bit
+    // no space so or Called Off Panic with interrupt off get the message out!
+    // make space Enter Polled IO mode
+    while (i == usartMap[serial]->usart_tx_buffer->tail || ((__get_PRIMASK() & 1) && usartMap[serial]->usart_tx_buffer->head != usartMap[serial]->usart_tx_buffer->tail) ) {
+        // Interrupts are on but they are not being serviced because this was called from a higher
+        // Priority interrupt
+        if (USART_GetITStatus(usartMap[serial]->usart_peripheral, USART_IT_TXE) && USART_GetFlagStatus(usartMap[serial]->usart_peripheral, USART_FLAG_TXE)) {
+            // protect for good measure
+            USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TXE, DISABLE);
+            // Write out a byte
+            USART_SendData(usartMap[serial]->usart_peripheral,  usartMap[serial]->usart_tx_buffer->buffer[usartMap[serial]->usart_tx_buffer->tail++]);
+            usartMap[serial]->usart_tx_buffer->tail %= SERIAL_BUFFER_SIZE;
+            // unprotect
+            USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TXE, ENABLE);
+        }
+    }
+
+    usartMap[serial]->usart_tx_buffer->buffer[usartMap[serial]->usart_tx_buffer->head] = data;
+    usartMap[serial]->usart_tx_buffer->head = i;
+    usartMap[serial]->usart_transmitting = true;
+    USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TXE, ENABLE);
+
+    return 1;
+}
+
+int32_t hal_usart_available(HAL_USART_Serial serial) {
+    return (unsigned int)(SERIAL_BUFFER_SIZE + usartMap[serial]->usart_rx_buffer->head - usartMap[serial]->usart_rx_buffer->tail) % SERIAL_BUFFER_SIZE;
+}
+
+int32_t hal_usart_available_data_for_write(HAL_USART_Serial serial) {
+    int32_t tail = usartMap[serial]->usart_tx_buffer->tail;
+    int32_t available = SERIAL_BUFFER_SIZE - (usartMap[serial]->usart_tx_buffer->head >= tail ?
+                                              usartMap[serial]->usart_tx_buffer->head - tail :
+                                              (SERIAL_BUFFER_SIZE + usartMap[serial]->usart_tx_buffer->head - tail) - 1);
+
+    return available;
 }
 
 
-int32_t HAL_USART_Read_Data(HAL_USART_Serial serial)
-{
-	// if the head isn't ahead of the tail, we don't have any characters
-	if (usartMap[serial]->usart_rx_buffer->head == usartMap[serial]->usart_rx_buffer->tail)
-	{
-		return -1;
-	}
-	else
-	{
-		uint16_t c = usartMap[serial]->usart_rx_buffer->buffer[usartMap[serial]->usart_rx_buffer->tail];
-		usartMap[serial]->usart_rx_buffer->tail = (unsigned int)(usartMap[serial]->usart_rx_buffer->tail + 1) % SERIAL_BUFFER_SIZE;
-		return c;
-	}
+int32_t hal_usart_read(HAL_USART_Serial serial) {
+    // if the head isn't ahead of the tail, we don't have any characters
+    if (usartMap[serial]->usart_rx_buffer->head == usartMap[serial]->usart_rx_buffer->tail) {
+        return -1;
+    } else {
+        uint16_t c = usartMap[serial]->usart_rx_buffer->buffer[usartMap[serial]->usart_rx_buffer->tail];
+        usartMap[serial]->usart_rx_buffer->tail = (unsigned int)(usartMap[serial]->usart_rx_buffer->tail + 1) % SERIAL_BUFFER_SIZE;
+        return c;
+    }
 }
 
-int32_t HAL_USART_Peek_Data(HAL_USART_Serial serial)
-{
-	if (usartMap[serial]->usart_rx_buffer->head == usartMap[serial]->usart_rx_buffer->tail)
-	{
-		return -1;
-	}
-	else
-	{
-		return usartMap[serial]->usart_rx_buffer->buffer[usartMap[serial]->usart_rx_buffer->tail];
-	}
+int32_t hal_usart_peek(HAL_USART_Serial serial) {
+    if (usartMap[serial]->usart_rx_buffer->head == usartMap[serial]->usart_rx_buffer->tail) {
+        return -1;
+    } else {
+        return usartMap[serial]->usart_rx_buffer->buffer[usartMap[serial]->usart_rx_buffer->tail];
+    }
 }
 
-void HAL_USART_Flush_Data(HAL_USART_Serial serial)
-{
-	// Loop until USART DR register is empty
-	while ( usartMap[serial]->usart_tx_buffer->head != usartMap[serial]->usart_tx_buffer->tail );
-	// Loop until last frame transmission complete
-	while (usartMap[serial]->usart_transmitting && (USART_GetFlagStatus(usartMap[serial]->usart_peripheral, USART_FLAG_TC) == RESET));
-	usartMap[serial]->usart_transmitting = false;
+void hal_usart_flush(HAL_USART_Serial serial) {
+    // Loop until USART DR register is empty
+    while ( usartMap[serial]->usart_tx_buffer->head != usartMap[serial]->usart_tx_buffer->tail );
+    // Loop until last frame transmission complete
+    while (usartMap[serial]->usart_transmitting && (USART_GetFlagStatus(usartMap[serial]->usart_peripheral, USART_FLAG_TC) == RESET));
+    usartMap[serial]->usart_transmitting = false;
 }
 
-bool HAL_USART_Is_Enabled(HAL_USART_Serial serial)
-{
-	return usartMap[serial]->usart_enabled;
+bool hal_usart_is_enabled(HAL_USART_Serial serial) {
+    return usartMap[serial]->usart_enabled;
 }
 
-void HAL_USART_Half_Duplex(HAL_USART_Serial serial, bool Enable)
-{
-	if (HAL_USART_Is_Enabled(serial)) {
-		USART_Cmd(usartMap[serial]->usart_peripheral, DISABLE);
-	}
+void hal_usart_half_duplex(HAL_USART_Serial serial, bool enable) {
+    if (hal_usart_is_enabled(serial)) {
+        USART_Cmd(usartMap[serial]->usart_peripheral, DISABLE);
+    }
 
-	if (Enable) {
-		usartMap[serial]->usart_config |= SERIAL_HALF_DUPLEX;
-	} else {
-		usartMap[serial]->usart_config &= ~(SERIAL_HALF_DUPLEX);
-	}
-	HAL_USART_Configure_Pin_Modes(serial, usartMap[serial]->usart_config);
+    if (enable) {
+        usartMap[serial]->conf.config |= SERIAL_HALF_DUPLEX;
+    } else {
+        usartMap[serial]->conf.config &= ~(SERIAL_HALF_DUPLEX);
+    }
+    configurePinsMode(serial, usartMap[serial]->conf.config);
 
-	// These bits need to be cleared according to the reference manual
-	usartMap[serial]->usart_peripheral->CR2 &= ~(USART_CR2_LINEN | USART_CR2_CLKEN);
-  	usartMap[serial]->usart_peripheral->CR3 &= ~(USART_CR3_IREN | USART_CR3_SCEN);
-	USART_HalfDuplexCmd(usartMap[serial]->usart_peripheral, Enable ? ENABLE : DISABLE);
+    // These bits need to be cleared according to the reference manual
+    usartMap[serial]->usart_peripheral->CR2 &= ~(USART_CR2_LINEN | USART_CR2_CLKEN);
+    usartMap[serial]->usart_peripheral->CR3 &= ~(USART_CR3_IREN | USART_CR3_SCEN);
+    USART_HalfDuplexCmd(usartMap[serial]->usart_peripheral, enable ? ENABLE : DISABLE);
 
 
-	if (HAL_USART_Is_Enabled(serial)) {
-		USART_Cmd(usartMap[serial]->usart_peripheral, ENABLE);
-	}
+    if (hal_usart_is_enabled(serial)) {
+        USART_Cmd(usartMap[serial]->usart_peripheral, ENABLE);
+    }
 }
 
-void HAL_USART_Send_Break(HAL_USART_Serial serial, void* reserved)
-{
-	int32_t state = HAL_disable_irq();
-	while((usartMap[serial]->usart_peripheral->CR1 & USART_CR1_SBK) == SET);
-	USART_SendBreak(usartMap[serial]->usart_peripheral);
-	while((usartMap[serial]->usart_peripheral->CR1 & USART_CR1_SBK) == SET);
-	HAL_enable_irq(state);
+void hal_usart_send_break(HAL_USART_Serial serial, void* reserved) {
+    int32_t state = HAL_disable_irq();
+    while((usartMap[serial]->usart_peripheral->CR1 & USART_CR1_SBK) == SET);
+    USART_SendBreak(usartMap[serial]->usart_peripheral);
+    while((usartMap[serial]->usart_peripheral->CR1 & USART_CR1_SBK) == SET);
+    HAL_enable_irq(state);
 }
 
-uint8_t HAL_USART_Break_Detected(HAL_USART_Serial serial)
-{
-	if (USART_GetFlagStatus(usartMap[serial]->usart_peripheral, USART_FLAG_LBD)) {
-		// Clear LBD flag
-		USART_ClearFlag(usartMap[serial]->usart_peripheral, USART_FLAG_LBD);
-		return 1;
-	}
-
-	return 0;
+uint8_t hal_usart_break_detected(HAL_USART_Serial serial) {
+    if (USART_GetFlagStatus(usartMap[serial]->usart_peripheral, USART_FLAG_LBD)) {
+        // Clear LBD flag
+        USART_ClearFlag(usartMap[serial]->usart_peripheral, USART_FLAG_LBD);
+        return 1;
+    }
+    return 0;
 }
 
 // Shared Interrupt Handler for USART2/Serial1 and USART1/Serial2
 // WARNING: This function MUST remain reentrance compliant -- no local static variables etc.
-static void HAL_USART_Handler(HAL_USART_Serial serial)
-{
-	if(USART_GetITStatus(usartMap[serial]->usart_peripheral, USART_IT_RXNE) != RESET)
-	{
-		// Read byte from the receive data register
-		uint16_t c = USART_ReceiveData(usartMap[serial]->usart_peripheral);
-		// Remove parity bits from data
-		c &= HAL_USART_Calculate_Data_Bits_Mask(usartMap[serial]->usart_config);
-		store_char(c, usartMap[serial]->usart_rx_buffer);
+static void usartIntHandler(HAL_USART_Serial serial) {
+    if (USART_GetITStatus(usartMap[serial]->usart_peripheral, USART_IT_RXNE) != RESET) {
+        // Read byte from the receive data register
+        uint16_t c = USART_ReceiveData(usartMap[serial]->usart_peripheral);
+        // Remove parity bits from data
+        c &= calculateDataBitsMask(usartMap[serial]->conf.config);
+        storeChar(c, usartMap[serial]->usart_rx_buffer);
+    }
+
+    uint8_t noecho = (usartMap[serial]->conf.config & (SERIAL_HALF_DUPLEX | SERIAL_HALF_DUPLEX_NO_ECHO)) == (SERIAL_HALF_DUPLEX | SERIAL_HALF_DUPLEX_NO_ECHO);
+
+    if (USART_GetITStatus(usartMap[serial]->usart_peripheral, USART_IT_TC) != RESET) {
+        if (noecho) {
+            USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TC, DISABLE);
+            configureTransmitReceive(serial, 0, 1);
+        }
+    }
+
+    if (USART_GetITStatus(usartMap[serial]->usart_peripheral, USART_IT_TXE) != RESET) {
+        // Write byte to the transmit data register
+        if (usartMap[serial]->usart_tx_buffer->head == usartMap[serial]->usart_tx_buffer->tail) {
+            // Buffer empty, so disable the USART Transmit interrupt
+            USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TXE, DISABLE);
+            if (noecho) {
+                USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TC, ENABLE);
+            }
+        } else {
+            if (noecho) {
+                configureTransmitReceive(serial, 1, 0);
+            }
+            // There is more data in the output buffer. Send the next byte
+            USART_SendData(usartMap[serial]->usart_peripheral, usartMap[serial]->usart_tx_buffer->buffer[usartMap[serial]->usart_tx_buffer->tail++]);
+            usartMap[serial]->usart_tx_buffer->tail %= SERIAL_BUFFER_SIZE;
+        }
+    }
+
+    if (USART_GetFlagStatus(usartMap[serial]->usart_peripheral, USART_FLAG_ORE) != RESET) {
+        // If Overrun flag is still set, clear it
+        (void)USART_ReceiveData(usartMap[serial]->usart_peripheral);
+    }
+}
+
+int hal_usart_sleep(HAL_USART_Serial serial, bool sleep, void* reserved) {
+	if (sleep) {
+        CHECK_TRUE(usartMap[serial]->usart_enabled, SYSTEM_ERROR_NONE);
+        CHECK_FALSE(usartMap[serial]->usart_suspended, SYSTEM_ERROR_NONE);
+		usartMap[serial]->usart_suspended = true;
+		hal_usart_flush(serial);
+		usartEndImpl(serial, true);
+	} else {
+		CHECK_TRUE(usartMap[serial]->usart_configured, SYSTEM_ERROR_INVALID_STATE);
+		CHECK_TRUE(usartMap[serial]->usart_suspended, SYSTEM_ERROR_NONE);
+		hal_usart_begin_config(serial, usartMap[serial]->conf.baud_rate, usartMap[serial]->conf.config, NULL);
 	}
-
-	uint8_t noecho = (usartMap[serial]->usart_config & (SERIAL_HALF_DUPLEX | SERIAL_HALF_DUPLEX_NO_ECHO)) == (SERIAL_HALF_DUPLEX | SERIAL_HALF_DUPLEX_NO_ECHO);
-
-	if(USART_GetITStatus(usartMap[serial]->usart_peripheral, USART_IT_TC) != RESET) {
-		if (noecho) {
-			USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TC, DISABLE);
-			HAL_USART_Configure_Transmit_Receive(serial, 0, 1);
-		}
-	}
-
-	if(USART_GetITStatus(usartMap[serial]->usart_peripheral, USART_IT_TXE) != RESET)
-	{
-		// Write byte to the transmit data register
-		if (usartMap[serial]->usart_tx_buffer->head == usartMap[serial]->usart_tx_buffer->tail)
-		{
-			// Buffer empty, so disable the USART Transmit interrupt
-			USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TXE, DISABLE);
-			if (noecho) {
-				USART_ITConfig(usartMap[serial]->usart_peripheral, USART_IT_TC, ENABLE);
-			}
-		}
-		else
-		{
-			if (noecho) {
-				HAL_USART_Configure_Transmit_Receive(serial, 1, 0);
-			}
-			// There is more data in the output buffer. Send the next byte
-			USART_SendData(usartMap[serial]->usart_peripheral, usartMap[serial]->usart_tx_buffer->buffer[usartMap[serial]->usart_tx_buffer->tail++]);
-			usartMap[serial]->usart_tx_buffer->tail %= SERIAL_BUFFER_SIZE;
-		}
-	}
-
-	if (USART_GetFlagStatus(usartMap[serial]->usart_peripheral, USART_FLAG_ORE) != RESET)
-	{
-		// If Overrun flag is still set, clear it
-		(void)USART_ReceiveData(usartMap[serial]->usart_peripheral);
-	}
-
+	return SYSTEM_ERROR_NONE;
 }
 
 // Serial1 interrupt handler
@@ -722,9 +748,8 @@ static void HAL_USART_Handler(HAL_USART_Serial serial)
  * Output         : None.
  * Return         : None.
  *******************************************************************************/
-void HAL_USART1_Handler(void)
-{
-	HAL_USART_Handler(HAL_USART_SERIAL1);
+void HAL_USART1_Handler(void) {
+    usartIntHandler(HAL_USART_SERIAL1);
 }
 
 // Serial2 interrupt handler
@@ -735,12 +760,12 @@ void HAL_USART1_Handler(void)
  * Output         : None.
  * Return         : None.
  *******************************************************************************/
-void HAL_USART2_Handler(void)
-{
-	HAL_USART_Handler(HAL_USART_SERIAL2);
+void HAL_USART2_Handler(void) {
+    usartIntHandler(HAL_USART_SERIAL2);
 }
 
-#if PLATFORM_ID == 10 // Only Electron
+#if PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION
+
 #if 0
 // Serial3 interrupt handler
 /*******************************************************************************
@@ -750,9 +775,8 @@ void HAL_USART2_Handler(void)
  * Output         : None.
  * Return         : None.
  *******************************************************************************/
-void HAL_USART3_Handler(void)
-{
-	HAL_USART_Handler(HAL_USART_SERIAL3);
+void HAL_USART3_Handler(void) {
+    usartIntHandler(HAL_USART_SERIAL3);
 }
 #endif
 
@@ -764,9 +788,8 @@ void HAL_USART3_Handler(void)
  * Output         : None.
  * Return         : None.
  *******************************************************************************/
-void HAL_USART4_Handler(void)
-{
-	HAL_USART_Handler(HAL_USART_SERIAL4);
+void HAL_USART4_Handler(void) {
+    usartIntHandler(HAL_USART_SERIAL4);
 }
 
 // Serial5 interrupt handler
@@ -777,8 +800,8 @@ void HAL_USART4_Handler(void)
  * Output         : None.
  * Return         : None.
  *******************************************************************************/
-void HAL_USART5_Handler(void)
-{
-	HAL_USART_Handler(HAL_USART_SERIAL5);
+void HAL_USART5_Handler(void) {
+    usartIntHandler(HAL_USART_SERIAL5);
 }
-#endif
+
+#endif // PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION

--- a/hal/src/template/usart_hal.cpp
+++ b/hal/src/template/usart_hal.cpp
@@ -26,52 +26,52 @@
 /* Includes ------------------------------------------------------------------*/
 #include "usart_hal.h"
 
-void HAL_USART_Init(HAL_USART_Serial serial, Ring_Buffer *rx_buffer, Ring_Buffer *tx_buffer)
+void hal_usart_init(HAL_USART_Serial serial, Ring_Buffer *rx_buffer, Ring_Buffer *tx_buffer)
 {
 }
 
-void HAL_USART_Begin(HAL_USART_Serial serial, uint32_t baud, uint8_t config, void*)
+void hal_usart_begin(HAL_USART_Serial serial, uint32_t baud, uint8_t config, void*)
 {
 }
 
-void HAL_USART_End(HAL_USART_Serial serial)
+void hal_usart_end(HAL_USART_Serial serial)
 {
 }
 
-uint32_t HAL_USART_Write_Data(HAL_USART_Serial serial, uint8_t data)
+uint32_t hal_usart_write(HAL_USART_Serial serial, uint8_t data)
 {
   return 0;
 }
 
-int32_t HAL_USART_Available_Data(HAL_USART_Serial serial)
+int32_t hal_usart_available(HAL_USART_Serial serial)
 {
     return 0;
 }
 
-int32_t HAL_USART_Read_Data(HAL_USART_Serial serial)
+int32_t hal_usart_read(HAL_USART_Serial serial)
 {
     return 0;
 }
 
-int32_t HAL_USART_Peek_Data(HAL_USART_Serial serial)
+int32_t hal_usart_peek(HAL_USART_Serial serial)
 {
     return 0;
 }
 
-void HAL_USART_Flush_Data(HAL_USART_Serial serial)
+void hal_usart_flush(HAL_USART_Serial serial)
 {
 }
 
-bool HAL_USART_Is_Enabled(HAL_USART_Serial serial)
+bool hal_usart_is_enabled(HAL_USART_Serial serial)
 {
     return false;
 }
 
-void HAL_USART_Half_Duplex(HAL_USART_Serial serial, bool Enable)
+void hal_usart_half_duplex(HAL_USART_Serial serial, bool Enable)
 {
 }
 
-int32_t HAL_USART_Available_Data_For_Write(HAL_USART_Serial serial)
+int32_t hal_usart_available_data_for_write(HAL_USART_Serial serial)
 {
     return 0;
 }

--- a/hal/src/template/usart_hal.cpp
+++ b/hal/src/template/usart_hal.cpp
@@ -26,52 +26,52 @@
 /* Includes ------------------------------------------------------------------*/
 #include "usart_hal.h"
 
-void hal_usart_init(HAL_USART_Serial serial, Ring_Buffer *rx_buffer, Ring_Buffer *tx_buffer)
+void hal_usart_init(hal_usart_interface_t serial, hal_usart_ring_buffer_t *rx_buffer, hal_usart_ring_buffer_t *tx_buffer)
 {
 }
 
-void hal_usart_begin(HAL_USART_Serial serial, uint32_t baud, uint8_t config, void*)
+void hal_usart_begin(hal_usart_interface_t serial, uint32_t baud, uint8_t config, void*)
 {
 }
 
-void hal_usart_end(HAL_USART_Serial serial)
+void hal_usart_end(hal_usart_interface_t serial)
 {
 }
 
-uint32_t hal_usart_write(HAL_USART_Serial serial, uint8_t data)
+uint32_t hal_usart_write(hal_usart_interface_t serial, uint8_t data)
 {
   return 0;
 }
 
-int32_t hal_usart_available(HAL_USART_Serial serial)
+int32_t hal_usart_available(hal_usart_interface_t serial)
 {
     return 0;
 }
 
-int32_t hal_usart_read(HAL_USART_Serial serial)
+int32_t hal_usart_read(hal_usart_interface_t serial)
 {
     return 0;
 }
 
-int32_t hal_usart_peek(HAL_USART_Serial serial)
+int32_t hal_usart_peek(hal_usart_interface_t serial)
 {
     return 0;
 }
 
-void hal_usart_flush(HAL_USART_Serial serial)
+void hal_usart_flush(hal_usart_interface_t serial)
 {
 }
 
-bool hal_usart_is_enabled(HAL_USART_Serial serial)
+bool hal_usart_is_enabled(hal_usart_interface_t serial)
 {
     return false;
 }
 
-void hal_usart_half_duplex(HAL_USART_Serial serial, bool Enable)
+void hal_usart_half_duplex(hal_usart_interface_t serial, bool Enable)
 {
 }
 
-int32_t hal_usart_available_data_for_write(HAL_USART_Serial serial)
+int32_t hal_usart_available_data_for_write(hal_usart_interface_t serial)
 {
     return 0;
 }

--- a/hal/src/template/usart_hal.cpp
+++ b/hal/src/template/usart_hal.cpp
@@ -40,7 +40,7 @@ void hal_usart_end(hal_usart_interface_t serial)
 
 uint32_t hal_usart_write(hal_usart_interface_t serial, uint8_t data)
 {
-  return 0;
+    return 0;
 }
 
 int32_t hal_usart_available(hal_usart_interface_t serial)
@@ -72,6 +72,11 @@ void hal_usart_half_duplex(hal_usart_interface_t serial, bool Enable)
 }
 
 int32_t hal_usart_available_data_for_write(hal_usart_interface_t serial)
+{
+    return 0;
+}
+
+int hal_usart_sleep(hal_usart_interface_t serial, bool sleep, void* reserved)
 {
     return 0;
 }

--- a/services/inc/ringbuffer.h
+++ b/services/inc/ringbuffer.h
@@ -37,6 +37,7 @@ public:
 
     void init(T* buffer, size_t size);
     void reset();
+    void prune();
 
     size_t size() const;
 
@@ -113,6 +114,12 @@ inline void RingBuffer<T>::reset() {
 
     head_ = tail_ = headPending_ = tailPending_ = 0;
     full_ = false;
+}
+
+template <typename T>
+inline void RingBuffer<T>::prune() {
+    curSize_ = size_;
+    headPending_ = tailPending_ = 0;
 }
 
 template <typename T>

--- a/user/libraries/Serial2/Serial2.h
+++ b/user/libraries/Serial2/Serial2.h
@@ -6,8 +6,8 @@
 #if Wiring_Serial2
 
 // instantiate Serial2
-static Ring_Buffer serial2_rx_buffer;
-static Ring_Buffer serial2_tx_buffer;
+static hal_usart_ring_buffer_t serial2_rx_buffer;
+static hal_usart_ring_buffer_t serial2_tx_buffer;
 
 USARTSerial& __fetch_global_Serial2()
 {

--- a/user/libraries/Serial3/Serial3.h
+++ b/user/libraries/Serial3/Serial3.h
@@ -5,8 +5,8 @@
 #if Wiring_Serial3
 
 // instantiate Serial3
-static Ring_Buffer serial3_rx_buffer;
-static Ring_Buffer serial3_tx_buffer;
+static hal_usart_ring_buffer_t serial3_rx_buffer;
+static hal_usart_ring_buffer_t serial3_tx_buffer;
 
 
 USARTSerial& __fetch_global_Serial3()

--- a/user/libraries/Serial4/Serial4.h
+++ b/user/libraries/Serial4/Serial4.h
@@ -6,8 +6,8 @@
 #if Wiring_Serial4
 
 // instantiate Serial4
-static Ring_Buffer serial4_rx_buffer;
-static Ring_Buffer serial4_tx_buffer;
+static hal_usart_ring_buffer_t serial4_rx_buffer;
+static hal_usart_ring_buffer_t serial4_tx_buffer;
 
 USARTSerial& __fetch_global_Serial4()
 {

--- a/user/libraries/Serial5/Serial5.h
+++ b/user/libraries/Serial5/Serial5.h
@@ -6,8 +6,8 @@
 #if Wiring_Serial5
 
 // instantiate Serial5
-static Ring_Buffer serial5_rx_buffer;
-static Ring_Buffer serial5_tx_buffer;
+static hal_usart_ring_buffer_t serial5_rx_buffer;
+static hal_usart_ring_buffer_t serial5_tx_buffer;
 
 USARTSerial& __fetch_global_Serial5()
 {

--- a/user/tests/hal/uart/test_uart.cpp
+++ b/user/tests/hal/uart/test_uart.cpp
@@ -21,8 +21,8 @@
 
 SYSTEM_MODE(SEMI_AUTOMATIC);
 
-Ring_Buffer uart_tx_buffer;
-Ring_Buffer uart_rx_buffer;
+hal_usart_ring_buffer_t uart_tx_buffer;
+hal_usart_ring_buffer_t uart_rx_buffer;
 
 
 /* executes once at startup */

--- a/user/tests/hal/uart/test_uart.cpp
+++ b/user/tests/hal/uart/test_uart.cpp
@@ -30,17 +30,17 @@ void setup() {
     // uint32_t config = SERIAL_STOP_BITS_1 | SERIAL_PARITY_EVEN | SERIAL_DATA_BITS_8 | SERIAL_FLOW_CONTROL_RTS_CTS;
     uint32_t config = 0;
 
-    HAL_USART_Init(HAL_USART_SERIAL1, &uart_rx_buffer, &uart_tx_buffer);
-    HAL_USART_BeginConfig(HAL_USART_SERIAL1, 115200, config, NULL);
+    hal_usart_init(HAL_USART_SERIAL1, &uart_rx_buffer, &uart_tx_buffer);
+    hal_usart_begin_config(HAL_USART_SERIAL1, 115200, config, NULL);
 }
 
 /* executes continuously after setup() runs */
 void loop() {
     uint8_t data;
 
-    if (HAL_USART_Available_Data(HAL_USART_SERIAL1))
+    if (hal_usart_available(HAL_USART_SERIAL1))
     {
-        data = HAL_USART_Read_Data(HAL_USART_SERIAL1);
-        HAL_USART_Write_Data(HAL_USART_SERIAL1, data);
+        data = hal_usart_read(HAL_USART_SERIAL1);
+        hal_usart_write(HAL_USART_SERIAL1, data);
     }
 }

--- a/user/tests/wiring/no_fixture_long_running/network.cpp
+++ b/user/tests/wiring/no_fixture_long_running/network.cpp
@@ -174,8 +174,8 @@ test(NETWORK_02_network_connection_recovers_after_ncp_failure) {
     // FIXME: when a new platform is added not using HAL_USART_SERIAL2 or not using
     // UART for talking to NCP.
     SINGLE_THREADED_BLOCK() {
-        HAL_USART_End(HAL_USART_SERIAL2);
-        HAL_USART_BeginConfig(HAL_USART_SERIAL2, 57600, SERIAL_8N1, nullptr);
+        hal_usart_end(HAL_USART_SERIAL2);
+        hal_usart_begin_config(HAL_USART_SERIAL2, 57600, SERIAL_8N1, nullptr);
     }
 
     delay(NCP_FAILURE_TIMEOUT);

--- a/user/tests/wiring/serial_loopback2/loopback.cpp
+++ b/user/tests/wiring/serial_loopback2/loopback.cpp
@@ -99,6 +99,6 @@ test(SERIAL_02_LoopbackReceivedDataShouldRetainAfterSleepWakeup) {
     Serial1.begin(BAUD_RATE);
 
     for (unsigned i = 0; i < ITERATIONS; ++i) {
-        runLoopback(TEST_BUFFER_SIZE_MIN, TEST_BUFFER_SIZE_MAX, false);
+        runLoopback(TEST_BUFFER_SIZE_MIN, TEST_BUFFER_SIZE_MAX, true);
     }
 }

--- a/wiring/inc/spark_wiring_usartserial.h
+++ b/wiring/inc/spark_wiring_usartserial.h
@@ -34,10 +34,10 @@
 class USARTSerial : public Stream
 {
 private:
-  HAL_USART_Serial _serial;
+  hal_usart_interface_t _serial;
   bool _blocking;
 public:
-  USARTSerial(HAL_USART_Serial serial, Ring_Buffer *rx_buffer, Ring_Buffer *tx_buffer);
+  USARTSerial(hal_usart_interface_t serial, hal_usart_ring_buffer_t *rx_buffer, hal_usart_ring_buffer_t *tx_buffer);
   virtual ~USARTSerial() {};
   void begin(unsigned long);
   void begin(unsigned long, uint32_t);

--- a/wiring/src/spark_wiring_usartserial.cpp
+++ b/wiring/src/spark_wiring_usartserial.cpp
@@ -31,7 +31,7 @@
 
 // Constructors ////////////////////////////////////////////////////////////////
 
-USARTSerial::USARTSerial(HAL_USART_Serial serial, Ring_Buffer *rx_buffer, Ring_Buffer *tx_buffer)
+USARTSerial::USARTSerial(hal_usart_interface_t serial, hal_usart_ring_buffer_t *rx_buffer, hal_usart_ring_buffer_t *tx_buffer)
 {
   _serial = serial;
   // Default is blocking mode
@@ -125,11 +125,11 @@ bool USARTSerial::breakRx() {
 #ifndef SPARK_WIRING_NO_USART_SERIAL
 // Preinstantiate Objects //////////////////////////////////////////////////////
 #if ((MODULE_FUNCTION == MOD_FUNC_USER_PART) || (MODULE_FUNCTION == MOD_FUNC_MONO_FIRMWARE))
-static Ring_Buffer serial1_rx_buffer;
-static Ring_Buffer serial1_tx_buffer;
+static hal_usart_ring_buffer_t serial1_rx_buffer;
+static hal_usart_ring_buffer_t serial1_tx_buffer;
 #else
-static Ring_Buffer* serial1_rx_buffer = nullptr;
-static Ring_Buffer* serial1_tx_buffer = nullptr;
+static hal_usart_ring_buffer_t* serial1_rx_buffer = nullptr;
+static hal_usart_ring_buffer_t* serial1_tx_buffer = nullptr;
 #endif
 
 USARTSerial& __fetch_global_Serial1()
@@ -138,10 +138,10 @@ USARTSerial& __fetch_global_Serial1()
 	static USARTSerial serial1(HAL_USART_SERIAL1, &serial1_rx_buffer, &serial1_tx_buffer);
 #else
   if (!serial1_rx_buffer) {
-    serial1_rx_buffer = new Ring_Buffer();
+    serial1_rx_buffer = new hal_usart_ring_buffer_t();
   }
   if (!serial1_tx_buffer) {
-    serial1_tx_buffer = new Ring_Buffer();
+    serial1_tx_buffer = new hal_usart_ring_buffer_t();
   }
   static USARTSerial serial1(HAL_USART_SERIAL1, serial1_rx_buffer, serial1_tx_buffer);
 #endif

--- a/wiring/src/spark_wiring_usartserial.cpp
+++ b/wiring/src/spark_wiring_usartserial.cpp
@@ -36,7 +36,7 @@ USARTSerial::USARTSerial(HAL_USART_Serial serial, Ring_Buffer *rx_buffer, Ring_B
   _serial = serial;
   // Default is blocking mode
   _blocking = true;
-  HAL_USART_Init(serial, rx_buffer, tx_buffer);
+  hal_usart_init(serial, rx_buffer, tx_buffer);
 }
 // Public Methods //////////////////////////////////////////////////////////////
 
@@ -47,17 +47,17 @@ void USARTSerial::begin(unsigned long baud)
 
 void USARTSerial::begin(unsigned long baud, uint32_t config)
 {
-  HAL_USART_BeginConfig(_serial, baud, config, 0);
+  hal_usart_begin_config(_serial, baud, config, nullptr);
 }
 
 void USARTSerial::end()
 {
-  HAL_USART_End(_serial);
+  hal_usart_end(_serial);
 }
 
 void USARTSerial::halfduplex(bool Enable)
 {
-    HAL_USART_Half_Duplex(_serial, Enable);
+    hal_usart_half_duplex(_serial, Enable);
 }
 
 void USARTSerial::blockOnOverrun(bool block)
@@ -68,42 +68,42 @@ void USARTSerial::blockOnOverrun(bool block)
 
 int USARTSerial::availableForWrite(void)
 {
-  return std::max(0, (int)HAL_USART_Available_Data_For_Write(_serial));
+  return std::max(0, (int)hal_usart_available_data_for_write(_serial));
 }
 
 int USARTSerial::available(void)
 {
-  return std::max(0, (int)HAL_USART_Available_Data(_serial));
+  return std::max(0, (int)hal_usart_available(_serial));
 }
 
 int USARTSerial::peek(void)
 {
-  return std::max(-1, (int)HAL_USART_Peek_Data(_serial));
+  return std::max(-1, (int)hal_usart_peek(_serial));
 }
 
 int USARTSerial::read(void)
 {
-  return std::max(-1, (int)HAL_USART_Read_Data(_serial));
+  return std::max(-1, (int)hal_usart_read(_serial));
 }
 
 void USARTSerial::flush()
 {
-  HAL_USART_Flush_Data(_serial);
+  hal_usart_flush(_serial);
 }
 
 size_t USARTSerial::write(uint8_t c)
 {
   // attempt a write if blocking, or for non-blocking if there is room.
-  if (_blocking || HAL_USART_Available_Data_For_Write(_serial) > 0) {
+  if (_blocking || hal_usart_available_data_for_write(_serial) > 0) {
     // the HAL always blocks.
-	  return HAL_USART_Write_Data(_serial, c);
+	  return hal_usart_write(_serial, c);
   }
   return 0;
 }
 
 size_t USARTSerial::write(uint16_t c)
 {
-  return HAL_USART_Write_NineBitData(_serial, c);
+  return hal_usart_write_nine_bits(_serial, c);
 }
 
 USARTSerial::operator bool() {
@@ -111,15 +111,15 @@ USARTSerial::operator bool() {
 }
 
 bool USARTSerial::isEnabled() {
-  return HAL_USART_Is_Enabled(_serial);
+  return hal_usart_is_enabled(_serial);
 }
 
 void USARTSerial::breakTx() {
-  HAL_USART_Send_Break(_serial, NULL);
+  hal_usart_send_break(_serial, nullptr);
 }
 
 bool USARTSerial::breakRx() {
-  return (bool)HAL_USART_Break_Detected(_serial);
+  return (bool)hal_usart_break_detected(_serial);
 }
 
 #ifndef SPARK_WIRING_NO_USART_SERIAL
@@ -128,8 +128,8 @@ bool USARTSerial::breakRx() {
 static Ring_Buffer serial1_rx_buffer;
 static Ring_Buffer serial1_tx_buffer;
 #else
-static Ring_Buffer* serial1_rx_buffer = NULL;
-static Ring_Buffer* serial1_tx_buffer = NULL;
+static Ring_Buffer* serial1_rx_buffer = nullptr;
+static Ring_Buffer* serial1_tx_buffer = nullptr;
 #endif
 
 USARTSerial& __fetch_global_Serial1()


### PR DESCRIPTION

### Example App

```c
#include "Particle.h"

SYSTEM_MODE(MANUAL);

void setup() {
    Serial1.begin(115200);

    Serial1.println("Application started.");
}

void loop() {
    static system_tick_t now = millis();
    if (millis() - now >= 1000) {
        now = millis();
        Serial1.println("Suspend UART");
        hal_usart_sleep(HAL_USART_SERIAL1, true, nullptr);
        delay(1000);
        hal_usart_sleep(HAL_USART_SERIAL1, false, nullptr);
        Serial1.println("UART state is restored");
        Serial1.println("fjkgsajfgkajsgfkyusdgh");
    }
}
```

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
