### PR TITLE
[Gen2] Detect IMSI switches

### DIFF
--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1389,9 +1389,11 @@ bool MDMParser::registerNet(const char* apn, NetStatus* status, system_tick_t ti
                 }
                 // Query IMSI every 60 sec if not regsitered, to detect IMSI switches
                 if (HAL_Timer_Get_Milli_Seconds() - start_imsi_check > 60000UL) {
-                        start_imsi_check = HAL_Timer_Get_Milli_Seconds();
-                        sendFormated("AT+CIMI\r\n");
-                        waitFinalResp();
+                    start_imsi_check = HAL_Timer_Get_Milli_Seconds();
+                    sendFormated("AT+CIMI\r\n");
+                    if (RESP_OK != waitFinalResp()) {
+                        goto failure;
+                    }
                 }
             }
             if (_net.csd == REG_DENIED) MDM_ERROR("CSD Registration Denied\r\n");


### PR DESCRIPTION
### Problem

On Gen2, detect IMSI switches when not registered, and read IMSI with which the radio is registered with the network immediately when registered. Update `_dev.imsi` which stores the IMSI in work.

### Solution

- Read IMSI immediately when registered to check which IMSI the radio module registered with
- When not registered, check IMSI periodically as currently there is no special URC support on ublox based radios used in Gen2. Timer for IMSI query when not registered yet is set to 60 sec.

### Steps to Test

### Example App

```c
void setup() {
}

void loop() {
}
```

### References

https://github.com/particle-iot/device-os/pull/2174/
[ch60650](https://app.clubhouse.io/particle/story/60650/twilio-identify-imsi-switching-with-it-s-urc-and-trigger-an-at-cimi-to-query-new-imsi)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
