### PR TITLE
Add unit tests for SPISettings

### DIFF
--- a/user/tests/wiring/api/spi.cpp
+++ b/user/tests/wiring/api/spi.cpp
@@ -143,7 +143,7 @@ test(spi_clock)
 test(spi_transfer)
 {
     API_COMPILE({ int32_t r = SPI.beginTransaction(); (void)r; });
-    API_COMPILE({ int32_t r = SPI.beginTransaction(__SPISettings(SPI_CLK_SYSTEM, SPI_MODE0, MSBFIRST)); (void)r; });
+    API_COMPILE({ int32_t r = SPI.beginTransaction(SPISettings(SPI_CLK_SYSTEM, SPI_MODE0, MSBFIRST)); (void)r; });
     API_COMPILE(SPI.transfer(0));
     API_COMPILE(SPI.transfer(NULL, NULL, 1, NULL));
     API_COMPILE(SPI.transferCancel());
@@ -151,7 +151,7 @@ test(spi_transfer)
 
 #if Wiring_SPI1
     API_COMPILE({ int32_t r = SPI1.beginTransaction(); (void)r; });
-    API_COMPILE({ int32_t r = SPI1.beginTransaction(__SPISettings(SPI_CLK_SYSTEM, SPI_MODE0, MSBFIRST)); (void)r; });
+    API_COMPILE({ int32_t r = SPI1.beginTransaction(SPISettings(SPI_CLK_SYSTEM, SPI_MODE0, MSBFIRST)); (void)r; });
     API_COMPILE(SPI1.transfer(0));
     API_COMPILE(SPI1.transfer(NULL, NULL, 1, NULL));
     API_COMPILE(SPI1.transferCancel());
@@ -160,7 +160,7 @@ test(spi_transfer)
 
 #if Wiring_SPI2
     API_COMPILE({ int32_t r = SPI2.beginTransaction(); (void)r; });
-    API_COMPILE({ int32_t r = SPI2.beginTransaction(__SPISettings(SPI_CLK_SYSTEM, SPI_MODE0, MSBFIRST)); (void)r; });
+    API_COMPILE({ int32_t r = SPI2.beginTransaction(SPISettings(SPI_CLK_SYSTEM, SPI_MODE0, MSBFIRST)); (void)r; });
     API_COMPILE(SPI2.transfer(0));
     API_COMPILE(SPI2.transfer(NULL, NULL, 1, NULL));
     API_COMPILE(SPI2.transferCancel());

--- a/user/tests/wiring/api/spi.cpp
+++ b/user/tests/wiring/api/spi.cpp
@@ -1,9 +1,6 @@
 
 #include "testapi.h"
 
-// without Arduino.h we should not get a clash redefining SPISettings
-class SPISettings {};
-
 namespace api_test_namespace {
 // We should be able to define variables and types named SPI, SPI1 and SPI2
 

--- a/user/tests/wiring/no_fixture_spi/spi.cpp
+++ b/user/tests/wiring/no_fixture_spi/spi.cpp
@@ -8,7 +8,7 @@ static volatile uint8_t DMA_Completed_Flag = 0;
 static uint8_t* tempBuf = nullptr;
 static uint8_t* tempBuf1 = nullptr;
 
-using particle::__SPISettings;
+using particle::SPISettings;
 
 static void querySpiInfo(HAL_SPI_Interface spi, hal_spi_info_t* info)
 {
@@ -17,14 +17,14 @@ static void querySpiInfo(HAL_SPI_Interface spi, hal_spi_info_t* info)
   HAL_SPI_Info(spi, info, nullptr);
 }
 
-static __SPISettings spiSettingsFromSpiInfo(hal_spi_info_t* info)
+static SPISettings spiSettingsFromSpiInfo(hal_spi_info_t* info)
 {
   if (!info->enabled || info->default_settings)
-    return __SPISettings();
-  return __SPISettings(info->clock, info->bit_order, info->data_mode);
+    return SPISettings();
+  return SPISettings(info->clock, info->bit_order, info->data_mode);
 }
 
-static bool spiSettingsApplyCheck(SPIClass& spi, const __SPISettings& settings, HAL_SPI_Interface interface = HAL_SPI_INTERFACE1)
+static bool spiSettingsApplyCheck(SPIClass& spi, const SPISettings& settings, HAL_SPI_Interface interface = HAL_SPI_INTERFACE1)
 {
     hal_spi_info_t info;
     spi.beginTransaction(settings);
@@ -238,28 +238,28 @@ test(SPI_07_SPI_Settings_Are_Applied_In_Begin_Transaction)
 
     // Get current SPISettings
     hal_spi_info_t info;
-    __SPISettings current, settings;
+    SPISettings current, settings;
     querySpiInfo(HAL_SPI_INTERFACE1, &info);
     settings = spiSettingsFromSpiInfo(&info);
 
     // Configure SPI with default settings
-    SPI.beginTransaction(__SPISettings());
+    SPI.beginTransaction(SPISettings());
     querySpiInfo(HAL_SPI_INTERFACE1, &info);
     current = spiSettingsFromSpiInfo(&info);
     assertEqual(current, settings);
     SPI.endTransaction();
 
-    assertTrue(spiSettingsApplyCheck(SPI, __SPISettings(15*MHZ, MSBFIRST, SPI_MODE0)));
-    assertTrue(spiSettingsApplyCheck(SPI, __SPISettings(10*MHZ, LSBFIRST, SPI_MODE1)));
-    assertTrue(spiSettingsApplyCheck(SPI, __SPISettings(15*MHZ, MSBFIRST, SPI_MODE2)));
-    assertTrue(spiSettingsApplyCheck(SPI, __SPISettings(10*MHZ, LSBFIRST, SPI_MODE3)));
+    assertTrue(spiSettingsApplyCheck(SPI, SPISettings(15*MHZ, MSBFIRST, SPI_MODE0)));
+    assertTrue(spiSettingsApplyCheck(SPI, SPISettings(10*MHZ, LSBFIRST, SPI_MODE1)));
+    assertTrue(spiSettingsApplyCheck(SPI, SPISettings(15*MHZ, MSBFIRST, SPI_MODE2)));
+    assertTrue(spiSettingsApplyCheck(SPI, SPISettings(10*MHZ, LSBFIRST, SPI_MODE3)));
 
-    assertTrue(spiSettingsApplyCheck(SPI, __SPISettings(15*MHZ, MSBFIRST, SPI_MODE0)));
-    assertTrue(spiSettingsApplyCheck(SPI, __SPISettings(10*MHZ, LSBFIRST, SPI_MODE1)));
-    assertTrue(spiSettingsApplyCheck(SPI, __SPISettings(15*MHZ, MSBFIRST, SPI_MODE2)));
-    assertTrue(spiSettingsApplyCheck(SPI, __SPISettings(10*MHZ, LSBFIRST, SPI_MODE3)));
+    assertTrue(spiSettingsApplyCheck(SPI, SPISettings(15*MHZ, MSBFIRST, SPI_MODE0)));
+    assertTrue(spiSettingsApplyCheck(SPI, SPISettings(10*MHZ, LSBFIRST, SPI_MODE1)));
+    assertTrue(spiSettingsApplyCheck(SPI, SPISettings(15*MHZ, MSBFIRST, SPI_MODE2)));
+    assertTrue(spiSettingsApplyCheck(SPI, SPISettings(10*MHZ, LSBFIRST, SPI_MODE3)));
 
-    assertTrue(spiSettingsApplyCheck(SPI, __SPISettings()));
+    assertTrue(spiSettingsApplyCheck(SPI, SPISettings()));
 
     SPI.end();
 }
@@ -274,29 +274,29 @@ test(SPI_08_SPI1_Settings_Are_Applied_In_Begin_Transaction)
 
     // Get current SPISettings
     hal_spi_info_t info;
-    __SPISettings current, settings;
+    SPISettings current, settings;
 
     querySpiInfo(HAL_SPI_INTERFACE2, &info);
     settings = spiSettingsFromSpiInfo(&info);
 
     // Configure SPI with default settings
-    SPI1.beginTransaction(__SPISettings());
+    SPI1.beginTransaction(SPISettings());
     querySpiInfo(HAL_SPI_INTERFACE2, &info);
     current = spiSettingsFromSpiInfo(&info);
     assertEqual(current, settings);
     SPI1.endTransaction();
 
-    assertTrue(spiSettingsApplyCheck(SPI1, __SPISettings(15*MHZ, MSBFIRST, SPI_MODE0), HAL_SPI_INTERFACE2));
-    assertTrue(spiSettingsApplyCheck(SPI1, __SPISettings(10*MHZ, LSBFIRST, SPI_MODE1), HAL_SPI_INTERFACE2));
-    assertTrue(spiSettingsApplyCheck(SPI1, __SPISettings(15*MHZ, MSBFIRST, SPI_MODE2), HAL_SPI_INTERFACE2));
-    assertTrue(spiSettingsApplyCheck(SPI1, __SPISettings(10*MHZ, LSBFIRST, SPI_MODE3), HAL_SPI_INTERFACE2));
+    assertTrue(spiSettingsApplyCheck(SPI1, SPISettings(15*MHZ, MSBFIRST, SPI_MODE0), HAL_SPI_INTERFACE2));
+    assertTrue(spiSettingsApplyCheck(SPI1, SPISettings(10*MHZ, LSBFIRST, SPI_MODE1), HAL_SPI_INTERFACE2));
+    assertTrue(spiSettingsApplyCheck(SPI1, SPISettings(15*MHZ, MSBFIRST, SPI_MODE2), HAL_SPI_INTERFACE2));
+    assertTrue(spiSettingsApplyCheck(SPI1, SPISettings(10*MHZ, LSBFIRST, SPI_MODE3), HAL_SPI_INTERFACE2));
 
-    assertTrue(spiSettingsApplyCheck(SPI1, __SPISettings(15*MHZ, MSBFIRST, SPI_MODE0), HAL_SPI_INTERFACE2));
-    assertTrue(spiSettingsApplyCheck(SPI1, __SPISettings(10*MHZ, LSBFIRST, SPI_MODE1), HAL_SPI_INTERFACE2));
-    assertTrue(spiSettingsApplyCheck(SPI1, __SPISettings(15*MHZ, MSBFIRST, SPI_MODE2), HAL_SPI_INTERFACE2));
-    assertTrue(spiSettingsApplyCheck(SPI1, __SPISettings(10*MHZ, LSBFIRST, SPI_MODE3), HAL_SPI_INTERFACE2));
+    assertTrue(spiSettingsApplyCheck(SPI1, SPISettings(15*MHZ, MSBFIRST, SPI_MODE0), HAL_SPI_INTERFACE2));
+    assertTrue(spiSettingsApplyCheck(SPI1, SPISettings(10*MHZ, LSBFIRST, SPI_MODE1), HAL_SPI_INTERFACE2));
+    assertTrue(spiSettingsApplyCheck(SPI1, SPISettings(15*MHZ, MSBFIRST, SPI_MODE2), HAL_SPI_INTERFACE2));
+    assertTrue(spiSettingsApplyCheck(SPI1, SPISettings(10*MHZ, LSBFIRST, SPI_MODE3), HAL_SPI_INTERFACE2));
 
-    assertTrue(spiSettingsApplyCheck(SPI1, __SPISettings(), HAL_SPI_INTERFACE2));
+    assertTrue(spiSettingsApplyCheck(SPI1, SPISettings(), HAL_SPI_INTERFACE2));
 
     SPI1.end();
 }
@@ -312,29 +312,29 @@ test(SPI_09_SPI2_Settings_Are_Applied_In_Begin_Transaction)
 
     // Get current SPISettings
     hal_spi_info_t info;
-    __SPISettings current, settings;
+    SPISettings current, settings;
 
     querySpiInfo(HAL_SPI_INTERFACE3, &info);
     settings = spiSettingsFromSpiInfo(&info);
 
     // Configure SPI with default settings
-    SPI2.beginTransaction(__SPISettings());
+    SPI2.beginTransaction(SPISettings());
     querySpiInfo(HAL_SPI_INTERFACE3, &info);
     current = spiSettingsFromSpiInfo(&info);
     assertEqual(current, settings);
     SPI2.endTransaction();
 
-    assertTrue(spiSettingsApplyCheck(SPI2, __SPISettings(15*MHZ, MSBFIRST, SPI_MODE0), HAL_SPI_INTERFACE3));
-    assertTrue(spiSettingsApplyCheck(SPI2, __SPISettings(10*MHZ, LSBFIRST, SPI_MODE1), HAL_SPI_INTERFACE3));
-    assertTrue(spiSettingsApplyCheck(SPI2, __SPISettings(15*MHZ, MSBFIRST, SPI_MODE2), HAL_SPI_INTERFACE3));
-    assertTrue(spiSettingsApplyCheck(SPI2, __SPISettings(10*MHZ, LSBFIRST, SPI_MODE3), HAL_SPI_INTERFACE3));
+    assertTrue(spiSettingsApplyCheck(SPI2, SPISettings(15*MHZ, MSBFIRST, SPI_MODE0), HAL_SPI_INTERFACE3));
+    assertTrue(spiSettingsApplyCheck(SPI2, SPISettings(10*MHZ, LSBFIRST, SPI_MODE1), HAL_SPI_INTERFACE3));
+    assertTrue(spiSettingsApplyCheck(SPI2, SPISettings(15*MHZ, MSBFIRST, SPI_MODE2), HAL_SPI_INTERFACE3));
+    assertTrue(spiSettingsApplyCheck(SPI2, SPISettings(10*MHZ, LSBFIRST, SPI_MODE3), HAL_SPI_INTERFACE3));
 
-    assertTrue(spiSettingsApplyCheck(SPI2, __SPISettings(15*MHZ, MSBFIRST, SPI_MODE0), HAL_SPI_INTERFACE3));
-    assertTrue(spiSettingsApplyCheck(SPI2, __SPISettings(10*MHZ, LSBFIRST, SPI_MODE1), HAL_SPI_INTERFACE3));
-    assertTrue(spiSettingsApplyCheck(SPI2, __SPISettings(15*MHZ, MSBFIRST, SPI_MODE2), HAL_SPI_INTERFACE3));
-    assertTrue(spiSettingsApplyCheck(SPI2, __SPISettings(10*MHZ, LSBFIRST, SPI_MODE3), HAL_SPI_INTERFACE3));
+    assertTrue(spiSettingsApplyCheck(SPI2, SPISettings(15*MHZ, MSBFIRST, SPI_MODE0), HAL_SPI_INTERFACE3));
+    assertTrue(spiSettingsApplyCheck(SPI2, SPISettings(10*MHZ, LSBFIRST, SPI_MODE1), HAL_SPI_INTERFACE3));
+    assertTrue(spiSettingsApplyCheck(SPI2, SPISettings(15*MHZ, MSBFIRST, SPI_MODE2), HAL_SPI_INTERFACE3));
+    assertTrue(spiSettingsApplyCheck(SPI2, SPISettings(10*MHZ, LSBFIRST, SPI_MODE3), HAL_SPI_INTERFACE3));
 
-    assertTrue(spiSettingsApplyCheck(SPI2, __SPISettings(), HAL_SPI_INTERFACE3));
+    assertTrue(spiSettingsApplyCheck(SPI2, SPISettings(), HAL_SPI_INTERFACE3));
 
     SPI2.end();
 }
