### PR TITLE
[hal] core: expose functions to fetch serial/secret through dynalib

### DIFF
--- a/hal/inc/hal_dynalib_core.h
+++ b/hal/inc/hal_dynalib_core.h
@@ -85,6 +85,8 @@ DYNALIB_FN(36, hal_core, hal_sleep_enter, int(const hal_sleep_config_t*, hal_wak
 
 DYNALIB_FN(37, hal_core, hal_get_device_hw_version, int(uint32_t*, void*))
 DYNALIB_FN(38, hal_core, hal_get_device_hw_model, int(uint32_t*, uint32_t*, void*))
+DYNALIB_FN(39, hal_core, hal_get_device_serial_number, int(char*, size_t, void*))
+DYNALIB_FN(40, hal_core, hal_get_device_secret, int(char*, size_t, void*))
 
 DYNALIB_END(hal_core)
 


### PR DESCRIPTION
### Problem

Certain applications might require access to device serial and secret, currently it's only possible to do so with monolithic builds.

### Solution

Expose the appropriate functions through dynalib.

### Steps to Test

Run test app on Gen 2 (only recently manufactured) and Gen 3 devices.

### Example App

```c++

SYSTEM_MODE(SEMI_AUTOMATIC);
SerialLogHandler dbg(LOG_LEVEL_ALL);

void setup() {
    waitUntil(Serial.isConnected);

    char tmp[64] = {};
    int sz = hal_get_device_serial_number(tmp, sizeof(tmp), nullptr);
    if (sz > 0) {
        Log.info("Device serial: %s", tmp);
    } else {
        Log.error("Device serial: unknown (error=%d)", sz);
    }

    memset(tmp, 0, sizeof(tmp));
    sz = hal_get_device_secret(tmp, sizeof(tmp), nullptr);
    if (sz > 0) {
        Log.info("Device secret: %s", tmp);
    } else {
        Log.error("Device secret: unknown (error=%d)", sz);
    }
}
```

### References

- [CH42002]

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
