### PR TITLE
[Boron] Fix warm bootup on R4-based devices

### DIFF
--- a/hal/network/lwip/ppp_client.cpp
+++ b/hal/network/lwip/ppp_client.cpp
@@ -292,7 +292,7 @@ void Client::loop() {
           transition(STATE_CONNECT);
           break;
         }
-        err_t err = pppapi_connect(pcb_, 1);
+        err_t err = pppapi_connect(pcb_, 0);
         if (err != ERR_OK) {
           LOG(TRACE, "PPP error connecting: %x", err);
           transition(STATE_CONNECT);


### PR DESCRIPTION
### Problem

When warm booting into a state where SARA R4 modem is registered on the network and there is an ongoing PPP session on the data channel, we fail to interrupt/resume it and start another one. This usually showcases itself in the logs as:
```
0000002548 [net.ppp.client] TRACE: State READY -> CONNECT
0000002554 [net.ppp.client] TRACE: State CONNECT -> CONNECTING
0000002544 [ncp.at] TRACE: > AT+CIMI
0000002560 [ncp.at] TRACE: < 732123200153425
0000002565 [ncp.at] TRACE: < OK
0000003591 [ncp.at] TRACE: > AT
0000004616 [ncp.at] TRACE: > AT
0000005641 [ncp.at] TRACE: > AT
0000006666 [ncp.at] TRACE: > AT
0000007691 [ncp.at] TRACE: > AT
0000008715 [ncp.client] ERROR: Failed to enter data mode
0000008716 [net.ppp.client] ERROR: Failed to dial
```

According to the documentation SARA R4 modems do not support `~+++` escape sequence to exit PPP session. `+++` is supported, but `ATH` doesn't interrupt an ongoing PPP session and we are left in some weird state where we receive both PPP frames and AT command responses.

### Solution

We are instead going to send a fake constructed PPP LCP Termination Request as an interrupt sequence in order to exit PPP session.

### Steps to Test

1. Make sure your LTE Boron/BSoM connects to the cloud
2. Hit reset
3. Watch the logs
4. It should not report 'Failed to enter data mode' and should interrupt ongoing session and start a new one

```
0000004125 [net.ppp.client] TRACE: PPP thread event LOWER_UP
0000004125 [net.ppp.client] TRACE: State READY -> CONNECT
0000004126 [ncp.at] TRACE: > AT+CIMI
0000004125 [net.ppp.client] TRACE: State CONNECT -> CONNECTING
0000004130 [ncp.at] TRACE: < 310410152914563
0000004130 [ncp.at] TRACE: < OK
0000005142 [ncp.at] TRACE: > AT
0000005151 [ncp.at] TRACE: < NO CARRIER
0000006175 [ncp.at] TRACE: > AT
0000006183 [ncp.at] TRACE: < OK
0000006184 [ncp.at] TRACE: > ATH
0000006192 [ncp.at] TRACE: < OK
0000006192 [ncp.at] TRACE: > ATD*99***1#
0000006201 [ncp.at] TRACE: < CONNECT 150000000
0000006201 [net.ppp.client] TRACE: PPP phase -> 3
0000006202 [net.ppp.client] TRACE: PPP phase -> 6
0000006360 [net.ppp.client] TRACE: PPP phase -> 7
0000008929 [net.ppp.client] TRACE: PPP phase -> 9
0000011370 [system.nm] INFO: State changed: IFACE_UP -> IFACE_LINK_UP
0000011371 [net.ppp.client] TRACE: PPP thread event UP
0000011371 [net.ppp.client] TRACE: State CONNECTING -> CONNECTED
0000011371 [net.pppncp] TRACE: Negotiated MTU: 1500
```

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
