### PR TITLE
[Gen3] Workaround when unable to obtain DNS servers from remote

### DIFF
--- a/hal/network/lwip/ppp_client.cpp
+++ b/hal/network/lwip/ppp_client.cpp
@@ -40,6 +40,10 @@ extern "C" {
 
 LOG_SOURCE_CATEGORY("net.ppp.client");
 
+/* Public Google DNS Servers */
+const uint32_t GOOGLE_DNS_PRIMARY = 0x08080808UL;
+const uint32_t GOOGLE_DNS_SECONDARY = 0x08080404UL;
+
 using namespace particle::net::ppp;
 
 std::once_flag Client::once_;
@@ -126,6 +130,12 @@ int Client::prepareConnect() {
   ipcp_->requestOption(ipcp::CONFIGURATION_OPTION_IP_ADDRESS, CONFIGURATION_OPTION_FLAG_ACCEPT_REMOTE_ALWAYS);
   ipcp_->requestOption(ipcp::CONFIGURATION_OPTION_PRIMARY_DNS_SERVER, CONFIGURATION_OPTION_FLAG_ACCEPT_REMOTE_ALWAYS);
   ipcp_->requestOption(ipcp::CONFIGURATION_OPTION_SECONDARY_DNS_SERVER, CONFIGURATION_OPTION_FLAG_ACCEPT_REMOTE_ALWAYS);
+
+  ip4_addr_t pdns, sdns;
+  ip4_addr_set_u32(&pdns, lwip_htonl(GOOGLE_DNS_PRIMARY));
+  ip4_addr_set_u32(&sdns, lwip_htonl(GOOGLE_DNS_SECONDARY));
+  ipcp_->setPrimaryDns(pdns);
+  ipcp_->setSecondaryDns(sdns);
 
 #if PPP_IPV6_SUPPORT
   LOCK_TCPIP_CORE();

--- a/hal/network/lwip/ppp_ipcp.cpp
+++ b/hal/network/lwip/ppp_ipcp.cpp
@@ -148,7 +148,7 @@ void Ipcp::resetConfigurationInformation() {
       }
       case ipcp::CONFIGURATION_OPTION_SECONDARY_DNS_SERVER: {
         auto o = static_cast<ipcp::CommonConfigurationOptionIpAddress*>(opt);
-         o->setLocalAddress(conf.secondaryDns);
+        o->setLocalAddress(conf.secondaryDns);
         break;
       }
       case ipcp::CONFIGURATION_OPTION_IP_NETMASK: {

--- a/hal/network/lwip/ppp_ipcp.cpp
+++ b/hal/network/lwip/ppp_ipcp.cpp
@@ -215,12 +215,14 @@ int Ipcp::ackConfigurationInformation(uint8_t* buf, int len) {
 
 /* NAK our Configuration Information */
 int Ipcp::nakConfigurationInformation(uint8_t* buf, int len, int treatAsReject) {
+  int ret = 1;
   while (len > 0) {
     uint8_t id = *buf;
     auto opt = findOption(id);
     if (opt != nullptr) {
       int l = opt->recvConfigureNak(buf, len);
       if (l == 0) {
+        ret = 0;
         break;
       }
       buf += l;
@@ -231,7 +233,7 @@ int Ipcp::nakConfigurationInformation(uint8_t* buf, int len, int treatAsReject) 
     }
   }
 
-  return len == 0;
+  return ret;
 }
 
 /* Reject our Configuration Information */

--- a/hal/network/lwip/ppp_ipcp.cpp
+++ b/hal/network/lwip/ppp_ipcp.cpp
@@ -143,12 +143,12 @@ void Ipcp::resetConfigurationInformation() {
       }
       case ipcp::CONFIGURATION_OPTION_PRIMARY_DNS_SERVER: {
         auto o = static_cast<ipcp::CommonConfigurationOptionIpAddress*>(opt);
-        o->setPeerAddress(conf.primaryDns);
+        o->setLocalAddress(conf.primaryDns);
         break;
       }
       case ipcp::CONFIGURATION_OPTION_SECONDARY_DNS_SERVER: {
         auto o = static_cast<ipcp::CommonConfigurationOptionIpAddress*>(opt);
-        o->setPeerAddress(conf.secondaryDns);
+         o->setLocalAddress(conf.secondaryDns);
         break;
       }
       case ipcp::CONFIGURATION_OPTION_IP_NETMASK: {


### PR DESCRIPTION
### Problem

Sometimes the device may not the DNS servers from the remote in which case we don't progress further.

### Solution

Start off by requesting public primary and secondary DNS servers (in this case, google's) which will help when we are unable to obtain DNS servers from remote (Separately, if the remote changes them, they are overwritten.)

### Steps to Test

### Example App

```c
void setup() {
}

void loop() {
}
```

### References

Links to the Community, Docs, Other Issues, etc..

[ch59747](https://app.clubhouse.io/particle/story/59747/gen3-hard-code-dns-servers-if-unable-to-obtain-automatically)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
