### PR TITLE
[gen3] syscall: our newlib variant implements rename as _link + _unlink

### DIFF
--- a/user/tests/wiring/filesystem/posix.cpp
+++ b/user/tests/wiring/filesystem/posix.cpp
@@ -50,6 +50,17 @@ bool dirExists(const char* path) {
     return false;
 }
 
+bool fileExists(const char* path) {
+    struct stat st;
+    if (!stat(path, &st)) {
+        if (S_ISREG(st.st_mode)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 struct FsEntryHelper {
     explicit FsEntryHelper(const char* n, int p = -1)
             : FsEntryHelper(n, dirExists(n), p) {
@@ -231,10 +242,18 @@ test(FS_POSIX_01_Directories) {
         assertTrue(dirExists(dirs[i]));
     }
 
+    auto dirMove = generateRandomFilenames(TEST_DIR, num);
+    for (int i = 0; i < num; i++) {
+        assertEqual(0, rename(dirs[i], dirMove[i]));
+        assertEqual(0, errno);
+        assertTrue(dirExists(dirMove[i]));
+        assertFalse(dirExists(dirs[i]));
+    }
+
     listFsContents();
 
     for (int i = 0; i < num; i++) {
-        assertEqual(0, rmdir(dirs[i]));
+        assertEqual(0, rmdir(dirMove[i]));
     }
 }
 
@@ -390,6 +409,13 @@ test(FS_POSIX_02_File) {
         close(fd);
     }
 
+    auto fileMove = generateRandomFilenames(TEST_DIR, num);
+    for (int i = 0; i < num; i++) {
+        assertEqual(0, rename(files[i], fileMove[i]));
+        assertEqual(0, errno);
+        assertTrue(fileExists(fileMove[i]));
+        assertFalse(fileExists(files[i]));
+    }
 }
 
 test(FS_POSIX_99_Cleanup) {


### PR DESCRIPTION
### Problem

`rename()` does not actually call into dynalib-exposed `_rename()` due to `HAVE_RENAME` not defined with our variant of newlib supplied with ARM GCC toolchain and it's actually implemented as `_link()` + `_unlink()`: https://github.com/mirror/newlib-cygwin/blob/master/newlib/libc/reent/renamer.c#L43

### Solution

Disclaimer: it's a hack

Rename in `_link` if `HAVE_RENAME` is not defined and temporarily cache the oldpath to an unused location in the reentrant thread-local structure and suppress errors in subsequent `_unlink()` call if the path matches.

### Steps to Test

`wiring/filesystem`.

### Example App

N/A

### References

- [CH57479]

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
