### PR TITLE
first take on adding a timeout parameter to the pulseIn function

### DIFF
--- a/hal/inc/gpio_hal.h
+++ b/hal/inc/gpio_hal.h
@@ -61,6 +61,7 @@ PinMode HAL_Get_Pin_Mode(pin_t pin);
 void HAL_GPIO_Write(pin_t pin, uint8_t value);
 int32_t HAL_GPIO_Read(pin_t pin);
 uint32_t HAL_Pulse_In(pin_t pin, uint16_t value);
+uint32_t HAL_Pulse_In(pin_t pin, uint16_t value, unsigned long timeout);
 
 #ifdef __cplusplus
 }

--- a/hal/src/gcc/gpio_hal.cpp
+++ b/hal/src/gcc/gpio_hal.cpp
@@ -217,3 +217,8 @@ uint32_t HAL_Pulse_In(pin_t pin, uint16_t value)
 	return 0;
 }
 
+
+uint32_t HAL_Pulse_In(pin_t pin, uint16_t value, unsigned long timeout)
+{
+    return 0;
+}

--- a/wiring/inc/spark_wiring.h
+++ b/wiring/inc/spark_wiring.h
@@ -81,6 +81,7 @@ uint8_t shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder);
 void serialReadLine(Stream *serialObj, char *dst, int max_len, system_tick_t timeout);
 
 uint32_t pulseIn(pin_t pin, uint16_t value);
+uint32_t pulseIn(pin_t pin, uint16_t value, unsigned long timeout);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Problem

The 'pulseIn' function has a static 3 second timeout, I added another version to mimic Arduino. This has third parameter that specifies the number of microseconds to wait before timing out.

### Solution

Adds addition parameter to a copied function and uses this value to calculate the number of systems ticks to wait, then uses this value in all of the timeout comparison statements

### Steps to Test

This is my first contribution to Particle device-os, so I have yet to add testing

### References

I'm new, so similar to the tests, I have yet to add an addition to the docs.

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
