### PR TITLE
[gen3] cellular: parser should not be accessed without a lock

### DIFF
--- a/hal/network/ncp/cellular/cellular_hal.cpp
+++ b/hal/network/ncp/cellular/cellular_hal.cpp
@@ -445,9 +445,10 @@ int cellular_command(_CALLBACKPTR_MDM cb, void* param, system_tick_t timeout_ms,
     CHECK_TRUE(client, SYSTEM_ERROR_UNKNOWN);
     auto parser = client->atParser();
     CHECK_TRUE(parser, SYSTEM_ERROR_UNKNOWN);
-    CHECK(client->checkParser());
 
     NcpClientLock lock(client);
+
+    CHECK(client->checkParser());
 
     // WORKAROUND: cut "\r\n", it has been resolved in AT Parser
     size_t n = strlen(format);


### PR DESCRIPTION
### Problem

AT parser is accessed without a lock on Gen 3 cellular platforms.

### Solution

Access it under a lock.

### Steps to Test

N/A

### Example App

N/A

### References

- [CH56485]

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
