### PR TITLE
 Implement sleep API for ADC on Gen2 and Gen3 device

### DIFF
--- a/hal/inc/adc_hal.h
+++ b/hal/inc/adc_hal.h
@@ -45,6 +45,7 @@ extern "C" {
 void HAL_ADC_Set_Sample_Time(uint8_t ADC_SampleTime);
 int32_t HAL_ADC_Read(pin_t pin);
 void HAL_ADC_DMA_Init();
+int HAL_ADC_Sleep(bool sleep, void* reserved);
 
 #ifdef __cplusplus
 }

--- a/hal/inc/adc_hal.h
+++ b/hal/inc/adc_hal.h
@@ -23,20 +23,16 @@
  ******************************************************************************
  */
 
-/* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef __ADC_HAL_H
 #define __ADC_HAL_H
 
-/* Includes ------------------------------------------------------------------*/
 #include "pinmap_hal.h"
 
-/* Exported types ------------------------------------------------------------*/
-
-/* Exported constants --------------------------------------------------------*/
-
-/* Exported macros -----------------------------------------------------------*/
-
-/* Exported functions --------------------------------------------------------*/
+typedef enum hal_adc_state_t {
+    HAL_ADC_STATE_DISABLED,
+    HAL_ADC_STATE_ENABLED,
+    HAL_ADC_STATE_SUSPENDED
+} hal_adc_state_t;
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/inc/adc_hal.h
+++ b/hal/inc/adc_hal.h
@@ -1,26 +1,25 @@
-/**
- ******************************************************************************
+/******************************************************************************
  * @file    adc_hal.h
  * @authors Satish Nair, Brett Walach
  * @version V1.0.0
  * @date    12-Sept-2014
  * @brief
- ******************************************************************************
-  Copyright (c) 2013-2015 Particle Industries, Inc.  All rights reserved.
-
-  This library is free software; you can redistribute it and/or
-  modify it under the terms of the GNU Lesser General Public
-  License as published by the Free Software Foundation, either
-  version 3 of the License, or (at your option) any later version.
-
-  This library is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  Lesser General Public License for more details.
-
-  You should have received a copy of the GNU Lesser General Public
-  License along with this library; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
+ ******************************************************************************/
+/*
+ * Copyright (c) 2020 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHAN'TABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifndef __ADC_HAL_H
@@ -38,10 +37,10 @@ typedef enum hal_adc_state_t {
 extern "C" {
 #endif
 
-void HAL_ADC_Set_Sample_Time(uint8_t ADC_SampleTime);
-int32_t HAL_ADC_Read(pin_t pin);
-void HAL_ADC_DMA_Init();
-int HAL_ADC_Sleep(bool sleep, void* reserved);
+void hal_adc_set_sample_time(uint8_t sample_time);
+int32_t hal_adc_read(pin_t pin);
+void hal_adc_dma_init();
+int hal_adc_sleep(bool sleep, void* reserved);
 
 #ifdef __cplusplus
 }

--- a/hal/inc/hal_dynalib_gpio.h
+++ b/hal/inc/hal_dynalib_gpio.h
@@ -86,6 +86,7 @@ DYNALIB_FN(33, hal_gpio, HAL_PWM_Get_AnalogValue_Ext, uint32_t(uint16_t))
 DYNALIB_FN(34, hal_gpio, HAL_PWM_Get_Max_Frequency, uint32_t(uint16_t))
 DYNALIB_FN(35, hal_gpio, HAL_Interrupts_Detach_Ext, int(uint16_t, uint8_t, void*))
 DYNALIB_FN(36, hal_gpio, HAL_Set_Direct_Interrupt_Handler, int(IRQn_Type irqn, HAL_Direct_Interrupt_Handler handler, uint32_t flags, void* reserved))
+DYNALIB_FN(37, hal_gpio, HAL_ADC_Sleep, int(bool sleep, void* reserved))
 
 DYNALIB_END(hal_gpio)
 

--- a/hal/inc/hal_dynalib_gpio.h
+++ b/hal/inc/hal_dynalib_gpio.h
@@ -86,7 +86,7 @@ DYNALIB_FN(33, hal_gpio, HAL_PWM_Get_AnalogValue_Ext, uint32_t(uint16_t))
 DYNALIB_FN(34, hal_gpio, HAL_PWM_Get_Max_Frequency, uint32_t(uint16_t))
 DYNALIB_FN(35, hal_gpio, HAL_Interrupts_Detach_Ext, int(uint16_t, uint8_t, void*))
 DYNALIB_FN(36, hal_gpio, HAL_Set_Direct_Interrupt_Handler, int(IRQn_Type irqn, HAL_Direct_Interrupt_Handler handler, uint32_t flags, void* reserved))
-DYNALIB_FN(37, hal_gpio, HAL_ADC_Sleep, int(bool sleep, void* reserved))
+DYNALIB_FN(37, hal_gpio, HAL_ADC_Sleep, int(bool, void*))
 
 DYNALIB_END(hal_gpio)
 

--- a/hal/inc/hal_dynalib_gpio.h
+++ b/hal/inc/hal_dynalib_gpio.h
@@ -55,8 +55,8 @@ DYNALIB_FN(8, hal_gpio, HAL_Interrupts_Enable_All, void(void))
 DYNALIB_FN(9, hal_gpio, HAL_Interrupts_Disable_All, void(void))
 
 DYNALIB_FN(10, hal_gpio, HAL_DAC_Write, void(pin_t, uint16_t))
-DYNALIB_FN(11, hal_gpio, HAL_ADC_Set_Sample_Time, void(uint8_t))
-DYNALIB_FN(12, hal_gpio, HAL_ADC_Read, int32_t(uint16_t))
+DYNALIB_FN(11, hal_gpio, hal_adc_set_sample_time, void(uint8_t))
+DYNALIB_FN(12, hal_gpio, hal_adc_read, int32_t(uint16_t))
 
 DYNALIB_FN(13, hal_gpio, HAL_PWM_Write, void(uint16_t, uint8_t))
 DYNALIB_FN(14, hal_gpio, HAL_PWM_Get_Frequency, uint16_t(uint16_t))
@@ -86,7 +86,7 @@ DYNALIB_FN(33, hal_gpio, HAL_PWM_Get_AnalogValue_Ext, uint32_t(uint16_t))
 DYNALIB_FN(34, hal_gpio, HAL_PWM_Get_Max_Frequency, uint32_t(uint16_t))
 DYNALIB_FN(35, hal_gpio, HAL_Interrupts_Detach_Ext, int(uint16_t, uint8_t, void*))
 DYNALIB_FN(36, hal_gpio, HAL_Set_Direct_Interrupt_Handler, int(IRQn_Type irqn, HAL_Direct_Interrupt_Handler handler, uint32_t flags, void* reserved))
-DYNALIB_FN(37, hal_gpio, HAL_ADC_Sleep, int(bool, void*))
+DYNALIB_FN(37, hal_gpio, hal_adc_sleep, int(bool, void*))
 
 DYNALIB_END(hal_gpio)
 

--- a/hal/src/nRF52840/adc_hal.cpp
+++ b/hal/src/nRF52840/adc_hal.cpp
@@ -151,7 +151,6 @@ int HAL_ADC_Sleep(bool sleep, void* reserved)
         // Restore ADC
         CHECK_TRUE(m_adc_state == HAL_ADC_STATE_SUSPENDED, SYSTEM_ERROR_INVALID_STATE);
         HAL_ADC_DMA_Init();
-        m_adc_state = HAL_ADC_STATE_ENABLED;
     }
 
     return SYSTEM_ERROR_NONE;

--- a/hal/src/stm32f2xx/adc_hal.c
+++ b/hal/src/stm32f2xx/adc_hal.c
@@ -261,7 +261,6 @@ int HAL_ADC_Sleep(bool sleep, void* reserved)
             return SYSTEM_ERROR_INVALID_STATE;
         }
         HAL_ADC_DMA_Init();
-        adcState = HAL_ADC_STATE_ENABLED;
     }
 
     return SYSTEM_ERROR_NONE;

--- a/hal/src/stm32f2xx/adc_hal.c
+++ b/hal/src/stm32f2xx/adc_hal.c
@@ -1,26 +1,25 @@
-/**
- ******************************************************************************
+/******************************************************************************
  * @file    adc_hal.c
  * @authors Satish Nair
  * @version V1.0.0
  * @date    22-Dec-2014
  * @brief
- ******************************************************************************
-  Copyright (c) 2013-2015 Particle Industries, Inc.  All rights reserved.
-
-  This library is free software; you can redistribute it and/or
-  modify it under the terms of the GNU Lesser General Public
-  License as published by the Free Software Foundation, either
-  version 3 of the License, or (at your option) any later version.
-
-  This library is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  Lesser General Public License for more details.
-
-  You should have received a copy of the GNU Lesser General Public
-  License along with this library; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
+ ******************************************************************************/
+/*
+ * Copyright (c) 2020 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHAN'TABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
  */
 
 /* Includes ------------------------------------------------------------------*/
