### PR TITLE
FuelGauge waking up enhancement

### DIFF
--- a/system/src/system_power_manager.cpp
+++ b/system/src/system_power_manager.cpp
@@ -328,8 +328,8 @@ void PowerManager::loop(void* arg) {
         self->initDefault(false);
         self->update_ = true;
       } else if (ev == Event::Wakeup) {
-        initDefault();
         FuelGauge fuel(true);
+        initDefault();
         fuel.wakeup();
         HAL_Delay_Milliseconds(500);
         handleUpdate();

--- a/system/src/system_power_manager.cpp
+++ b/system/src/system_power_manager.cpp
@@ -329,10 +329,10 @@ void PowerManager::loop(void* arg) {
         self->update_ = true;
       } else if (ev == Event::Wakeup) {
         FuelGauge fuel(true);
-        initDefault();
+        self->initDefault();
         fuel.wakeup();
         HAL_Delay_Milliseconds(500);
-        handleUpdate();
+        self->handleUpdate();
       }
     }
     while (self->update_) {

--- a/system/src/system_power_manager.h
+++ b/system/src/system_power_manager.h
@@ -61,7 +61,8 @@ private:
 private:
   enum class Event {
     Update = 0,
-    ReloadConfig = 1
+    ReloadConfig = 1,
+    Wakeup = 2
   };
 
   static volatile bool update_;


### PR DESCRIPTION

By applying the changes, device can resume from sleep faster if system power manager is enabled.
### Example App

```c
#include "Particle.h"

SYSTEM_MODE(MANUAL);

Serial1LogHandler log(115200, LOG_LEVEL_ALL);

void startup() {
    SystemPowerConfiguration conf;
    // conf.feature(SystemPowerFeature::DISABLE);
    System.setPowerConfiguration(conf);
}

STARTUP( startup() );

void setup() {
    System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::STOP).duration(3s));
    LOG(TRACE, "Now: %d", millis());
}

void loop() {
}
```

Log if system power manager is not enabled:
>0000004027 [app] application.cpp:17, setup(): TRACE: Now: 4027

Log if system power manager is enabled:
>0000003537 [app] application.cpp:17, setup(): TRACE: Now: 3537
---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
