### PR TITLE
[Boron LTE] Muxer resumption to be checked at multiple baud rates as needed

### DIFF
--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -1265,8 +1265,6 @@ int SaraNcpClient::checkRuntimeState(ModemState& state) {
     unsigned runtimeBaudrate = ncpId() == PLATFORM_NCP_SARA_R410 ? UBLOX_NCP_RUNTIME_SERIAL_BAUDRATE_R4 :
             UBLOX_NCP_RUNTIME_SERIAL_BAUDRATE_U2;
 
-    CHECK(serial_->setBaudRate(runtimeBaudrate));
-
     // Feeling optimistic, try to see if the muxer is already available
     if (!muxer_.isRunning()) {
         LOG(TRACE, "Muxer is not currently running");

--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -839,17 +839,7 @@ int SaraNcpClient::waitReady(bool powerOn) {
         ready_ = waitAtResponseFromPowerOn(modemState) == 0;
     } else if (ncpState() == NcpState::OFF) {
         LOG_DEBUG(TRACE, "Waiting for modem to be ready from current unknown state");
-        if (ncpId() != PLATFORM_NCP_SARA_R410) {
-            ready_ = checkRuntimeState(modemState, UBLOX_NCP_RUNTIME_SERIAL_BAUDRATE_U2) == 0;
-        } else {
-            int res = checkRuntimeState(modemState, UBLOX_NCP_RUNTIME_SERIAL_BAUDRATE_R4);
-            if (res != SYSTEM_ERROR_NONE) {
-                // AT has not responded probably because of baud rate. Try with other baud rate
-                LOG_DEBUG(TRACE, "Checking muxer at %d baud", UBLOX_NCP_DEFAULT_SERIAL_BAUDRATE);
-                res = checkRuntimeState(modemState, UBLOX_NCP_DEFAULT_SERIAL_BAUDRATE);
-            }
-            ready_ = (res == 0);
-        }
+        ready_ = checkRuntimeState(modemState) == 0;
         if (ready_) {
             LOG_DEBUG(TRACE, "Runtime state %d", (int)modemState);
         }
@@ -1269,15 +1259,22 @@ bool SaraNcpClient::checkRuntimeStateMuxer(unsigned int baudrate) {
     return false;
 }
 
-int SaraNcpClient::checkRuntimeState(ModemState& state, unsigned runtimeBaudrate) {
+int SaraNcpClient::checkRuntimeState(ModemState& state) {
+
+    // Assume we are running at the runtime baudrate
+    unsigned runtimeBaudrate = ncpId() == PLATFORM_NCP_SARA_R410 ? UBLOX_NCP_RUNTIME_SERIAL_BAUDRATE_R4 :
+            UBLOX_NCP_RUNTIME_SERIAL_BAUDRATE_U2;
+
+    CHECK(serial_->setBaudRate(runtimeBaudrate));
+
     // Feeling optimistic, try to see if the muxer is already available
     if (!muxer_.isRunning()) {
         LOG(TRACE, "Muxer is not currently running");
         if (ncpId() != PLATFORM_NCP_SARA_R410) {
             checkRuntimeStateMuxer(runtimeBaudrate);
         } else {
-            LOG_DEBUG(TRACE, "Attempt to start/resume muxer at %u baud", UBLOX_NCP_RUNTIME_SERIAL_BAUDRATE_R4);
-            int ret = checkRuntimeStateMuxer(UBLOX_NCP_RUNTIME_SERIAL_BAUDRATE_R4);
+            LOG_DEBUG(TRACE, "Attempt to start/resume muxer at %u baud", runtimeBaudrate);
+            bool ret = checkRuntimeStateMuxer(runtimeBaudrate);
             if (!ret) {
                 LOG_DEBUG(TRACE, "Attempt to start/resume muxer at %u baud", UBLOX_NCP_DEFAULT_SERIAL_BAUDRATE);
                 checkRuntimeStateMuxer(UBLOX_NCP_DEFAULT_SERIAL_BAUDRATE);

--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -1322,6 +1322,7 @@ int SaraNcpClient::checkRuntimeState(ModemState& state) {
 
     // We are not in the mulitplexed mode yet
     // Check if the modem is responsive at the runtime baudrate
+    CHECK(serial_->setBaudRate(runtimeBaudrate));
     CHECK(initParser(serial_.get()));
     skipAll(serial_.get());
     parser_.reset();

--- a/hal/network/ncp_client/sara/sara_ncp_client.h
+++ b/hal/network/ncp_client/sara/sara_ncp_client.h
@@ -118,7 +118,7 @@ private:
     int initParser(Stream* stream);
     int waitReady(bool powerOn = false);
     int initReady(ModemState state);
-    int checkRuntimeState(ModemState& state, unsigned runtimeBaudrate);
+    int checkRuntimeState(ModemState& state);
     bool checkRuntimeStateMuxer(unsigned baudrate);
     int initMuxer();
     int waitAtResponse(unsigned int timeout, unsigned int period = 1000);

--- a/hal/network/ncp_client/sara/sara_ncp_client.h
+++ b/hal/network/ncp_client/sara/sara_ncp_client.h
@@ -119,6 +119,7 @@ private:
     int waitReady(bool powerOn = false);
     int initReady(ModemState state);
     int checkRuntimeState(ModemState& state, unsigned runtimeBaudrate);
+    bool checkRuntimeStateMuxer(unsigned baudrate);
     int initMuxer();
     int waitAtResponse(unsigned int timeout, unsigned int period = 1000);
     int selectSimCard(ModemState& state);

--- a/hal/network/ncp_client/sara/sara_ncp_client.h
+++ b/hal/network/ncp_client/sara/sara_ncp_client.h
@@ -118,7 +118,7 @@ private:
     int initParser(Stream* stream);
     int waitReady(bool powerOn = false);
     int initReady(ModemState state);
-    int checkRuntimeState(ModemState& state);
+    int checkRuntimeState(ModemState& state, unsigned runtimeBaudrate);
     int initMuxer();
     int waitAtResponse(unsigned int timeout, unsigned int period = 1000);
     int selectSimCard(ModemState& state);


### PR DESCRIPTION
### Problem

Older cell radio firmware versions of Boron LTE support only `115200` baud rate where the newer versions support `460800`. When we resume with warm boot up, we need to check more than one baud rate to resume session correctly. 

### Solution

Check for `460800` baud for session resumption and if we fail there, we will check muxer session resumption with `115200` baud. 

### Steps to Test

Make sure Boron LTE has muxer thread started in the previous run. This is can ensured by connecting to cloud. And then hit RESET button, this will make the modem resume with warm boot up. Check that we are able to resume session without issues. We can use a basic tinker app.

### Example App

```c
void setup() {
}

void loop() {
}
```

### References

[ch58180](https://app.clubhouse.io/particle/story/58180/boron-lte-bsom-lte-unreliable-warm-bootup)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