@@ -31,26 +30,15 @@
 #include "system_error.h"
 #include <stddef.h>
 
-/* Private typedef -----------------------------------------------------------*/
-
 /* Private define ------------------------------------------------------------*/
-
 #define ADC_CDR_ADDRESS     ((uint32_t)0x40012308)
 #define ADC_DMA_BUFFERSIZE  10
 #define ADC_SAMPLING_TIME   ADC_SampleTime_480Cycles
 
-/* Private macro -------------------------------------------------------------*/
-
-/* Private variables ---------------------------------------------------------*/
-
-__IO uint16_t ADC_ConvertedValues[ADC_DMA_BUFFERSIZE];
+__IO uint16_t convertedValues[ADC_DMA_BUFFERSIZE];
 static hal_adc_state_t adcState = HAL_ADC_STATE_DISABLED;
-static uint8_t adcChannelConfigured = ADC_CHANNEL_NONE;
-static uint8_t ADC_Sample_Time = ADC_SAMPLING_TIME;
-
-/* Extern variables ----------------------------------------------------------*/
-
-/* Private function prototypes -----------------------------------------------*/
+static uint8_t channelConfigured = ADC_CHANNEL_NONE;
+static uint8_t sampleTime = ADC_SAMPLING_TIME;
 
 /*
  * @brief  Override the default ADC Sample time depending on requirement
@@ -66,15 +54,11 @@ static uint8_t ADC_Sample_Time = ADC_SAMPLING_TIME;
  * @arg ADC_SampleTime_480Cycles: Sample time equal to 480 cycles
  * @retval None
  */
