### PR TITLE
Enable the buck converter of PMIC by default.

### DIFF
--- a/system/src/system_power_manager.cpp
+++ b/system/src/system_power_manager.cpp
@@ -367,6 +367,7 @@ void PowerManager::initDefault(bool dpdm) {
   }
   // Enable charging
   power.enableCharging();
+  power.enableBuck();
 
   faultSuppressed_ = 0;
 }


### PR DESCRIPTION
### Problem

The buck converter might be disabled occasionally by the PMIC itself while the MCU is stopped by pulling down the EN pin, in which case charging cannot resume after MCU powering up.

### Solution

Enable the buck converter by default on every startup.

### References

https://community.particle.io/t/battery-charge-doesnt-work-if-starting-when-en-grounded/56082

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
