### PR TITLE
[ublox] Do not run AT+COPS=0 when performing warm bootup if already registering/registered

### DIFF
--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -1215,9 +1215,10 @@ void QuectelNcpClient::connectionState(NcpConnectionState state) {
             return SYSTEM_ERROR_NONE;
         }, this);
         if (r) {
+            LOG(ERROR, "Failed to open data channel");
+            ready_ = false;
             connState_ = NcpConnectionState::DISCONNECTED;
         }
-        muxer_.resumeChannel(QUECTEL_NCP_PPP_CHANNEL);
     }
 
     const auto handler = conf_.eventHandler();

--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -986,6 +986,9 @@ int QuectelNcpClient::initReady(ModemState state) {
     // just in case
     CHECK_PARSER(parser_.execCommand("AT+QCFG=\"cmux/urcport\",1"));
 
+    // Enable packet domain error reporting
+    CHECK_PARSER_OK(parser_.execCommand("AT+CGEREP=1,0"));
+
     return SYSTEM_ERROR_NONE;
 }
 

--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -1131,19 +1131,7 @@ int QuectelNcpClient::registerNet() {
     connectionState(NcpConnectionState::CONNECTING);
 
     // NOTE: up to 3 mins
-    auto resp = parser_.sendCommand("AT+COPS?");
-    int copsState = -1;
-    r = CHECK_PARSER(resp.scanf("+COPS: %d", &copsState));
-    CHECK_TRUE(r == 1, SYSTEM_ERROR_AT_RESPONSE_UNEXPECTED);
-    r = CHECK_PARSER(resp.readResult());
-    CHECK_TRUE(r == AtResponse::OK, SYSTEM_ERROR_AT_NOT_OK);
-
-    // NOTE: up to 3 mins
-    if (copsState != 0) {
-        // If the set command with <mode>=0 is issued, a further set
-        // command with <mode>=0 is managed as a user reselection
-        r = CHECK_PARSER(parser_.execCommand(5 * 60 * 1000, "AT+COPS=0,2"));
-    }
+    r = CHECK_PARSER(parser_.execCommand(3 * 60 * 1000, "AT+COPS=0,2"));
     // Ignore response code here
     // CHECK_TRUE(r == AtResponse::OK, SYSTEM_ERROR_UNKNOWN);
 

--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -119,6 +119,9 @@ const auto ICCID_MAX_LENGTH = 20;
 using LacType = decltype(CellularGlobalIdentity::location_area_code);
 using CidType = decltype(CellularGlobalIdentity::cell_id);
 
+const int QUECTEL_DEFAULT_CID = 1;
+const char QUECTEL_DEFAULT_PDP_TYPE[] = "IP";
+
 } // anonymous
 
 QuectelNcpClient::QuectelNcpClient() {
@@ -1106,7 +1109,8 @@ int QuectelNcpClient::configureApn(const CellularNetworkConfig& conf) {
         netConf_ = networkConfigForImsi(buf, strlen(buf));
     }
     // FIXME: for now IPv4 context only
-    auto resp = parser_.sendCommand("AT+CGDCONT=1,\"IP\",\"%s\"",
+    auto resp = parser_.sendCommand("AT+CGDCONT=%d,\"%s\",\"%s\"",
+            QUECTEL_DEFAULT_CID, QUECTEL_DEFAULT_PDP_TYPE,
             netConf_.hasApn() ? netConf_.apn() : "");
     const int r = CHECK_PARSER(resp.readResult());
     CHECK_TRUE(r == AtResponse::OK, SYSTEM_ERROR_UNKNOWN);
@@ -1127,7 +1131,19 @@ int QuectelNcpClient::registerNet() {
     connectionState(NcpConnectionState::CONNECTING);
 
     // NOTE: up to 3 mins
-    r = CHECK_PARSER(parser_.execCommand(3 * 60 * 1000, "AT+COPS=0,2"));
+    auto resp = parser_.sendCommand("AT+COPS?");
+    int copsState = -1;
+    r = CHECK_PARSER(resp.scanf("+COPS: %d", &copsState));
+    CHECK_TRUE(r == 1, SYSTEM_ERROR_AT_RESPONSE_UNEXPECTED);
+    r = CHECK_PARSER(resp.readResult());
+    CHECK_TRUE(r == AtResponse::OK, SYSTEM_ERROR_AT_NOT_OK);
+
+    // NOTE: up to 3 mins
+    if (copsState != 0) {
+        // If the set command with <mode>=0 is issued, a further set
+        // command with <mode>=0 is managed as a user reselection
+        r = CHECK_PARSER(parser_.execCommand(5 * 60 * 1000, "AT+COPS=0,2"));
+    }
     // Ignore response code here
     // CHECK_TRUE(r == AtResponse::OK, SYSTEM_ERROR_UNKNOWN);
 

--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -1459,9 +1459,10 @@ void SaraNcpClient::connectionState(NcpConnectionState state) {
             return SYSTEM_ERROR_NONE;
         }, this);
         if (r) {
+            LOG(ERROR, "Failed to open data channel");
+            ready_ = false;
             connState_ = NcpConnectionState::DISCONNECTED;
         }
-        muxer_.resumeChannel(UBLOX_NCP_PPP_CHANNEL);
     }
 
     const auto handler = conf_.eventHandler();

--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -1081,6 +1081,9 @@ int SaraNcpClient::initReady(ModemState state) {
     // (allows the capture of `mcc` and `mnc`)
     int r = CHECK_PARSER(parser_.execCommand("AT+COPS=3,2"));
 
+    // Enable packet domain error reporting
+    CHECK_PARSER_OK(parser_.execCommand("AT+CGEREP=1,0"));
+
     if (state != ModemState::MuxerAtChannel) {
         if (conf_.ncpIdentifier() != PLATFORM_NCP_SARA_R410) {
             // Change the baudrate to 921600


### PR DESCRIPTION
### Problem

![image](https://user-images.githubusercontent.com/388478/85690172-830efc80-b6fd-11ea-8824-cabee43c6d48.png)

Despite being registered, an `AT+COPS=0` call under some conditions may take substantial amount of time, which will prolong the bootup times.

### Solution

1. Only perform `AT+COPS=0` conditionally. This is only implemented for uBlox-based devices, as Quectel seems to behave correctly and also we cannot reliably tell whether it's attempting to perform registration or not (it may report `+COPS: 0` even if it's not attempting to find an operator).
2. Additionally we've enabled packet domain errors (`AT+CGEREP`) which are useful in debugging connectivity issues
3. This PR also makes sure that failure to open muxer data channel used for PPP connections is treated as a non-recoverable failure, causing modem reset.

### Steps to Test

1. Make sure a cellular device is connected to the cloud
2. Reset
3. `AT+COPS=0` should not be executed
4. It should reconnect back to the cloud almost instantaneously without blocking for up to minutes in `AT+COPS=0` despite being already registered

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
