### PR TITLE
Support woken up by USART on Gen2 platforms.

### DIFF
--- a/hal/src/stm32f2xx/sleep_hal.cpp
+++ b/hal/src/stm32f2xx/sleep_hal.cpp
@@ -104,20 +104,23 @@ static int constructAnalogWakeupReason(hal_wakeup_source_base_t** wakeupReason, 
         } else {
             return SYSTEM_ERROR_NO_MEMORY;
         }
+    }
     return SYSTEM_ERROR_NONE;
 }
 
 static int constructUsartWakeupReason(hal_wakeup_source_base_t** wakeupReason, hal_usart_interface_t serial) {
-    auto usart = (hal_wakeup_source_usart_t*)malloc(sizeof(hal_wakeup_source_usart_t));
-    if (usart) {
-        usart->base.size = sizeof(hal_wakeup_source_usart_t);
-        usart->base.version = HAL_SLEEP_VERSION;
-        usart->base.type = HAL_WAKEUP_SOURCE_TYPE_USART;
-        usart->base.next = nullptr;
-        usart->serial = serial;
-        *wakeupReason = reinterpret_cast<hal_wakeup_source_base_t*>(usart);
-    } else {
-        return SYSTEM_ERROR_NO_MEMORY;
+    if (wakeupReason) {
+        auto usart = (hal_wakeup_source_usart_t*)malloc(sizeof(hal_wakeup_source_usart_t));
+        if (usart) {
+            usart->base.size = sizeof(hal_wakeup_source_usart_t);
+            usart->base.version = HAL_SLEEP_VERSION;
+            usart->base.type = HAL_WAKEUP_SOURCE_TYPE_USART;
+            usart->base.next = nullptr;
+            usart->serial = serial;
+            *wakeupReason = reinterpret_cast<hal_wakeup_source_base_t*>(usart);
+        } else {
+            return SYSTEM_ERROR_NO_MEMORY;
+        }
     }
     return SYSTEM_ERROR_NONE;
 }

--- a/platform/MCU/shared/STM32/src/hw_ticks.c
+++ b/platform/MCU/shared/STM32/src/hw_ticks.c
@@ -66,9 +66,7 @@ uint64_t GetSystem1MsTick64()
     const int is = __get_PRIMASK();
     __disable_irq();
 
-    system_tick_t elapsedTicks = (DWT->CYCCNT >= system_millis_clock) ? (DWT->CYCCNT - system_millis_clock) : (sizeof(uint32_t) - system_millis_clock + DWT->CYCCNT);
-
-    millis = system_millis + elapsedTicks / SYSTEM_US_TICKS / 1000;
+    millis = system_millis + (DWT->CYCCNT - system_millis_clock) / SYSTEM_US_TICKS / 1000;
 
     if ((is & 1) == 0) {
         __enable_irq();
@@ -91,9 +89,8 @@ system_tick_t GetSystem1UsTick()
 
     base_millis = system_millis;
     base_clock = system_millis_clock;
-    system_tick_t elapsedTicks = (DWT->CYCCNT >= base_clock) ? (DWT->CYCCNT - base_clock) : (sizeof(uint32_t) - base_clock + DWT->CYCCNT);
 
-    system_tick_t elapsed_since_millis = (elapsedTicks / SYSTEM_US_TICKS);
+    system_tick_t elapsed_since_millis = ((DWT->CYCCNT-base_clock) / SYSTEM_US_TICKS);
 
     if ((is & 1) == 0) {
         __enable_irq();

--- a/platform/MCU/shared/STM32/src/hw_ticks.c
+++ b/platform/MCU/shared/STM32/src/hw_ticks.c
@@ -66,7 +66,9 @@ uint64_t GetSystem1MsTick64()
     const int is = __get_PRIMASK();
     __disable_irq();
 
-    millis = system_millis + (DWT->CYCCNT - system_millis_clock) / SYSTEM_US_TICKS / 1000;
+    system_tick_t elapsedTicks = (DWT->CYCCNT >= system_millis_clock) ? (DWT->CYCCNT - system_millis_clock) : (sizeof(uint32_t) - system_millis_clock + DWT->CYCCNT);
+
+    millis = system_millis + elapsedTicks / SYSTEM_US_TICKS / 1000;
 
     if ((is & 1) == 0) {
         __enable_irq();
@@ -89,8 +91,9 @@ system_tick_t GetSystem1UsTick()
 
     base_millis = system_millis;
     base_clock = system_millis_clock;
+    system_tick_t elapsedTicks = (DWT->CYCCNT >= base_clock) ? (DWT->CYCCNT - base_clock) : (sizeof(uint32_t) - base_clock + DWT->CYCCNT);
 
-    system_tick_t elapsed_since_millis = ((DWT->CYCCNT-base_clock) / SYSTEM_US_TICKS);
+    system_tick_t elapsed_since_millis = (elapsedTicks / SYSTEM_US_TICKS);
 
     if ((is & 1) == 0) {
         __enable_irq();


### PR DESCRIPTION
As the title describes. But unlike the same wakeup source on Gen3, this wakeup source is only valid when it is used accompany with the STOP mode only.

### Example App

```c
#include "Particle.h"

SYSTEM_MODE(AUTOMATIC);

Serial1LogHandler log(115200, LOG_LEVEL_ALL);

void setup() {
}

void loop() {
    delay(1000);
    System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::STOP).usart(Serial1));
    LOG(TRACE, "Device wakes up.");
}
```

### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
