### PR TITLE
Implement sleep function for external flash

### DIFF
--- a/hal/inc/exflash_hal.h
+++ b/hal/inc/exflash_hal.h
@@ -20,6 +20,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,6 +51,7 @@ int hal_exflash_read_special(hal_exflash_special_sector_t sp, uintptr_t addr, ui
 int hal_exflash_write_special(hal_exflash_special_sector_t sp, uintptr_t addr, const uint8_t* data_buf, size_t data_size);
 int hal_exflash_erase_special(hal_exflash_special_sector_t sp, uintptr_t addr, size_t size);
 int hal_exflash_special_command(hal_exflash_special_sector_t sp, hal_exflash_command_t cmd, const uint8_t* data, uint8_t* result, size_t size);
+int hal_exflash_sleep(bool sleep, void* reserved);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/hal/inc/exflash_hal.h
+++ b/hal/inc/exflash_hal.h
@@ -39,6 +39,12 @@ typedef enum {
     HAL_EXFLASH_COMMAND_SUSPEND_PGMERS  = 4
 } hal_exflash_command_t;
 
+typedef enum exflash_state_t {
+    HAL_EXFLASH_STATE_DISABLED,
+    HAL_EXFLASH_STATE_ENABLED,
+    HAL_EXFLASH_STATE_SUSPENDED
+} exflash_state_t;
+
 int hal_exflash_init(void);
 int hal_exflash_uninit(void);
 int hal_exflash_write(uintptr_t addr, const uint8_t* data_buf, size_t data_size);

--- a/hal/inc/exflash_hal.h
+++ b/hal/inc/exflash_hal.h
@@ -26,24 +26,25 @@
 extern "C" {
 #endif /* __cplusplus */
 
-typedef enum {
+typedef enum hal_exflash_special_sector_t {
     HAL_EXFLASH_SPECIAL_SECTOR_NONE = 0,
     HAL_EXFLASH_SPECIAL_SECTOR_OTP  = 1
 } hal_exflash_special_sector_t;
 
-typedef enum {
+typedef enum hal_exflash_command_t {
     HAL_EXFLASH_COMMAND_NONE            = 0,
     HAL_EXFLASH_COMMAND_LOCK_ENTIRE_OTP = 1,
     HAL_EXFLASH_COMMAND_SLEEP           = 2,
     HAL_EXFLASH_COMMAND_WAKEUP          = 3,
-    HAL_EXFLASH_COMMAND_SUSPEND_PGMERS  = 4
+    HAL_EXFLASH_COMMAND_SUSPEND_PGMERS  = 4,
+    HAL_EXFLASH_COMMAND_RESET           = 5
 } hal_exflash_command_t;
 
-typedef enum exflash_state_t {
+typedef enum hal_exflash_state_t {
     HAL_EXFLASH_STATE_DISABLED,
     HAL_EXFLASH_STATE_ENABLED,
     HAL_EXFLASH_STATE_SUSPENDED
-} exflash_state_t;
+} hal_exflash_state_t;
 
 int hal_exflash_init(void);
 int hal_exflash_uninit(void);


### PR DESCRIPTION
### Feature

Implement sleep function for external flash

### Steps to Test

Test the sleep API with the example application, make sure the sleep API won't affect the behavior of the file system.

### Example App

```c
void setup(void) {
}

void loop() {
    static int index = 0;
    EEPROM.begin();
    EEPROM.write(10, '0' + index++ % 10);
    Log.info("Read: %c", EEPROM.read(10));
    EEPROM.end();
    hal_exflash_sleep(true, nullptr);
    delay(1000);
    hal_exflash_sleep(false, nullptr);
}
```

### References

[CH55886]

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
