### PR TITLE
[gen2] rtc: hal_rtc_get_time() is not thread-safe

### DIFF
--- a/hal/src/stm32f2xx/rtc_hal.c
+++ b/hal/src/stm32f2xx/rtc_hal.c
@@ -183,9 +183,11 @@ int hal_rtc_get_time(struct timeval* tv, void* reserved) {
     RTC_TimeTypeDef RTC_TimeStructure;
     RTC_DateTypeDef RTC_DateStructure;
 
+    int32_t state = HAL_disable_irq();
     /* Get the current Time and Date */
     RTC_GetTime(RTC_Format_BIN, &RTC_TimeStructure);
     RTC_GetDate(RTC_Format_BIN, &RTC_DateStructure);
+    HAL_enable_irq(state);
 
     struct tm calendar_time = {0};
 


### PR DESCRIPTION
### Problem

As the title says.

### Solution

Add an atomic section around RTC time/date fetch calls.

### Steps to Test

N/A

### Example App

N/A

### References

- [CH42243]

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
