### PR TITLE
Define C++-compatible pin map for Argon

### DIFF
--- a/hal/src/argon/pinmap_defines.h
+++ b/hal/src/argon/pinmap_defines.h
@@ -19,6 +19,79 @@
 
 #if PLATFORM_ID == PLATFORM_ARGON
 
+#ifdef __cplusplus
+
+constexpr pin_t TOTAL_PINS = 36;
+
+// Digital pins
+constexpr pin_t D0 = 0;
+constexpr pin_t D1 = 1;
+constexpr pin_t D2 = 2;
+constexpr pin_t D3 = 3;
+constexpr pin_t D4 = 4;
+constexpr pin_t D5 = 5;
+constexpr pin_t D6 = 6;
+constexpr pin_t D7 = 7;
+constexpr pin_t D8 = 8;
+constexpr pin_t D9 = 9;
+constexpr pin_t D10 = 10;
+constexpr pin_t D11 = 11;
+constexpr pin_t D12 = 12;
+constexpr pin_t D13 = 13;
+constexpr pin_t D14 = 14;
+constexpr pin_t D15 = 15;
+constexpr pin_t D16 = 16;
+constexpr pin_t D17 = 17;
+constexpr pin_t D18 = 18;
+constexpr pin_t D19 = 19;
+
+constexpr pin_t BTN = 20;
+constexpr pin_t RGBR = 21;
+constexpr pin_t RGBG = 22;
+constexpr pin_t RGBB = 23;
+
+// Analog pins
+constexpr pin_t TOTAL_ANALOG_PINS = 6;
+constexpr pin_t FIRST_ANALOG_PIN = D14;
+
+constexpr pin_t A0 = D19;
+constexpr pin_t A1 = D18;
+constexpr pin_t A2 = D17;
+constexpr pin_t A3 = D16;
+constexpr pin_t A4 = D15;
+constexpr pin_t A5 = D14;
+
+constexpr pin_t SS = D14;
+constexpr pin_t SCK = D13;
+constexpr pin_t MISO = D11;
+constexpr pin_t MOSI = D12;
+
+constexpr pin_t SDA = D0;
+constexpr pin_t SCL = D1;
+
+constexpr pin_t TX = D9;
+constexpr pin_t RX = D10;
+constexpr pin_t CTS = D3;
+constexpr pin_t RTS = D2;
+
+constexpr pin_t WKP = D8;
+
+constexpr pin_t TX1 = 24;
+constexpr pin_t RX1 = 25;
+constexpr pin_t CTS1 = 26;
+constexpr pin_t RTS1 = 27;
+
+constexpr pin_t ESPBOOT = 28;
+constexpr pin_t ESPEN = 29;
+constexpr pin_t HWAKE = 30;
+constexpr pin_t ANTSW1 = 31;
+constexpr pin_t ANTSW2 = 32;
+constexpr pin_t BATT = 33;
+constexpr pin_t PWR = 34;
+constexpr pin_t CHG = 35;
+
+#else // !__cplusplus
+
 #define TOTAL_PINS 36
 #define TOTAL_ANALOG_PINS 6
 #define FIRST_ANALOG_PIN D14
@@ -86,6 +159,8 @@
 #define BATT 33
 #define PWR 34
 #define CHG 35
+
+#endif // !__cplusplus
 
 #endif // PLATFORM_ID == PLATFORM_ARGON
 


### PR DESCRIPTION
### Problem

The Particle `pinmap_defines.h` headers establish pin IDs like `SCA` with a `#define`, meaning that any stand-alone use of the token `SCA` gets replaced with a number by the preprocessor. Other Arduino-based platforms don't do this. Because of Particle's headers, Particle apps cannot directly use [some Arduino libraries](https://github.com/pololu/tic-arduino) that use a token like `SCA` internally, such as:

```
enum class TicPin
{
  SCL = 0,
  SDA = 1,
  TX  = 2,
  RX  = 3,
  RC  = 4,
};
```

### Solution

We should use C++ to establish constants when we're building in C++. This allows library code to safely use tokens like `SCA` without preprocessor interference.

Since `pinmap_defines.h` is also used to compile some nRF platform code in C, we unfortunately need to make the pin mappings available through both C and C++ means, whichever we're compiling with. That said, these defines are unlikely to change, to put it mildly, so I think this poses a negligible maintenance burden.

This PR offers this change for the Argon platform only (since that's what I'm using for my current project). If we believe that this is overall a good idea, I'm happy to make the change for all headers and platforms.

### Steps to Test

Build `device-os/main` with `make PLATFORM=argon`.

---

### Completeness

- [x] User is totes amazing for contributing!
- [X] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [X] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
