### PR TITLE
[gen3] tone: fixes behavior with duration = 0

### DIFF
--- a/hal/src/nRF52840/tone_hal.cpp
+++ b/hal/src/nRF52840/tone_hal.cpp
@@ -69,7 +69,12 @@ void HAL_Tone_Start(uint8_t pin, uint32_t frequency, uint32_t duration) {
     }
 
     g_tone[timer_index].pin = pin;
-    ret = os_timer_create(&g_tone[timer_index].timer, duration, tone_timer_timeout_handler, nullptr, true, nullptr);
+    bool one_shot = true;
+    if (duration == 0) {
+        duration = 0xffffffff;
+        one_shot = false;
+    }
+    ret = os_timer_create(&g_tone[timer_index].timer, duration, tone_timer_timeout_handler, nullptr, one_shot, nullptr);
     if (ret != 0) {
         return;
     }

--- a/user/tests/wiring/no_fixture/tone.cpp
+++ b/user/tests/wiring/no_fixture/tone.cpp
@@ -92,3 +92,13 @@ test(TONE_04_GeneratedOnPinStopsWhenStopped) {
     //To Do : Add test for remaining pins if required
 }
 
+test(TONE_05_ZeroDurationInfiniteToneDuration) {
+    uint32_t frequency = 500;
+    uint32_t duration = 0;
+    tone(pin, frequency, duration);
+    assertEqual(HAL_Tone_Is_Stopped(pin), false);
+    delay(1000);
+    assertEqual(HAL_Tone_Is_Stopped(pin), false);
+    noTone(pin);
+    assertEqual(HAL_Tone_Is_Stopped(pin), true);
+}


### PR DESCRIPTION
### Problem

Closes #2170

### Solution

As title says

### Steps to Test

- `wiring/no_fixture`

### Example App

N/A

### References

- [CH60815]

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
