### PR TITLE
Stream definition should be Arduino-compliant

### DIFF
--- a/wiring/inc/spark_wiring_stream.h
+++ b/wiring/inc/spark_wiring_stream.h
@@ -83,6 +83,8 @@ class Stream : public Print
   // terminates if length characters have been read or timeout (see setTimeout)
   // returns the number of characters placed in the buffer (0 means no valid data found)
 
+  size_t readBytes(uint8_t *buffer, size_t length) { return readBytes(reinterpret_cast<char*>(buffer), length); }
+
   size_t readBytesUntil( char terminator, char *buffer, size_t length); // as readBytes with terminator character
   // terminates if length characters have been read, timeout, or if the terminator character  detected
   // returns the number of characters placed in the buffer (0 means no valid data found)


### PR DESCRIPTION
### Problem

The definition of `Stream::readBytes` is not fully Arduino-compliant: it [should accept both a `char*` and `uint8_t*` for its buffer pointer](https://www.arduino.cc/reference/en/language/functions/communication/serial/readbytes/). Particle's default compiler settings won't allow the cast to happen automagically, which means some dependent libraries don't compile. Sadness.

### Solution

Create a function that accepts the missing type and forwards it with an appropriate cast.

### Steps to Test

Build `device-os/main` with `make PLATFORM=argon`.

### References

Thanks to @DavidEGrayson for recommending this fix on https://github.com/pololu/tic-arduino/pull/1.

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
