### PR TITLE
[wiring] print: exclude printable objects from an overload taking integral and uint convertible types

### DIFF
--- a/test/unit_tests/wiring/print.cpp
+++ b/test/unit_tests/wiring/print.cpp
@@ -47,6 +47,17 @@ private:
     size_t  size_;
 };
 
+class TestConvertiblePrintable: public Printable {
+public:
+    virtual size_t printTo(Print& p) const override {
+        return p.write("TestConvertiblePrintable");
+    }
+
+    operator bool() const {
+        return true;
+    }
+};
+
 } // namespace
 
 TEST_CASE("Print tests for all types") {
@@ -132,6 +143,14 @@ TEST_CASE("Print tests for all types") {
     SECTION("Print others") {
         REQUIRE(printTest.print("") == 0);
         REQUIRE(printTest.isEqual(""));
+    }
+
+    SECTION("Printable objects that are implicitly convertible to integra/unsigned integer types") {
+        TestConvertiblePrintable printable;
+        REQUIRE(printTest.print(printable));
+        REQUIRE(printTest.isEqual("TestConvertiblePrintable"));
+        REQUIRE(printTest.println(printable));
+        REQUIRE(printTest.isEqual("TestConvertiblePrintable\r\n"));
     }
 
 }

--- a/wiring/inc/spark_wiring_print.h
+++ b/wiring/inc/spark_wiring_print.h
@@ -80,8 +80,8 @@ class Print
 
     size_t print(const char[]);
     size_t print(char);
-    template <typename T, std::enable_if_t<std::is_integral<T>::value || std::is_convertible<T, unsigned long long>::value ||
-        std::is_convertible<T, long long>::value, int> = 0>
+    template <typename T, std::enable_if_t<!std::is_base_of<Printable, T>::value && (std::is_integral<T>::value || std::is_convertible<T, unsigned long long>::value ||
+        std::is_convertible<T, long long>::value), int> = 0>
     size_t print(T, int = DEC);
     size_t print(float, int = 2);
     size_t print(double, int = 2);
@@ -90,8 +90,8 @@ class Print
 
     size_t println(const char[]);
     size_t println(char);
-    template <typename T, std::enable_if_t<std::is_integral<T>::value || std::is_convertible<T, unsigned long long>::value ||
-        std::is_convertible<T, long long>::value, int> = 0>
+    template <typename T, std::enable_if_t<!std::is_base_of<Printable, T>::value && (std::is_integral<T>::value || std::is_convertible<T, unsigned long long>::value ||
+        std::is_convertible<T, long long>::value), int> = 0>
     size_t println(T b, int base = DEC) {
         size_t n = print(b, base);
         n += println();
@@ -117,8 +117,8 @@ class Print
 
 };
 
-template <typename T, std::enable_if_t<std::is_integral<T>::value || std::is_convertible<T, unsigned long long>::value ||
-    std::is_convertible<T, long long>::value, int>>
+template <typename T, std::enable_if_t<!std::is_base_of<Printable, T>::value && (std::is_integral<T>::value || std::is_convertible<T, unsigned long long>::value ||
+    std::is_convertible<T, long long>::value), int>>
 size_t Print::print(T n, int base)
 {
     if (base == 0) {


### PR DESCRIPTION
### Problem

For printable types (e.g. `IPAddress`) that also happen to be implicitly convertible to an integral or unsigned integer type (e.g. `bool`) `Print` overload printing integers will take precedence over the overload taking `const Printable&`.

For example:
```c++
Serial.println(WiFi.localIP());
```

This will print only `0` or `1`, instead of an actual address.

### Solution

As title says.

### Steps to Test

- unit tests

### Example App

N/A

### References

- Closes #2124 

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
