### PR TITLE
[gen 2][electron] fixes timestamp wrapping at boot

### DIFF
--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -262,7 +262,6 @@ MDMParser::MDMParser(void)
         _sockets[socket].handle = MDM_SOCKET_ERROR;
 #ifdef MDM_DEBUG
     _debugLevel = 3;
-    _debugTime = HAL_Timer_Get_Milli_Seconds();
 #endif
 }
 
@@ -293,7 +292,7 @@ int MDMParser::send(const char* buf, int len)
 {
 #ifdef MDM_DEBUG
     if (_debugLevel >= 3) {
-        MDM_PRINTF("%10.3f AT send    ", (HAL_Timer_Get_Milli_Seconds()-_debugTime)*0.001);
+        MDM_PRINTF("%10.3f AT send    ", HAL_Timer_Get_Milli_Seconds() * 0.001);
         dumpAtCmd(buf,len);
 #ifdef MDM_DEBUG_TX_PIPE
         // When using this, look for dangling stuff in the TX pipe just before a send.
@@ -390,7 +389,7 @@ int MDMParser::waitFinalResp(_CALLBACKPTR cb /* = NULL*/,
                             (type == TYPE_PLUS)   ? CYA " + " DEF :
                             (type == TYPE_PROMPT) ? BLU " > " DEF :
                                                         "..." ;
-            MDM_PRINTF("%10.3f AT read %s", (HAL_Timer_Get_Milli_Seconds()-_debugTime)*0.001, s);
+            MDM_PRINTF("%10.3f AT read %s", HAL_Timer_Get_Milli_Seconds() * 0.001, s);
             dumpAtCmd(buf, len);
             (void)s;
 #ifdef MDM_DEBUG_RX_PIPE

--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -649,7 +649,6 @@ protected:
     volatile bool _cancel_all_operations;
 #ifdef MDM_DEBUG
     int _debugLevel;
-    system_tick_t _debugTime;
     void _debugPrint(int level, const char* color, const char* format, ...) __attribute__((format(printf, 4, 5)));
 #endif
 };


### PR DESCRIPTION
### Problem

Every other release the Gen 2 Electron logging timestamp seems to wrap at boot, starting at very high numbers.

### Solution

There was a variable used for detecting when the debugging level was changed, that was inadvertently set in a constructor and subtracted from all timestamps.  Doing things like this in constructors is unpredictable.  Solution is just to remove this variable in the timestamps.

### Steps to Test

- build system firmware
- run `particle flash --usb tinker-usb-debugging` on the DUT.
- observe no timestamps at very high values at boot

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
