### PR TITLE
Gen2: fix the electron power leakage issue when device is asleep.

### DIFF
--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -271,6 +271,16 @@ MDMParser::MDMParser(void)
 #ifdef MDM_DEBUG
     _debugLevel = 3;
 #endif
+
+    Hal_Pin_Info* pinMap = HAL_Pin_Map();
+    pinMap[PWR_UC].gpio_peripheral->BSRRL = pinMap[PWR_UC].gpio_pin;
+    HAL_Pin_Mode(PWR_UC, OUTPUT);
+    pinMap[RESET_UC].gpio_peripheral->BSRRL = pinMap[RESET_UC].gpio_pin;
+    HAL_Pin_Mode(RESET_UC, OUTPUT);
+    HAL_Pin_Mode(LVLOE_UC, OUTPUT);
+    HAL_GPIO_Write(LVLOE_UC, 0);
+    HAL_Pin_Mode(RXD_UC, INPUT_PULLDOWN);
+    HAL_Pin_Mode(RTS_UC, OUTPUT);
 }
 
 void MDMParser::setPowerMode(int mode) {

--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -528,6 +528,10 @@ protected:
     */
     void SMSreceived(int index);
 
+    /** Detects the modem power state
+    */
+    bool powerState(void) const;
+
 protected:
     // String helper to prevent buffer overrun
     struct CStringHelper {

--- a/system/src/system_network_compat.cpp
+++ b/system/src/system_network_compat.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "hal_platform.h"
+#include "gpio_hal.h"
 
 /* FIXME: there should be a define that tells whether there is NetworkManager available
  * or not */
@@ -147,7 +148,24 @@ void network_off(network_handle_t network, uint32_t flags, uint32_t param, void*
 }
 
 int network_wait_off(network_handle_t network, system_tick_t timeout, void*) {
-    // Temporarily not necessary for Gen2 platforms.
+    /* This is a workaround for the power leakage issue that happens when the
+     * device is powered on and it enters sleep before the modem is initialized.
+     */
+#if PLATFORM_ID == PLATFORM_ELECTRON
+    cellular_pause(nullptr);
+    if (HAL_GPIO_Read(RXD_UC)) {
+        // Delay this long period so that the modem is fully on to accept the power-off sequence.
+        HAL_Delay_Milliseconds(12000);
+
+        HAL_GPIO_Write(PWR_UC, 0);
+        // >1.5 seconds on SARA R410M
+        // >1 second on SARA U2
+        // plus a little extra for good luck
+        HAL_Delay_Milliseconds(2000);
+        HAL_GPIO_Write(PWR_UC, 1);
+    }
+#endif
+
     return SYSTEM_ERROR_NONE;
 }
 

--- a/system/src/system_network_compat.cpp
+++ b/system/src/system_network_compat.cpp
@@ -18,7 +18,6 @@
  */
 
 #include "hal_platform.h"
-#include "gpio_hal.h"
 
 /* FIXME: there should be a define that tells whether there is NetworkManager available
  * or not */
@@ -42,7 +41,6 @@ uint32_t wlan_watchdog_duration = 0;
 volatile uint8_t SPARK_WLAN_RESET = 0;
 volatile uint8_t SPARK_WLAN_SLEEP = 0;
 volatile uint8_t SPARK_WLAN_STARTED = 0;
-volatile uint8_t SPARK_WLAN_INITIALIZED = 0; // Used by Electron only
 
 
 #if Wiring_WiFi

--- a/system/src/system_network_compat.cpp
+++ b/system/src/system_network_compat.cpp
@@ -42,6 +42,7 @@ uint32_t wlan_watchdog_duration = 0;
 volatile uint8_t SPARK_WLAN_RESET = 0;
 volatile uint8_t SPARK_WLAN_SLEEP = 0;
 volatile uint8_t SPARK_WLAN_STARTED = 0;
+volatile uint8_t SPARK_WLAN_INITIALIZED = 0; // Used by Electron only
 
 
 #if Wiring_WiFi
@@ -148,24 +149,7 @@ void network_off(network_handle_t network, uint32_t flags, uint32_t param, void*
 }
 
 int network_wait_off(network_handle_t network, system_tick_t timeout, void*) {
-    /* This is a workaround for the power leakage issue that happens when the
-     * device is powered on and it enters sleep before the modem is initialized.
-     */
-#if PLATFORM_ID == PLATFORM_ELECTRON
-    cellular_pause(nullptr);
-    if (HAL_GPIO_Read(RXD_UC)) {
-        // Delay this long period so that the modem is fully on to accept the power-off sequence.
-        HAL_Delay_Milliseconds(12000);
-
-        HAL_GPIO_Write(PWR_UC, 0);
-        // >1.5 seconds on SARA R410M
-        // >1 second on SARA U2
-        // plus a little extra for good luck
-        HAL_Delay_Milliseconds(2000);
-        HAL_GPIO_Write(PWR_UC, 1);
-    }
-#endif
-
+    // Temporarily not necessary for Gen2 platforms.
     return SYSTEM_ERROR_NONE;
 }
 

--- a/system/src/system_network_internal.h
+++ b/system/src/system_network_internal.h
@@ -43,7 +43,6 @@ enum eWanTimings
 extern volatile uint8_t SPARK_WLAN_RESET;
 extern volatile uint8_t SPARK_WLAN_SLEEP;
 extern volatile uint8_t SPARK_WLAN_STARTED;
-extern volatile uint8_t SPARK_WLAN_INITIALIZED;
 
 extern uint32_t wlan_watchdog_duration;
 extern uint32_t wlan_watchdog_base;
@@ -259,7 +258,8 @@ private:
     volatile uint8_t WLAN_CONNECTING = 0;
     volatile uint8_t WLAN_DHCP_PENDING = 0;
     volatile uint8_t WLAN_LISTEN_ON_FAILED_CONNECT = 0;
-#if PLATFORM_ID == 10 // Electron
+    volatile uint8_t WLAN_INITIALIZED = 0;
+#if PLATFORM_ID == PLATFORM_ELECTRON // Electron
     volatile uint32_t START_LISTENING_TIMER_MS = 300000UL; // 5 minute default on Electron
 #else
     volatile uint32_t START_LISTENING_TIMER_MS = 0UL; // Disabled by default on Photon/P1/Core
@@ -615,7 +615,7 @@ public:
             update_config(true);
             SPARK_WLAN_STARTED = 1;
             SPARK_WLAN_SLEEP = 0;
-            SPARK_WLAN_INITIALIZED = 1;
+            WLAN_INITIALIZED = 1;
             LED_SIGNAL_START(NETWORK_ON, BACKGROUND);
             diag->status(NetworkDiagnostics::DISCONNECTED);
             system_notify_event(network_status, network_status_on);
@@ -648,7 +648,7 @@ public:
             LED_SIGNAL_START(NETWORK_OFF, BACKGROUND);
             diag->status(NetworkDiagnostics::TURNED_OFF);
             system_notify_event(network_status, network_status_off);
-        } else if (!SPARK_WLAN_INITIALIZED) {
+        } else if (!WLAN_INITIALIZED) {
             off_now();
         }
     }

