### PR TITLE
Only run AT+COPS=0 if currently de-registered, to avoid PLMN reselection

### DIFF
--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -1192,15 +1192,14 @@ int QuectelNcpClient::registerNet() {
     connectionState(NcpConnectionState::CONNECTING);
 
     auto resp = parser_.sendCommand("AT+COPS?");
-    int copsState = -1;
+    int copsState = 2;
     r = CHECK_PARSER(resp.scanf("+COPS: %d", &copsState));
     CHECK_TRUE(r == 1, SYSTEM_ERROR_AT_RESPONSE_UNEXPECTED);
     r = CHECK_PARSER(resp.readResult());
     CHECK_TRUE(r == AtResponse::OK, SYSTEM_ERROR_AT_NOT_OK);
 
-    if (copsState != 0) {
-        // Only run AT+COPS=0 if not currently registering, otherwise we will
-        // perform PLMN reselection
+    if (copsState != 0 && copsState != 1) {
+        // Only run AT+COPS=0 if currently de-registered, to avoid PLMN reselection
         // NOTE: up to 3 mins
         r = CHECK_PARSER(parser_.execCommand(QUECTEL_COPS_TIMEOUT, "AT+COPS=0,2"));
         // Ignore response code here

--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -1461,7 +1461,7 @@ int SaraNcpClient::registerNet() {
     registeredTime_ = 0;
 
     auto resp = parser_.sendCommand("AT+COPS?");
-    int copsState = -1;
+    int copsState = 2;
     r = CHECK_PARSER(resp.scanf("+COPS: %d", &copsState));
     CHECK_TRUE(r == 1, SYSTEM_ERROR_AT_RESPONSE_UNEXPECTED);
     r = CHECK_PARSER(resp.readResult());
@@ -1469,13 +1469,12 @@ int SaraNcpClient::registerNet() {
 
     // NOTE: up to 3 mins (FIXME: there seems to be a bug where this timeout of 3 minutes
     //       is not being respected by u-blox modems.  Setting to 5 for now.)
-    if (copsState != 0) {
-        // If the set command with <mode>=0 is issued, a further set
-        // command with <mode>=0 is managed as a user reselection
+    if (copsState != 0 && copsState != 1) {
+        // Only run AT+COPS=0 if currently de-registered, to avoid PLMN reselection
         r = CHECK_PARSER(parser_.execCommand(UBLOX_COPS_TIMEOUT, "AT+COPS=0,2"));
+        // Ignore response code here
+        // CHECK_TRUE(r == AtResponse::OK, SYSTEM_ERROR_AT_NOT_OK);
     }
-    // Ignore response code here
-    // CHECK_TRUE(r == AtResponse::OK, SYSTEM_ERROR_AT_NOT_OK);
 
     if (conf_.ncpIdentifier() != PLATFORM_NCP_SARA_R410) {
         r = CHECK_PARSER(parser_.execCommand("AT+CREG?"));

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1363,13 +1363,13 @@ bool MDMParser::registerNet(const char* apn, NetStatus* status, system_tick_t ti
             if (!_atOk()) {
                 goto failure;
             }
+            _net.cops = 2; // Re-init to de-registered state in case of COPS? error, to force auto connection
             sendFormated("AT+COPS?\r\n");
             if (RESP_OK != waitFinalResp(_cbCOPS, &_net, COPS_TIMEOUT)) {
                 goto failure;
             }
-            // If the set command with <mode>=0 is issued, a further set
-            // command with <mode>=0 is managed as a user reselection
-            if (_net.cops != 0) {
+            // Only run AT+COPS=0 if currently de-registered, to avoid PLMN reselection
+            if (_net.cops != 0 && _net.cops != 1) {
                 sendFormated("AT+COPS=0,2\r\n");
                 if (waitFinalResp(nullptr, nullptr, COPS_TIMEOUT) != RESP_OK) {
                     goto failure;


### PR DESCRIPTION
### Problem

COPS=0 running when not de-registered.

### Solution

Only check for COPS: 2 mode and switch to automatic registration when deregistered.

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] N/A Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
