### PR TITLE
Gen2: supports network wakeup source for Electron specifically.

### DIFF
--- a/hal/src/nRF52840/sleep_hal.cpp
+++ b/hal/src/nRF52840/sleep_hal.cpp
@@ -82,9 +82,12 @@ static void bumpWakeupSourcesPriority(const hal_wakeup_source_base_t* wakeupSour
             NVIC_SetPriority(UARTE0_UART0_IRQn, newPriority);
             nrf_uarte_int_enable(NRF_UARTE0, NRF_UARTE_INT_RXDRDY_MASK);
         } else if (source->type == HAL_WAKEUP_SOURCE_TYPE_NETWORK) {
-            priority->usart1Priority = NVIC_GetPriority(UARTE1_IRQn);
-            NVIC_SetPriority(UARTE1_IRQn, newPriority);
-            nrf_uarte_int_enable(NRF_UARTE1, NRF_UARTE_INT_RXDRDY_MASK);
+            auto network = reinterpret_cast<const hal_wakeup_source_network_t*>(source);
+            if (!(network->flags & HAL_SLEEP_NETWORK_FLAG_INACTIVE_STANDBY)) {
+                priority->usart1Priority = NVIC_GetPriority(UARTE1_IRQn);
+                NVIC_SetPriority(UARTE1_IRQn, newPriority);
+                nrf_uarte_int_enable(NRF_UARTE1, NRF_UARTE_INT_RXDRDY_MASK);
+            }
         }
         source = source->next;
     }
@@ -113,8 +116,11 @@ static void unbumpWakeupSourcesPriority(const hal_wakeup_source_base_t* wakeupSo
             NVIC_SetPriority(UARTE0_UART0_IRQn, priority->usart0Priority);
             nrf_uarte_int_disable(NRF_UARTE0, NRF_UARTE_INT_RXDRDY_MASK);
         } else if (source->type == HAL_WAKEUP_SOURCE_TYPE_NETWORK) {
-            NVIC_SetPriority(UARTE1_IRQn, priority->usart1Priority);
-            nrf_uarte_int_disable(NRF_UARTE1, NRF_UARTE_INT_RXDRDY_MASK);
+            auto network = reinterpret_cast<const hal_wakeup_source_network_t*>(source);
+            if (!(network->flags & HAL_SLEEP_NETWORK_FLAG_INACTIVE_STANDBY)) {
+                NVIC_SetPriority(UARTE1_IRQn, priority->usart1Priority);
+                nrf_uarte_int_disable(NRF_UARTE1, NRF_UARTE_INT_RXDRDY_MASK);
+            }
         }
         source = source->next;
     }

--- a/hal/src/stm32f2xx/sleep_hal.cpp
+++ b/hal/src/stm32f2xx/sleep_hal.cpp
@@ -125,8 +125,8 @@ static int constructUsartWakeupReason(hal_wakeup_source_base_t** wakeupReason, h
     return SYSTEM_ERROR_NONE;
 }
 