--- a/system/src/system_network_internal.h
+++ b/system/src/system_network_internal.h
@@ -43,6 +43,7 @@ enum eWanTimings
 extern volatile uint8_t SPARK_WLAN_RESET;
 extern volatile uint8_t SPARK_WLAN_SLEEP;
 extern volatile uint8_t SPARK_WLAN_STARTED;
+extern volatile uint8_t SPARK_WLAN_INITIALIZED;
 
 extern uint32_t wlan_watchdog_duration;
 extern uint32_t wlan_watchdog_base;
@@ -614,6 +615,7 @@ public:
             update_config(true);
             SPARK_WLAN_STARTED = 1;
             SPARK_WLAN_SLEEP = 0;
+            SPARK_WLAN_INITIALIZED = 1;
             LED_SIGNAL_START(NETWORK_ON, BACKGROUND);
             diag->status(NetworkDiagnostics::DISCONNECTED);
             system_notify_event(network_status, network_status_on);
@@ -646,6 +648,8 @@ public:
             LED_SIGNAL_START(NETWORK_OFF, BACKGROUND);
             diag->status(NetworkDiagnostics::TURNED_OFF);
             system_notify_event(network_status, network_status_off);
+        } else if (!SPARK_WLAN_INITIALIZED) {
+            off_now();
         }
     }
 


### PR DESCRIPTION
**Note: this PR is targeting to the fix/electron-recovery-non-responsive branch**

### Problem

If the Electron is powered on but the modem is not initialized (by calling Cellular.on() or Particle.connect()) before entering sleep mode in the MANUAL mode, the modem persist on and it will consume additional ~15mA after device entering sleep mode.

### Solution

1. We initialize the pins interacting with the modem.
2. Check the modem power state before entering sleep mode. If the modem is on, then perform the power-off sequence to turn off the modem.

### Example App

```c
#include "Particle.h"

SYSTEM_MODE(MANUAL);
SYSTEM_THREAD(ENABLED);

Serial1LogHandler log(115200, LOG_LEVEL_ALL);

void setup() {
    System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::HIBERNATE));
}

void loop() {
}
```

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
