### PR TITLE
Workaround for Gen 3 devices not connecting to the cloud in non-automatic threaded mode

### DIFF
--- a/system/src/system_network_manager_api.cpp
+++ b/system/src/system_network_manager_api.cpp
@@ -408,12 +408,14 @@ void manage_network_connection() {
     /* Need to disconnect and disable networking */
     /* FIXME: refactor */
     if (SPARK_WLAN_RESET || SPARK_WLAN_SLEEP) {
-        auto wasSleeping = SPARK_WLAN_SLEEP;
-        network_disconnect(0, SPARK_WLAN_SLEEP ? NETWORK_DISCONNECT_REASON_UNKNOWN : NETWORK_DISCONNECT_REASON_RESET, nullptr);
-        network_off(0, 0, 0, 0);
-        SPARK_WLAN_RESET = 0;
-        SPARK_WLAN_SLEEP = wasSleeping;
-        cfod_count = 0;
+        if (NetworkManager::instance()->isConnectivityAvailable() || NetworkManager::instance()->isEstablishingConnections()) {
+            auto wasSleeping = SPARK_WLAN_SLEEP;
+            network_disconnect(0, SPARK_WLAN_SLEEP ? NETWORK_DISCONNECT_REASON_UNKNOWN : NETWORK_DISCONNECT_REASON_RESET, nullptr);
+            network_off(0, 0, 0, 0);
+            SPARK_WLAN_RESET = 0;
+            SPARK_WLAN_SLEEP = wasSleeping;
+            cfod_count = 0;
+        }
     } else {
         if (spark_cloud_flag_auto_connect() && (!s_forcedDisconnect || !SPARK_WLAN_SLEEP)) {
             if (!NetworkManager::instance()->isConnectivityAvailable() && !NetworkManager::instance()->isEstablishingConnections()) {


### PR DESCRIPTION
### Problem

The system loop on Gen 3 modifies the value of the `SPARK_WLAN_SLEEP` flag, which may prevent `Particle.connect()` from initiating a connection to the cloud when the app is running in threaded mode.

### Solution

Do not call `network_off()` in the system loop if `SPARK_WLAN_SLEEP` is set but there's no active or ongoing network connection.

Note that this is more a workaround rather than a solution. Ideally, we need to refactor the system state management logic so that `SPARK_WLAN_SLEEP` (or its equivalent) only controls the "administrative" state of the networking subsystem, i.e. whether the user wants networking to be enabled, rather than both the administrative state and the actual one.

### Steps to Test

The easiest way to reproduce this issue is to introduce artificial delays in the system loop:

1. Apply [this diff](https://github.com/particle-iot/device-os/files/4939890/add_delay.diff.txt) to `develop`, build and flash the system firmware and the example application to a Gen 3 device.
2. Verify that the device is breathing white despite that `Particle.connect()` has been called in `setup()`.
3. Check out this branch and reintroduce the same delay in the system loop.
4. Verify that the device running the same application is connecting to the cloud.

### Example App

```cpp
#include "application.h"

SYSTEM_MODE(SEMI_AUTOMATIC)
SYSTEM_THREAD(ENABLED)

void setup() {
    HAL_Delay_Milliseconds(250);
    Particle.connect();
}

void loop() {
}
```

### References

- [ch59176]