### PR TITLE
[electron] network: abort poweron/initialization sequence

### DIFF
--- a/system/src/system_network_cellular.h
+++ b/system/src/system_network_cellular.h
@@ -63,9 +63,9 @@ protected:
                 connect_cancelled = false;
             }
             connecting = false;
-            if (require_resume) {
-                cellular_cancel(false, true, nullptr);
-            }
+        }
+        if (require_resume) {
+            cellular_cancel(false, true, nullptr);
         }
         return require_resume;
     }
@@ -83,14 +83,13 @@ protected:
     }
 
     int on_now() override {
+        resume_if_needed();
         cellular_result_t ret = cellular_on(nullptr);
         if (ret != 0) {
-            resume_if_needed();
             return ret;
         }
         ret = cellular_init(nullptr);
         if (ret != 0) {
-            resume_if_needed();
             return ret;
         }
         return 0;


### PR DESCRIPTION
### Problem

> When the cellular modem is powering on for Electron it will potentially block for a long period of time during initialization and waiting for the modem to register onto the network. In bad cases, where network registration is not possible, this may block the system thread for up to 5 minutes.

> Cellular.off calls a cellular_cancel function to abort a connection attempt. This allows the system thread to return out of the network registration phase, become more responsive, and process the Cellular.off.

> However, if the modem is caught during its initial init/power-on sequence cellular_cancel will be skipped and the thread will block until either success or five-minutes till failure before powering down the modem. It appears the cellular_cancel is protected behind a check for active connection attempt that misses the init which will be followed by a connection attempt.

### Solution

Make sure that we call `cellular_cancel` when the modem hal is in early initialization.

### Steps to Test

Use the following test program with a terminal that can enter serial input and build of Device-OS with trace cellular modem output.

Pressing any key will toggle between shutting off the Cellular.off and Particle.connect.

Detach the modem antenna.

Turn off the modem after boot by pressing any key. Turn it on again by pressing any key and off again during the initial startup sequence (for example, during the initial AT/OK checks after powering on the modem). The window might be pretty narrow depending on how fast the modem starts.

On develop: the modem will continue its init and begin registering to the network without aborting. After five minutes it will fail and then shut off.

With this branch: it will abort and immediately turn off.

### Example App

```c++
#include "Particle.h"

SerialLogHandler logHandler(Serial, LOG_LEVEL_TRACE);

SYSTEM_THREAD(ENABLED);
SYSTEM_MODE(SEMI_AUTOMATIC);

void setup() {
    Particle.connect();
}

void loop() {
    static bool cancel = true;

    if (Serial.available()) {
        Serial.read();
        Log.info("Cellular %s", cancel ? "CANCEL" : "RESUME");
        if (cancel) {
            // NOTE: we need to disconnect otherwise, DeviceOS will anyway attempt to turn on the modem
            // and connect to the cloud
            Particle.disconnect();
            Cellular.off();
        } else {
            Cellular.on();
            Particle.connect();
        }
        Log.info("Cellular %s COMPLETE", cancel ? "CANCEL" : "RESUME");
        cancel = !cancel;
    }
}

```

### References

- [CH62159]

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
