### PR TITLE
[wiring] cellular: mark CellularSignal::rssi and CellularSignal::qual as deprecated

### DIFF
--- a/wiring/inc/spark_wiring_cellular_printable.h
+++ b/wiring/inc/spark_wiring_cellular_printable.h
@@ -36,12 +36,17 @@
  */
 class CellularSignal : public particle::Signal, public Printable {
 public:
-    int rssi = 0;
-    int qual = 0;
+    int rssi __attribute__((deprecated("Use getSignalStrengthValue() instead"))) = 0;
+    int qual __attribute__((deprecated("Use getSignalQualityValue() instead"))) = 0;
 
+// TODO: remove once rssi/qual are removed
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     CellularSignal() {}
     CellularSignal(const cellular_signal_t& sig);
     virtual ~CellularSignal() {};
+    CellularSignal(const CellularSignal&) = default;
+#pragma GCC diagnostic pop
 
     bool fromHalCellularSignal(const cellular_signal_t& sig);
 

--- a/wiring/src/spark_wiring_cellular.cpp
+++ b/wiring/src/spark_wiring_cellular.cpp
@@ -26,6 +26,9 @@
 namespace spark {
 
     CellularSignal CellularClass::RSSI() {
+// TODO: remove once rssi/qual are removed
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         CellularSignal sig;
         if (!network_ready(*this, 0, NULL)) {
             sig.rssi = 0;
@@ -46,6 +49,7 @@ namespace spark {
         }
         sig.fromHalCellularSignal(sigext);
         return sig;
+#pragma GCC diagnostic pop
     }
 
     CellularDataHal data_hal;

--- a/wiring/src/spark_wiring_cellular_printable.cpp
+++ b/wiring/src/spark_wiring_cellular_printable.cpp
@@ -24,6 +24,9 @@
 
 #if Wiring_Cellular || defined(UNIT_TEST)
 
+// TODO: remove once rssi/qual are removed
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 CellularSignal::CellularSignal(const cellular_signal_t& sig)
     : sig_(sig)
 {
@@ -34,6 +37,7 @@ bool CellularSignal::fromHalCellularSignal(const cellular_signal_t& sig)
     sig_ = sig;
     return true;
 }
+#pragma GCC diagnostic pop
 
 hal_net_access_tech_t CellularSignal::getAccessTechnology() const
 {
@@ -76,6 +80,9 @@ float CellularSignal::getQualityValue() const
     return 0.0f;
 }
 
+// TODO: remove once rssi/qual are removed
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 size_t CellularSignal::printTo(Print& p) const
 {
     size_t n = 0;
@@ -84,6 +91,7 @@ size_t CellularSignal::printTo(Print& p) const
     n += p.print((*this).qual, DEC);
     return n;
 }
+#pragma GCC diagnostic pop
 
 size_t CellularData::printTo(Print& p) const
 {


### PR DESCRIPTION
### Problem

These are old APIs that don't account well for RAT (Radio Access Technology).

`getStrengthValue()` and `getQualityValue()` with `getAccessTechnology()` should be preferred going forward.

https://docs.particle.io/reference/device-os/firmware/electron/#getstrengthvalue-

### Solution

Mark these class member variables as deprecated.

### Steps to Test

Build the test app, it should provide deprecated warnings.

### Example App

```c++
void loop() {
    auto s = Cellular.RSSI();
    Log.trace("%d", s.rssi);
    Log.trace("%d", s.qual);
}
```

### References

- [CH61037]

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
