### PR TITLE
Some changes in order to run no fixture tests under test runner / CI

### DIFF
--- a/build/release.sh
+++ b/build/release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -o errexit -o pipefail -o noclobber -o nounset
 
-VERSION="2.0.0-alpha.2"
+VERSION="2.0.0-alpha.3"
 
 function display_help ()
 {

--- a/build/version.mk
+++ b/build/version.mk
@@ -1,7 +1,7 @@
-VERSION_STRING = 2.0.0-alpha.2
+VERSION_STRING = 2.0.0-alpha.3
 
 # PRODUCT_FIRMWARE_VERSION reported by default
 # FIXME: Unclear if this is used, PRODUCT_FIRMWARE_VERSION defaults to 65535 every release
-VERSION = 2001
+VERSION = 2002
 
 CFLAGS += -DSYSTEM_VERSION_STRING=$(VERSION_STRING)

--- a/modules/shared/system_module_version.mk
+++ b/modules/shared/system_module_version.mk
@@ -1,6 +1,6 @@
 # Skip to next 100 every v0.x.0 release (e.g. 108 for v0.6.2 to 200 for v0.7.0-rc.1)
 # Bump by 1 for every prerelease or release with the same v0.x.* base.
-COMMON_MODULE_VERSION ?= 2001
+COMMON_MODULE_VERSION ?= 2002
 SYSTEM_PART1_MODULE_VERSION ?= $(COMMON_MODULE_VERSION)
 SYSTEM_PART2_MODULE_VERSION ?= $(COMMON_MODULE_VERSION)
 SYSTEM_PART3_MODULE_VERSION ?= $(COMMON_MODULE_VERSION)

--- a/system/inc/system_version.h
+++ b/system/inc/system_version.h
@@ -155,7 +155,8 @@ extern "C" {
 #define SYSTEM_VERSION_v153TRACKER1 SYSTEM_VERSION_RC(1, 5, 3, 1)
 #define SYSTEM_VERSION_v200ALPHA1   SYSTEM_VERSION_ALPHA(2, 0, 0, 1)
 #define SYSTEM_VERSION_v200ALPHA2   SYSTEM_VERSION_ALPHA(2, 0, 0, 2)
-#define SYSTEM_VERSION SYSTEM_VERSION_v200ALPHA2
+#define SYSTEM_VERSION_v200ALPHA3   SYSTEM_VERSION_ALPHA(2, 0, 0, 3)
+#define SYSTEM_VERSION SYSTEM_VERSION_v200ALPHA3
 
 /**
  * Previously we would set the least significant byte to 0 for the final release, but to make
@@ -275,6 +276,7 @@ extern "C" {
 #define SYSTEM_VERSION_153TRACKER1
 #define SYSTEM_VERSION_200ALPHA1
 #define SYSTEM_VERSION_200ALPHA2
+#define SYSTEM_VERSION_200ALPHA3
 
 typedef struct __attribute__((packed)) SystemVersionInfo
 {

--- a/system/system-versions.md
+++ b/system/system-versions.md
@@ -121,6 +121,7 @@
 | 502 | 1513 | 1.5.3-tracker.1 |     Tracker |
 | 1000 | 2000 | 2.0.0-alpha.1 |      Photon, P1, Electron, Argon, Boron, B SoM, B5 SoM, Tracker |
 | 1000 | 2001 | 2.0.0-alpha.2 |      Photon, P1, Electron, Argon, Boron, B SoM, B5 SoM, Tracker |
+| 1000 | 2002 | 2.0.0-alpha.3 |      Photon, P1, Electron, Argon, Boron, B SoM, B5 SoM, Tracker |
 
 [1] For 0.8.0-rc.1, The v101 bootloader was also released in the Github releases as v200. Thus the next released bootloader in the 0.8.x line should be v201. As of 4/5/2018: 22 device had v200 bootloaders.
 

--- a/user/tests/integration/application/src/application.cpp
+++ b/user/tests/integration/application/src/application.cpp
@@ -10,6 +10,6 @@ using namespace particle;
 STARTUP({
     System.enableFeature(FEATURE_RETAINED_MEMORY);
     TestSuite::instance()->init();
-})
+});
 
-UNIT_TEST_APP()
+UNIT_TEST_APP();

--- a/user/tests/integration/wiring/no_fixture
+++ b/user/tests/integration/wiring/no_fixture
@@ -1,0 +1,1 @@
+../../wiring/no_fixture

--- a/user/tests/wiring/no_fixture/application.cpp
+++ b/user/tests/wiring/no_fixture/application.cpp
@@ -1,3 +1,4 @@
+#ifndef PARTICLE_TEST_RUNNER
 #include "application.h"
 #include "unit-test/unit-test.h"
 
@@ -15,3 +16,5 @@ UNIT_TEST_APP();
 #if PLATFORM_THREADING == 1 && USE_THREADING == 1
 SYSTEM_THREAD(ENABLED);
 #endif
+
+#endif // PARTICLE_TEST_RUNNER

--- a/user/tests/wiring/no_fixture/cellular.cpp
+++ b/user/tests/wiring/no_fixture/cellular.cpp
@@ -289,6 +289,10 @@ test(MDM_01_socket_writes_with_length_more_than_1023_work_correctly) {
     bool contains = false;
     if (responseSize > 0 && !c.connected()) {
         contains = strstr(responseBuf.get(), randData.get()) != nullptr;
+        if (!contains) {
+            // A workaround for httpbin.org sometimes returning an error for large requests
+            contains = strstr(responseBuf.get(), "Request Body Too Large") != nullptr;
+        }
     }
 
     assertTrue(contains);

--- a/user/tests/wiring/no_fixture/cellular.cpp
+++ b/user/tests/wiring/no_fixture/cellular.cpp
@@ -276,7 +276,7 @@ test(MDM_01_socket_writes_with_length_more_than_1023_work_correctly) {
         while (c.available() && responseSize < bufferSize) {
             responseBuf.get()[responseSize++] = c.read();
         }
-        if (!c.connected())
+        if (!c.connected() && c.available() <= 0)
             break;
         if (millis() - mil >= 20000UL) {
             if (c.connected()) {

--- a/user/tests/wiring/no_fixture/led.cpp
+++ b/user/tests/wiring/no_fixture/led.cpp
@@ -151,6 +151,8 @@ test(LED_06_SettingRGBAfterOverrideShouldChangeLED) {
 
 test(LED_07_SettingRGBWithoutOverrideShouldNotChangeLED) {
     // given
+    RGB.control(true);
+    RGB.color(1, 2, 3);
     RGB.control(false);
 
     // when

--- a/user/tests/wiring/no_fixture/no_fixture.spec.js
+++ b/user/tests/wiring/no_fixture/no_fixture.spec.js
@@ -1,0 +1,3 @@
+suite('No fixture');
+
+platform('gen2', 'gen3');

--- a/user/tests/wiring/no_fixture/time.cpp
+++ b/user/tests/wiring/no_fixture/time.cpp
@@ -255,7 +255,7 @@ test(TIME_16_TimeChangedEvent) {
     system_tick_t syncedLastMillis = Particle.timeSyncedLast();
 
     System.on(time_changed, time_changed_handler);
-    Time.setTime(946684800);
+    Time.setTime(1514764800);
     assertEqual(s_time_changed_reason, (int)time_changed_manually);
     s_time_changed_reason = -1;
 

--- a/user/tests/wiring/no_fixture/wifi.cpp
+++ b/user/tests/wiring/no_fixture/wifi.cpp
@@ -219,6 +219,8 @@ test(WIFI_12_scan_returns_zero_result_or_error_when_wifi_is_off)
             assertTrue(false);
         }
     }
+    // Delay a bit here just in case
+    delay(5000);
     assertLessOrEqual(WiFi.scan(results, 5), 0);
 }
 


### PR DESCRIPTION

### Description

Currently test runner expects tests to be in integration folder. As a quick workaround for now we've added a spec file to no_fixture test suite and symlinked it to integration.

This PR also contains a number of fixes for no_fixture tests.

This PR also bumps version to 2.0.0-alpha.3 in order not to mess with existing alpha.1/alpha.2 releases on CI.

### Steps to Test

N/A

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
