### PR TITLE
Tracker: an easy way to configure Wi-Fi/GNSS/FuelGauge as a wakeup source

### DIFF
--- a/hal/src/tracker/mcp23s17.cpp
+++ b/hal/src/tracker/mcp23s17.cpp
@@ -311,6 +311,35 @@ int Mcp23s17::detachPinInterrupt(uint8_t port, uint8_t pin, bool verify) {
     return SYSTEM_ERROR_NONE;
 }
 
+int Mcp23s17::interruptsSuspend() {
+    Mcp23s17Lock lock();
+    CHECK_TRUE(initialized_, SYSTEM_ERROR_INVALID_STATE);
+    // Simply reset the registers, since we have cached current registers' value
+    CHECK(writeRegister(GPINTEN_ADDR[0], 0x00));
+    CHECK(writeRegister(GPINTEN_ADDR[1], 0x00));
+    CHECK(writeRegister(INTCON_ADDR[0], 0x00));
+    CHECK(writeRegister(INTCON_ADDR[1], 0x00));
+    CHECK(writeRegister(DEFVAL_ADDR[0], 0x00));
+    CHECK(writeRegister(DEFVAL_ADDR[1], 0x00));
+    // Clear the pending interrupts flag
+    uint8_t dummy;
+    CHECK(readRegister(INTCAP_ADDR[0], &dummy));
+    CHECK(readRegister(INTCAP_ADDR[1], &dummy));
+    return SYSTEM_ERROR_NONE;
+}
+
+int Mcp23s17::interruptsRestore() {
+    Mcp23s17Lock lock();
+    CHECK_TRUE(initialized_, SYSTEM_ERROR_INVALID_STATE);
+    CHECK(writeRegister(INTCON_ADDR[0], intcon_[0]));
+    CHECK(writeRegister(INTCON_ADDR[1], intcon_[1]));
+    CHECK(writeRegister(DEFVAL_ADDR[0], defval_[0]));
+    CHECK(writeRegister(DEFVAL_ADDR[1], defval_[1]));
+    CHECK(writeRegister(GPINTEN_ADDR[0], gpinten_[0]));
+    CHECK(writeRegister(GPINTEN_ADDR[1], gpinten_[1]));
+    return SYSTEM_ERROR_NONE;
+}
+
 Mcp23s17& Mcp23s17::getInstance() {
     static Mcp23s17 mcp23s17;
     return mcp23s17;

--- a/hal/src/tracker/mcp23s17.cpp
+++ b/hal/src/tracker/mcp23s17.cpp
@@ -328,9 +328,11 @@ int Mcp23s17::interruptsSuspend() {
     return SYSTEM_ERROR_NONE;
 }
 
-int Mcp23s17::interruptsRestore() {
+int Mcp23s17::interruptsRestore(uint8_t intStatus[2]) {
     Mcp23s17Lock lock();
     CHECK_TRUE(initialized_, SYSTEM_ERROR_INVALID_STATE);
+    CHECK(readRegister(INTF_ADDR[0], &intStatus[0]));
+    CHECK(readRegister(INTF_ADDR[1], &intStatus[1]));
     CHECK(writeRegister(INTCON_ADDR[0], intcon_[0]));
     CHECK(writeRegister(INTCON_ADDR[1], intcon_[1]));
     CHECK(writeRegister(DEFVAL_ADDR[0], defval_[0]));
@@ -380,6 +382,7 @@ int Mcp23s17::writeRegister(const uint8_t addr, const uint8_t val) const {
 
 int Mcp23s17::readRegister(const uint8_t addr, uint8_t* const val) const {
     CHECK_TRUE(initialized_, SYSTEM_ERROR_NONE);
+    CHECK_TRUE(val != nullptr, SYSTEM_ERROR_INVALID_ARGUMENT);
     Mcp23s17SpiConfigurationGuarder spiGuarder(spi_);
     HAL_GPIO_Write(IOE_CS, 0);
     hal_spi_transfer(spi_, MCP23S17_CMD_READ);
@@ -391,6 +394,7 @@ int Mcp23s17::readRegister(const uint8_t addr, uint8_t* const val) const {
 
 int Mcp23s17::readContinuousRegisters(const uint8_t start_addr, uint8_t* const val, uint8_t len) const {
     CHECK_TRUE(initialized_, SYSTEM_ERROR_NONE);
+    CHECK_TRUE(val != nullptr, SYSTEM_ERROR_INVALID_ARGUMENT);
     Mcp23s17SpiConfigurationGuarder spiGuarder(spi_);
     HAL_GPIO_Write(IOE_CS, 0);
     hal_spi_transfer(spi_, MCP23S17_CMD_READ);
@@ -415,20 +419,26 @@ os_thread_return_t Mcp23s17::ioInterruptHandleThread(void* param) {
         os_semaphore_take(instance->ioExpanderWorkerSemaphore_, CONCURRENT_WAIT_FOREVER, false);
         {
             Mcp23s17Lock lock();
-            uint8_t intStatus;
-            uint8_t portValue;
-            if (instance->readRegister(instance->INTF_ADDR[0], &intStatus) != SYSTEM_ERROR_NONE) {
+            uint8_t intStatus[2];
+            uint8_t portValue[2];
+            if (instance->readRegister(instance->INTF_ADDR[0], &intStatus[0]) != SYSTEM_ERROR_NONE) {
+                continue;
+            }
+            if (instance->readRegister(instance->INTF_ADDR[1], &intStatus[1]) != SYSTEM_ERROR_NONE) {
                 continue;
             }
             // This will clear the interrupt flag.
-            if (instance->readRegister(instance->INTCAP_ADDR[0], &portValue) != SYSTEM_ERROR_NONE) {
+            if (instance->readRegister(instance->INTCAP_ADDR[0], &portValue[0]) != SYSTEM_ERROR_NONE) {
+                continue;
+            }
+            if (instance->readRegister(instance->INTCAP_ADDR[1], &portValue[1]) != SYSTEM_ERROR_NONE) {
                 continue;
             }
             for (const auto& config : instance->intConfigs_) {
                 uint8_t bitMask = 0x01 << config.pin;
-                if ((intStatus & bitMask) && (config.cb != nullptr)) {
-                    if ( ((config.trig == RISING) && (portValue & bitMask)) ||
-                         ((config.trig == FALLING) && !(portValue & bitMask)) ||
+                if ((intStatus[config.port] & bitMask) && (config.cb != nullptr)) {
+                    if ( ((config.trig == RISING) && (portValue[config.port] & bitMask)) ||
+                         ((config.trig == FALLING) && !(portValue[config.port] & bitMask)) ||
                           (config.trig == CHANGE) ) {
                         config.cb(config.context);
                     }

--- a/hal/src/tracker/mcp23s17.h
+++ b/hal/src/tracker/mcp23s17.h
@@ -51,11 +51,31 @@ public:
     int readPinValue(uint8_t port, uint8_t pin, uint8_t* value);
     int attachPinInterrupt(uint8_t port, uint8_t pin, InterruptMode trig, Mcp23s17InterruptCallback callback, void* context, bool verify = true);
     int detachPinInterrupt(uint8_t port, uint8_t pin, bool verify = true);
+    int interruptsSuspend();
+    int interruptsRestore();
+
+    void resetRegValue();
+    int writeRegister(const uint8_t addr, const uint8_t val) const;
+    int readRegister(const uint8_t addr, uint8_t* const val) const;
+    int readContinuousRegisters(const uint8_t start_addr, uint8_t* const val, uint8_t len) const;
 
     int lock();
     int unlock();
 
     static Mcp23s17& getInstance();
+
+    // Resister address
+    static constexpr uint8_t IODIR_ADDR[2]     = {0x00, 0x01};
+    static constexpr uint8_t IPOL_ADDR[2]      = {0x02, 0x03};
+    static constexpr uint8_t GPINTEN_ADDR[2]   = {0x04, 0x05};
+    static constexpr uint8_t DEFVAL_ADDR[2]    = {0x06, 0x07};
+    static constexpr uint8_t INTCON_ADDR[2]    = {0x08, 0x09};
+    static constexpr uint8_t IOCON_ADDR[2]     = {0x0A, 0x0B};
+    static constexpr uint8_t GPPU_ADDR[2]      = {0x0C, 0x0D};
+    static constexpr uint8_t INTF_ADDR[2]      = {0x0E, 0x0F};
+    static constexpr uint8_t INTCAP_ADDR[2]    = {0x10, 0x11};
+    static constexpr uint8_t GPIO_ADDR[2]      = {0x12, 0x13};
+    static constexpr uint8_t OLAT_ADDR[2]      = {0x14, 0x15};
 
 private:
     struct IoPinInterruptConfig {
@@ -160,24 +180,7 @@ private:
     Mcp23s17();
     ~Mcp23s17();
 
-    void resetRegValue();
-    int writeRegister(const uint8_t addr, const uint8_t val) const;
-    int readRegister(const uint8_t addr, uint8_t* const val) const;
-    int readContinuousRegisters(const uint8_t start_addr, uint8_t* const val, uint8_t len) const;
     static os_thread_return_t ioInterruptHandleThread(void* param);
-
-    // Resister address
-    static constexpr uint8_t IODIR_ADDR[2]     = {0x00, 0x01};
-    static constexpr uint8_t IPOL_ADDR[2]      = {0x02, 0x03};
-    static constexpr uint8_t GPINTEN_ADDR[2]   = {0x04, 0x05};
-    static constexpr uint8_t DEFVAL_ADDR[2]    = {0x06, 0x07};
-    static constexpr uint8_t INTCON_ADDR[2]    = {0x08, 0x09};
-    static constexpr uint8_t IOCON_ADDR[2]     = {0x0A, 0x0B};
-    static constexpr uint8_t GPPU_ADDR[2]      = {0x0C, 0x0D};
-    static constexpr uint8_t INTF_ADDR[2]      = {0x0E, 0x0F};
-    static constexpr uint8_t INTCAP_ADDR[2]    = {0x10, 0x11};
-    static constexpr uint8_t GPIO_ADDR[2]      = {0x12, 0x13};
-    static constexpr uint8_t OLAT_ADDR[2]      = {0x14, 0x15};
 
     // Read/write coomand
     static constexpr uint8_t MCP23S17_CMD_READ = 0x41;

--- a/hal/src/tracker/mcp23s17.h
+++ b/hal/src/tracker/mcp23s17.h
@@ -52,7 +52,7 @@ public:
     int attachPinInterrupt(uint8_t port, uint8_t pin, InterruptMode trig, Mcp23s17InterruptCallback callback, void* context, bool verify = true);
     int detachPinInterrupt(uint8_t port, uint8_t pin, bool verify = true);
     int interruptsSuspend();
-    int interruptsRestore();
+    int interruptsRestore(uint8_t intStatus[2]);
 
     void resetRegValue();
     int writeRegister(const uint8_t addr, const uint8_t val) const;

--- a/system/inc/system_power.h
+++ b/system/inc/system_power.h
@@ -46,7 +46,8 @@ typedef enum {
 } power_source_t;
 
 void system_power_management_init();
-void system_power_management_sleep(bool sleep = true);
+void system_power_management_sleep(bool sleep);
+void system_power_management_wakeup();
 int system_power_management_set_config(const hal_power_config* conf, void* reserved);
 
 #ifdef __cplusplus

--- a/system/inc/system_power.h
+++ b/system/inc/system_power.h
@@ -46,7 +46,7 @@ typedef enum {
 } power_source_t;
 
 void system_power_management_init();
-void system_power_management_sleep(bool sleep);
+void system_power_management_sleep(bool fuelGaugeSleep);
 void system_power_management_wakeup();
 int system_power_management_set_config(const hal_power_config* conf, void* reserved);
 

--- a/system/inc/system_sleep_configuration.h
+++ b/system/inc/system_sleep_configuration.h
@@ -87,6 +87,20 @@ public:
         return true; 
     }
 
+    bool wakeupByFuelGauge() const {
+#if HAL_PLATFORM_FUELGAUGE_MAX17043
+        auto wakeup = wakeupSourceFeatured(HAL_WAKEUP_SOURCE_TYPE_GPIO);
+        while (wakeup) {
+            auto gpioWakeup = reinterpret_cast<const hal_wakeup_source_gpio_t*>(wakeup);
+            if (gpioWakeup->pin == LOW_BAT_UC) {
+                return true;
+            }
+            wakeup = wakeupSourceFeatured(HAL_WAKEUP_SOURCE_TYPE_GPIO, wakeup->next);
+        }
+#endif
+        return false;
+    }
+
     bool wakeupByNetworkInterface(network_interface_index index) const {
         auto wakeup = wakeupSourceFeatured(HAL_WAKEUP_SOURCE_TYPE_NETWORK);
         while (wakeup) {

--- a/system/src/system_power.cpp
+++ b/system/src/system_power.cpp
@@ -46,6 +46,10 @@ void system_power_management_sleep(bool sleep) {
     PowerManager::instance()->sleep(sleep);
 }
 
+void system_power_management_wakeup() {
+    PowerManager::instance()->wakeup();
+}
+
 int system_power_management_set_config(const hal_power_config* conf, void* reserved) {
     return PowerManager::instance()->setConfig(conf);
 }
@@ -56,6 +60,9 @@ void system_power_management_init() {
 }
 
 void system_power_management_sleep(bool sleep) {
+}
+
+void system_power_management_wakeup() {
 }
 
 int system_power_management_set_config(const hal_power_config* conf, void* reserved) {

--- a/system/src/system_power.cpp
+++ b/system/src/system_power.cpp
@@ -42,8 +42,8 @@ void system_power_management_init()
     PowerManager::instance()->init();
 }
 
-void system_power_management_sleep(bool sleep) {
-    PowerManager::instance()->sleep(sleep);
+void system_power_management_sleep(bool fuelGaugeSleep) {
+    PowerManager::instance()->sleep(fuelGaugeSleep);
 }
 
 void system_power_management_wakeup() {
@@ -59,7 +59,7 @@ int system_power_management_set_config(const hal_power_config* conf, void* reser
 void system_power_management_init() {
 }
 
-void system_power_management_sleep(bool sleep) {
+void system_power_management_sleep(bool fuelGaugeSleep) {
 }
 
 void system_power_management_wakeup() {

--- a/system/src/system_power_manager.cpp
+++ b/system/src/system_power_manager.cpp
@@ -124,7 +124,7 @@ void PowerManager::update() {
   os_queue_put(queue_, (const void*)&ev, 0, nullptr);
 }
 
-void PowerManager::sleep(bool s) {
+void PowerManager::sleep(bool fuelGaugeSleep) {
 #if HAL_PLATFORM_POWER_MANAGEMENT_OPTIONAL
   if (detect_ && isRunning()) {
 #else
@@ -141,7 +141,7 @@ void PowerManager::sleep(bool s) {
     // XXX:
     power.disableWatchdog();
 #endif // HAL_PLATFORM_POWER_MANAGEMENT_PMIC_WATCHDOG
-    if (s && fuelGaugeAwake_) {
+    if (fuelGaugeSleep && fuelGaugeAwake_) {
       FuelGauge gauge;
       gauge.sleep();
       fuelGaugeAwake_ = false;

--- a/system/src/system_power_manager.cpp
+++ b/system/src/system_power_manager.cpp
@@ -133,23 +133,32 @@ void PowerManager::sleep(bool s) {
     // When going into sleep we do not want to exceed the default charging parameters set
     // by initDefault(), which will be reset in case we are in a DISCONNECTED state with
     // PMIC watchdog enabled. Reset to the defaults and disable watchdog before going into sleep.
-    if (s) {
-      // Going into sleep
-      if (g_batteryState == BATTERY_STATE_DISCONNECTED) {
-        initDefault();
-      }
+    if (g_batteryState == BATTERY_STATE_DISCONNECTED) {
+      initDefault();
+    }
 #if HAL_PLATFORM_POWER_MANAGEMENT_PMIC_WATCHDOG
-      PMIC power;
-      // XXX:
-      power.disableWatchdog();
+    PMIC power;
+    // XXX:
+    power.disableWatchdog();
 #endif // HAL_PLATFORM_POWER_MANAGEMENT_PMIC_WATCHDOG
+    if (s && fuelGaugeAwake_) {
       FuelGauge gauge;
       gauge.sleep();
+      fuelGaugeAwake_ = false;
     } else {
-      // Wake up
-      Event ev = Event::Wakeup;
-      os_queue_put(queue_, (const void*)&ev, CONCURRENT_WAIT_FOREVER, nullptr);
+      fuelGaugeAwake_ = true;
     }
+  }
+}
+
+void PowerManager::wakeup() {
+#if HAL_PLATFORM_POWER_MANAGEMENT_OPTIONAL
+  if (detect_ && isRunning()) {
+#else
+  if (isRunning()) {
+#endif
+    Event ev = Event::Wakeup;
+    os_queue_put(queue_, (const void*)&ev, CONCURRENT_WAIT_FOREVER, nullptr);
   }
 }
 
@@ -345,10 +354,13 @@ void PowerManager::loop(void* arg) {
         self->initDefault(false);
         self->update_ = true;
       } else if (ev == Event::Wakeup) {
-        FuelGauge fuel(true);
         self->initDefault();
-        fuel.wakeup();
-        HAL_Delay_Milliseconds(500);
+        if (!self->fuelGaugeAwake_) {
+          FuelGauge fuel(true);
+          fuel.wakeup();
+          self->fuelGaugeAwake_ = true;
+          HAL_Delay_Milliseconds(500);
+        }
         self->handleUpdate();
       }
     }

--- a/system/src/system_power_manager.h
+++ b/system/src/system_power_manager.h
@@ -31,6 +31,7 @@ public:
 
   void init();
   void sleep(bool s = true);
+  void wakeup();
   int setConfig(const hal_power_config* conf);
 
 protected:
@@ -76,6 +77,7 @@ private:
   system_tick_t possibleFaultTimestamp_ = 0;
   bool lowBatEnabled_ = true;
   system_tick_t chargingDisabledTimestamp_ = 0;
+  bool fuelGaugeAwake_ = true;
 #if HAL_PLATFORM_POWER_MANAGEMENT_OPTIONAL
   bool detect_ = false;
 #endif // HAL_PLATFORM_POWER_MANAGEMENT_OPTIONAL

--- a/system/src/system_power_manager.h
+++ b/system/src/system_power_manager.h
@@ -30,7 +30,7 @@ public:
   static PowerManager* instance();
 
   void init();
-  void sleep(bool s = true);
+  void sleep(bool fuelGaugeSleep = true);
   void wakeup();
   int setConfig(const hal_power_config* conf);
 

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -157,12 +157,12 @@ int system_sleep_ext(const hal_sleep_config_t* config, hal_wakeup_source_base_t*
     led_set_update_enabled(0, nullptr); // Disable background LED updates
     LED_Off(LED_RGB);
 
-    system_power_management_sleep();
+    system_power_management_sleep(configHelper.wakeupByFuelGauge() ? false : true);
 
     // Now enter sleep mode
     int ret = hal_sleep_enter(config, reason, nullptr);
 
-    system_power_management_sleep(false);
+    system_power_management_wakeup();
 
     led_set_update_enabled(1, nullptr); // Enable background LED updates
     LED_On(LED_RGB); // Turn RGB on in case that RGB is controlled by user application before entering sleep mode.

--- a/user/tests/app/tracker_wakeup/esp32_soch.h
+++ b/user/tests/app/tracker_wakeup/esp32_soch.h
@@ -1,0 +1,461 @@
+// Copyright 2010-2018 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _ESP32_SOC_H_
+#define _ESP32_SOC_H_
+
+#include "Particle.h"
+
+#if PLATFORM_ID == PLATFORM_TRACKER
+
+#ifndef __ASSEMBLER__
+#include <stdint.h>
+// #include "esp_assert.h"
+#endif
+
+//Register Bits{{
+#define BIT31   0x80000000
+#define BIT30   0x40000000
+#define BIT29   0x20000000
+#define BIT28   0x10000000
+#define BIT27   0x08000000
+#define BIT26   0x04000000
+#define BIT25   0x02000000
+#define BIT24   0x01000000
+#define BIT23   0x00800000
+#define BIT22   0x00400000
+#define BIT21   0x00200000
+#define BIT20   0x00100000
+#define BIT19   0x00080000
+#define BIT18   0x00040000
+#define BIT17   0x00020000
+#define BIT16   0x00010000
+#define BIT15   0x00008000
+#define BIT14   0x00004000
+#define BIT13   0x00002000
+#define BIT12   0x00001000
+#define BIT11   0x00000800
+#define BIT10   0x00000400
+#define BIT9     0x00000200
+#define BIT8     0x00000100
+#define BIT7     0x00000080
+#define BIT6     0x00000040
+#define BIT5     0x00000020
+#define BIT4     0x00000010
+#define BIT3     0x00000008
+#define BIT2     0x00000004
+#define BIT1     0x00000002
+#define BIT0     0x00000001
+//}}
+
+#define PRO_CPU_NUM (0)
+#define APP_CPU_NUM (1)
+
+/* Overall memory map */
+#define SOC_IROM_LOW            0x400D0000
+#define SOC_IROM_HIGH           0x40400000
+#define SOC_DROM_LOW            0x3F400000
+#define SOC_DROM_HIGH           0x3F800000
+#define SOC_DRAM_LOW            0x3FAE0000
+#define SOC_DRAM_HIGH           0x40000000
+#define SOC_RTC_IRAM_LOW        0x400C0000
+#define SOC_RTC_IRAM_HIGH       0x400C2000
+#define SOC_RTC_DATA_LOW        0x50000000
+#define SOC_RTC_DATA_HIGH       0x50002000
+#define SOC_EXTRAM_DATA_LOW     0x3F800000
+#define SOC_EXTRAM_DATA_HIGH    0x3FC00000
+
+#define SOC_MAX_CONTIGUOUS_RAM_SIZE 0x400000 ///< Largest span of contiguous memory (DRAM or IRAM) in the address space
+
+
+#define DR_REG_DPORT_BASE                       0x3ff00000
+#define DR_REG_AES_BASE                         0x3ff01000
+#define DR_REG_RSA_BASE                         0x3ff02000
+#define DR_REG_SHA_BASE                         0x3ff03000
+#define DR_REG_FLASH_MMU_TABLE_PRO              0x3ff10000
+#define DR_REG_FLASH_MMU_TABLE_APP              0x3ff12000
+#define DR_REG_DPORT_END                        0x3ff13FFC
+#define DR_REG_UART_BASE                        0x3ff40000
+#define DR_REG_SPI1_BASE                        0x3ff42000
+#define DR_REG_SPI0_BASE                        0x3ff43000
+#define DR_REG_GPIO_BASE                        0x3ff44000
+#define DR_REG_GPIO_SD_BASE                     0x3ff44f00
+#define DR_REG_FE2_BASE                         0x3ff45000
+#define DR_REG_FE_BASE                          0x3ff46000
+#define DR_REG_FRC_TIMER_BASE                   0x3ff47000
+#define DR_REG_RTCCNTL_BASE                     0x3ff48000
+#define DR_REG_RTCIO_BASE                       0x3ff48400
+#define DR_REG_SENS_BASE                        0x3ff48800
+#define DR_REG_RTC_I2C_BASE                     0x3ff48C00
+#define DR_REG_IO_MUX_BASE                      0x3ff49000
+#define DR_REG_HINF_BASE                        0x3ff4B000
+#define DR_REG_UHCI1_BASE                       0x3ff4C000
+#define DR_REG_I2S_BASE                         0x3ff4F000
+#define DR_REG_UART1_BASE                       0x3ff50000
+#define DR_REG_BT_BASE                          0x3ff51000
+#define DR_REG_I2C_EXT_BASE                     0x3ff53000
+#define DR_REG_UHCI0_BASE                       0x3ff54000
+#define DR_REG_SLCHOST_BASE                     0x3ff55000
+#define DR_REG_RMT_BASE                         0x3ff56000
+#define DR_REG_PCNT_BASE                        0x3ff57000
+#define DR_REG_SLC_BASE                         0x3ff58000
+#define DR_REG_LEDC_BASE                        0x3ff59000
+#define DR_REG_EFUSE_BASE                       0x3ff5A000
+#define DR_REG_SPI_ENCRYPT_BASE                 0x3ff5B000
+#define DR_REG_NRX_BASE                         0x3ff5CC00
+#define DR_REG_BB_BASE                          0x3ff5D000
+#define DR_REG_PWM_BASE                         0x3ff5E000
+#define DR_REG_TIMERGROUP0_BASE                 0x3ff5F000
+#define DR_REG_TIMERGROUP1_BASE                 0x3ff60000
+#define DR_REG_RTCMEM0_BASE                     0x3ff61000
+#define DR_REG_RTCMEM1_BASE                     0x3ff62000
+#define DR_REG_RTCMEM2_BASE                     0x3ff63000
+#define DR_REG_SPI2_BASE                        0x3ff64000
+#define DR_REG_SPI3_BASE                        0x3ff65000
+#define DR_REG_SYSCON_BASE                      0x3ff66000
+#define DR_REG_APB_CTRL_BASE                    0x3ff66000    /* Old name for SYSCON, to be removed */
+#define DR_REG_I2C1_EXT_BASE                    0x3ff67000
+#define DR_REG_SDMMC_BASE                       0x3ff68000
+#define DR_REG_EMAC_BASE                        0x3ff69000
+#define DR_REG_CAN_BASE                         0x3ff6B000
+#define DR_REG_PWM1_BASE                        0x3ff6C000
+#define DR_REG_I2S1_BASE                        0x3ff6D000
+#define DR_REG_UART2_BASE                       0x3ff6E000
+#define DR_REG_PWM2_BASE                        0x3ff6F000
+#define DR_REG_PWM3_BASE                        0x3ff70000
+#define PERIPHS_SPI_ENCRYPT_BASEADDR            DR_REG_SPI_ENCRYPT_BASE
+
+//Registers Operation {{
+#define ETS_UNCACHED_ADDR(addr) (addr)
+#define ETS_CACHED_ADDR(addr) (addr)
+
+#ifndef __ASSEMBLER__
+#define BIT(nr)                 (1UL << (nr))
+#define BIT64(nr)               (1ULL << (nr))
+#else
+#define BIT(nr)                 (1 << (nr))
+#endif
+
+#ifndef __ASSEMBLER__
+
+#define IS_DPORT_REG(_r) (((_r) >= DR_REG_DPORT_BASE) && (_r) <= DR_REG_DPORT_END)
+
+#if !defined( BOOTLOADER_BUILD ) && defined( CONFIG_ESP32_DPORT_WORKAROUND ) && defined( ESP_PLATFORM )
+#define ASSERT_IF_DPORT_REG(_r, OP)  TRY_STATIC_ASSERT(!IS_DPORT_REG(_r), (Cannot use OP for DPORT registers use DPORT_##OP));
+#else
+#define ASSERT_IF_DPORT_REG(_r, OP)
+#endif
+
+//write value to register
+#define REG_WRITE(_r, _v) ({                                                                                           \
+            ASSERT_IF_DPORT_REG((_r), REG_WRITE);                                                                      \
+            (*(volatile uint32_t *)(_r)) = (_v);                                                                       \
+        })
+
+//read value from register
+#define REG_READ(_r) ({                                                                                                \
+            ASSERT_IF_DPORT_REG((_r), REG_READ);                                                                       \
+            (*(volatile uint32_t *)(_r));                                                                              \
+        })
+
+//get bit or get bits from register
+#define REG_GET_BIT(_r, _b)  ({                                                                                        \
+            ASSERT_IF_DPORT_REG((_r), REG_GET_BIT);                                                                    \
+            (*(volatile uint32_t*)(_r) & (_b));                                                                        \
+        })
+
+//set bit or set bits to register
+#define REG_SET_BIT(_r, _b)  ({                                                                                        \
+            ASSERT_IF_DPORT_REG((_r), REG_SET_BIT);                                                                    \
+            (*(volatile uint32_t*)(_r) |= (_b));                                                                       \
+        })
+
+//clear bit or clear bits of register
+#define REG_CLR_BIT(_r, _b)  ({                                                                                        \
+            ASSERT_IF_DPORT_REG((_r), REG_CLR_BIT);                                                                    \
+            (*(volatile uint32_t*)(_r) &= ~(_b));                                                                      \
+        })
+
+//set bits of register controlled by mask
+#define REG_SET_BITS(_r, _b, _m) ({                                                                                    \
+            ASSERT_IF_DPORT_REG((_r), REG_SET_BITS);                                                                   \
+            (*(volatile uint32_t*)(_r) = (*(volatile uint32_t*)(_r) & ~(_m)) | ((_b) & (_m)));                         \
+        })
+
+//get field from register, uses field _S & _V to determine mask
+#define REG_GET_FIELD(_r, _f) ({                                                                                       \
+            ASSERT_IF_DPORT_REG((_r), REG_GET_FIELD);                                                                  \
+            ((REG_READ(_r) >> (_f##_S)) & (_f##_V));                                                                   \
+        })
+
+//set field of a register from variable, uses field _S & _V to determine mask
+#define REG_SET_FIELD(_r, _f, _v) ({                                                                                   \
+            ASSERT_IF_DPORT_REG((_r), REG_SET_FIELD);                                                                  \
+            (REG_WRITE((_r),((REG_READ(_r) & ~((_f##_V) << (_f##_S)))|(((_v) & (_f##_V))<<(_f##_S)))));                \
+        })
+
+//get field value from a variable, used when _f is not left shifted by _f##_S
+#define VALUE_GET_FIELD(_r, _f) (((_r) >> (_f##_S)) & (_f))
+
+//get field value from a variable, used when _f is left shifted by _f##_S
+#define VALUE_GET_FIELD2(_r, _f) (((_r) & (_f))>> (_f##_S))
+
+//set field value to a variable, used when _f is not left shifted by _f##_S
+#define VALUE_SET_FIELD(_r, _f, _v) ((_r)=(((_r) & ~((_f) << (_f##_S)))|((_v)<<(_f##_S))))
+
+//set field value to a variable, used when _f is left shifted by _f##_S
+#define VALUE_SET_FIELD2(_r, _f, _v) ((_r)=(((_r) & ~(_f))|((_v)<<(_f##_S))))
+
+//generate a value from a field value, used when _f is not left shifted by _f##_S
+#define FIELD_TO_VALUE(_f, _v) (((_v)&(_f))<<_f##_S)
+
+//generate a value from a field value, used when _f is left shifted by _f##_S
+#define FIELD_TO_VALUE2(_f, _v) (((_v)<<_f##_S) & (_f))
+
+//read value from register
+#define READ_PERI_REG(addr) ({                                                                                         \
+            ASSERT_IF_DPORT_REG((addr), READ_PERI_REG);                                                                \
+            (*((volatile uint32_t *)ETS_UNCACHED_ADDR(addr)));                                                         \
+        })
+
+//write value to register
+#define WRITE_PERI_REG(addr, val) ({                                                                                   \
+            ASSERT_IF_DPORT_REG((addr), WRITE_PERI_REG);                                                               \
+            (*((volatile uint32_t *)ETS_UNCACHED_ADDR(addr))) = (uint32_t)(val);                                       \
+        })
+
+//clear bits of register controlled by mask
+#define CLEAR_PERI_REG_MASK(reg, mask) ({                                                                              \
+            ASSERT_IF_DPORT_REG((reg), CLEAR_PERI_REG_MASK);                                                           \
+            WRITE_PERI_REG((reg), (READ_PERI_REG(reg)&(~(mask))));                                                     \
+        })
+
+//set bits of register controlled by mask
+#define SET_PERI_REG_MASK(reg, mask) ({                                                                                \
+            ASSERT_IF_DPORT_REG((reg), SET_PERI_REG_MASK);                                                             \
+            WRITE_PERI_REG((reg), (READ_PERI_REG(reg)|(mask)));                                                        \
+        })
+
+//get bits of register controlled by mask
+#define GET_PERI_REG_MASK(reg, mask) ({                                                                                \
+            ASSERT_IF_DPORT_REG((reg), GET_PERI_REG_MASK);                                                             \
+            (READ_PERI_REG(reg) & (mask));                                                                             \
+        })
+
+//get bits of register controlled by highest bit and lowest bit
+#define GET_PERI_REG_BITS(reg, hipos,lowpos) ({                                                                        \
+            ASSERT_IF_DPORT_REG((reg), GET_PERI_REG_BITS);                                                             \
+            ((READ_PERI_REG(reg)>>(lowpos))&((1<<((hipos)-(lowpos)+1))-1));                                            \
+        })
+
+//set bits of register controlled by mask and shift
+#define SET_PERI_REG_BITS(reg,bit_map,value,shift) ({                                                                  \
+            ASSERT_IF_DPORT_REG((reg), SET_PERI_REG_BITS);                                                             \
+            (WRITE_PERI_REG((reg),(READ_PERI_REG(reg)&(~((bit_map)<<(shift))))|(((value) & bit_map)<<(shift)) ));      \
+        })
+
+//get field of register
+#define GET_PERI_REG_BITS2(reg, mask,shift) ({                                                                         \
+            ASSERT_IF_DPORT_REG((reg), GET_PERI_REG_BITS2);                                                            \
+            ((READ_PERI_REG(reg)>>(shift))&(mask));                                                                    \
+        })
+
+#endif /* !__ASSEMBLER__ */
+//}}
+
+//Periheral Clock {{
+#define  APB_CLK_FREQ_ROM                            ( 26*1000000 )
+#define  CPU_CLK_FREQ_ROM                            APB_CLK_FREQ_ROM
+#define  CPU_CLK_FREQ                                APB_CLK_FREQ
+#define  APB_CLK_FREQ                                ( 80*1000000 )       //unit: Hz
+#define  REF_CLK_FREQ                                ( 1000000 )
+#define  UART_CLK_FREQ                               APB_CLK_FREQ
+#define  WDT_CLK_FREQ                                APB_CLK_FREQ
+#define  TIMER_CLK_FREQ                              (80000000>>4) //80MHz divided by 16
+#define  SPI_CLK_DIV                                 4
+#define  TICKS_PER_US_ROM                            26              // CPU is 80MHz
+//}}
+
+/* Overall memory map */
+#define SOC_DROM_LOW    0x3F400000
+#define SOC_DROM_HIGH   0x3F800000
+#define SOC_IROM_LOW    0x400D0000
+#define SOC_IROM_HIGH   0x40400000
+#define SOC_IROM_MASK_LOW   0x40000000
+#define SOC_IROM_MASK_HIGH  0x40070000
+#define SOC_CACHE_PRO_LOW   0x40070000
+#define SOC_CACHE_PRO_HIGH  0x40078000
+#define SOC_CACHE_APP_LOW   0x40078000
+#define SOC_CACHE_APP_HIGH  0x40080000
+#define SOC_IRAM_LOW    0x40080000
+#define SOC_IRAM_HIGH   0x400A0000
+#define SOC_RTC_IRAM_LOW  0x400C0000
+#define SOC_RTC_IRAM_HIGH 0x400C2000
+#define SOC_RTC_DRAM_LOW  0x3FF80000
+#define SOC_RTC_DRAM_HIGH 0x3FF82000
+#define SOC_RTC_DATA_LOW  0x50000000
+#define SOC_RTC_DATA_HIGH 0x50002000
+
+//First and last words of the D/IRAM region, for both the DRAM address as well as the IRAM alias.
+#define SOC_DIRAM_IRAM_LOW    0x400A0000
+#define SOC_DIRAM_IRAM_HIGH   0x400BFFFC
+#define SOC_DIRAM_DRAM_LOW    0x3FFE0000
+#define SOC_DIRAM_DRAM_HIGH   0x3FFFFFFC
+
+// Region of memory accessible via DMA. See esp_ptr_dma_capable().
+#define SOC_DMA_LOW  0x3FFAE000
+#define SOC_DMA_HIGH 0x40000000
+
+// Region of memory that is byte-accessible. See esp_ptr_byte_accessible().
+#define SOC_BYTE_ACCESSIBLE_LOW     0x3FF90000
+#define SOC_BYTE_ACCESSIBLE_HIGH    0x40000000
+
+//Region of memory that is internal, as in on the same silicon die as the ESP32 CPUs
+//(excluding RTC data region, that's checked separately.) See esp_ptr_internal().
+#define SOC_MEM_INTERNAL_LOW        0x3FF90000
+#define SOC_MEM_INTERNAL_HIGH       0x400C2000
+
+//Interrupt hardware source table
+//This table is decided by hardware, don't touch this.
+#define ETS_WIFI_MAC_INTR_SOURCE                0/**< interrupt of WiFi MAC, level*/
+#define ETS_WIFI_MAC_NMI_SOURCE                 1/**< interrupt of WiFi MAC, NMI, use if MAC have bug to fix in NMI*/
+#define ETS_WIFI_BB_INTR_SOURCE                 2/**< interrupt of WiFi BB, level, we can do some calibartion*/
+#define ETS_BT_MAC_INTR_SOURCE                  3/**< will be cancelled*/
+#define ETS_BT_BB_INTR_SOURCE                   4/**< interrupt of BT BB, level*/
+#define ETS_BT_BB_NMI_SOURCE                    5/**< interrupt of BT BB, NMI, use if BB have bug to fix in NMI*/
+#define ETS_RWBT_INTR_SOURCE                    6/**< interrupt of RWBT, level*/
+#define ETS_RWBLE_INTR_SOURCE                   7/**< interrupt of RWBLE, level*/
+#define ETS_RWBT_NMI_SOURCE                     8/**< interrupt of RWBT, NMI, use if RWBT have bug to fix in NMI*/
+#define ETS_RWBLE_NMI_SOURCE                    9/**< interrupt of RWBLE, NMI, use if RWBT have bug to fix in NMI*/
+#define ETS_SLC0_INTR_SOURCE                    10/**< interrupt of SLC0, level*/
+#define ETS_SLC1_INTR_SOURCE                    11/**< interrupt of SLC1, level*/
+#define ETS_UHCI0_INTR_SOURCE                   12/**< interrupt of UHCI0, level*/
+#define ETS_UHCI1_INTR_SOURCE                   13/**< interrupt of UHCI1, level*/
+#define ETS_TG0_T0_LEVEL_INTR_SOURCE            14/**< interrupt of TIMER_GROUP0, TIMER0, level, we would like use EDGE for timer if permission*/
+#define ETS_TG0_T1_LEVEL_INTR_SOURCE            15/**< interrupt of TIMER_GROUP0, TIMER1, level, we would like use EDGE for timer if permission*/
+#define ETS_TG0_WDT_LEVEL_INTR_SOURCE           16/**< interrupt of TIMER_GROUP0, WATCHDOG, level*/
+#define ETS_TG0_LACT_LEVEL_INTR_SOURCE          17/**< interrupt of TIMER_GROUP0, LACT, level*/
+#define ETS_TG1_T0_LEVEL_INTR_SOURCE            18/**< interrupt of TIMER_GROUP1, TIMER0, level, we would like use EDGE for timer if permission*/
+#define ETS_TG1_T1_LEVEL_INTR_SOURCE            19/**< interrupt of TIMER_GROUP1, TIMER1, level, we would like use EDGE for timer if permission*/
+#define ETS_TG1_WDT_LEVEL_INTR_SOURCE           20/**< interrupt of TIMER_GROUP1, WATCHDOG, level*/
+#define ETS_TG1_LACT_LEVEL_INTR_SOURCE          21/**< interrupt of TIMER_GROUP1, LACT, level*/
+#define ETS_GPIO_INTR_SOURCE                    22/**< interrupt of GPIO, level*/
+#define ETS_GPIO_NMI_SOURCE                     23/**< interrupt of GPIO, NMI*/
+#define ETS_FROM_CPU_INTR0_SOURCE               24/**< interrupt0 generated from a CPU, level*/ /* Used for FreeRTOS */
+#define ETS_FROM_CPU_INTR1_SOURCE               25/**< interrupt1 generated from a CPU, level*/ /* Used for FreeRTOS */
+#define ETS_FROM_CPU_INTR2_SOURCE               26/**< interrupt2 generated from a CPU, level*/ /* Used for DPORT Access */
+#define ETS_FROM_CPU_INTR3_SOURCE               27/**< interrupt3 generated from a CPU, level*/ /* Used for DPORT Access */
+#define ETS_SPI0_INTR_SOURCE                    28/**< interrupt of SPI0, level, SPI0 is for Cache Access, do not use this*/
+#define ETS_SPI1_INTR_SOURCE                    29/**< interrupt of SPI1, level, SPI1 is for flash read/write, do not use this*/
+#define ETS_SPI2_INTR_SOURCE                    30/**< interrupt of SPI2, level*/
+#define ETS_SPI3_INTR_SOURCE                    31/**< interrupt of SPI3, level*/
+#define ETS_I2S0_INTR_SOURCE                    32/**< interrupt of I2S0, level*/
+#define ETS_I2S1_INTR_SOURCE                    33/**< interrupt of I2S1, level*/
+#define ETS_UART0_INTR_SOURCE                   34/**< interrupt of UART0, level*/
+#define ETS_UART1_INTR_SOURCE                   35/**< interrupt of UART1, level*/
+#define ETS_UART2_INTR_SOURCE                   36/**< interrupt of UART2, level*/
+#define ETS_SDIO_HOST_INTR_SOURCE               37/**< interrupt of SD/SDIO/MMC HOST, level*/
+#define ETS_ETH_MAC_INTR_SOURCE                 38/**< interrupt of ethernet mac, level*/
+#define ETS_PWM0_INTR_SOURCE                    39/**< interrupt of PWM0, level, Reserved*/
+#define ETS_PWM1_INTR_SOURCE                    40/**< interrupt of PWM1, level, Reserved*/
+#define ETS_PWM2_INTR_SOURCE                    41/**< interrupt of PWM2, level*/
+#define ETS_PWM3_INTR_SOURCE                    42/**< interruot of PWM3, level*/
+#define ETS_LEDC_INTR_SOURCE                    43/**< interrupt of LED PWM, level*/
+#define ETS_EFUSE_INTR_SOURCE                   44/**< interrupt of efuse, level, not likely to use*/
+#define ETS_CAN_INTR_SOURCE                     45/**< interrupt of can, level*/
+#define ETS_RTC_CORE_INTR_SOURCE                46/**< interrupt of rtc core, level, include rtc watchdog*/
+#define ETS_RMT_INTR_SOURCE                     47/**< interrupt of remote controller, level*/
+#define ETS_PCNT_INTR_SOURCE                    48/**< interrupt of pluse count, level*/
+#define ETS_I2C_EXT0_INTR_SOURCE                49/**< interrupt of I2C controller1, level*/
+#define ETS_I2C_EXT1_INTR_SOURCE                50/**< interrupt of I2C controller0, level*/
+#define ETS_RSA_INTR_SOURCE                     51/**< interrupt of RSA accelerator, level*/
+#define ETS_SPI1_DMA_INTR_SOURCE                52/**< interrupt of SPI1 DMA, SPI1 is for flash read/write, do not use this*/
+#define ETS_SPI2_DMA_INTR_SOURCE                53/**< interrupt of SPI2 DMA, level*/
+#define ETS_SPI3_DMA_INTR_SOURCE                54/**< interrupt of SPI3 DMA, level*/
+#define ETS_WDT_INTR_SOURCE                     55/**< will be cancelled*/
+#define ETS_TIMER1_INTR_SOURCE                  56/**< will be cancelled*/
+#define ETS_TIMER2_INTR_SOURCE                  57/**< will be cancelled*/
+#define ETS_TG0_T0_EDGE_INTR_SOURCE             58/**< interrupt of TIMER_GROUP0, TIMER0, EDGE*/
+#define ETS_TG0_T1_EDGE_INTR_SOURCE             59/**< interrupt of TIMER_GROUP0, TIMER1, EDGE*/
+#define ETS_TG0_WDT_EDGE_INTR_SOURCE            60/**< interrupt of TIMER_GROUP0, WATCH DOG, EDGE*/
+#define ETS_TG0_LACT_EDGE_INTR_SOURCE           61/**< interrupt of TIMER_GROUP0, LACT, EDGE*/
+#define ETS_TG1_T0_EDGE_INTR_SOURCE             62/**< interrupt of TIMER_GROUP1, TIMER0, EDGE*/
+#define ETS_TG1_T1_EDGE_INTR_SOURCE             63/**< interrupt of TIMER_GROUP1, TIMER1, EDGE*/
+#define ETS_TG1_WDT_EDGE_INTR_SOURCE            64/**< interrupt of TIMER_GROUP1, WATCHDOG, EDGE*/
+#define ETS_TG1_LACT_EDGE_INTR_SOURCE           65/**< interrupt of TIMER_GROUP0, LACT, EDGE*/
+#define ETS_MMU_IA_INTR_SOURCE                  66/**< interrupt of MMU Invalid Access, LEVEL*/
+#define ETS_MPU_IA_INTR_SOURCE                  67/**< interrupt of MPU Invalid Access, LEVEL*/
+#define ETS_CACHE_IA_INTR_SOURCE                68/**< interrupt of Cache Invalied Access, LEVEL*/
+
+//interrupt cpu using table, Please see the core-isa.h
+/*************************************************************************************************************
+ *      Intr num                Level           Type                    PRO CPU usage           APP CPU uasge
+ *      0                       1               extern level            WMAC                    Reserved
+ *      1                       1               extern level            BT/BLE Host HCI DMA     BT/BLE Host HCI DMA
+ *      2                       1               extern level
+ *      3                       1               extern level
+ *      4                       1               extern level            WBB
+ *      5                       1               extern level            BT/BLE Controller       BT/BLE Controller
+ *      6                       1               timer                   FreeRTOS Tick(L1)       FreeRTOS Tick(L1)
+ *      7                       1               software                BT/BLE VHCI             BT/BLE VHCI
+ *      8                       1               extern level            BT/BLE BB(RX/TX)        BT/BLE BB(RX/TX)
+ *      9                       1               extern level
+ *      10                      1               extern edge
+ *      11                      3               profiling
+ *      12                      1               extern level
+ *      13                      1               extern level
+ *      14                      7               nmi                     Reserved                Reserved
+ *      15                      3               timer                   FreeRTOS Tick(L3)       FreeRTOS Tick(L3)
+ *      16                      5               timer
+ *      17                      1               extern level
+ *      18                      1               extern level
+ *      19                      2               extern level
+ *      20                      2               extern level
+ *      21                      2               extern level
+ *      22                      3               extern edge
+ *      23                      3               extern level
+ *      24                      4               extern level            TG1_WDT
+ *      25                      4               extern level            CACHEERR
+ *      26                      5               extern level
+ *      27                      3               extern level            Reserved                Reserved
+ *      28                      4               extern edge             DPORT ACCESS            DPORT ACCESS
+ *      29                      3               software                Reserved                Reserved
+ *      30                      4               extern edge             Reserved                Reserved
+ *      31                      5               extern level
+ *************************************************************************************************************
+ */
+
+//CPU0 Interrupt number reserved, not touch this.
+#define ETS_WMAC_INUM                           0
+#define ETS_BT_HOST_INUM                        1
+#define ETS_WBB_INUM                            4
+#define ETS_TG0_T1_INUM                         10 /**< use edge interrupt*/
+#define ETS_FRC1_INUM                           22
+#define ETS_T1_WDT_INUM                         24
+#define ETS_CACHEERR_INUM                       25
+#define ETS_DPORT_INUM                          28
+
+//CPU0 Interrupt number used in ROM, should be cancelled in SDK
+#define ETS_SLC_INUM                            1
+#define ETS_UART0_INUM                          5
+#define ETS_UART1_INUM                          5
+//Other interrupt number should be managed by the user
+
+//Invalid interrupt for number interrupt matrix
+#define ETS_INVALID_INUM                        6
+
+#endif // PLATFORM_ID == PLATFORM_TRACKER
+
+#endif /* _ESP32_SOC_H_ */
+

--- a/user/tests/app/tracker_wakeup/port.cpp
+++ b/user/tests/app/tracker_wakeup/port.cpp
@@ -1,0 +1,127 @@
+
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2019 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#include "application.h"
+#include "port.h"
+#include "concurrent_hal.h"
+#include "delay_hal.h"
+#include "sdspi_host.h"
+
+#if PLATFORM_ID == PLATFORM_TRACKER
+
+// The semaphore indicating the slave is ready to receive stuff.
+os_semaphore_t wifiIntSem = nullptr;
+
+/// Set CS high
+void at_cs_high(void) {
+    digitalWrite(PORT_CS_PIN, HIGH);
+    PORT_SPI.endTransaction();
+}
+
+/// Set CS low
+void at_cs_low(void) {
+    PORT_SPI.beginTransaction(__SPISettings(1*MHZ, MSBFIRST, SPI_MODE0));
+    digitalWrite(PORT_CS_PIN, LOW);
+}
+
+esp_err_t at_spi_transmit(void* tx_buff, void* rx_buff, uint32_t len) {
+    PORT_SPI.transfer(tx_buff, rx_buff, len, NULL);
+    return ESP_OK;
+}
+
+static void esp32WakeupPinHandler(void) {
+    if (wifiIntSem) {
+        os_semaphore_give(wifiIntSem, false);
+    }
+}
+
+esp_err_t at_spi_slot_init(void) {
+    // Initialize PORT_SPI bus
+    // For SD cards, CS must stay low during the whole read/write operation,
+    // rather than a single SPI transaction.
+    // pinMode(MISO, INPUT_PULLUP);
+    PORT_SPI.setClockSpeed(100, KHZ);
+    PORT_SPI.setDataMode(SPI_MODE0);
+    PORT_SPI.begin();
+
+    // Configure CS pin
+    pinMode(PORT_CS_PIN, OUTPUT);
+    digitalWrite(PORT_CS_PIN, HIGH);
+
+    pinMode(PORT_INT_PIN, INPUT_PULLUP);
+    // NOTE: Don't enable interrupt here on ATSoMv0.2
+    // The unexpected interrupt casuses a SPI read on IO Expander,
+    // which interferes with initial sequence of SDIO
+    // attachInterrupt(PORT_INT_PIN, esp32WakeupPinHandler, FALLING);
+
+    return ESP_OK;
+}
+
+esp_err_t at_spi_int_init(void) {
+    attachInterrupt(PORT_INT_PIN, esp32WakeupPinHandler, FALLING);
+    SPARK_ASSERT(os_semaphore_create(&wifiIntSem, 1, 0) == 0);
+    if (digitalRead(PORT_INT_PIN) == LOW) {
+        SPARK_ASSERT(os_semaphore_give(wifiIntSem, false) == 0);
+    }
+    return ESP_OK;
+}
+
+esp_err_t at_spi_wait_int(uint32_t wait_ms) {
+    //wait for semaphore
+    int ret = os_semaphore_take(wifiIntSem, wait_ms, false);
+    if (ret) {
+        // Log.error("wifiIntSem TIMEOUT!");
+        return ESP_ERR_TIMEOUT;
+    } else {
+        // Log.info("wifiIntSem SUCCESS!");
+    }
+
+    return ESP_OK;
+}
+
+void at_do_delay(uint32_t wait_ms) {
+    HAL_Delay_Milliseconds(wait_ms);
+}
+
+AT_MUTEX_T at_mutex_init(void) {
+    os_mutex_t mutex = NULL;
+    SPARK_ASSERT(os_mutex_create(&mutex) == 0);
+    return mutex;
+}
+
+void at_mutex_lock(AT_MUTEX_T pxMutex) {
+    os_mutex_lock(pxMutex);
+}
+
+void at_mutex_unlock(AT_MUTEX_T pxMutex) {
+    os_mutex_unlock(pxMutex);
+}
+
+void at_mutex_free(AT_MUTEX_T pxMutex) {
+    os_mutex_destroy(pxMutex);
+    pxMutex = NULL;
+}
+
+#endif // PLATFORM_ID == PLATFORM_TRACKER
+

--- a/user/tests/app/tracker_wakeup/port.h
+++ b/user/tests/app/tracker_wakeup/port.h
@@ -1,0 +1,184 @@
+
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2019 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+ 
+#ifndef PORT_H
+#define PORT_H
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include "logging.h"
+#include "service_debug.h"
+#include "platforms.h"
+
+#if PLATFORM_ID == PLATFORM_TRACKER
+
+#define PORT_SPI        SPI1
+#define PORT_CS_PIN     WIFI_CS
+#define PORT_INT_PIN    WIFI_INT
+#define PORT_EN_PIN     WIFI_EN
+#define PORT_BOOT_PIN   WIFI_BOOT
+
+
+//typedef SemaphoreHandle_t AT_MUTEX_T;
+typedef void* AT_MUTEX_T;
+
+typedef int32_t esp_err_t;
+
+#ifndef assert
+#define assert SPARK_ASSERT
+#endif
+
+/* Definitions for error constants. */
+
+#define ESP_OK                  0
+#define ESP_FAIL                -1
+#define ESP_ERR_NO_MEM          0x101
+#define ESP_ERR_INVALID_ARG     0x102
+#define ESP_ERR_INVALID_STATE   0x103
+#define ESP_ERR_INVALID_SIZE    0x104
+#define ESP_ERR_NOT_FOUND       0x105
+#define ESP_ERR_NOT_SUPPORTED   0x106
+#define ESP_ERR_TIMEOUT         0x107
+#define ESP_ERR_INVALID_RESPONSE    0x108
+
+#define at_debugLevel 2
+
+#define ESP_AT_LOGE(x, ...) {if(at_debugLevel >= 0) {LOG_DEBUG_PRINTF(ERROR, "E %s: ",x); LOG_DEBUG_PRINTF(ERROR, __VA_ARGS__); LOG_DEBUG_PRINTF(ERROR, "\r\n");}}
+#define ESP_AT_LOGW(x, ...) {if(at_debugLevel >= 1) {LOG_DEBUG_PRINTF(WARN, "W %s: ",x);  LOG_DEBUG_PRINTF(WARN, __VA_ARGS__);  LOG_DEBUG_PRINTF(WARN, "\r\n");}}
+#define ESP_AT_LOGI(x, ...) {if(at_debugLevel >= 2) {LOG_DEBUG_PRINTF(INFO, "I %s: ",x);  LOG_DEBUG_PRINTF(INFO, __VA_ARGS__);  LOG_DEBUG_PRINTF(INFO, "\r\n");}}
+#define ESP_AT_LOGD(x, ...) {if(at_debugLevel >= 3) {LOG_DEBUG_PRINTF(TRACE, "D %s: ",x); LOG_DEBUG_PRINTF(TRACE, __VA_ARGS__); LOG_DEBUG_PRINTF(TRACE, "\r\n");}}
+#define ESP_AT_LOGV(x, ...) {if(at_debugLevel >= 4) {LOG_DEBUG_PRINTF(TRACE, "V %s: ",x); LOG_DEBUG_PRINTF(TRACE, __VA_ARGS__); LOG_DEBUG_PRINTF(TRACE, "\r\n");}}
+
+// Forces data to be 4 bytes aligned
+#define WORD_ALIGNED_ATTR __attribute__((aligned(4)))
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Set cs line to high.
+ * 
+ * @return None
+ */
+void at_cs_high(void);
+
+/**
+ * @brief Set cs line to low.
+ * 
+ * @return None
+ */
+void at_cs_low(void);
+
+/**
+  * @brief  Delay some time.
+  *
+  * @param  uint32_t  Delay time in ms.
+  *
+  * @return None
+  */
+void at_do_delay(uint32_t wait_ms);
+
+/**
+ * @brief Send a SPI transaction, wait for it to complete, and return the result.
+ * 
+ * @param tx_buff Pointer to transmit buffer
+ * @param rx_buff Pointer to receive buffer
+ * @param len     Total data length, in bytes
+ * 
+ * @return 
+ *   - ESP_OK if success
+ *   - ESP_ERR_INVALID_ARG if channal not valid 
+ */
+esp_err_t at_spi_transmit(void* tx_buff, void* rx_buff, uint32_t len);
+
+/**
+ * @brief Initialize peripherals, include SPI and GPIO.
+ * 
+ * @return 
+ *   - ESP_OK if success
+ *   - ESP_FAIL if fail
+ */
+esp_err_t at_spi_slot_init(void);
+
+esp_err_t at_spi_int_init(void);
+
+/**
+ * @brief Wait interrupt line.
+ * 
+ * @param wait_ms Wait time in ms.
+ * 
+ * @return 
+ *   - ESP_OK if success
+ *   - ESP_ERR_TIMEOUT if timeout 
+ */
+esp_err_t at_spi_wait_int(uint32_t wait_ms);
+
+/**
+ * @brief create a new mutex
+ * 
+ * @return 
+ *   - The handle to the created mutex if the mutex type semaphore was created successfully
+ *   - NULL if fail
+ */
+AT_MUTEX_T at_mutex_init(void);
+
+/**
+ * @brief lock a mutex
+ * 
+ * @param pxMutex -- the mutex to lock
+ * 
+ * @return None
+ */
+void at_mutex_lock(AT_MUTEX_T pxMutex);
+
+/**
+ * @brief unlock a mutex
+ * 
+ * @param pxMutex -- the mutex to unlock
+ * 
+ * @return None
+ */
+void at_mutex_unlock(AT_MUTEX_T pxMutex);
+
+/**
+ * @brief Delete a mutex
+ * 
+ * @param pxMutex -- the mutex to delete
+ * 
+ * @return None
+ */
+void at_mutex_free(AT_MUTEX_T pxMutex);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PLATFORM_ID == PLATFORM_TRACKER
+
+#endif // PORT_H
+
+

--- a/user/tests/app/tracker_wakeup/sdspi_host.cpp
+++ b/user/tests/app/tracker_wakeup/sdspi_host.cpp
@@ -1,0 +1,1155 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2019 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+#include"sdspi_host.h"
+#include"port.h"
+
+#if PLATFORM_ID == PLATFORM_TRACKER
+
+// #define offsetof(TYPE, MEMBER) ((size_t) &((TYPE *)0)->MEMBER)
+
+//#define FOUR_BYTE_ALIGNMENT
+
+static const char* TAG = "sdspi_transaction";
+
+uint8_t flag_2 = 0;
+
+AT_MUTEX_T spi_lock = NULL;
+
+static inline uint32_t bswap32(uint32_t val32)
+{
+    val32 = ((val32 << 8) & 0xFF00FF00) | ((val32 >> 8) & 0x00FF00FF);
+    return (val32 << 16) | (val32 >> 16);
+}
+
+void make_hw_cmd(uint32_t opcode, uint32_t arg, sdspi_hw_cmd_t* hw_cmd)
+{
+    hw_cmd->start_bit = 0;
+    hw_cmd->transmission_bit = 1;
+    hw_cmd->cmd_index = opcode;
+    hw_cmd->stop_bit = 1;
+    hw_cmd->r1 = 0xff;
+    memset(hw_cmd->response, 0xff, sizeof(hw_cmd->response));
+    hw_cmd->ncr = 0xff;
+    //printf("cmd_index: %d, Before swap: %x\n",opcode, arg);
+    //uint32_t arg_s = __builtin_bswap32(arg);         // reverse bytes
+    uint32_t arg_s = bswap32(arg);         // reverse bytes
+    //printf("After swap: %x\n",arg_s);
+    memcpy(hw_cmd->arguments, &arg_s, sizeof(arg_s));
+    hw_cmd->crc7 = 0x0;
+}
+
+/// Clock out 80 cycles (10 bytes) before GO_IDLE command
+void go_idle_clockout()
+{
+    esp_err_t ret;
+
+    //actually we need 10, declare 12 to meet requirement of RXDMA
+    uint8_t data[12];
+    memset(data, 0xFF, sizeof(data));
+
+    ret = at_spi_transmit(data, data, 10);
+
+    if (ret != ESP_OK) {
+        ESP_AT_LOGE(TAG, "SPI transmit error\n");
+    }
+}
+
+// the r1 respond could appear 1-8 clocks after the command token is sent
+// this function search buffer after 1 clocks to max 8 clocks for r1
+// and shift the data after R1, to 1 clocks after the command to match the definition of sdspi_hw_cmd_t.
+static esp_err_t shift_cmd_response(sdspi_hw_cmd_t* cmd, int sent_bytes)
+{
+    uint8_t* pr1 = &cmd->r1;
+    int ncr_cnt = 1;
+
+    for (;;) {
+        if ((*pr1 & SD_SPI_R1_NO_RESPONSE) == 0) {
+            break;
+        }
+
+        pr1++;
+
+        if (++ncr_cnt > 8) {
+            ESP_AT_LOGE(TAG, "Not found response");
+            return ESP_ERR_NOT_FOUND;
+        }
+    }
+
+    int copy_bytes = sent_bytes - SDSPI_CMD_SIZE - ncr_cnt;
+
+    if (copy_bytes > 0) {
+        memcpy(&cmd->r1, pr1, copy_bytes);
+    }
+
+    return ESP_OK;
+}
+
+static esp_err_t start_command_default(int flags, sdspi_hw_cmd_t* cmd)
+{
+    size_t cmd_size = SDSPI_CMD_R1_SIZE;
+
+    if ((flags & SDSPI_CMD_FLAG_RSP_R1) ||
+            (flags & SDSPI_CMD_FLAG_NORSP)) {
+        cmd_size = SDSPI_CMD_R1_SIZE;
+    } else if (flags & SDSPI_CMD_FLAG_RSP_R4) {
+        cmd_size = SDSPI_CMD_R4_SIZE;
+    } else if (flags & SDSPI_CMD_FLAG_RSP_R5) {
+        cmd_size = SDSPI_CMD_R5_SIZE;
+    }
+
+    //add extra clocks to avoid polling
+    cmd_size += (SDSPI_NCR_MAX_SIZE - SDSPI_NCR_MIN_SIZE);
+
+    esp_err_t ret = at_spi_transmit(cmd, cmd, cmd_size);
+
+    if (ret != ESP_OK) {
+        ESP_AT_LOGE(TAG, "%s: spi_device_transmit returned 0x%x", __func__, ret);
+        return ret;
+    }
+
+    if (flags & SDSPI_CMD_FLAG_NORSP) {
+        /* no (correct) response expected from the card, so skip polling loop */
+        //ESP_AT_LOGI(TAG, "%s: ignoring response byte", __func__);
+        cmd->r1 = 0x00;
+    }
+
+    ret = shift_cmd_response(cmd, cmd_size);
+
+    if (ret != ESP_OK) {
+        return ESP_ERR_TIMEOUT;
+    }
+
+    return ESP_OK;
+}
+
+// Wait until MISO goes high
+static esp_err_t poll_busy()
+{
+    esp_err_t ret;
+    uint8_t t_rx, t_tx;
+    uint32_t nonzero_count = 0;
+
+    do {
+        t_tx = SDSPI_MOSI_IDLE_VAL;
+        t_rx = 0;
+        ret = at_spi_transmit(&t_tx, &t_rx, 1);
+
+        if (ret != ESP_OK) {
+            return ret;
+        }
+
+        if (t_rx == 0XFF) {
+            return ESP_OK;
+        }
+
+        flag_2 = 9;
+    } while (++nonzero_count < UINT32_MAX);
+
+    flag_2 = 10;
+    ESP_AT_LOGE(TAG, "%s: timeout error", __func__);
+
+    return ESP_OK;
+}
+
+// For CMD53, we can send in byte mode, or block mode
+// The data start token is different, and cannot be determined by the length
+// That's why we need ``multi_block``.
+static esp_err_t start_command_write_blocks(sdspi_hw_cmd_t* cmd,
+        uint8_t* data, uint32_t tx_length, bool multi_block)
+{
+    esp_err_t ret;
+    // Send the minimum length that is sure to get the complete response
+    // SD cards always return R1 (1bytes), SDIO returns R5 (2 bytes)
+    int send_bytes = SDSPI_CMD_R5_SIZE + SDSPI_NCR_MAX_SIZE - SDSPI_NCR_MIN_SIZE;
+
+    at_spi_transmit(cmd, cmd, send_bytes);
+    // check for command response validate
+    ret = shift_cmd_response(cmd, send_bytes);
+
+    if (ret != ESP_OK) {
+        ESP_AT_LOGE(TAG, "%s: check_cmd_response returned 0x%x", __func__, ret);
+        return ret;
+    }
+
+    uint8_t start_token = //tx_length <= SDSPI_MAX_DATA_LEN ?
+        (!multi_block) ? TOKEN_BLOCK_START : TOKEN_BLOCK_START_WRITE_MULTI;
+
+    while (tx_length > 0) {
+        ESP_AT_LOGV(TAG, "%s: Remained len:%d", __func__, tx_length);
+        // Write block start token
+        ret = at_spi_transmit(&start_token, NULL, sizeof(start_token));
+
+        if (ret != ESP_OK) {
+            return ret;
+        }
+
+        // Prepare data to be sent
+        size_t will_send = MIN(tx_length, SDSPI_MAX_DATA_LEN);
+
+        // Write data
+        ret = at_spi_transmit(data, NULL, will_send);
+
+        if (ret != ESP_OK) {
+            return ret;
+        }
+
+        uint8_t crc_tx[4];
+        uint8_t crc_rx[4];
+
+        memset(crc_tx, 0xff, 4);
+
+        ret = at_spi_transmit(crc_tx, crc_rx, 3);
+
+        if (ret != ESP_OK) {
+            return ret;
+        }
+
+        ESP_AT_LOGV(TAG, "crc_rx[2] = %x\n", crc_rx[2]);
+        // assert((crc_rx[2] & 0xf) == 5);
+
+        // Wait for the card to finish writing data
+        ret = poll_busy();
+
+        if (ret != ESP_OK) {
+            ESP_AT_LOGE(TAG, "poll_busy returned 0x%x",  ret);
+            return ret;
+        }
+
+        tx_length -= will_send;
+        data += will_send;
+    }
+
+    return ESP_OK;
+}
+
+// Wait for data token, reading 8 bytes at a time.
+// If the token is found, write all subsequent bytes to extra_ptr,
+// and store the number of bytes written to extra_size.
+static esp_err_t poll_data_token(uint8_t* extra_ptr, size_t* extra_size)
+{
+    uint8_t t_rx[8];
+    esp_err_t ret;
+    uint8_t count_time = 0;
+
+    do {
+        memset(t_rx, SDSPI_MOSI_IDLE_VAL, sizeof(t_rx));
+        ret = at_spi_transmit(t_rx, t_rx, sizeof(t_rx));
+
+        if (ret != ESP_OK) {
+            ESP_AT_LOGE(TAG, "SPI trans error %d", ret);
+            return ret;
+        }
+
+        bool found = false;
+
+        for (uint8_t byte_idx = 0; byte_idx < sizeof(t_rx); byte_idx++) {
+            uint8_t rd_data = t_rx[byte_idx];
+
+            if (rd_data == TOKEN_BLOCK_START) {
+                found = true;
+                memcpy(extra_ptr, t_rx + byte_idx + 1, sizeof(t_rx) - byte_idx - 1);
+                *extra_size = sizeof(t_rx) - byte_idx - 1;
+                break;
+            }
+
+            if ((rd_data != 0xff) && (rd_data != 0)) {
+                ESP_AT_LOGE(TAG, "%s: received 0x%02x while waiting for data",
+                            __func__, rd_data);
+                return ESP_ERR_INVALID_RESPONSE;
+            }
+        }
+
+        if (found) {
+            return ESP_OK;
+        }
+
+    } while (++count_time < 1000);
+
+    ESP_AT_LOGE(TAG, "%s: timeout", __func__);
+    return ESP_ERR_TIMEOUT;
+}
+
+/**
+ * Receiving one or more blocks of data happens as follows:
+ * 1. send command + receive r1 response (SDSPI_CMD_R1_SIZE bytes total)
+ * 2. keep receiving bytes until TOKEN_BLOCK_START is encountered (this may
+ *    take a while, depending on card's read speed)
+ * 3. receive up to SDSPI_MAX_DATA_LEN = 512 bytes of actual data
+ * 4. receive 2 bytes of CRC
+ * 5. for multi block transfers, go to step 2
+ *
+ * These steps can be done separately, but that leads to a less than optimal
+ * performance on large transfers because of delays between each step.
+ * For example, if steps 3 and 4 are separate SPI transactions queued one after
+ * another, there will be ~16 microseconds of dead time between end of step 3
+ * and the beginning of step 4. A delay between two blocking SPI transactions
+ * in step 2 is even higher (~60 microseconds).
+ *
+ * To improve read performance the following sequence is adopted:
+ * 1. Do the first transfer: command + r1 response + 8 extra bytes.
+ *    Set pre_scan_data_ptr to point to the 8 extra bytes, and set
+ *    pre_scan_data_size to 8.
+ * 2. Search pre_scan_data_size bytes for TOKEN_BLOCK_START.
+ *    If found, the rest of the bytes contain part of the actual data.
+ *    Store pointer to and size of that extra data as extra_data_{ptr,size}.
+ *    If not found, fall back to polling for TOKEN_BLOCK_START, 8 bytes at a
+ *    time (in poll_data_token function). Deal with extra data in the same way,
+ *    by setting extra_data_{ptr,size}.
+ * 3. Receive the remaining 512 - extra_data_size bytes, plus 4 extra bytes
+ *    (i.e. 516 - extra_data_size). Of the 4 extra bytes, first two will capture
+ *    the CRC value, and the other two will capture 0xff 0xfe sequence
+ *    indicating the start of the next block. Actual scanning is done by
+ *    setting pre_scan_data_ptr to point to these last 2 bytes, and setting
+ *    pre_scan_data_size = 2, then going to step 2 to receive the next block.
+ *    When the final block is being received, the number of extra bytes is 2
+ *    (only for CRC), because we don't need to wait for start token of the
+ *    next block, and some cards are getting confused by these two extra bytes.
+ *
+ * With this approach the delay between blocks of a multi-block transfer is
+ * ~95 microseconds, out of which 35 microseconds are spend doing the CRC check.
+ * Further speedup is possible by pipelining transfers and CRC checks, at an
+ * expense of one extra temporary buffer.
+ */
+static esp_err_t start_command_read_blocks(sdspi_hw_cmd_t* cmd,
+        uint8_t* data, uint32_t rx_length)
+{
+    esp_err_t ret;
+    // TODO: Don't use so large buffer in the stack
+    static uint8_t rx_data[SDSPI_BLOCK_BUF_SIZE];
+    bool need_stop_command = rx_length > SDSPI_MAX_DATA_LEN;
+
+    ret = at_spi_transmit(cmd, cmd, (SDSPI_CMD_R1_SIZE + SDSPI_RESPONSE_MAX_DELAY));
+
+    if (ret != ESP_OK) {
+        ESP_AT_LOGE(TAG, "SPI transmit error");
+        return ret;
+    }
+
+    uint8_t* cmd_u8 = (uint8_t*) cmd;
+    size_t pre_scan_data_size = SDSPI_RESPONSE_MAX_DELAY;
+    uint8_t* pre_scan_data_ptr = cmd_u8 + SDSPI_CMD_R1_SIZE;
+
+    /* R1 response is delayed by 1-8 bytes from the request.
+     * This loop searches for the response and writes it to cmd->r1.
+     */
+    while ((cmd->r1 & SD_SPI_R1_NO_RESPONSE) != 0 && pre_scan_data_size > 0) {
+        cmd->r1 = *pre_scan_data_ptr;
+        ++pre_scan_data_ptr;
+        --pre_scan_data_size;
+    }
+
+    if (cmd->r1 & SD_SPI_R1_NO_RESPONSE) {
+        ESP_AT_LOGE(TAG, "no response token found");
+        return ESP_ERR_TIMEOUT;
+    }
+
+    while (rx_length > 0) {
+        size_t extra_data_size = 0;
+        const uint8_t* extra_data_ptr = NULL;
+        bool need_poll = true;
+
+        for (uint16_t i = 0; i < pre_scan_data_size; ++i) {
+            if (pre_scan_data_ptr[i] == TOKEN_BLOCK_START) {
+                extra_data_size = pre_scan_data_size - i - 1;
+                extra_data_ptr = pre_scan_data_ptr + i + 1;
+                need_poll = false;
+                break;
+            }
+        }
+
+        if (need_poll) {
+            // Wait for data to be ready
+            ret = poll_data_token(cmd_u8 + SDSPI_CMD_R1_SIZE, &extra_data_size);
+
+            //release_transaction(slot);
+            if (ret != ESP_OK) {
+                ESP_AT_LOGE(TAG, "poll_data_token return %d", ret);
+                return ret;
+            }
+
+            if (extra_data_size) {
+                extra_data_ptr = cmd_u8 + SDSPI_CMD_R1_SIZE;
+            }
+        }
+
+        // Arrange RX buffer
+        size_t will_receive = MIN(rx_length, SDSPI_MAX_DATA_LEN) - extra_data_size;
+
+        // receive actual data
+        const size_t receive_extra_bytes = (rx_length > SDSPI_MAX_DATA_LEN) ? 4 : 2;
+        memset(rx_data, 0xff, will_receive + receive_extra_bytes);
+
+        ret = at_spi_transmit(rx_data, rx_data, (will_receive + receive_extra_bytes));
+
+        if (ret != ESP_OK) {
+            ESP_AT_LOGE(TAG, "SPI transmit error");
+            return ret;
+        }
+
+        // CRC bytes need to be received even if CRC is not enabled
+        uint16_t crc = UINT16_MAX;
+        memcpy(&crc, rx_data + will_receive, sizeof(crc));
+
+        // Bytes to scan for the start token
+        pre_scan_data_size = receive_extra_bytes - sizeof(crc);
+        pre_scan_data_ptr = rx_data + will_receive + sizeof(crc);
+
+        // Copy data to the destination buffer
+        memcpy(data + extra_data_size, rx_data, will_receive);
+
+        if (extra_data_size) {
+            memcpy(data, extra_data_ptr, extra_data_size);
+        }
+
+        data += will_receive + extra_data_size;
+        rx_length -= will_receive + extra_data_size;
+        extra_data_size = 0;
+        extra_data_ptr = NULL;
+    }
+
+    if (need_stop_command) {
+        // To end multi block transfer, send stop command and wait for the
+        // card to process it
+        sdspi_hw_cmd_t stop_cmd;
+        make_hw_cmd(MMC_STOP_TRANSMISSION, 0, &stop_cmd);
+        ret = start_command_default(SDSPI_CMD_FLAG_RSP_R1, &stop_cmd);
+
+        if (ret != ESP_OK) {
+            ESP_AT_LOGE(TAG, "%s: start_command_default error", __func__);
+            return ret;
+        }
+
+        ret = poll_busy();
+
+        if (ret != ESP_OK) {
+            ESP_AT_LOGE(TAG, "%s: poll_busy error", __func__);
+            return ret;
+        }
+    }
+
+    return ESP_OK;
+}
+
+
+esp_err_t sdspi_host_start_command(sdspi_hw_cmd_t* cmd, void* data,
+                                   uint32_t data_size, int flags)
+{
+    esp_err_t ret = ESP_OK;
+    // char tx_byte = 0xff;
+    at_cs_low();
+
+    if (flags & SDSPI_CMD_FLAG_DATA) {
+        if (flags & SDSPI_CMD_FLAG_WRITE) {
+            ret = start_command_write_blocks(cmd, (uint8_t *) data, data_size, flags & SDSPI_CMD_FLAG_MULTI_BLK);
+        } else {
+            ret = start_command_read_blocks(cmd, (uint8_t *) data, data_size);
+
+            if (ret != ESP_OK) {
+                ESP_AT_LOGE(TAG, "read blocks error");
+            }
+        }
+    } else {
+        ret = start_command_default(flags, cmd);
+    }
+
+    at_cs_high();
+
+    return ret;
+}
+
+esp_err_t spi_send_cmd(spi_command_t* cmdinfo)
+{
+    if (spi_lock == NULL) {
+        spi_lock = at_mutex_init();
+    }
+
+    at_mutex_lock(spi_lock);
+    WORD_ALIGNED_ATTR sdspi_hw_cmd_t hw_cmd;
+    make_hw_cmd(cmdinfo->opcode, cmdinfo->arg, &hw_cmd);
+
+    if (cmdinfo->opcode == 0) {
+        ESP_AT_LOGV(TAG, "CMD0");
+        hw_cmd.crc7 = 0x4a;
+    }
+
+    // Flags indicate which of the transfer types should be used
+    int flags = 0;
+
+    if (SCF_CMD(cmdinfo->flags) == SCF_CMD_ADTC) {
+        flags = SDSPI_CMD_FLAG_DATA | SDSPI_CMD_FLAG_WRITE;
+    } else if (SCF_CMD(cmdinfo->flags) == (SCF_CMD_ADTC | SCF_CMD_READ)) {
+        flags = SDSPI_CMD_FLAG_DATA;
+    }
+
+    // The max block size is 512, when larger than 512, the data must send in multi blocks
+    if (cmdinfo->datalen > SDSPI_MAX_DATA_LEN) {
+        flags |= SDSPI_CMD_FLAG_MULTI_BLK;
+    }
+
+    // In fact, most of the commands
+    // use R1 response. Therefore, instead of adding another parallel set of
+    // response flags for the SPI mode, response format is determined here:
+    if (cmdinfo->opcode == MMC_GO_IDLE_STATE && !(cmdinfo->flags & SCF_RSP_R1)) {
+        /* used to send CMD0 without expecting a response */
+        flags |= SDSPI_CMD_FLAG_NORSP;
+    } else if (cmdinfo->opcode == SD_IO_SEND_OP_COND) {
+        flags |= SDSPI_CMD_FLAG_RSP_R4;
+    } else if (cmdinfo->opcode == SD_IO_RW_DIRECT) {
+        flags |= SDSPI_CMD_FLAG_RSP_R5;
+    } else if (cmdinfo->opcode == SD_IO_RW_EXTENDED) {
+        flags |= SDSPI_CMD_FLAG_RSP_R5 | SDSPI_CMD_FLAG_DATA;
+
+        if (cmdinfo->arg & SD_ARG_CMD53_WRITE) {
+            flags |= SDSPI_CMD_FLAG_WRITE;
+        }
+
+        // The CMD53 can assign block mode in the arg when the length is exactly 512 bytes
+        if (cmdinfo->arg & SD_ARG_CMD53_BLOCK_MODE) {
+            flags |= SDSPI_CMD_FLAG_MULTI_BLK;
+        }
+    } else {
+        flags |= SDSPI_CMD_FLAG_RSP_R1;
+    }
+
+    // Send the command and get the response.
+    esp_err_t ret = sdspi_host_start_command(&hw_cmd,
+                    cmdinfo->data, cmdinfo->datalen, flags);
+
+    // Extract response bytes and store them into cmdinfo structure
+    if (ret == ESP_OK) {
+        ESP_AT_LOGV(TAG, "r1 = 0x%02x hw_cmd.r[0]=0x%08x", hw_cmd.r1, hw_cmd.response[0]);
+
+        // Some errors should be reported using return code
+        if (flags & SDSPI_CMD_FLAG_RSP_R1) {
+            cmdinfo->response[0] = hw_cmd.r1;
+        } else if (flags & SDSPI_CMD_FLAG_RSP_R5) {
+            cmdinfo->response[0] = hw_cmd.response[0];
+        } else if (flags & SDSPI_CMD_FLAG_RSP_R4) {
+            cmdinfo->response[0] = 0xff;
+        }
+    }
+
+    at_mutex_unlock(spi_lock);
+    return ret;
+}
+
+esp_err_t at_spi_init_io()
+{
+    /* IO_SEND_OP_COND(CMD5), Determine if the card is an IO card.
+     * Non-IO cards will not respond to this command.
+     */
+    uint32_t ocr = MMC_OCR_3_3V_3_4V;
+    spi_command_t cmd = {};
+    cmd.flags = SCF_CMD_BCR | SCF_RSP_R4;
+    cmd.arg = ocr;
+    cmd.opcode = SD_IO_SEND_OP_COND;
+
+    esp_err_t err = spi_send_cmd(&cmd);
+
+    if (err != ESP_OK) {
+        ESP_AT_LOGE(TAG, "%s: spi_send_cmd error", __func__);
+        return err;
+    }
+
+    at_do_delay(20);
+
+    err = spi_send_cmd(&cmd);
+
+    if (err != ESP_OK) {
+        ESP_AT_LOGE(TAG, "%s: spi_send_cmd error", __func__);
+        return err;
+    }
+
+
+    return err;
+}
+
+esp_err_t at_spi_cmd_go_idle_state()
+{
+    go_idle_clockout();
+
+    spi_command_t cmd = {};
+    cmd.opcode =  0;  // MMC_GO_IDLE_STATE,
+    cmd.flags = SCF_CMD_BC | SCF_RSP_R0;
+
+    esp_err_t err = spi_send_cmd(&cmd);
+    at_do_delay(20);
+
+    cmd.flags |= SCF_RSP_R1;
+    err = spi_send_cmd(&cmd);
+    at_do_delay(20);
+    ESP_AT_LOGV(TAG, "CMD0 response 0x%x", cmd.response[0]);
+
+    // Response 0x1 means enter into SPI mode
+    if (cmd.response[0] != 0x1) {
+        ESP_AT_LOGE(TAG, "CMD0 response error, expect 0x1, response %x", cmd.response[0]);
+        return ESP_ERR_INVALID_RESPONSE;
+    }
+
+    return err;
+}
+
+esp_err_t at_spi_io_rw_direct(int func,
+                              uint32_t reg, uint32_t arg, uint8_t* byte)
+{
+    esp_err_t err;
+    spi_command_t cmd = {};
+    cmd.flags = SCF_CMD_AC | SCF_RSP_R5;
+    cmd.arg = 0;
+    cmd.opcode = SD_IO_RW_DIRECT;
+
+    arg |= (func & SD_ARG_CMD52_FUNC_MASK) << SD_ARG_CMD52_FUNC_SHIFT;
+    arg |= (reg & SD_ARG_CMD52_REG_MASK) << SD_ARG_CMD52_REG_SHIFT;
+    arg |= (*byte & SD_ARG_CMD52_DATA_MASK) << SD_ARG_CMD52_DATA_SHIFT;
+    cmd.arg = arg;
+
+    err = spi_send_cmd(&cmd);
+
+    if (err != ESP_OK) {
+        ESP_AT_LOGE(TAG, "%s: sdmmc_send_cmd returned 0x%x", __func__, err);
+        return err;
+    }
+
+    *byte = SD_R5_DATA(cmd.response);
+
+    return ESP_OK;
+}
+
+esp_err_t spi_io_rw_extended(int func,
+                             uint32_t reg, int arg, void* datap, size_t datalen)
+{
+    esp_err_t err;
+    const size_t max_byte_transfer_size = 512;
+    spi_command_t cmd = {};
+    cmd.flags = SCF_CMD_AC | SCF_RSP_R5;
+    cmd.arg = 0;
+    cmd.opcode = SD_IO_RW_EXTENDED;
+    cmd.data = datap;
+    cmd.datalen = datalen;
+    cmd.blklen = max_byte_transfer_size; /* TODO: read max block size from CIS */
+
+    uint32_t count; /* number of bytes or blocks, depending on transfer mode */
+
+    if (arg & SD_ARG_CMD53_BLOCK_MODE) {
+        if (cmd.datalen % cmd.blklen != 0) {
+            return ESP_ERR_INVALID_SIZE;
+        }
+
+        count = cmd.datalen / cmd.blklen;
+    } else {
+        if (datalen > max_byte_transfer_size) {
+            /* TODO: split into multiple operations? */
+            return ESP_ERR_INVALID_SIZE;
+        }
+
+        if (datalen == max_byte_transfer_size) {
+            count = 0;  // See 5.3.1 SDIO simplifed spec
+        } else {
+            count = datalen;
+        }
+
+        cmd.blklen = datalen;
+    }
+
+    arg |= (func & SD_ARG_CMD53_FUNC_MASK) << SD_ARG_CMD53_FUNC_SHIFT;
+    arg |= (reg & SD_ARG_CMD53_REG_MASK) << SD_ARG_CMD53_REG_SHIFT;
+    arg |= (count & SD_ARG_CMD53_LENGTH_MASK) << SD_ARG_CMD53_LENGTH_SHIFT;
+    cmd.arg = arg;
+
+    if ((arg & SD_ARG_CMD53_WRITE) == 0) {
+        cmd.flags |= SCF_CMD_READ;
+    }
+
+    err = spi_send_cmd(&cmd);
+
+    if (err != ESP_OK) {
+        ESP_AT_LOGE(TAG, "%s: sdmmc_send_cmd returned 0x%x", __func__, err);
+        return err;
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t spi_io_read_bytes(uint32_t function,
+                            uint32_t addr, void* dst, size_t size)
+{
+    /* host quirk: SDIO transfer with length not divisible by 4 bytes
+     * has to be split into two transfers: one with aligned length,
+     * the other one for the remaining 1-3 bytes.
+     */
+
+#ifdef FOUR_BYTE_ALIGNMENT
+    uint8_t* pc_dst = dst;
+
+    while (size > 0) {
+        size_t size_aligned = size & (~3);
+        size_t will_transfer = size_aligned > 0 ? size_aligned : size;
+        ESP_AT_LOGD(TAG, "%s, size: %d, will_transfer:%d\n", __func__, size, will_transfer);
+        esp_err_t err = spi_io_rw_extended(function, addr,
+                                           SD_ARG_CMD53_READ | SD_ARG_CMD53_INCREMENT,
+                                           pc_dst, will_transfer);
+
+        if (err != ESP_OK) {
+            return err;
+        }
+
+        pc_dst += will_transfer;
+        size -= will_transfer;
+        addr += will_transfer;
+    }
+
+#else
+    ESP_AT_LOGD(TAG, "%s, will transfer size: %d\n", __func__, size);
+    esp_err_t err = spi_io_rw_extended(function, addr,
+                                       SD_ARG_CMD53_READ | SD_ARG_CMD53_INCREMENT,
+                                       dst, size);
+
+    if (err != ESP_OK) {
+        ESP_AT_LOGE(TAG, "Read bytes spi_io_rw_extended return %d", err);
+        return err;
+    }
+
+#endif
+    return ESP_OK;
+}
+
+esp_err_t spi_io_write_bytes(uint32_t function,
+                             uint32_t addr, void* src, size_t size)
+{
+    /* same host quirk as in sdmmc_io_read_bytes */
+#ifdef FOUR_BYTE_ALIGNMENT
+    const uint8_t* pc_src = (const uint8_t*) src;
+
+    while (size > 0) {
+        size_t size_aligned = size & (~3);
+        size_t will_transfer = size_aligned > 0 ? size_aligned : size;
+
+        esp_err_t err = spi_io_rw_extended(function, addr,
+                                           SD_ARG_CMD53_WRITE | SD_ARG_CMD53_INCREMENT,
+                                           (void*) pc_src, will_transfer);
+
+        if (err != ESP_OK) {
+            return err;
+        }
+
+        pc_src += will_transfer;
+        size -= will_transfer;
+        addr += will_transfer;
+    }
+
+#else
+    ESP_AT_LOGD(TAG, "%s, will transfer size: %d\n", __func__, size);
+    esp_err_t err = spi_io_rw_extended(function, addr,
+                                       SD_ARG_CMD53_WRITE | SD_ARG_CMD53_INCREMENT,
+                                       src, size);
+
+    if (err != ESP_OK) {
+        ESP_AT_LOGE(TAG, "Write bytes spi_io_rw_extended return %d", err);
+        return err;
+    }
+
+#endif
+    return ESP_OK;
+}
+
+esp_err_t spi_io_write_byte(uint32_t function,
+                            uint32_t addr, uint8_t in_byte, uint8_t* out_byte)
+{
+    uint8_t tmp_byte = in_byte;
+    esp_err_t ret = at_spi_io_rw_direct(function, addr,
+                                        SD_ARG_CMD52_WRITE | SD_ARG_CMD52_EXCHANGE, &tmp_byte);
+
+    if (ret != ESP_OK) {
+        ESP_AT_LOGE(TAG, "%s: sdmmc_io_rw_direct (write 0x%x) returned 0x%x", __func__, addr, ret);
+        return ret;
+    }
+
+    if (out_byte != NULL) {
+        *out_byte = tmp_byte;
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t spi_io_read_byte(uint32_t function,
+                           uint32_t addr, uint8_t* out_byte)
+{
+    esp_err_t ret = at_spi_io_rw_direct(function, addr, SD_ARG_CMD52_READ, out_byte);
+
+    if (ret != ESP_OK) {
+        ESP_AT_LOGE(TAG, "%s: sdmmc_io_rw_direct (read 0x%x) returned 0x%x", __func__, addr, ret);
+    }
+
+    return ret;
+}
+
+static inline esp_err_t esp_slave_write_bytes(uint32_t addr, uint8_t* val, int len)
+{
+    return spi_io_write_bytes(1, addr & 0x3FF, val, len);
+}
+
+static inline esp_err_t esp_slave_read_bytes(uint32_t addr, uint8_t* val_o, int len)
+{
+    return spi_io_read_bytes(1, addr & 0x3FF, val_o, len);
+}
+
+esp_err_t at_sdspi_clear_intr(uint32_t intr_mask)
+{
+    ESP_AT_LOGV(TAG, "clear_intr: %08X", intr_mask);
+    return esp_slave_write_bytes(HOST_SLC0HOST_INT_CLR_REG, (uint8_t*)&intr_mask, 4);
+}
+
+//esp_err_t at_sdspi_get_intr(uint32_t* intr_raw, uint32_t* intr_st)
+esp_err_t at_sdspi_get_intr(uint32_t* intr_raw)
+{
+    esp_err_t r;
+    ESP_AT_LOGV(TAG, "get_intr");
+
+    if (intr_raw == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (intr_raw != NULL) {
+        r = esp_slave_read_bytes(HOST_SLC0HOST_INT_RAW_REG, (uint8_t*)intr_raw, 4);
+
+        if (r != ESP_OK) {
+            return r;
+        }
+    }
+
+    return ESP_OK;
+}
+
+static esp_err_t esp_slave_get_rx_data_size(spi_context_t* context, uint32_t* rx_size)
+{
+    uint32_t len;
+    esp_err_t err;
+
+    ESP_AT_LOGD(TAG, "get_rx_data_size: got_bytes: %d", context->rx_got_bytes);
+    err = esp_slave_read_bytes(HOST_SLCHOST_PKT_LEN_REG, (uint8_t*)&len, 4);
+
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    len &= RX_BYTE_MASK;
+    len = (len + RX_BYTE_MAX - context->rx_got_bytes) % RX_BYTE_MAX;
+    *rx_size = len;
+    return ESP_OK;
+}
+
+static esp_err_t sdmmc_io_read_blocks(uint32_t function,
+                                      uint32_t addr, void* dst, size_t size)
+{
+    if (size % 4 != 0) {
+        return ESP_ERR_INVALID_SIZE;
+    }
+
+    return spi_io_rw_extended(function, addr,
+                              SD_ARG_CMD53_READ | SD_ARG_CMD53_INCREMENT | SD_ARG_CMD53_BLOCK_MODE,
+                              dst, size);
+}
+
+static esp_err_t sdmmc_io_write_blocks(uint32_t function,
+                                       uint32_t addr, const void* src, size_t size)
+{
+    if (size % 4 != 0) {
+        return ESP_ERR_INVALID_SIZE;
+    }
+
+    ESP_AT_LOGV(TAG, "Write blocks len: %d", size);
+
+    return spi_io_rw_extended(function, addr,
+                              SD_ARG_CMD53_WRITE | SD_ARG_CMD53_INCREMENT | SD_ARG_CMD53_BLOCK_MODE,
+                              (void*) src, size);
+}
+
+esp_err_t at_sdspi_get_packet(spi_context_t* context, void* out_data, size_t size, size_t* out_length)
+{
+    esp_err_t err = ESP_OK;
+    uint32_t len = 0;
+    uint32_t try_time = 0;
+
+    assert(size > 0);
+
+    do {
+        err = esp_slave_get_rx_data_size(context, &len);
+
+        if (err == ESP_OK && len > 0) {
+            break;
+        }
+
+        if (err != ESP_OK && err != ESP_ERR_TIMEOUT) {
+            return err;
+        }
+
+        //not error and no data, retry ``timeout_cnt`` times.
+        at_do_delay(1);
+    } while (++try_time < 1000);
+
+    if (try_time == 100) {
+        ESP_AT_LOGE(TAG, "esp_slave_get_rx_data_size timeout.");
+        return ESP_ERR_TIMEOUT;
+    }
+
+    ESP_AT_LOGD(TAG, "get_packet: slave len=%d, max read size=%d", len, size);
+
+    if (len > size) {
+        len = size;
+        err = ESP_ERR_NOT_FINISHED;
+    }
+
+    uint8_t* start = (uint8_t*) out_data;
+    uint32_t len_remain = len;
+
+    do {
+        const int block_size = 512; //currently our driver don't support block size other than 512
+        int len_to_send;
+
+        int block_n = len_remain / block_size;
+
+        if (block_n != 0) {
+            len_to_send = block_n * block_size;
+            err = sdmmc_io_read_blocks(1, ESP_SLAVE_CMD53_END_ADDR - len_remain, start, len_to_send);
+        } else {
+            len_to_send = len_remain;
+            /* though the driver supports to split packet of unaligned size into length
+             * of 4x and 1~3, we still get aligned size of data to get higher
+             * effeciency. The length is determined by the SDIO address, and the
+             * remainning will be ignored by the slave hardware.
+             */
+            err = spi_io_read_bytes(1, ESP_SLAVE_CMD53_END_ADDR - len_remain, start, (len_to_send + 3) & (~3));
+        }
+
+        if (err != ESP_OK) {
+            return err;
+        }
+
+        start += len_to_send;
+        len_remain -= len_to_send;
+    } while (len_remain != 0);
+
+    context->rx_got_bytes += len;
+    *out_length = len;
+    return err;
+}
+
+static esp_err_t esp_slave_get_tx_buffer_num(spi_context_t* context, uint32_t* tx_num)
+{
+    uint32_t len;
+    esp_err_t err;
+
+    ESP_AT_LOGV(TAG, "get_tx_buffer_num");
+    err = esp_slave_read_bytes(HOST_SLC0HOST_TOKEN_RDATA_REG, (uint8_t*)&len, 4);
+
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    len = (len >> 16)&TX_BUFFER_MASK;
+    len = (len + TX_BUFFER_MAX - context->tx_sent_buffers) % TX_BUFFER_MAX;
+    *tx_num = len;
+    return ESP_OK;
+}
+
+esp_err_t at_sdspi_send_packet(spi_context_t* context, const void* start, size_t length, uint32_t wait_ms)
+{
+    uint16_t buffer_size = 512;
+    int buffer_used = (length + buffer_size - 1) / buffer_size;
+    esp_err_t err;
+    uint32_t try_time = 0;
+    assert(length > 0);
+
+    do {
+        uint32_t num = 0;
+        err = esp_slave_get_tx_buffer_num(context, &num);
+
+        if (err == ESP_OK && num * buffer_size >= length) {
+            break;
+        }
+
+        if (err != ESP_OK && err != ESP_ERR_TIMEOUT) {
+            return err;
+        }
+
+        at_do_delay(1);
+    } while (++try_time < wait_ms);
+
+    if (try_time == wait_ms) {
+        ESP_AT_LOGE(TAG, "buffer is not enough.");
+        return ESP_ERR_TIMEOUT;
+    }
+
+    ESP_AT_LOGV(TAG, "send_packet: len: %d", length);
+    uint8_t* start_ptr = (uint8_t*)start;
+    uint32_t len_remain = length;
+
+    do {
+        const int block_size = 512;
+        /* Though the driver supports to split packet of unaligned size into
+         * length of 4x and 1~3, we still send aligned size of data to get
+         * higher effeciency. The length is determined by the SDIO address, and
+         * the remainning will be discard by the slave hardware.
+         */
+        int len_to_send;
+
+        if (len_remain > block_size) {
+            int block_n = len_remain / block_size;
+            len_to_send = block_n * block_size;
+            err = sdmmc_io_write_blocks(1, ESP_SLAVE_CMD53_END_ADDR - len_remain, start_ptr, len_to_send);
+        } else {
+            len_to_send = len_remain;
+            err = spi_io_write_bytes(1, ESP_SLAVE_CMD53_END_ADDR - len_remain, start_ptr, (len_to_send + 3) & (~3));
+        }
+
+        if (err != ESP_OK) {
+            ESP_AT_LOGE(TAG, "Write data error %d\n", err);
+            return err;
+        }
+
+        start_ptr += len_to_send;
+        len_remain -= len_to_send;
+    } while (len_remain);
+
+    context->tx_sent_buffers += buffer_used;
+    return ESP_OK;
+}
+
+static esp_err_t sdspi_cmd_init()
+{
+    esp_err_t err;
+    /*For ESP32 & ESP8266, the init value is 0 */
+    uint8_t ioe = 0, ie = 0;
+
+    /* GO_IDLE_STATE (CMD0) command resets the card */
+    err = at_spi_cmd_go_idle_state();
+
+    while (err == ESP_ERR_INVALID_RESPONSE) {
+        ESP_AT_LOGE(TAG, "Please restart slave and test again,error code:%d", err);
+        at_do_delay(1000);
+        err = at_spi_cmd_go_idle_state();
+    }
+
+    if (err != ESP_OK) {
+        ESP_AT_LOGE(TAG, "Send CMD0 error, error code:%d", err);
+        return err;
+    }
+
+    /* IO_SEND_OP_COND(CMD5), Determine if the card is an IO card. */
+    err = at_spi_init_io();
+
+    if (err != ESP_OK) {
+        ESP_AT_LOGE(TAG, "Send CMD5 error, error code:%d", err);
+        return err;
+    }
+
+    /* Enable CRC16 checks for data transfers in SPI mode */
+    //at_spi_cmd_init_spi_crc(false);
+
+    // enable function 1
+    ioe |= BIT(1);
+    err = spi_io_write_byte(0, SD_IO_CCCR_FN_ENABLE, ioe, &ioe);
+
+    if (err != ESP_OK) {
+        ESP_AT_LOGE(TAG, "spi_io_write_byte(0, SD_IO_CCCR_FN_ENABLE...");
+        return err;
+    }
+
+    ESP_AT_LOGI(TAG, "IOE: 0x%02x", ioe);
+
+    // enable interrupts for function 1&2 and master enable
+    ie |= BIT(0) | BIT(1);
+    err = spi_io_write_byte(0, SD_IO_CCCR_INT_ENABLE, ie, &ie); // ESP32 slave 此时拉低WIFI_INT
+
+    if (err != ESP_OK) {
+        ESP_AT_LOGE(TAG, "spi_io_write_byte(0, SD_IO_CCCR_INT_ENABLE...", err);
+        return err;
+    }
+
+    ESP_AT_LOGI(TAG, "IE: 0x%02x", ie);
+
+
+    // get bus width register
+    uint8_t bus_width;
+    err = spi_io_read_byte(0, SD_IO_CCCR_BUS_WIDTH, &bus_width);
+
+    if (err != ESP_OK) {
+        ESP_AT_LOGE(TAG, "spi_io_read_byte(0, SD_IO_CCCR_BUS_WIDTH...", err);
+        return err;
+    }
+
+    ESP_AT_LOGI(TAG, "BUS_WIDTH: 0x%02x", bus_width);
+
+    // enable continuous SPI interrupts
+    bus_width |= CCCR_BUS_WIDTH_ECSI;
+    err = spi_io_write_byte(0, SD_IO_CCCR_BUS_WIDTH, bus_width, &bus_width);
+
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    ESP_AT_LOGI(TAG, "BUS_WIDTH: 0x%02x", bus_width);
+
+    uint16_t bs = 512;
+    const uint8_t* bs_u8 = (const uint8_t*) &bs;
+    uint16_t bs_read = 0;
+    uint8_t* bs_read_u8 = (uint8_t*) &bs_read;
+
+    // Set block sizes for functions 1 to given value (default value = 512).
+    size_t offset = 0x100;
+    spi_io_read_byte(0, 0x100 + SD_IO_CCCR_BLKSIZEL, &bs_read_u8[0]);
+    spi_io_read_byte(0, offset + SD_IO_CCCR_BLKSIZEH, &bs_read_u8[1]);
+    ESP_AT_LOGI(TAG, "Function 1 BS: %04x", (int) bs_read);
+
+    spi_io_write_byte(0, offset + SD_IO_CCCR_BLKSIZEL, bs_u8[0], NULL);
+    spi_io_write_byte(0, offset + SD_IO_CCCR_BLKSIZEH, bs_u8[1], NULL);
+    spi_io_read_byte(0, offset + SD_IO_CCCR_BLKSIZEL, &bs_read_u8[0]);
+    spi_io_read_byte(0, offset + SD_IO_CCCR_BLKSIZEH, &bs_read_u8[1]);
+    ESP_AT_LOGI(TAG, "Function 1 BS: %04x", (int) bs_read);
+
+    return ESP_OK;
+}
+
+//host use this to initialize the slave card as well as SPI mode
+esp_err_t at_sdspi_init()
+{
+    esp_err_t err = at_spi_slot_init();
+    SPARK_ASSERT(err == ESP_OK);
+
+    err = sdspi_cmd_init();
+    SPARK_ASSERT(err == ESP_OK);
+
+    err = at_spi_int_init();
+    SPARK_ASSERT(err == ESP_OK);
+
+    return err;
+}
+
+#endif // PLATFORM_ID == PLATFORM_TRACKER
+

--- a/user/tests/app/tracker_wakeup/sdspi_host.h
+++ b/user/tests/app/tracker_wakeup/sdspi_host.h
@@ -1,0 +1,257 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2019 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+ 
+ #ifndef SDSPI_HOST_H
+ #define SDSPI_HOST_H
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+#include "Particle.h"
+
+#if PLATFORM_ID == PLATFORM_TRACKER
+
+typedef int32_t esp_err_t;
+
+// #define MIN(x, y)  ((x) < (y) ? (x) : (y))
+
+/// Transfer format in SPI mode. See section 7.3.1.1 of SD simplified spec.
+typedef struct {
+    // These fields form the command sent from host to the card (6 bytes)
+    uint8_t cmd_index : 6;
+    uint8_t transmission_bit : 1;
+    uint8_t start_bit : 1;
+    uint8_t arguments[4];
+    uint8_t stop_bit : 1;
+    uint8_t crc7 : 7;
+    /// Ncr is the dead time between command and response; should be 0xff
+    uint8_t ncr;
+    /// Response data, should be set by host to 0xff for read operations
+    uint8_t r1;
+    /// Up to 16 bytes of response. Luckily, this is aligned on 4 byte boundary.
+    uint32_t response[4];
+    /// response timeout, in milliseconds
+    //int timeout_ms;
+} sdspi_hw_cmd_t;
+
+#define MMC_GO_IDLE_STATE               0       /* R0 */
+/* SD IO commands */
+#define SD_IO_SEND_OP_COND              5       /* R4 */
+#define SD_IO_RW_DIRECT                 52      /* R5 */
+#define SD_IO_RW_EXTENDED               53      /* R5 */
+#define SD_CRC_ON_OFF                   59      /* R1 */
+
+/* CMD53 arguments */
+#define SD_ARG_CMD53_READ           ((uint32_t)0<<31)
+#define SD_ARG_CMD53_WRITE          ((uint32_t)1<<31)
+#define SD_ARG_CMD53_BLOCK_MODE     ((uint32_t)1<<27)
+
+#define SDSPI_CMD_SIZE      6
+#define SDSPI_NCR_MIN_SIZE  1
+#define SDSPI_NCR_MAX_SIZE  8
+
+#define MMC_OCR_3_3V_3_4V               ((uint32_t)1<<21)
+//#define MMC_OCR_3_2V_3_3V               ((uint32_t)1<<20)
+
+//the size here contains 6 bytes of CMD, 1 bytes of dummy and the actual response
+#define SDSPI_CMD_NORESP_SIZE   (SDSPI_CMD_SIZE+0)   //!< Size of the command without any response
+#define SDSPI_CMD_R1_SIZE       (SDSPI_CMD_SIZE+SDSPI_NCR_MIN_SIZE+1)   //!< Size of the command with R1 response
+#define SDSPI_CMD_R4_SIZE       (SDSPI_CMD_SIZE+SDSPI_NCR_MIN_SIZE+5)  //!< Size of the command with R4 response
+#define SDSPI_CMD_R5_SIZE       (SDSPI_CMD_SIZE+SDSPI_NCR_MIN_SIZE+2)   //!< Size of the command with R5 response
+
+#define SDSPI_CMD_FLAG_DATA     BIT(0)  //!< Command has data transfer
+#define SDSPI_CMD_FLAG_WRITE    BIT(1)  //!< Data is written to the card
+#define SDSPI_CMD_FLAG_RSP_R1   BIT(2)  //!< Response format R1 (1 byte)
+#define SDSPI_CMD_FLAG_RSP_R4   BIT(5)  //!< Response format R4 (5 bytes)
+#define SDSPI_CMD_FLAG_RSP_R5   BIT(6)  //!< Response format R5 (2 bytes)
+#define SDSPI_CMD_FLAG_NORSP    BIT(8)  //!< Don't expect response (used when sending CMD0 first time).
+#define SDSPI_CMD_FLAG_MULTI_BLK BIT(9)  //!< This indicates the start token should be a multiblock one
+
+/* SPI mode R1 response type bits */
+#define SD_SPI_R1_IDLE_STATE            (1<<0)
+#define SD_SPI_R1_ERASE_RST             (1<<1)
+#define SD_SPI_R1_ILLEGAL_CMD           (1<<2)
+#define SD_SPI_R1_CMD_CRC_ERR           (1<<3)
+#define SD_SPI_R1_ERASE_SEQ_ERR         (1<<4)
+#define SD_SPI_R1_ADDR_ERR              (1<<5)
+#define SD_SPI_R1_PARAM_ERR             (1<<6)
+#define SD_SPI_R1_NO_RESPONSE           (1<<7)
+
+#define SDSPI_MAX_DATA_LEN      512     //!< Max size of single block transfer
+
+#define SCF_CMD(flags)   ((flags) & 0x00f0)
+
+/* CMD52 arguments */
+#define SD_ARG_CMD52_READ           ((uint32_t)0<<31)
+#define SD_ARG_CMD52_WRITE          ((uint32_t)1<<31)
+#define SD_ARG_CMD52_FUNC_SHIFT     28
+#define SD_ARG_CMD52_FUNC_MASK      0x7
+#define SD_ARG_CMD52_EXCHANGE       ((uint32_t)1<<27)
+#define SD_ARG_CMD52_REG_SHIFT      9
+#define SD_ARG_CMD52_REG_MASK       0x1ffff
+#define SD_ARG_CMD52_DATA_SHIFT     0
+#define SD_ARG_CMD52_DATA_MASK      0xff
+#define SD_R5_DATA(resp)            ((resp)[0] & 0xff)
+
+/// Maximum number of dummy bytes between the request and response (minimum is 1)
+#define SDSPI_RESPONSE_MAX_DELAY  8
+
+#define SDSPI_MOSI_IDLE_VAL     0xff    //!< Data value which causes MOSI to stay high
+
+/// Token sent before single/multi block reads and single block writes
+#define TOKEN_BLOCK_START                   0xFE
+/// Token sent before multi block writes
+#define TOKEN_BLOCK_START_WRITE_MULTI       0xFC
+/// Token used to stop multi block write (for reads, CMD12 is used instead)
+#define TOKEN_BLOCK_STOP_WRITE_MULTI        0
+
+#define ESP_SLAVE_CMD53_END_ADDR    0x1f800
+
+#define TX_BUFFER_MAX   0x1000
+#define TX_BUFFER_MASK  0xFFF
+#define RX_BYTE_MAX     0x100000
+#define RX_BYTE_MASK    0xFFFFF
+
+#define SD_ARG_CMD53_FUNC_SHIFT     28
+
+#define SD_ARG_CMD53_REG_SHIFT      9
+
+#define SD_ARG_CMD53_LENGTH_SHIFT   0
+
+#define SD_ARG_CMD53_INCREMENT      ((uint32_t)1<<26)
+
+#define SD_ARG_CMD53_REG_MASK       0x1ffff
+#define SD_ARG_CMD53_LENGTH_MASK    0x1ff
+
+#define MMC_STOP_TRANSMISSION           12      /* R1B */
+#define SD_ARG_CMD53_FUNC_MASK      0x7
+
+#define SDSPI_BLOCK_BUF_SIZE    (512 + 4)
+
+#define ESP_ERR_NOT_FINISHED    0x201
+
+#define BIT(x)  (uint32_t)1<<(x)
+
+// #define assert(x)   do { if (!(x)) { printf("SDIO SPI error %s %u\r\n", __FILE__, __LINE__); while(1);}} while (0)
+
+/**
+ * SD/MMC command response buffer
+ */
+typedef uint32_t spi_cmd_response_t[4];
+
+/**
+ * SD/MMC command information
+ */
+typedef struct {
+        uint32_t opcode;            /*!< SD or MMC command index */
+        uint32_t arg;               /*!< SD/MMC command argument */
+        spi_cmd_response_t response;  /*!< response buffer */
+        void* data;                 /*!< buffer to send or read into */
+        size_t datalen;             /*!< length of data buffer */
+        size_t blklen;              /*!< block length */
+        uint32_t flags;                  /*!< see below */
+/** @cond */
+
+#define SCF_CMD(flags)   ((flags) & 0x00f0)
+#define SCF_CMD_AC       0x0000
+#define SCF_CMD_ADTC     0x0010
+#define SCF_CMD_BC       0x0020
+#define SCF_CMD_BCR      0x0030
+#define SCF_CMD_READ     0x0040     /*!< read command (data expected) */
+//#define SCF_RSP_BSY      0x0100
+//#define SCF_RSP_136      0x0200
+#define SCF_RSP_CRC      0x0400
+#define SCF_RSP_IDX      0x0800
+#define SCF_RSP_PRESENT  0x1000
+/* response types */
+#define SCF_RSP_R0       0 /*!< none */
+#define SCF_RSP_R1       (SCF_RSP_PRESENT|SCF_RSP_CRC|SCF_RSP_IDX)
+//#define SCF_RSP_R1B      (SCF_RSP_PRESENT|SCF_RSP_CRC|SCF_RSP_IDX|SCF_RSP_BSY)
+#define SCF_RSP_R4       (SCF_RSP_PRESENT)
+#define SCF_RSP_R5       (SCF_RSP_PRESENT|SCF_RSP_CRC|SCF_RSP_IDX)
+
+#define SD_IO_CCCR_FN_ENABLE        0x02
+#define SD_IO_CCCR_INT_ENABLE       0x04
+#define SD_IO_CCCR_BUS_WIDTH        0x07
+
+#define  CCCR_BUS_WIDTH_ECSI        (1<<5)
+
+#define SD_IO_CCCR_BLKSIZEL         0x10
+#define SD_IO_CCCR_BLKSIZEH         0x11
+
+#define SD_IO_CCCR_CTL              0x06
+#define  CCCR_CTL_RES               (1<<3)
+
+/** @endcond */
+        int8_t error;            /*!< error returned from transfer */
+        uint32_t timeout_ms;             /*!< response timeout, in milliseconds */
+} spi_command_t;
+
+typedef struct {
+    uint16_t        buffer_size;
+                        ///< All data that do not fully fill a buffer is still counted as one buffer. E.g. 10 bytes data costs 2 buffers if the size is 8 bytes per buffer.
+                        ///< Buffer size of the slave pre-defined between host and slave before communication.
+    uint16_t        block_size;
+                        ///< If this is too large, it takes time to send stuff bits; while if too small, intervals between blocks cost much.
+                        ///< Should be set according to length of data, and larger than ``TRANS_LEN_MAX/511``.
+                        ///< Block size of the SDIO function 1. After the initialization this will hold the value the slave really do. Valid value is 1-2048.
+    size_t          tx_sent_buffers;    ///< Counter hold the amount of buffers already sent to ESP32 slave. Should be set to 0 when initialization.
+    size_t          rx_got_bytes;       ///< Counter hold the amount of bytes already received from ESP32 slave. Should be set to 0 when initialization.
+} spi_context_t;
+
+#define DR_REG_SLCHOST_BASE                     0x3ff55000
+#define HOST_SLC0HOST_TOKEN_RDATA_REG          (DR_REG_SLCHOST_BASE + 0x44)
+#define HOST_SLC0HOST_INT_CLR_REG          (DR_REG_SLCHOST_BASE + 0xD4)
+#define HOST_SLC0HOST_INT_RAW_REG          (DR_REG_SLCHOST_BASE + 0x50)
+#define HOST_SLC0HOST_INT_ST_REG           (DR_REG_SLCHOST_BASE + 0x58)
+#define HOST_SLCHOST_PKT_LEN_REG          (DR_REG_SLCHOST_BASE + 0x60)
+
+#define HOST_SLC0_RX_NEW_PACKET_INT_ST  (BIT(23))
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+esp_err_t at_sdspi_get_packet(spi_context_t* context, void* out_data, size_t size, size_t *out_length);
+
+esp_err_t at_sdspi_send_packet(spi_context_t* context, const void* start, size_t length, uint32_t wait_ms);
+
+esp_err_t at_sdspi_clear_intr(uint32_t intr_mask);
+
+//esp_err_t at_sdspi_get_intr(uint32_t *intr_raw, uint32_t *intr_st);
+esp_err_t at_sdspi_get_intr(uint32_t *intr_raw);
+
+esp_err_t at_sdspi_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PLATFORM_ID == PLATFORM_TRACKER
+
+#endif // SDSPI_HOST_H
+
+

--- a/user/tests/app/tracker_wakeup/tracker_wakeup.cpp
+++ b/user/tests/app/tracker_wakeup/tracker_wakeup.cpp
@@ -1,0 +1,263 @@
+#include "Particle.h"
+#include "esp32_soch.h"
+#include "sdspi_host.h"
+#include "port.h"
+
+#define GPS_WAKEUP          1
+#define WIFI_WAKEUP         1
+/* To test against the fuel wakeup source using this application,
+ * we need to comment "attachInterrupt(LOW_BAT_UC, &PowerManager::isrHandler, FALLING);"
+ * and "gauge.sleep()" in system_power_manager.cpp, as we'll attach an interrupt for it herein. */
+#define FUEL_WAKEUP         1
+
+SYSTEM_MODE(MANUAL);
+SYSTEM_THREAD(ENABLED);
+
+STARTUP( []() {
+    System.setPowerConfiguration(SystemPowerConfiguration().feature(SystemPowerFeature::DISABLE));
+} );
+
+Serial1LogHandler log(115200, LOG_LEVEL_ALL);
+
+volatile bool idle = true;
+
+#if GPS_WAKEUP
+os_semaphore_t gpsReadySem = nullptr;
+// Dirty hack!
+uint8_t ubxCfgMsg[] = {
+    0xB5, 0x62, 0x06, 0x00, 0x14, 0x00, 0x04, 0x00, 0x3B, 0x01, 0x00, 0x32, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x96, 0x07,
+    0xB5, 0x62, 0x05, 0x01, 0x02, 0x00, 0x06, 0x00, 0x0E, 0x37,
+    0xb5, 0x62, 0x06, 0x00, 0x01, 0x00, 0x04, 0x0b, 0x25,
+    0xb5, 0x62, 0x06, 0x00, 0x14, 0x00, 0x04, 0x00, 0x3b, 0x01, 0x00, 0x32, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x96, 0x07,
+    0xB5, 0x62, 0x05, 0x01, 0x02, 0x00, 0x06, 0x00, 0x0E, 0x37
+};
+
+void gpsIntHandler(void) {
+    if (gpsReadySem) {
+        os_semaphore_give(gpsReadySem, false);
+    }
+}
+
+os_thread_return_t gpsThread(void *param) {
+    while (1) {
+        if (os_semaphore_take(gpsReadySem, 10000/*ms*/, false)) {
+            Log.error("Waiting GPS data timeout!");
+            continue;
+        }
+        idle = false;
+        Log.info("Reading GPS data...");
+        // Read data
+        SPI1.beginTransaction(SPISettings(5*MHZ, MSBFIRST, SPI_MODE0));
+        digitalWrite(GPS_CS, LOW);
+        // delayMicroseconds(50);
+        uint8_t temp;
+        uint16_t len = 0;
+        while(SPI1.transfer(0xFF) == 0xFF); // Just in case
+        do {
+            temp = SPI1.transfer(0xFF);
+            // Serial1.printf("%c", temp);
+            len++;
+        } while (temp != 0xFF);
+        digitalWrite(GPS_CS, HIGH);
+        SPI1.endTransaction();
+        Log.info("Reading GPS data DONE: %d bytes\r\n", len);
+        idle = true;
+    }
+}
+
+void initGps() {
+    pinMode(GPS_INT, INPUT_PULLUP);
+    pinMode(GPS_BOOT, OUTPUT);
+    digitalWrite(GPS_BOOT, HIGH);
+    pinMode(GPS_PWR, OUTPUT);
+    digitalWrite(GPS_PWR, HIGH);
+    pinMode(GPS_CS, OUTPUT);
+    digitalWrite(GPS_CS, HIGH);
+    pinMode(GPS_RST, OUTPUT);
+    digitalWrite(GPS_RST, HIGH);
+    digitalWrite(GPS_RST, LOW);
+    delay(50);
+    digitalWrite(GPS_RST, HIGH);
+
+    if (!os_semaphore_create(&gpsReadySem, 1, 0)) {
+        Thread* thread = new Thread("gpsThread", gpsThread);
+
+        attachInterrupt(GPS_INT, gpsIntHandler, FALLING);
+        // Enable TX-ready
+        SPI1.beginTransaction(SPISettings(5*MHZ, MSBFIRST, SPI_MODE0));
+        digitalWrite(GPS_CS, LOW);
+        delay(50);
+        uint8_t in_byte;
+        for (uint8_t i = 0; i < sizeof(ubxCfgMsg); i++) {
+            in_byte = SPI1.transfer(ubxCfgMsg[i]);
+            if (in_byte != 0xFF) {
+                Serial1.write(in_byte);
+            }
+            delay(10);
+        }
+        digitalWrite(GPS_CS, HIGH);
+        delay(5);
+        SPI1.endTransaction();
+        Log.info("Initialize GPS done.");
+    } else {
+        LOG(ERROR, "Creating GNSS ready semophore failed.");
+    }
+}
+#endif // WGPS_WAKEUP
+
+#if WIFI_WAKEUP
+#define READ_BUFFER_LEN 4096
+spi_context_t context;
+uint8_t espTxBuffer[READ_BUFFER_LEN] = "";
+uint8_t espRxBuffer[READ_BUFFER_LEN + 1] = "";
+os_semaphore_t wifiReadySem = nullptr;
+
+void wifiIntHandler(void) {
+    if (wifiReadySem) {
+        os_semaphore_give(wifiReadySem, false);
+    }
+}
+
+os_thread_return_t esp32Thread(void *param) {
+    while (1) {
+        if (os_semaphore_take(wifiReadySem, 20000/*ms*/, false)) {
+            Log.error("Waiting Wi-Fi data timeout!");
+            continue;
+        }
+        idle = false;
+        if (digitalRead(WIFI_INT) == LOW) {
+            Log.info("[WIFI] Reading WIFI data...");
+            while (digitalRead(WIFI_INT) == LOW) {
+                size_t size_read = READ_BUFFER_LEN;
+                esp_err_t err = at_sdspi_get_packet(&context, espRxBuffer, READ_BUFFER_LEN, &size_read);
+                if (err == ESP_ERR_NOT_FOUND) {
+                    Log.info("interrupt but no data can be read");
+                } else if (err != ESP_OK && err != ESP_ERR_NOT_FINISHED) {
+                    Log.info("rx packet error: %08X", err);
+                }
+                Log.info("RX: %s", espRxBuffer);
+                memset(espRxBuffer, '\0', sizeof(espRxBuffer));
+            }
+            Log.info("[WIFI] Reading WIFI data DONE!!!");
+        }
+        idle = true;
+    }
+}
+
+void initWifi() {
+    pinMode(WIFI_INT, INPUT_PULLUP);
+    pinMode(WIFI_CS, OUTPUT);
+    digitalWrite(WIFI_CS, HIGH);
+    pinMode(WIFI_BOOT, OUTPUT);
+    digitalWrite(WIFI_BOOT, HIGH);
+    pinMode(WIFI_EN, OUTPUT);
+    digitalWrite(WIFI_EN, LOW);
+    delay(500);
+    digitalWrite(WIFI_EN, HIGH);
+    delay(100);
+    
+    esp_err_t err = at_sdspi_init();
+    assert(err == ESP_OK);
+    memset(&context, 0x0, sizeof(spi_context_t));
+
+    if (!os_semaphore_create(&wifiReadySem, 1, 0)) {
+        Log.info("Initialize Wi-Fi done.");
+    }
+    Thread* thread = new Thread("esp32Thread", esp32Thread);
+
+    attachInterrupt(WIFI_INT, wifiIntHandler, FALLING);
+}
+
+void wifiScan() {
+    Log.info("[WIFI] Send request to scan.");
+    char cmd[] = "AT+CWLAP\r\n";
+    int atDataLen = strlen(cmd);
+    memcpy(espTxBuffer, cmd, atDataLen);
+    Log.info("[WIFI] atDataLen: %d, data: %s", atDataLen, espTxBuffer);
+    esp_err_t err = at_sdspi_send_packet(&context, espTxBuffer, atDataLen, UINT32_MAX);
+    Log.info("[WIFI] end at_sdspi_send_packet");
+    if (err != ESP_OK) {
+        Log.info("[WIFI] Send error, %d\n", err);
+    }
+    memset(espTxBuffer, '\0', sizeof(espTxBuffer));
+}
+#endif // WIFI_WAKEUP
+
+#if FUEL_WAKEUP
+void lowBatHandler() {
+    FuelGauge fuelGauge(true);
+    fuelGauge.clearAlert();
+}
+
+void initFuelGauge() {
+    FuelGauge fuelGauge(true);
+    fuelGauge.begin(); 
+    fuelGauge.quickStart();
+    fuelGauge.wakeup();
+    fuelGauge.setAlertThreshold(30);
+    fuelGauge.clearAlert();
+    Log.info("Current percentage: %.2f%%", fuelGauge.getSoC());
+
+    pinMode(LOW_BAT_UC, INPUT_PULLUP);
+    attachInterrupt(LOW_BAT_UC, lowBatHandler, FALLING);
+}
+#endif
+
+void setup() {
+    Log.info("Application started.");
+
+    SPI1.begin();
+
+#if WIFI_WAKEUP
+    initWifi();
+#endif
+
+#if GPS_WAKEUP
+    initGps();
+#endif
+
+#if FUEL_WAKEUP
+    initFuelGauge();
+#endif
+}
+
+void loop() {
+    if (idle) {
+        Log.info("Enter sleep mode.");
+        SystemSleepConfiguration config;
+        config.mode(SystemSleepMode::STOP).duration(60s).network(Cellular, SystemSleepNetworkFlag::INACTIVE_STANDBY);
+#if GPS_WAKEUP
+        config.gpio(GPS_INT, FALLING);
+#endif
+#if WIFI_WAKEUP
+        config.gpio(WIFI_INT, FALLING);
+#endif
+#if FUEL_WAKEUP
+        config.gpio(LOW_BAT_UC, FALLING);
+#endif
+        SystemSleepResult result = System.sleep(config);
+        if (result.error() != SYSTEM_ERROR_NONE) {
+            Log.error("Failed to enter sleep mode");
+            delay(3s);
+        } else {
+            Log.info("Exit sleep mode.");
+            if (result.wakeupReason() == SystemSleepWakeupReason::BY_GPIO) {
+                Log.info("Device is woken up by pin: %d", result.wakeupPin());
+            } else if (result.wakeupReason() == SystemSleepWakeupReason::BY_RTC) {
+                Log.info("Device is woken up by RTC");
+#if WIFI_WAKEUP
+                wifiScan();
+#endif
+            } else {
+                Log.error("Device is woken up unexpectedly");
+            }
+        }
+    }
+#if WIFI_WAKEUP
+    static system_tick_t elapsed = millis();
+    if (millis() - elapsed > 10000) {
+        elapsed = millis();
+        wifiScan();
+    }
+#endif
+}

--- a/user/tests/wiring/sleep20/sleep20.cpp
+++ b/user/tests/wiring/sleep20/sleep20.cpp
@@ -20,6 +20,8 @@
 
 //Serial1LogHandler logHandler(115200, LOG_LEVEL_INFO);
 
+//TODO: Run user/tests/app/tracker_wakeup to verify the additional wakeup sources for platform tracker.
+
 STARTUP(System.enableFeature(FEATURE_RETAINED_MEMORY));
 static retained uint32_t magick = 0;
 static retained uint32_t phase = 0;


### PR DESCRIPTION
Currently if we want to utilize the Wi-Fi/GNSS/FuelGauge to wake up device from sleep mode, we need to attach an interrupt to the INT pin of these peripherals followed by specifying the `IOE_INT`, which is the INT pin of the IO expander, as the wakeup source. For instance:

```
void handler() {
    // Do nothing
}

void sleepNow() {
    System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::STOP).gpio(IOE_INT, FALLING));
}

void setup() {
    attachInterrupt(GPS_INT, handler, FALLING);
}
```

This PR will simplify the code to configure the INT pins of these peripherals as a wakeup source directly:

```
void sleepNow() {
    System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::STOP).gpio(GPS_INT, FALLING));
}
```

### Example App

Test application added within this PR.

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
