### PR TITLE
Support woken up by analog pin on Gen2 platforms.

### DIFF
--- a/hal/src/stm32f2xx/sleep_hal.cpp
+++ b/hal/src/stm32f2xx/sleep_hal.cpp
@@ -313,30 +313,18 @@ static void enterPlatformSleepMode() {
     int basePri = __get_BASEPRI();
     __set_BASEPRI(2 << (8 - __NVIC_PRIO_BITS));
 
-    /* Enable HSI */
-    RCC_HSICmd(ENABLE);
-    while (RCC_GetFlagStatus(RCC_FLAG_HSIRDY) == RESET);
+    /* Select HSE as system clock source */
+    RCC_SYSCLKConfig(RCC_SYSCLKSource_HSE);
+    /* Wait till HSE is used as system clock source */
+    while (RCC_GetSYSCLKSource() != 0x04);
 
-    /* Select HSI as system clock source */
-    RCC_SYSCLKConfig(RCC_SYSCLKSource_HSI);
-    /* Wait till HSI is used as system clock source */
-    while (RCC_GetSYSCLKSource() != 0x00);
-
-    /* Disable PLL and HSE */
+    /* Disable PLL */
     RCC_PLLCmd(DISABLE);
-    RCC_HSEConfig(RCC_HSE_OFF);
 
     __DSB();
     __WFI();
     __NOP();
     __ISB();
-
-    /* Enable HSE */
-    RCC_HSEConfig(RCC_HSE_ON);
-    if (RCC_WaitForHSEStartUp() != SUCCESS) {
-        /* If HSE startup fails try to recover by system reset */
-        NVIC_SystemReset();
-    }
 
     /* Enable PLL */
     RCC_PLLCmd(ENABLE);

--- a/platform/MCU/shared/STM32/src/hw_ticks.c
+++ b/platform/MCU/shared/STM32/src/hw_ticks.c
@@ -66,9 +66,7 @@ uint64_t GetSystem1MsTick64()
     const int is = __get_PRIMASK();
     __disable_irq();
 
-    system_tick_t elapsedTicks = (DWT->CYCCNT >= system_millis_clock) ? (DWT->CYCCNT - system_millis_clock) : (sizeof(uint32_t) - system_millis_clock + DWT->CYCCNT);
-
-    millis = system_millis + elapsedTicks / SYSTEM_US_TICKS / 1000;
+    millis = system_millis + (DWT->CYCCNT - system_millis_clock) / SYSTEM_US_TICKS / 1000;
 
     if ((is & 1) == 0) {
         __enable_irq();
@@ -91,9 +89,8 @@ system_tick_t GetSystem1UsTick()
 
     base_millis = system_millis;
     base_clock = system_millis_clock;
-    system_tick_t elapsedTicks = (DWT->CYCCNT >= base_clock) ? (DWT->CYCCNT - base_clock) : (sizeof(uint32_t) - base_clock + DWT->CYCCNT);
 
-    system_tick_t elapsed_since_millis = (elapsedTicks / SYSTEM_US_TICKS);
+    system_tick_t elapsed_since_millis = ((DWT->CYCCNT-base_clock) / SYSTEM_US_TICKS);
 
     if ((is & 1) == 0) {
         __enable_irq();

--- a/platform/MCU/shared/STM32/src/hw_ticks.c
+++ b/platform/MCU/shared/STM32/src/hw_ticks.c
@@ -66,7 +66,9 @@ uint64_t GetSystem1MsTick64()
     const int is = __get_PRIMASK();
     __disable_irq();
 
-    millis = system_millis + (DWT->CYCCNT - system_millis_clock) / SYSTEM_US_TICKS / 1000;
+    system_tick_t elapsedTicks = (DWT->CYCCNT >= system_millis_clock) ? (DWT->CYCCNT - system_millis_clock) : (sizeof(uint32_t) - system_millis_clock + DWT->CYCCNT);
+
+    millis = system_millis + elapsedTicks / SYSTEM_US_TICKS / 1000;
 
     if ((is & 1) == 0) {
         __enable_irq();
@@ -89,8 +91,9 @@ system_tick_t GetSystem1UsTick()
 
     base_millis = system_millis;
     base_clock = system_millis_clock;
+    system_tick_t elapsedTicks = (DWT->CYCCNT >= base_clock) ? (DWT->CYCCNT - base_clock) : (sizeof(uint32_t) - base_clock + DWT->CYCCNT);
 
-    system_tick_t elapsed_since_millis = ((DWT->CYCCNT-base_clock) / SYSTEM_US_TICKS);
+    system_tick_t elapsed_since_millis = (elapsedTicks / SYSTEM_US_TICKS);
 
     if ((is & 1) == 0) {
         __enable_irq();


### PR DESCRIPTION
As the title describes. But unlike the same wakeup source on Gen3, this wakeup source is only valid when it is used accompany with the STOP mode only.

### Example App

```c
#include "Particle.h"

SYSTEM_MODE(MANUAL);

Serial1LogHandler log(115200, LOG_LEVEL_ALL);

void setup() {
}

void loop() {
    static system_tick_t now = millis();
    if (millis() - now > 5000) {
        now = millis();
        System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::STOP).analog(A0, 1500, AnalogInterruptMode::ABOVE));
    } else {
        LOG(INFO, "A0: %d", analogRead(A0));
        delay(1000);
    }
}
```

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