@@ -349,7 +349,7 @@ test(SPI_10_SPI_Begin_Transaction_Locks)
     SPI.begin();
     assertTrue(SPI.trylock());
     SPI.unlock();
-    SPI.beginTransaction(__SPISettings());
+    SPI.beginTransaction(SPISettings());
     assertTrue(SPI.trylock());
     SPI.unlock();
     SPI.endTransaction();
@@ -367,7 +367,7 @@ test(SPI_11_SPI1_Begin_Transaction_Locks)
     SPI1.begin();
     assertTrue(SPI1.trylock());
     SPI1.unlock();
-    SPI1.beginTransaction(__SPISettings());
+    SPI1.beginTransaction(SPISettings());
     assertTrue(SPI1.trylock());
     SPI1.unlock();
     SPI1.endTransaction();
@@ -386,7 +386,7 @@ test(SPI_12_SPI2_Begin_Transaction_Locks)
     SPI2.begin();
     assertTrue(SPI2.trylock());
     SPI2.unlock();
-    SPI2.beginTransaction(__SPISettings());
+    SPI2.beginTransaction(SPISettings());
     assertTrue(SPI2.trylock());
     SPI2.unlock();
     SPI2.endTransaction();

--- a/user/tests/wiring/spi1_stress/application.cpp
+++ b/user/tests/wiring/spi1_stress/application.cpp
@@ -116,7 +116,7 @@ os_thread_return_t gnssThread(void *param) {
 #if GNSS_ENABLE_TX_READY
     attachInterrupt(GPS_INT, gnssIntHandler, FALLING);
     // Enable TX-ready
-    SPI1.beginTransaction(__SPISettings(5*MHZ, MSBFIRST, SPI_MODE0));
+    SPI1.beginTransaction(SPISettings(5*MHZ, MSBFIRST, SPI_MODE0));
     digitalWrite(GPS_CS, LOW);
     delay(50);
     uint8_t in_byte;
@@ -140,7 +140,7 @@ os_thread_return_t gnssThread(void *param) {
             continue;
         }
         // Read data
-        SPI1.beginTransaction(__SPISettings(5*MHZ, MSBFIRST, SPI_MODE0));
+        SPI1.beginTransaction(SPISettings(5*MHZ, MSBFIRST, SPI_MODE0));
         digitalWrite(GPS_CS, LOW);
         delayMicroseconds(50);
         uint8_t temp;
@@ -160,7 +160,7 @@ os_thread_return_t gnssThread(void *param) {
 #else
         bool echoed = false;
         system_tick_t start = millis();
-        SPI1.beginTransaction(__SPISettings(5*MHZ, MSBFIRST, SPI_MODE0));
+        SPI1.beginTransaction(SPISettings(5*MHZ, MSBFIRST, SPI_MODE0));
         digitalWrite(GPS_CS, LOW);
         delayMicroseconds(50);
         while ((millis() - start) < 2000) {
@@ -202,7 +202,7 @@ os_thread_return_t bmi160Thread(void *param) {
     digitalWrite(SEN_CS, HIGH); //Rising edge on the /CSB pin to select SPI interface.
 
     // Perform a single read access to the 0x7F register before actual communication.
-    SPI1.beginTransaction(__SPISettings(16*MHZ, MSBFIRST, SPI_MODE3));
+    SPI1.beginTransaction(SPISettings(16*MHZ, MSBFIRST, SPI_MODE3));
     digitalWrite(SEN_CS, LOW);
     SPI1.transfer(0xFF); // R/W bit along with register address
     SPI1.transfer(0xFF);
@@ -210,7 +210,7 @@ os_thread_return_t bmi160Thread(void *param) {
     SPI1.endTransaction();
 
     while (1) {
-        SPI1.beginTransaction(__SPISettings(16*MHZ, MSBFIRST, SPI_MODE3));
+        SPI1.beginTransaction(SPISettings(16*MHZ, MSBFIRST, SPI_MODE3));
         digitalWrite(SEN_CS, LOW);
         SPI1.transfer(0x80); // R/W bit along with register address
         uint8_t id = SPI1.transfer(0xFF);
@@ -303,14 +303,14 @@ os_thread_return_t canThread(void *param) {
     delay(100);
     digitalWrite(CAN_RST, HIGH);
 
-    SPI1.beginTransaction(__SPISettings(16*MHZ, MSBFIRST, SPI_MODE0));
+    SPI1.beginTransaction(SPISettings(16*MHZ, MSBFIRST, SPI_MODE0));
     digitalWrite(CAN_CS, LOW);
     SPI1.transfer(0xC0); // CMD: Reset registers
     digitalWrite(CAN_CS, HIGH);
     SPI1.endTransaction();
 
     while (1) {
-        SPI1.beginTransaction(__SPISettings(1*MHZ, MSBFIRST, SPI_MODE0));
+        SPI1.beginTransaction(SPISettings(1*MHZ, MSBFIRST, SPI_MODE0));
         digitalWrite(CAN_CS, LOW);
         SPI1.transfer(0x03); // CMD: Read
         SPI1.transfer(0x7F); // Register Address

--- a/user/tests/wiring/spi1_stress/port.cpp
+++ b/user/tests/wiring/spi1_stress/port.cpp
@@ -35,7 +35,7 @@ void at_cs_high(void) {
 
 /// Set CS low
 void at_cs_low(void) {
-    PORT_SPI.beginTransaction(__SPISettings(1*MHZ, MSBFIRST, SPI_MODE0));
+    PORT_SPI.beginTransaction(SPISettings(1*MHZ, MSBFIRST, SPI_MODE0));
     digitalWrite(PORT_CS_PIN, LOW);
 }
 


### PR DESCRIPTION
### Problem

To add unit tests for `__SPISettings` renamed to `SPISettings`. See [PR2138](https://github.com/particle-iot/device-os/pull/2138)

### Solution
Added tests

### Steps to Test

### References

[PR2138](https://github.com/particle-iot/device-os/pull/2138)
[ch55527](https://app.clubhouse.io/particle/story/55527/rename-spisettings-to-spisettings-while-keeping-spisettings-as-an-alias)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
