### PR TITLE
Add SPISettings while keeping __SPISettings as an alias for wiring layer

### DIFF
--- a/wiring/inc/spark_wiring_spi.h
+++ b/wiring/inc/spark_wiring_spi.h
@@ -47,9 +47,9 @@ enum FrequencyScale
 };
 
 namespace particle {
-class __SPISettings : public Printable {
+class SPISettings : public Printable {
 public:
-  __SPISettings(uint32_t clock, uint8_t bitOrder, uint8_t dataMode)
+  SPISettings(uint32_t clock, uint8_t bitOrder, uint8_t dataMode)
     : default_{false},
       clock_{clock},
       bitOrder_{bitOrder},
@@ -57,11 +57,11 @@ public:
   {
   }
 
-  __SPISettings()
+  SPISettings()
   {
   }
 
-  bool operator==(const __SPISettings& other) const
+  bool operator==(const SPISettings& other) const
   {
     if (default_ && other.default_)
       return true;
@@ -77,7 +77,7 @@ public:
     return false;
   }
 
-  bool operator>=(const __SPISettings& other) const
+  bool operator>=(const SPISettings& other) const
   {
     if (default_ && other.default_)
       return true;
@@ -93,7 +93,7 @@ public:
     return false;
   }
 
-  bool operator<=(const __SPISettings& other) const
+  bool operator<=(const SPISettings& other) const
   {
     if (default_ && other.default_)
       return true;
@@ -109,7 +109,7 @@ public:
     return false;
   }
 
-  bool operator!=(const __SPISettings& other) const
+  bool operator!=(const SPISettings& other) const
   {
     return !(other == *this);
   }
@@ -133,6 +133,7 @@ private:
   uint8_t bitOrder_ = 0;
   uint8_t dataMode_ = 0;
 };
+typedef SPISettings __SPISettings;
 }
 
 // NOTE: when modifying this class (method signatures, adding/removing methods)


### PR DESCRIPTION
### Problem

__SPISettings naming is not compatible with Arduino layer

### Solution

Rename `__SPISettings` to `SPISettings` and still keep `__SPISettings` as an alias

### Steps to Test

Existing unit tests, but also something like this app should compile without errors 

```
#include "application.h"

void setup() {
    int32_t r = SPI.beginTransaction(__SPISettings(SPI_CLK_SYSTEM, SPI_MODE0, MSBFIRST));
    (void)r;
    int32_t r2 = SPI.beginTransaction(SPISettings(SPI_CLK_SYSTEM, SPI_MODE0, MSBFIRST));
    (void)r2;
}

void loop() {
}
```

### References

[ch55527](https://app.clubhouse.io/particle/story/55527/rename-spisettings-to-spisettings-while-keeping-spisettings-as-an-alias)
[ch54115](https://app.clubhouse.io/particle/story/54115/free-up-flash-space-removing-default-in-spisettings)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
