### PR TITLE
Fix issue with serviceUUID not returning UUID when there is an array

### DIFF
--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -703,11 +703,11 @@ size_t BleAdvertisingData::serviceUUID(BleAdvertisingDataType type, BleUuid* uui
         adsLen = locate(&selfData_[i], selfLen_ - i, type, &offset);
         if (adsLen > 0 && found < count) {
             if (type == BleAdvertisingDataType::SERVICE_UUID_16BIT_MORE_AVAILABLE || type == BleAdvertisingDataType::SERVICE_UUID_16BIT_COMPLETE) {
-                for(size_t array = 0; array < (adsLen - 2) / BLE_SIG_UUID_16BIT_LEN; array++) {
+                for(size_t array = 0; (array < (adsLen - 2) / BLE_SIG_UUID_16BIT_LEN) && (found < count); array++) {
                     uuids[found++] = (uint16_t)selfData_[i + offset + array * BLE_SIG_UUID_16BIT_LEN + 2] | ((uint16_t)selfData_[i + offset + array * BLE_SIG_UUID_16BIT_LEN + 3] << 8);
                 }
             } else if (type == BleAdvertisingDataType::SERVICE_UUID_128BIT_MORE_AVAILABLE || type == BleAdvertisingDataType::SERVICE_UUID_128BIT_COMPLETE) {
-                for(size_t array = 0; array < (adsLen - 2) / BLE_SIG_UUID_128BIT_LEN; array++) {
+                for(size_t array = 0; (array < (adsLen - 2) / BLE_SIG_UUID_128BIT_LEN) && (found < count); array++) {
                     uuids[found++] = &selfData_[i + offset + array * BLE_SIG_UUID_128BIT_LEN + 2];
                 }
             }

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -703,12 +703,12 @@ size_t BleAdvertisingData::serviceUUID(BleAdvertisingDataType type, BleUuid* uui
         adsLen = locate(&selfData_[i], selfLen_ - i, type, &offset);
         if (adsLen > 0 && found < count) {
             if (type == BleAdvertisingDataType::SERVICE_UUID_16BIT_MORE_AVAILABLE || type == BleAdvertisingDataType::SERVICE_UUID_16BIT_COMPLETE) {
-                for(size_t array = 0; array < (adsLen-2)/2; array++) {
-                    uuids[found++] = (uint16_t)selfData_[i + offset + array*2 + 2] | ((uint16_t)selfData_[i + offset + array*2 + 3] << 8);
+                for(size_t array = 0; array < (adsLen - 2) / BLE_SIG_UUID_16BIT_LEN; array++) {
+                    uuids[found++] = (uint16_t)selfData_[i + offset + array * BLE_SIG_UUID_16BIT_LEN + 2] | ((uint16_t)selfData_[i + offset + array * BLE_SIG_UUID_16BIT_LEN + 3] << 8);
                 }
             } else if (type == BleAdvertisingDataType::SERVICE_UUID_128BIT_MORE_AVAILABLE || type == BleAdvertisingDataType::SERVICE_UUID_128BIT_COMPLETE) {
-                for(size_t array = 0; array < (adsLen-2)/16; array++) {
-                    uuids[found++] = &selfData_[i + offset + array*2 + 2];
+                for(size_t array = 0; array < (adsLen - 2) / BLE_SIG_UUID_128BIT_LEN; array++) {
+                    uuids[found++] = &selfData_[i + offset + array * BLE_SIG_UUID_128BIT_LEN + 2];
                 }
             }
             continue;

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -702,10 +702,14 @@ size_t BleAdvertisingData::serviceUUID(BleAdvertisingDataType type, BleUuid* uui
     for (size_t i = 0; i < selfLen_; i += (offset + adsLen)) {
         adsLen = locate(&selfData_[i], selfLen_ - i, type, &offset);
         if (adsLen > 0 && found < count) {
-            if (adsLen == 4) { // length field + type field + 16-bits UUID
-                uuids[found++] = (uint16_t)selfData_[i + offset + 2] | ((uint16_t)selfData_[i + offset + 3] << 8);
-            } else if (adsLen == 18) {
-                uuids[found++] = &selfData_[i + offset + 2];
+            if (type == BleAdvertisingDataType::SERVICE_UUID_16BIT_MORE_AVAILABLE || type == BleAdvertisingDataType::SERVICE_UUID_16BIT_COMPLETE) {
+                for(size_t array = 0; array < (adsLen-2)/2; array++) {
+                    uuids[found++] = (uint16_t)selfData_[i + offset + array*2 + 2] | ((uint16_t)selfData_[i + offset + array*2 + 3] << 8);
+                }
+            } else if (type == BleAdvertisingDataType::SERVICE_UUID_128BIT_MORE_AVAILABLE || type == BleAdvertisingDataType::SERVICE_UUID_128BIT_COMPLETE) {
+                for(size_t array = 0; array < (adsLen-2)/16; array++) {
+                    uuids[found++] = &selfData_[i + offset + array*2 + 2];
+                }
             }
             continue;
         }


### PR DESCRIPTION
### Problem

If the peripheral device has an array of service UUIDs on any of the individual types, then none are returned for that type.

### Solution

Fixed by checking if returned size from locate is larger than a single service UUID (and a multiple of the expected size of UUID). If that's the case, iterate over the data to return all the available UUIDs.

### Steps to Test

Connect to a standard Heart Rate Monitor which provides several 16-bit service UUIDs, such as Heart Rate Service, Battery Service, Device Information Service. Prior to this PR, serviceUUID() returns 0 services. After, it returns 3.

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
