### PR TITLE
[build] Fixes monolithic build on photon

### DIFF
--- a/hal/src/photon/include.mk
+++ b/hal/src/photon/include.mk
@@ -46,6 +46,15 @@ HAL_WICED_LIB_FILES += $(HAL_SRC_COREV2_PATH)/lib/BESL.ARM_CM3.release.a
 
 HAL_LINK ?= $(findstring hal,$(MAKE_DEPENDENCIES))
 
+HAL_DEPS = third_party/miniz
+HAL_DEPS_INCLUDE_SCRIPTS =$(foreach module,$(HAL_DEPS),$(PROJECT_ROOT)/$(module)/import.mk)
+include $(HAL_DEPS_INCLUDE_SCRIPTS)
+
+ifneq ($(filter hal,$(LIBS)),)
+LIB_DIRS += $(MINIZ_LIB_DIR)
+LIBS += $(notdir $(HAL_DEPS))
+endif
+
 # if hal is used as a make dependency (linked) then add linker commands
 ifneq (,$(HAL_LINK))
 LINKER_FILE=$(WICED_MCU)/app_no_bootloader.ld


### PR DESCRIPTION
### Problem

`third_party/miniz` is not linked when linking `hal` module, which causes the following error:
```
firmware_public/hal/src/photon/compressed_resources.c:33: undefined reference to `tinfl_decompress'
```

### Solution

Add `third_party/miniz` to `HAL_DEPS`

### Steps to Test

```
> cd main
> make PLATFORM=photon TEST=app/blank MODULAR=n clean all
```

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
