### PR TITLE
Reset the device after applying an update while in listening mode

### DIFF
--- a/system/src/system_network_internal.h
+++ b/system/src/system_network_internal.h
@@ -398,6 +398,7 @@ protected:
             // TODO: Process BLE channel events in a separate thread
             system::SystemControl::instance()->run();
 #endif
+            system_shutdown_if_needed();
         // while (network_listening(0, 0, NULL))
         } start_listening_timer_destroy(); // immediately destroy timer if we are on our way out
 


### PR DESCRIPTION
### Problem

https://github.com/particle-iot/device-os/pull/1899 introduced a regression that prevents a Gen 2 device from resetting itself after applying an update received via YModem.

### Solution

Check the `SYSTEM_FLAG_RESET_PENDING` flag in the listening mode loop and reset the device if it's set.

### Steps to Test

Put a Gen 2 device into listening mode, flash a module binary via YModem and verify that the device resets after applying the update.

### References

- [ch56592]