-#if HAL_PLATFORM_CELLULAR
 static int constructNetworkWakeupReason(hal_wakeup_source_base_t** wakeupReason, network_interface_index index) {
+#if HAL_PLATFORM_CELLULAR
     auto network = (hal_wakeup_source_network_t*)malloc(sizeof(hal_wakeup_source_network_t));
     if (network) {
         network->base.size = sizeof(hal_wakeup_source_base_t);
@@ -139,8 +139,11 @@ static int constructNetworkWakeupReason(hal_wakeup_source_base_t** wakeupReason,
         return SYSTEM_ERROR_NO_MEMORY;
     }
     return SYSTEM_ERROR_NONE;
-}
+#else
+    return SYSTEM_ERROR_NOT_SUPPORTED;
 #endif
+}
+
 
 static int configGpioWakeupSource(const hal_wakeup_source_base_t* wakeupSources, uint8_t* extiPriorities) {
     auto source = wakeupSources;
@@ -340,13 +343,6 @@ static int configUsartWakeupSource(const hal_wakeup_source_base_t* wakeupSources
                     break;
                 }
 #if PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION
-                case HAL_USART_SERIAL3: {
-                    NVIC_DisableIRQ(USART3_IRQn);
-                    NVIC_ClearPendingIRQ(USART3_IRQn);
-                    NVIC_InitStructure.NVIC_IRQChannel = USART3_IRQn;
-                    USART_ITConfig(USART3, USART_IT_TXE, DISABLE);
-                    break;
-                }
                 case HAL_USART_SERIAL4: {
                     NVIC_DisableIRQ(UART4_IRQn);
                     NVIC_ClearPendingIRQ(UART4_IRQn);
@@ -375,15 +371,24 @@ static int configUsartWakeupSource(const hal_wakeup_source_base_t* wakeupSources
 }
 
 static int configNetworkWakeupSource(const hal_wakeup_source_base_t* wakeupSources, uint8_t* configured) {
+#if HAL_PLATFORM_CELLULAR
     auto source = wakeupSources;
     while (source) {
         if (source->type == HAL_WAKEUP_SOURCE_TYPE_NETWORK) {
-            *configured = 1;
-            // We don't need to configure anything, as the RX interrupt is enabled when the USART is enabled.
+            auto network = reinterpret_cast<const hal_wakeup_source_network_t*>(source);
+            if (!(network->flags & HAL_SLEEP_NETWORK_FLAG_INACTIVE_STANDBY)) {
+                *configured = 1;
+                // We don't need to bump the interrupt priority, since the priority has been set to 0 in electronserialpipe_hal.c
+                // We don't disable any USART interrupt here to make sure the modem driver behaves correctly.
+                break; // There is only one USART available for network modem. Stop traversing the list.
+            }
         }
         source = source->next;
     }
     return SYSTEM_ERROR_NONE;
+#else
+    return SYSTEM_ERROR_NOT_SUPPORTED
+#endif
 }
 
 static int validateGpioWakeupSource(hal_sleep_mode_t mode, const hal_wakeup_source_gpio_t* gpio) {
@@ -437,7 +442,7 @@ static int validateNetworkWakeupSource(hal_sleep_mode_t mode, const hal_wakeup_s
             return SYSTEM_ERROR_NOT_SUPPORTED;
         }
     } else {
-        if (!hal_usart_is_enabled(HAL_USART_SERIAL3)) {
+        if (!(USART3->CR1 & USART_CR1_UE)) {
             return SYSTEM_ERROR_INVALID_STATE;
         }
         if (mode != HAL_SLEEP_MODE_STOP) {
@@ -645,7 +650,6 @@ static int enterStopBasedSleep(const hal_sleep_config_t* config, hal_wakeup_sour
             if (   (NVIC_GetPendingIRQ(USART1_IRQn) && usartWakeup->serial == HAL_USART_SERIAL1)
                 || (NVIC_GetPendingIRQ(USART2_IRQn) && usartWakeup->serial == HAL_USART_SERIAL2)
 #if PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION // Electron
-                || (NVIC_GetPendingIRQ(USART3_IRQn) && usartWakeup->serial == HAL_USART_SERIAL3)
                 || (NVIC_GetPendingIRQ(UART4_IRQn) && usartWakeup->serial == HAL_USART_SERIAL4)
                 || (NVIC_GetPendingIRQ(UART5_IRQn) && usartWakeup->serial == HAL_USART_SERIAL5)
 #endif
@@ -654,15 +658,15 @@ static int enterStopBasedSleep(const hal_sleep_config_t* config, hal_wakeup_sour
             }
             break; // Stop traversing the wakeup sources list.
         }
-#if HAL_PLATFORM_CELLULAR
         else if (wakeupSource->type == HAL_WAKEUP_SOURCE_TYPE_NETWORK) {
+#if HAL_PLATFORM_CELLULAR
             auto networkWakeup = reinterpret_cast<hal_wakeup_source_network_t*>(wakeupSource);
             if (NVIC_GetPendingIRQ(USART3_IRQn) && networkWakeup->index == NETWORK_INTERFACE_CELLULAR) {
                 ret = constructNetworkWakeupReason(wakeupReason, networkWakeup->index);
             }
+#endif
             break; // Stop traversing the wakeup sources list.
         }
-#endif
         wakeupSource = wakeupSource->next;
     }
 
@@ -712,11 +716,6 @@ static int enterStopBasedSleep(const hal_sleep_config_t* config, hal_wakeup_sour
                     break;
                 }
 #if PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION
-                case HAL_USART_SERIAL3: {
-                    NVIC_InitStructure.NVIC_IRQChannel = USART3_IRQn;
-                    USART_ITConfig(USART3, USART_IT_TXE, ENABLE);
-                    break;
-                }
                 case HAL_USART_SERIAL4: {
                     NVIC_InitStructure.NVIC_IRQChannel = UART4_IRQn;
                     USART_ITConfig(UART4, USART_IT_TXE, ENABLE);
@@ -734,6 +733,13 @@ static int enterStopBasedSleep(const hal_sleep_config_t* config, hal_wakeup_sour
             NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
             NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
             NVIC_Init(&NVIC_InitStructure);
+        } else if (wakeupSource->type == HAL_WAKEUP_SOURCE_TYPE_NETWORK) {
+#if HAL_PLATFORM_CELLULAR
+            auto network = reinterpret_cast<const hal_wakeup_source_network_t*>(wakeupSource);
+            if (!(network->flags & HAL_SLEEP_NETWORK_FLAG_INACTIVE_STANDBY)) {
+                // We don't need to unbump the priority
+            }
+#endif
         }
         wakeupSource = wakeupSource->next;
     }

--- a/hal/src/stm32f2xx/sleep_hal.cpp
+++ b/hal/src/stm32f2xx/sleep_hal.cpp
@@ -125,8 +125,8 @@ static int constructUsartWakeupReason(hal_wakeup_source_base_t** wakeupReason, h
     return SYSTEM_ERROR_NONE;
 }
 
-static int constructNetworkWakeupReason(hal_wakeup_source_base_t** wakeupReason, network_interface_index index) {
 #if HAL_PLATFORM_CELLULAR
+static int constructNetworkWakeupReason(hal_wakeup_source_base_t** wakeupReason, network_interface_index index) {
     auto network = (hal_wakeup_source_network_t*)malloc(sizeof(hal_wakeup_source_network_t));
     if (network) {
         network->base.size = sizeof(hal_wakeup_source_base_t);
@@ -139,11 +139,8 @@ static int constructNetworkWakeupReason(hal_wakeup_source_base_t** wakeupReason,
         return SYSTEM_ERROR_NO_MEMORY;
     }
     return SYSTEM_ERROR_NONE;
-#else
-    return SYSTEM_ERROR_NOT_SUPPORTED;
-#endif
 }
-
+#endif
 
 static int configGpioWakeupSource(const hal_wakeup_source_base_t* wakeupSources, uint8_t* extiPriorities) {
     auto source = wakeupSources;
@@ -387,7 +384,7 @@ static int configNetworkWakeupSource(const hal_wakeup_source_base_t* wakeupSourc
     }
     return SYSTEM_ERROR_NONE;
 #else
-    return SYSTEM_ERROR_NOT_SUPPORTED
+    return SYSTEM_ERROR_NOT_SUPPORTED;
 #endif
 }
 

--- a/platform/MCU/shared/STM32/src/hw_ticks.c
+++ b/platform/MCU/shared/STM32/src/hw_ticks.c
@@ -66,9 +66,7 @@ uint64_t GetSystem1MsTick64()
     const int is = __get_PRIMASK();
     __disable_irq();
 
-    system_tick_t elapsedTicks = (DWT->CYCCNT >= system_millis_clock) ? (DWT->CYCCNT - system_millis_clock) : (sizeof(uint32_t) - system_millis_clock + DWT->CYCCNT);
-
-    millis = system_millis + elapsedTicks / SYSTEM_US_TICKS / 1000;
+    millis = system_millis + (DWT->CYCCNT - system_millis_clock) / SYSTEM_US_TICKS / 1000;
 
     if ((is & 1) == 0) {
         __enable_irq();
@@ -91,9 +89,8 @@ system_tick_t GetSystem1UsTick()
 
     base_millis = system_millis;
     base_clock = system_millis_clock;
-    system_tick_t elapsedTicks = (DWT->CYCCNT >= base_clock) ? (DWT->CYCCNT - base_clock) : (sizeof(uint32_t) - base_clock + DWT->CYCCNT);
 
-    system_tick_t elapsed_since_millis = (elapsedTicks / SYSTEM_US_TICKS);
+    system_tick_t elapsed_since_millis = ((DWT->CYCCNT-base_clock) / SYSTEM_US_TICKS);
 
     if ((is & 1) == 0) {
         __enable_irq();

--- a/platform/MCU/shared/STM32/src/hw_ticks.c
+++ b/platform/MCU/shared/STM32/src/hw_ticks.c
@@ -66,7 +66,9 @@ uint64_t GetSystem1MsTick64()
     const int is = __get_PRIMASK();
     __disable_irq();
 
-    millis = system_millis + (DWT->CYCCNT - system_millis_clock) / SYSTEM_US_TICKS / 1000;
+    system_tick_t elapsedTicks = (DWT->CYCCNT >= system_millis_clock) ? (DWT->CYCCNT - system_millis_clock) : (sizeof(uint32_t) - system_millis_clock + DWT->CYCCNT);
+
+    millis = system_millis + elapsedTicks / SYSTEM_US_TICKS / 1000;
 
     if ((is & 1) == 0) {
         __enable_irq();
@@ -89,8 +91,9 @@ system_tick_t GetSystem1UsTick()
 
     base_millis = system_millis;
     base_clock = system_millis_clock;
+    system_tick_t elapsedTicks = (DWT->CYCCNT >= base_clock) ? (DWT->CYCCNT - base_clock) : (sizeof(uint32_t) - base_clock + DWT->CYCCNT);
 
-    system_tick_t elapsed_since_millis = ((DWT->CYCCNT-base_clock) / SYSTEM_US_TICKS);
+    system_tick_t elapsed_since_millis = (elapsedTicks / SYSTEM_US_TICKS);
 
     if ((is & 1) == 0) {
         __enable_irq();

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -102,14 +102,15 @@ int system_sleep_ext(const hal_sleep_config_t* config, hal_wakeup_source_base_t*
     // FIXME: if_get_list() can be potentially used, instead of using pre-processor.
 #if HAL_PLATFORM_CELLULAR
     bool cellularResume = false;
-    if (!configHelper.wakeupByNetworkInterface(NETWORK_INTERFACE_CELLULAR) &&
-          !configHelper.networkFlags(NETWORK_INTERFACE_CELLULAR).isSet(SystemSleepNetworkFlag::INACTIVE_STANDBY)) {
-        if (system_sleep_network_suspend(NETWORK_INTERFACE_CELLULAR)) {
-            cellularResume = true;
+    if (!configHelper.wakeupByNetworkInterface(NETWORK_INTERFACE_CELLULAR)) {
+        if (configHelper.networkFlags(NETWORK_INTERFACE_CELLULAR).isSet(SystemSleepNetworkFlag::INACTIVE_STANDBY)) {
+            // Pause the modem Serial, while leaving the modem keeps running.
+            cellular_pause(nullptr);
+        } else {
+            if (system_sleep_network_suspend(NETWORK_INTERFACE_CELLULAR)) {
+                cellularResume = true;
+            }
         }
-    } else {
-        // Pause the modem Serial, while leaving the modem keeps running.
-        cellular_pause(nullptr);
     }
 #endif // HAL_PLATFORM_CELLULAR
 


### PR DESCRIPTION
**Note: This PR is targeting to the feature/gen2_usart_wakeup/ch60474 branch**

As the title says.

### Example App

```c
#include "application.h"

Serial1LogHandler handler(115200, LOG_LEVEL_ALL);

/* This function is called once at start up ----------------------------------*/
void setup()
{
    waitUntil(Particle.connected);
}

/* This function loops forever -----------------------------------------------*/
void loop()
{
    // This will run in a loop
    SystemSleepResult result = System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::STOP).network(Cellular));
    if (result.error() != SYSTEM_ERROR_NONE) {
        Log.error("Failed to enter sleep mode: %d", result.error());
    }
    delay(1s);
}
```

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
