### PR TITLE
Clear OTA slots after updating firmware modules

### DIFF
--- a/bootloader/src/main.c
+++ b/bootloader/src/main.c
@@ -33,11 +33,6 @@
 #include "dct.h"
 #include "feature_flags.h"
 
-#if PLATFORM_ID == 6 || PLATFORM_ID == 8
-#define LOAD_DCT_FUNCTIONS
-#include "bootloader_dct.h"
-#endif
-
 #if PLATFORM_ID == 6 || PLATFORM_ID == 8 || PLATFORM_ID == 10
 #define USE_LED_THEME
 #include "led_signal.h"
@@ -432,10 +427,6 @@ int main(void)
         if (FLASH_UpdateModules(flashModulesCallback) == FLASH_ACCESS_RESULT_RESET_PENDING) {
             HAL_Core_System_Reset_Ex(RESET_REASON_UPDATE, 0, NULL);
         }
-#ifdef LOAD_DCT_FUNCTIONS
-        // DCT functions may need to be reloaded after updating a system module
-        dct_reload_functions();
-#endif
 #else
         if (REFLASH_FROM_BACKUP == 1)
         {

--- a/bootloader/src/stm32f2xx/core_hal.c
+++ b/bootloader/src/stm32f2xx/core_hal.c
@@ -1,0 +1,5 @@
+#include "core_hal.h"
+
+void HAL_Core_System_Reset_Ex(int reason, uint32_t data, void *reserved) {
+    NVIC_SystemReset();
+}


### PR DESCRIPTION
### Problem

The bootloader prematurely clears OTA flags in the DCT before ensuring that the firmware modules have been successfully copied from the OTA section to the internal flash.

### Solution

Clear OTA flags **after** the firmware modules have been updated.

### Steps to Test

1. Compile and flash the bootloader from this branch to a Gen 2 or Gen 3 device.
2. Flash a system part to the device OTA.
3. Wait until the device resets to apply the update and reset it via the reset button.
4. The device should reapply the update after the reset.

### References

- [ch61683]
