### PR TITLE
Add printf attributes to appropriate wiring functions, change Time::now() to use time32_t

### DIFF
--- a/wiring/inc/fast_pin.h
+++ b/wiring/inc/fast_pin.h
@@ -22,12 +22,11 @@
 #define	FAST_PIN_H
 
 #include "platforms.h"
+#include "pinmap_hal.h"
 
 #ifdef	__cplusplus
 extern "C" {
 #endif
-
-#include "pinmap_hal.h"
 
 /* Disabling USE_BIT_BAND since bitbanding is much slower! as per comment
  * by @pkourany on PR: https://github.com/spark/firmware/pull/556 */

--- a/wiring/inc/spark_wiring_logging.h
+++ b/wiring/inc/spark_wiring_logging.h
@@ -211,8 +211,7 @@ protected:
 
         This method is equivalent to `stream()->printf(fmt, ...)`.
     */
-    template<typename... ArgsT>
-    void printf(const char *fmt, ArgsT... args);
+    void printf(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
 
 private:
     Print *stream_;
@@ -715,9 +714,11 @@ inline void spark::StreamLogHandler::write(char c) {
     write(&c, 1);
 }
 
-template<typename... ArgsT>
-inline void spark::StreamLogHandler::printf(const char *fmt, ArgsT... args) {
-    stream_->printf(fmt, args...);
+inline void spark::StreamLogHandler::printf(const char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    stream_->vprintf(false, fmt, args);
+    va_end(args);
 }
 
 // spark::JSONStreamLogHandler

--- a/wiring/inc/spark_wiring_print.h
+++ b/wiring/inc/spark_wiring_print.h
@@ -62,7 +62,6 @@ class Print
     size_t printFloat(double, uint8_t);
   protected:
     void setWriteError(int err = 1) { write_error = err; }
-    size_t printf_impl(bool newline, const char* format, ...);
 
   public:
     Print() : write_error(0) {}
@@ -103,18 +102,25 @@ class Print
     size_t println(void);
     size_t println(const __FlashStringHelper*);
 
-    template <typename... Args>
-    inline size_t printf(const char* format, Args... args)
+    size_t printf(const char* format, ...) __attribute__ ((format(printf, 2, 3)))
     {
-        return this->printf_impl(false, format, args...);
+        va_list args;
+        va_start(args, format);
+        auto r = this->vprintf(false, format, args);
+        va_end(args);
+        return r;
     }
 
-    template <typename... Args>
-    inline size_t printlnf(const char* format, Args... args)
+    size_t printlnf(const char* format, ...) __attribute__ ((format(printf, 2, 3)))
     {
-        return this->printf_impl(true, format, args...);
+        va_list args;
+        va_start(args, format);
+        auto r = this->vprintf(true, format, args);
+        va_end(args);
+        return r;
     }
 
+    size_t vprintf(bool newline, const char* format, va_list args) __attribute__ ((format(printf, 3, 0)));
 };
 
 template <typename T, std::enable_if_t<!std::is_base_of<Printable, T>::value && (std::is_integral<T>::value || std::is_convertible<T, unsigned long long>::value ||

--- a/wiring/inc/spark_wiring_spi.h
+++ b/wiring/inc/spark_wiring_spi.h
@@ -122,7 +122,8 @@ public:
     if (default_ && clock_ == 0)
       return p.print("<SPISettings default>");
     else
-      return p.printf("<SPISettings %s%lu %s MODE%d>", default_ ? "default " : "", clock_, bitOrder_ == MSBFIRST ? "MSB" : "LSB", dataMode_);
+      return p.printf("<SPISettings %s%u %s MODE%u>", default_ ? "default " : "", (unsigned int)clock_,
+          bitOrder_ == MSBFIRST ? "MSB" : "LSB", (unsigned int)dataMode_);
   }
 
   uint32_t getClock() const {

--- a/wiring/inc/spark_wiring_time.h
+++ b/wiring/inc/spark_wiring_time.h
@@ -27,6 +27,7 @@
 #define __SPARK_WIRING_TIME_H
 
 #include "spark_wiring_string.h"
+#include "time_compat.h"
 #include <time.h>
 
 extern const char* TIME_FORMAT_DEFAULT;
@@ -56,8 +57,10 @@ public:
 	static int     month(time_t t);   			// the month for the given time
 	static int     year();            			// current four digit year
 	static int     year(time_t t);    			// the year for the given time
-	static time_t  now();              			// return the current time as seconds since Jan 1 1970
-	static time_t  local();						// return the time as seconds since Jan 1 1970 in the local timezone.
+	// FIXME: For now using time32_t, until newlib printf %lld/%llu absence is resolved
+	// or at least %d/%u crashes with 64-bit arguments
+	static time32_t  now();              			// return the current time as seconds since Jan 1 1970
+	static time32_t  local();						// return the time as seconds since Jan 1 1970 in the local timezone.
 	static void    zone(float GMT_Offset);		// set the time zone (+/-) offset from GMT
 	static float	   zone();						// retrieve the current timezone
 	static void    setTime(time_t t);			// set the given time as unix/rtc time

--- a/wiring/src/spark_wiring_print.cpp
+++ b/wiring/src/spark_wiring_print.cpp
@@ -211,14 +211,11 @@ size_t Print::printFloat(double number, uint8_t digits)
   return n;
 }
 
-size_t Print::printf_impl(bool newline, const char* format, ...)
+size_t Print::vprintf(bool newline, const char* format, va_list args)
 {
     const int bufsize = 20;
     char test[bufsize];
-    va_list marker;
-    va_start(marker, format);
-    size_t n = vsnprintf(test, bufsize, format, marker);
-    va_end(marker);
+    size_t n = vsnprintf(test, bufsize, format, args);
 
     if (n<bufsize)
     {
@@ -227,9 +224,7 @@ size_t Print::printf_impl(bool newline, const char* format, ...)
     else
     {
         char bigger[n+1];
-        va_start(marker, format);
-        n = vsnprintf(bigger, n+1, format, marker);
-        va_end(marker);
+        n = vsnprintf(bigger, n+1, format, args);
         n = print(bigger);
     }
     if (newline)

--- a/wiring/src/spark_wiring_print.cpp
+++ b/wiring/src/spark_wiring_print.cpp
@@ -215,6 +215,8 @@ size_t Print::vprintf(bool newline, const char* format, va_list args)
 {
     const int bufsize = 20;
     char test[bufsize];
+    va_list args2;
+    va_copy(args2, args);
     size_t n = vsnprintf(test, bufsize, format, args);
 
     if (n<bufsize)
@@ -224,11 +226,13 @@ size_t Print::vprintf(bool newline, const char* format, va_list args)
     else
     {
         char bigger[n+1];
-        n = vsnprintf(bigger, n+1, format, args);
+        n = vsnprintf(bigger, n+1, format, args2);
         n = print(bigger);
     }
     if (newline)
         n += println();
+
+    va_end(args2);
     return n;
 }
 

--- a/wiring/src/spark_wiring_time.cpp
+++ b/wiring/src/spark_wiring_time.cpp
@@ -217,7 +217,7 @@ int TimeClass::year(time_t t)
 }
 
 /* return the current time as seconds since Jan 1 1970 */
-time_t TimeClass::now()
+time32_t TimeClass::now()
 {
     (void)isValid();
     struct timeval tv = {};
@@ -225,7 +225,7 @@ time_t TimeClass::now()
     return tv.tv_sec;
 }
 
-time_t TimeClass::local()
+time32_t TimeClass::local()
 {
 	return now() + time_zone_cache + dst_current_cache;
 }


### PR DESCRIPTION
### Problem

1. Stream-based objects providing `printf()` and `printlnf()` are not generating `-Wformat`
2. `time_t` printing with `%d` causes crashes sometimes and `%lld` format specifier is not supported in newlib-nano

### Solution

1. Add printf attributes to appropriate functions
2. For now changing `Time::now()` and `Time::local()` to return `time32_t`, until we can introduce 64-bit printf/scanf support

### Steps to Test

See example app. It should generate warnings for all cases:
```
tests/app/blank/blank.cpp: In function 'void loop()':
tests/app/blank/blank.cpp:30:28: warning: format '%d' expects argument of type 'int', but argument 3 has type 'long unsigned int' [-Wformat=]
   30 |     Serial.printlnf("test %d", test);
      |                           ~^   ~~~~
      |                            |   |
      |                            int long unsigned int
      |                           %ld
tests/app/blank/blank.cpp:31:26: warning: format '%d' expects argument of type 'int', but argument 3 has type 'long unsigned int' [-Wformat=]
   31 |     Serial.printf("test %d\r\n", test);
      |                         ~^       ~~~~
      |                          |       |
      |                          int     long unsigned int
      |                         %ld
tests/app/blank/blank.cpp:32:23: warning: format '%d' expects argument of type 'int', but argument 3 has type 'long unsigned int' [-Wformat=]
   32 |     Log.printf("test %d\r\n", test);
      |                      ~^       ~~~~
      |                       |       |
      |                       int     long unsigned int
      |                      %ld
tests/app/blank/blank.cpp:33:31: warning: format '%d' expects argument of type 'int', but argument 3 has type 'time32_t' {aka 'long int'} [-Wformat=]
   33 |     Serial.printlnf("Time is %d %s", Time.now(), Time.timeStr().c_str());
      |                              ~^      ~~~~~~~~~~
      |                               |              |
      |                               int            time32_t {aka long int}
      |                              %ld

```

It also shouldn't crash when printing time.

### Example App

```cpp
void loop() {
    long unsigned int test = 123;
    Serial.printlnf("test %d", test);
    Serial.printf("test %d\r\n", test); 
    Log.printf("test %d\r\n", test);
    Serial.printlnf("Time is %d %s", Time.now(), Time.timeStr().c_str());
    delay(1000);
}
```

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