-void HAL_ADC_Set_Sample_Time(uint8_t ADC_SampleTime)
-{
-    if(ADC_SampleTime < ADC_SampleTime_3Cycles || ADC_SampleTime > ADC_SampleTime_480Cycles)
-    {
-        ADC_Sample_Time = ADC_SAMPLING_TIME;
-    }
-    else
-    {
-        ADC_Sample_Time = ADC_SampleTime;
+void hal_adc_set_sample_time(uint8_t sample_time) {
+    if (sample_time < ADC_SampleTime_3Cycles || sample_time > ADC_SampleTime_480Cycles) {
+        sampleTime = ADC_SAMPLING_TIME;
+    } else {
+        sampleTime = sample_time;
     }
 }
 
@@ -83,36 +67,30 @@ void HAL_ADC_Set_Sample_Time(uint8_t ADC_SampleTime)
  * Should return a 16-bit value, 0-65536 (0 = LOW, 65536 = HIGH)
  * Note: ADC is 12-bit. Currently it returns 0-4096
  */
-int32_t HAL_ADC_Read(uint16_t pin)
-{
-
+int32_t hal_adc_read(uint16_t pin) {
     int i = 0;
     Hal_Pin_Info* PIN_MAP = HAL_Pin_Map();
 
-    if (PIN_MAP[pin].pin_mode != AN_INPUT)
-    {
+    if (PIN_MAP[pin].pin_mode != AN_INPUT) {
         HAL_GPIO_Save_Pin_Mode(pin);
         HAL_Pin_Mode(pin, AN_INPUT);
     }
 
-    if (adcState != HAL_ADC_STATE_ENABLED)
-    {
-        HAL_ADC_DMA_Init();
+    if (adcState != HAL_ADC_STATE_ENABLED) {
+        hal_adc_dma_init();
     }
 
-    if (adcChannelConfigured != PIN_MAP[pin].adc_channel)
-    {
+    if (channelConfigured != PIN_MAP[pin].adc_channel) {
         // ADC1 regular channel configuration
-        ADC_RegularChannelConfig(ADC1, PIN_MAP[pin].adc_channel, 1, ADC_Sample_Time);
+        ADC_RegularChannelConfig(ADC1, PIN_MAP[pin].adc_channel, 1, sampleTime);
         // ADC2 regular channel configuration
-        ADC_RegularChannelConfig(ADC2, PIN_MAP[pin].adc_channel, 1, ADC_Sample_Time);
+        ADC_RegularChannelConfig(ADC2, PIN_MAP[pin].adc_channel, 1, sampleTime);
         // Save the ADC configured channel
-        adcChannelConfigured = PIN_MAP[pin].adc_channel;
+        channelConfigured = PIN_MAP[pin].adc_channel;
     }
 
-    for(i = 0; i < ADC_DMA_BUFFERSIZE; i++)
-    {
-        ADC_ConvertedValues[i] = 0;
+    for (i = 0; i < ADC_DMA_BUFFERSIZE; i++) {
+        convertedValues[i] = 0;
     }
 
     // Enable DMA2_Stream0
@@ -131,7 +109,7 @@ int32_t HAL_ADC_Read(uint16_t pin)
     ADC_SoftwareStartConv(ADC1);
 
     // Test on DMA2 Stream0 DMA_FLAG_TCIF0 flag
-    while(!DMA_GetFlagStatus(DMA2_Stream0, DMA_FLAG_TCIF0));
+    while (!DMA_GetFlagStatus(DMA2_Stream0, DMA_FLAG_TCIF0));
 
     // Clear DMA2 Stream0 DMA_FLAG_TCIF0 flag
     DMA_ClearFlag(DMA2_Stream0, DMA_FLAG_TCIF0);
@@ -148,27 +126,24 @@ int32_t HAL_ADC_Read(uint16_t pin)
     // Disable ADC2
     ADC_Cmd(ADC2, DISABLE);
 
-    uint32_t ADC_SummatedValue = 0;
-    uint16_t ADC_AveragedValue = 0;
+    uint32_t summatedValue = 0;
+    uint16_t averagedValue = 0;
 
-    for(i = 0; i < ADC_DMA_BUFFERSIZE; i++)
-    {
-        ADC_SummatedValue += ADC_ConvertedValues[i];
+    for (i = 0; i < ADC_DMA_BUFFERSIZE; i++) {
+        summatedValue += convertedValues[i];
     }
 
-    ADC_AveragedValue = (uint16_t)(ADC_SummatedValue / ADC_DMA_BUFFERSIZE);
+    averagedValue = (uint16_t)(summatedValue / ADC_DMA_BUFFERSIZE);
 
     // Return ADC averaged value
-    return ADC_AveragedValue;
+    return averagedValue;
 }
 
 /*
  * @brief Initialize the ADC peripheral.
  */
-void HAL_ADC_DMA_Init()
-{
+void hal_adc_dma_init() {
     //Using Dual ADC Regular Simultaneous DMA Mode 1
-
     ADC_CommonInitTypeDef ADC_CommonInitStructure;
     ADC_InitTypeDef ADC_InitStructure;
     DMA_InitTypeDef DMA_InitStructure;
@@ -181,7 +156,7 @@ void HAL_ADC_DMA_Init()
 
     // DMA2 Stream0 channel0 configuration
     DMA_InitStructure.DMA_Channel = DMA_Channel_0;
-    DMA_InitStructure.DMA_Memory0BaseAddr = (uint32_t)&ADC_ConvertedValues;
+    DMA_InitStructure.DMA_Memory0BaseAddr = (uint32_t)&convertedValues;
     DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t)ADC_CDR_ADDRESS;
     DMA_InitStructure.DMA_DIR = DMA_DIR_PeripheralToMemory;
     DMA_InitStructure.DMA_BufferSize = ADC_DMA_BUFFERSIZE;
@@ -230,8 +205,7 @@ void HAL_ADC_DMA_Init()
 /*
  * @brief Uninitialize the ADC peripheral.
  */
-int HAL_ADC_DMA_Uninit(void* reserved)
-{
+int hal_adc_dma_uninit(void* reserved) {
     // Disable DMA2 clock
     RCC_AHB1PeriphClockCmd(RCC_AHB1Periph_DMA2, DISABLE);
 
@@ -246,23 +220,20 @@ int HAL_ADC_DMA_Uninit(void* reserved)
 /*
  * @brief ADC peripheral enters sleep mode
  */
-int HAL_ADC_Sleep(bool sleep, void* reserved)
-{
+int hal_adc_sleep(bool sleep, void* reserved) {
     if (sleep) {
         // Suspend ADC
         if (adcState != HAL_ADC_STATE_ENABLED) {
             return SYSTEM_ERROR_INVALID_STATE;
         }
-        HAL_ADC_DMA_Uninit(NULL);
+        hal_adc_dma_uninit(NULL);
         adcState = HAL_ADC_STATE_SUSPENDED;
     } else {
         // Restore ADC
         if (adcState != HAL_ADC_STATE_SUSPENDED) {
             return SYSTEM_ERROR_INVALID_STATE;
         }
-        HAL_ADC_DMA_Init();
+        hal_adc_dma_init();
     }
-
     return SYSTEM_ERROR_NONE;
-
 }

--- a/hal/src/template/adc_hal.cpp
+++ b/hal/src/template/adc_hal.cpp
@@ -25,7 +25,7 @@
 
 #include "adc_hal.h"
 
-void HAL_ADC_Set_Sample_Time(uint8_t ADC_SampleTime)
+void hal_adc_set_sample_time(uint8_t ADC_SampleTime)
 {
 }
 
@@ -34,7 +34,7 @@ void HAL_ADC_Set_Sample_Time(uint8_t ADC_SampleTime)
  * Should return a 16-bit value, 0-65536 (0 = LOW, 65536 = HIGH)
  * Note: ADC is 12-bit. Currently it returns 0-4096
  */
-int32_t HAL_ADC_Read(uint16_t pin)
+int32_t hal_adc_read(uint16_t pin)
 {
     return 0;
 }
@@ -42,6 +42,11 @@ int32_t HAL_ADC_Read(uint16_t pin)
 /*
  * @brief Initialize the ADC peripheral.
  */
-void HAL_ADC_DMA_Init()
+void hal_adc_dma_init()
 {
+}
+
+int hal_adc_sleep(bool sleep, void* reserved)
+{
+    return 0;
 }

--- a/user/tests/hal/adc/test_adc.cpp
+++ b/user/tests/hal/adc/test_adc.cpp
@@ -24,17 +24,17 @@ Serial1LogHandler logHandler(115200);
 
 /* executes once at startup */
 void setup() {
-    HAL_ADC_DMA_Init();
+    hal_adc_dma_init();
 }
 
 /* executes continuously after setup() runs */
 void loop() {
     Log.info("A0: %d, A1: %d, A2: %d, A3: %d, A4: %d, A5: %d", 
-             HAL_ADC_Read(A0),
-             HAL_ADC_Read(A1),
-             HAL_ADC_Read(A2),
-             HAL_ADC_Read(A3),
-             HAL_ADC_Read(A4),
-             HAL_ADC_Read(A5));
+             hal_adc_read(A0),
+             hal_adc_read(A1),
+             hal_adc_read(A2),
+             hal_adc_read(A3),
+             hal_adc_read(A4),
+             hal_adc_read(A5));
     delay(500);
 }

--- a/wiring/src/spark_wiring.cpp
+++ b/wiring/src/spark_wiring.cpp
@@ -32,7 +32,7 @@
  */
 void setADCSampleTime(uint8_t ADC_SampleTime)
 {
-    HAL_ADC_Set_Sample_Time(ADC_SampleTime);
+    hal_adc_set_sample_time(ADC_SampleTime);
 }
 
 int map(int value, int fromStart, int fromEnd, int toStart, int toEnd)

--- a/wiring_globals/src/spark_wiring_gpio.cpp
+++ b/wiring_globals/src/spark_wiring_gpio.cpp
@@ -175,7 +175,7 @@ int32_t analogRead(pin_t pin)
     return LOW;
   }
 
-  return HAL_ADC_Read(pin);
+  return hal_adc_read(pin);
 }
 
 /*


### PR DESCRIPTION
### Feature

Implement sleep API for ADC on Gen2 and Gen3 device

### Steps to Test

Download the example application, make sure the sleep API won't affect ADC function.

### TODO
Formatting changes will be added after the review.

### Example App

```c
void setup(void) {
}

void loop() {
    HAL_ADC_Sleep(true, nullptr);
    delay(1000);
    HAL_ADC_Sleep(false, nullptr);
    Log.info("A0: %ld", HAL_ADC_Read(A0));
}
```

### References

[CH55886]

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
