### PR TITLE
HAL: add always_inline attribute for deprecated APIs

### DIFF
--- a/hal/inc/adc_hal_compat.h
+++ b/hal/inc/adc_hal_compat.h
@@ -19,11 +19,13 @@
 #define ADC_HAL_COMPAT_H
 
 // Deprecated *dynalib* APIs for backwards compatibility
-inline void __attribute__((deprecated("Use hal_adc_set_sample_time() instead"))) HAL_ADC_Set_Sample_Time(uint8_t sample_time) {
+inline void __attribute__((deprecated("Use hal_adc_set_sample_time() instead"), always_inline))
+HAL_ADC_Set_Sample_Time(uint8_t sample_time) {
     hal_adc_set_sample_time(sample_time);
 }
 
-inline int32_t __attribute__((deprecated("Use hal_adc_read() instead"))) HAL_ADC_Read(pin_t pin) {
+inline int32_t __attribute__((deprecated("Use hal_adc_read() instead"), always_inline))
+HAL_ADC_Read(pin_t pin) {
     return hal_adc_read(pin);
 }
 

--- a/hal/inc/i2c_hal_compat.h
+++ b/hal/inc/i2c_hal_compat.h
@@ -24,87 +24,108 @@ typedef hal_i2c_config_t HAL_I2C_Config __attribute__((deprecated("Use hal_i2c_c
 typedef hal_i2c_transmission_config_t HAL_I2C_Transmission_Config __attribute__((deprecated("Use hal_i2c_transmission_config_t instead")));
 
 // Deprecated *dynalib* APIs for backwards compatibility
-inline int __attribute__((deprecated("Use hal_i2c_init() instead"))) HAL_I2C_Init(hal_i2c_interface_t i2c, const hal_i2c_config_t* config) {
+inline int __attribute__((deprecated("Use hal_i2c_init() instead"), always_inline))
+HAL_I2C_Init(hal_i2c_interface_t i2c, const hal_i2c_config_t* config) {
     return hal_i2c_init(i2c, config);
 }
 
-inline void __attribute__((deprecated("Use hal_i2c_set_speed() instead"))) HAL_I2C_Set_Speed(hal_i2c_interface_t i2c, uint32_t speed, void* reserved) {
+inline void __attribute__((deprecated("Use hal_i2c_set_speed() instead"), always_inline))
+HAL_I2C_Set_Speed(hal_i2c_interface_t i2c, uint32_t speed, void* reserved) {
     hal_i2c_set_speed(i2c, speed, reserved);
 }
 
-inline void __attribute__((deprecated("Use hal_i2c_enable_dma_mode() instead"))) HAL_I2C_Enable_DMA_Mode(hal_i2c_interface_t i2c, bool enable, void* reserved) {
+inline void __attribute__((deprecated("Use hal_i2c_enable_dma_mode() instead"), always_inline))
+HAL_I2C_Enable_DMA_Mode(hal_i2c_interface_t i2c, bool enable, void* reserved) {
     hal_i2c_enable_dma_mode(i2c, enable, reserved);
 }
 
-inline void __attribute__((deprecated("Use hal_i2c_stretch_clock() instead"))) HAL_I2C_Stretch_Clock(hal_i2c_interface_t i2c, bool stretch, void* reserved) {
+inline void __attribute__((deprecated("Use hal_i2c_stretch_clock() instead"), always_inline))
+HAL_I2C_Stretch_Clock(hal_i2c_interface_t i2c, bool stretch, void* reserved) {
     hal_i2c_stretch_clock(i2c, stretch, reserved);
 }
 
-inline void __attribute__((deprecated("Use hal_i2c_begin() instead"))) HAL_I2C_Begin(hal_i2c_interface_t i2c, hal_i2c_mode_t mode, uint8_t address, void* reserved) {
+inline void __attribute__((deprecated("Use hal_i2c_begin() instead"), always_inline))
+HAL_I2C_Begin(hal_i2c_interface_t i2c, hal_i2c_mode_t mode, uint8_t address, void* reserved) {
     hal_i2c_begin(i2c, mode, address, reserved);
 }
 
-inline void __attribute__((deprecated("Use hal_i2c_end() instead"))) HAL_I2C_End(hal_i2c_interface_t i2c, void* reserved) {
+inline void __attribute__((deprecated("Use hal_i2c_end() instead"), always_inline))
+HAL_I2C_End(hal_i2c_interface_t i2c, void* reserved) {
     hal_i2c_end(i2c, reserved);
 }
 
-inline uint32_t __attribute__((deprecated("Use hal_i2c_request() instead"))) HAL_I2C_Request_Data(hal_i2c_interface_t i2c, uint8_t address, uint8_t quantity, uint8_t stop, void* reserved) {
+inline uint32_t __attribute__((deprecated("Use hal_i2c_request() instead"), always_inline))
+HAL_I2C_Request_Data(hal_i2c_interface_t i2c, uint8_t address, uint8_t quantity, uint8_t stop, void* reserved) {
     return hal_i2c_request(i2c, address, quantity, stop, reserved);
 }
 
-inline int32_t __attribute__((deprecated("Use hal_i2c_request_ex() instead"))) HAL_I2C_Request_Data_Ex(hal_i2c_interface_t i2c, const hal_i2c_transmission_config_t* config, void* reserved) {
+inline int32_t __attribute__((deprecated("Use hal_i2c_request_ex() instead"), always_inline))
+HAL_I2C_Request_Data_Ex(hal_i2c_interface_t i2c, const hal_i2c_transmission_config_t* config, void* reserved) {
     return hal_i2c_request_ex(i2c, config, reserved);
 }
 
-inline void __attribute__((deprecated("Use hal_i2c_begin_transmission() instead"))) HAL_I2C_Begin_Transmission(hal_i2c_interface_t i2c, uint8_t address, const hal_i2c_transmission_config_t* config) {
+inline void __attribute__((deprecated("Use hal_i2c_begin_transmission() instead"), always_inline))
+HAL_I2C_Begin_Transmission(hal_i2c_interface_t i2c, uint8_t address, const hal_i2c_transmission_config_t* config) {
     hal_i2c_begin_transmission(i2c, address, config);
 }
 
-inline uint8_t __attribute__((deprecated("Use hal_i2c_end_transmission() instead"))) HAL_I2C_End_Transmission(hal_i2c_interface_t i2c, uint8_t stop, void* reserved) {
+inline uint8_t __attribute__((deprecated("Use hal_i2c_end_transmission() instead"), always_inline))
+HAL_I2C_End_Transmission(hal_i2c_interface_t i2c, uint8_t stop, void* reserved) {
     return hal_i2c_end_transmission(i2c, stop, reserved);
 }
 
-inline uint32_t __attribute__((deprecated("Use hal_i2c_write() instead"))) HAL_I2C_Write_Data(hal_i2c_interface_t i2c, uint8_t data, void* reserved) {
+inline uint32_t __attribute__((deprecated("Use hal_i2c_write() instead"), always_inline))
+HAL_I2C_Write_Data(hal_i2c_interface_t i2c, uint8_t data, void* reserved) {
     return hal_i2c_write(i2c, data, reserved);
 }
 
-inline int32_t __attribute__((deprecated("Use hal_i2c_available() instead"))) HAL_I2C_Available_Data(hal_i2c_interface_t i2c, void* reserved) {
+inline int32_t __attribute__((deprecated("Use hal_i2c_available() instead"), always_inline))
+HAL_I2C_Available_Data(hal_i2c_interface_t i2c, void* reserved) {
     return hal_i2c_available(i2c, reserved);
 }
 
-inline int32_t __attribute__((deprecated("Use hal_i2c_read() instead"))) HAL_I2C_Read_Data(hal_i2c_interface_t i2c, void* reserved) {
+inline int32_t __attribute__((deprecated("Use hal_i2c_read() instead"), always_inline))
+HAL_I2C_Read_Data(hal_i2c_interface_t i2c, void* reserved) {
     return hal_i2c_read(i2c, reserved);
 }
 
-inline int32_t __attribute__((deprecated("Use hal_i2c_peek() instead"))) HAL_I2C_Peek_Data(hal_i2c_interface_t i2c, void* reserved) {
+inline int32_t __attribute__((deprecated("Use hal_i2c_peek() instead"), always_inline))
+HAL_I2C_Peek_Data(hal_i2c_interface_t i2c, void* reserved) {
     return hal_i2c_peek(i2c, reserved);
 }
 
-inline void __attribute__((deprecated("Use hal_i2c_flush() instead"))) HAL_I2C_Flush_Data(hal_i2c_interface_t i2c, void* reserved) {
+inline void __attribute__((deprecated("Use hal_i2c_flush() instead"), always_inline))
+HAL_I2C_Flush_Data(hal_i2c_interface_t i2c, void* reserved) {
     hal_i2c_flush(i2c, reserved);
 }
 
-inline bool __attribute__((deprecated("Use hal_i2c_is_enabled() instead"))) HAL_I2C_Is_Enabled(hal_i2c_interface_t i2c, void* reserved) {
+inline bool __attribute__((deprecated("Use hal_i2c_is_enabled() instead"), always_inline))
+HAL_I2C_Is_Enabled(hal_i2c_interface_t i2c, void* reserved) {
     return hal_i2c_is_enabled(i2c, reserved);
 }
 
-inline void __attribute__((deprecated("Use hal_i2c_set_callback_on_received() instead"))) HAL_I2C_Set_Callback_On_Receive(hal_i2c_interface_t i2c, void (*function)(int), void* reserved) {
+inline void __attribute__((deprecated("Use hal_i2c_set_callback_on_received() instead"), always_inline))
+HAL_I2C_Set_Callback_On_Receive(hal_i2c_interface_t i2c, void (*function)(int), void* reserved) {
     hal_i2c_set_callback_on_received(i2c, function, reserved);
 }
 
-inline void __attribute__((deprecated("Use hal_i2c_set_callback_on_requested() instead"))) HAL_I2C_Set_Callback_On_Request(hal_i2c_interface_t i2c, void (*function)(void), void* reserved) {
+inline void __attribute__((deprecated("Use hal_i2c_set_callback_on_requested() instead"), always_inline))
+HAL_I2C_Set_Callback_On_Request(hal_i2c_interface_t i2c, void (*function)(void), void* reserved) {
     hal_i2c_set_callback_on_requested(i2c, function, reserved);
 }
 
-inline uint8_t __attribute__((deprecated("Use hal_i2c_reset() instead"))) HAL_I2C_Reset(hal_i2c_interface_t i2c, uint32_t reserved, void* reserved1) {
+inline uint8_t __attribute__((deprecated("Use hal_i2c_reset() instead"), always_inline))
+HAL_I2C_Reset(hal_i2c_interface_t i2c, uint32_t reserved, void* reserved1) {
     return hal_i2c_reset(i2c, reserved, reserved1);
 }
 
-inline int32_t __attribute__((deprecated("Use hal_i2c_lock() instead"))) HAL_I2C_Acquire(hal_i2c_interface_t i2c, void* reserved) {
+inline int32_t __attribute__((deprecated("Use hal_i2c_lock() instead"), always_inline))
+HAL_I2C_Acquire(hal_i2c_interface_t i2c, void* reserved) {
     return hal_i2c_lock(i2c, reserved);
 }
 
-inline int32_t __attribute__((deprecated("Use hal_i2c_unlock() instead"))) HAL_I2C_Release(hal_i2c_interface_t i2c, void* reserved) {
+inline int32_t __attribute__((deprecated("Use hal_i2c_unlock() instead"), always_inline))
+HAL_I2C_Release(hal_i2c_interface_t i2c, void* reserved) {
     return hal_i2c_unlock(i2c, reserved);
 }
 

--- a/hal/inc/pwm_hal_compat.h
+++ b/hal/inc/pwm_hal_compat.h
@@ -19,47 +19,58 @@
 #define PWM_HAL_COMPAT_H
 
 // Deprecated *dynalib* APIs for backwards compatibility
-inline void __attribute__((deprecated("Use hal_pwm_write() instead"))) HAL_PWM_Write(uint16_t pin, uint8_t value) {
+inline void __attribute__((deprecated("Use hal_pwm_write() instead"), always_inline))
+HAL_PWM_Write(uint16_t pin, uint8_t value) {
 	hal_pwm_write(pin, value);
 }
 
-inline void __attribute__((deprecated("Use hal_pwm_write_ext() instead"))) HAL_PWM_Write_Ext(uint16_t pin, uint32_t value) {
+inline void __attribute__((deprecated("Use hal_pwm_write_ext() instead"), always_inline))
+HAL_PWM_Write_Ext(uint16_t pin, uint32_t value) {
 	hal_pwm_write_ext(pin, value);
 }
 
-inline void __attribute__((deprecated("Use hal_pwm_write_with_frequency() instead"))) HAL_PWM_Write_With_Frequency(uint16_t pin, uint8_t value, uint16_t frequency) {
+inline void __attribute__((deprecated("Use hal_pwm_write_with_frequency() instead"), always_inline))
+HAL_PWM_Write_With_Frequency(uint16_t pin, uint8_t value, uint16_t frequency) {
 	hal_pwm_write_with_frequency(pin, value, frequency);
 }
 
-inline void __attribute__((deprecated("Use hal_pwm_write_with_frequency_ext() instead"))) HAL_PWM_Write_With_Frequency_Ext(uint16_t pin, uint32_t value, uint32_t frequency) {
+inline void __attribute__((deprecated("Use hal_pwm_write_with_frequency_ext() instead"), always_inline))
+HAL_PWM_Write_With_Frequency_Ext(uint16_t pin, uint32_t value, uint32_t frequency) {
 	hal_pwm_write_with_frequency_ext(pin, value, frequency);
 }
 
-inline uint16_t __attribute__((deprecated("Use hal_pwm_get_frequency() instead"))) HAL_PWM_Get_Frequency(uint16_t pin) {
+inline uint16_t __attribute__((deprecated("Use hal_pwm_get_frequency() instead"), always_inline))
+HAL_PWM_Get_Frequency(uint16_t pin) {
 	return hal_pwm_get_frequency(pin);
 }
 
-inline uint32_t __attribute__((deprecated("Use hal_pwm_get_frequency_ext() instead"))) HAL_PWM_Get_Frequency_Ext(uint16_t pin) {
+inline uint32_t __attribute__((deprecated("Use hal_pwm_get_frequency_ext() instead"), always_inline))
+HAL_PWM_Get_Frequency_Ext(uint16_t pin) {
 	return hal_pwm_get_frequency_ext(pin);
 }
 
-inline uint16_t __attribute__((deprecated("Use hal_pwm_get_analog_value() instead"))) HAL_PWM_Get_AnalogValue(uint16_t pin) {
+inline uint16_t __attribute__((deprecated("Use hal_pwm_get_analog_value() instead"), always_inline))
+HAL_PWM_Get_AnalogValue(uint16_t pin) {
 	return hal_pwm_get_analog_value(pin);
 }
 
-inline uint32_t __attribute__((deprecated("Use hal_pwm_get_analog_value_ext() instead"))) HAL_PWM_Get_AnalogValue_Ext(uint16_t pin) {
+inline uint32_t __attribute__((deprecated("Use hal_pwm_get_analog_value_ext() instead"), always_inline))
+HAL_PWM_Get_AnalogValue_Ext(uint16_t pin) {
 	return hal_pwm_get_analog_value_ext(pin);
 }
 
-inline uint32_t __attribute__((deprecated("Use hal_pwm_get_max_frequency() instead"))) HAL_PWM_Get_Max_Frequency(uint16_t pin) {
+inline uint32_t __attribute__((deprecated("Use hal_pwm_get_max_frequency() instead"), always_inline))
+HAL_PWM_Get_Max_Frequency(uint16_t pin) {
 	return hal_pwm_get_max_frequency(pin);
 }
 
-inline uint8_t __attribute__((deprecated("Use hal_pwm_get_resolution() instead"))) HAL_PWM_Get_Resolution(uint16_t pin) {
+inline uint8_t __attribute__((deprecated("Use hal_pwm_get_resolution() instead"), always_inline))
+HAL_PWM_Get_Resolution(uint16_t pin) {
 	return hal_pwm_get_resolution(pin);
 }
 
-inline void __attribute__((deprecated("Use hal_pwm_set_resolution() instead"))) HAL_PWM_Set_Resolution(uint16_t pin, uint8_t resolution) {
+inline void __attribute__((deprecated("Use hal_pwm_set_resolution() instead"), always_inline))
+HAL_PWM_Set_Resolution(uint16_t pin, uint8_t resolution) {
 	hal_pwm_set_resolution(pin, resolution);
 }
 

--- a/hal/inc/rtc_hal_compat.h
+++ b/hal/inc/rtc_hal_compat.h
@@ -21,24 +21,27 @@
 #include "time_compat.h"
 
 // Deprecated *dynalib* APIs for backwards compatibility
-inline void __attribute__((deprecated("use hal_rtc_init() instead"))) HAL_RTC_Configuration(void) {
+inline void __attribute__((deprecated("use hal_rtc_init() instead"), always_inline))
+HAL_RTC_Configuration(void) {
     hal_rtc_init();
 }
 
 // There is no replacement for these
-inline time32_t __attribute__((deprecated)) HAL_RTC_Get_UnixTime(void) {
+inline time32_t __attribute__((deprecated, always_inline)) HAL_RTC_Get_UnixTime(void) {
     return hal_rtc_get_unixtime_deprecated();
 }
 
-inline void __attribute__((deprecated)) HAL_RTC_Set_UnixTime(time32_t value) {
+inline void __attribute__((deprecated, always_inline)) HAL_RTC_Set_UnixTime(time32_t value) {
     hal_rtc_set_unixtime_deprecated(value);
 }
 
-inline void __attribute__((deprecated("use hal_rtc_cancel_alarm() instead"))) HAL_RTC_Cancel_UnixAlarm(void) {
+inline void __attribute__((deprecated("use hal_rtc_cancel_alarm() instead"), always_inline))
+HAL_RTC_Cancel_UnixAlarm(void) {
     hal_rtc_cancel_alarm();
 }
 
-inline uint8_t __attribute__((deprecated("use hal_rtc_time_is_valid() instead"))) HAL_RTC_Time_Is_Valid(void* reserved) {
+inline uint8_t __attribute__((deprecated("use hal_rtc_time_is_valid() instead"), always_inline))
+HAL_RTC_Time_Is_Valid(void* reserved) {
     return (uint8_t)hal_rtc_time_is_valid(reserved);
 }
 

--- a/hal/inc/spi_hal_compat.h
+++ b/hal/inc/spi_hal_compat.h
@@ -27,77 +27,95 @@ typedef hal_spi_dma_user_callback HAL_SPI_DMA_UserCallback;
 typedef hal_spi_select_user_callback HAL_SPI_Select_UserCallback;
 
 // Deprecated *dynalib* APIs for backwards compatibility
-inline void __attribute__((deprecated("Use hal_spi_init() instead"))) HAL_SPI_Init(hal_spi_interface_t spi) {
+inline void __attribute__((deprecated("Use hal_spi_init() instead"), always_inline))
+HAL_SPI_Init(hal_spi_interface_t spi) {
     hal_spi_init(spi);
 }
 
-inline void __attribute__((deprecated("Use hal_spi_begin() instead"))) HAL_SPI_Begin(hal_spi_interface_t spi, uint16_t pin) {
+inline void __attribute__((deprecated("Use hal_spi_begin() instead"), always_inline))
+HAL_SPI_Begin(hal_spi_interface_t spi, uint16_t pin) {
     hal_spi_begin(spi, pin);
 }
 
-inline void __attribute__((deprecated("Use hal_spi_begin_ext() instead"))) HAL_SPI_Begin_Ext(hal_spi_interface_t spi, hal_spi_mode_t mode, uint16_t pin, void* reserved) {
+inline void __attribute__((deprecated("Use hal_spi_begin_ext() instead"), always_inline))
+HAL_SPI_Begin_Ext(hal_spi_interface_t spi, hal_spi_mode_t mode, uint16_t pin, void* reserved) {
     hal_spi_begin_ext(spi, mode, pin, reserved);
 }
 
-inline void __attribute__((deprecated("Use hal_spi_end() instead"))) HAL_SPI_End(hal_spi_interface_t spi) {
+inline void __attribute__((deprecated("Use hal_spi_end() instead"), always_inline))
+HAL_SPI_End(hal_spi_interface_t spi) {
     hal_spi_end(spi);
 }
 
-inline void __attribute__((deprecated("Use hal_spi_set_bit_order() instead"))) HAL_SPI_Set_Bit_Order(hal_spi_interface_t spi, uint8_t order) {
+inline void __attribute__((deprecated("Use hal_spi_set_bit_order() instead"), always_inline))
+HAL_SPI_Set_Bit_Order(hal_spi_interface_t spi, uint8_t order) {
     hal_spi_set_bit_order(spi, order);
 }
 
-inline void __attribute__((deprecated("Use hal_spi_set_data_mode() instead"))) HAL_SPI_Set_Data_Mode(hal_spi_interface_t spi, uint8_t mode) {
+inline void __attribute__((deprecated("Use hal_spi_set_data_mode() instead"), always_inline))
+HAL_SPI_Set_Data_Mode(hal_spi_interface_t spi, uint8_t mode) {
     hal_spi_set_data_mode(spi, mode);
 }
 
-inline void __attribute__((deprecated("Use hal_spi_set_clock_divider() instead"))) HAL_SPI_Set_Clock_Divider(hal_spi_interface_t spi, uint8_t rate) {
+inline void __attribute__((deprecated("Use hal_spi_set_clock_divider() instead"), always_inline))
+HAL_SPI_Set_Clock_Divider(hal_spi_interface_t spi, uint8_t rate) {
     hal_spi_set_clock_divider(spi, rate);
 }
 
-inline uint16_t __attribute__((deprecated("Use hal_spi_transfer() instead"))) HAL_SPI_Send_Receive_Data(hal_spi_interface_t spi, uint16_t data) {
+inline uint16_t __attribute__((deprecated("Use hal_spi_transfer() instead"), always_inline))
+HAL_SPI_Send_Receive_Data(hal_spi_interface_t spi, uint16_t data) {
     return hal_spi_transfer(spi, data);
 }
 
-inline void __attribute__((deprecated("Use hal_spi_transfer_dma() instead"))) HAL_SPI_DMA_Transfer(hal_spi_interface_t spi, void* tx_buffer, void* rx_buffer, uint32_t length, HAL_SPI_DMA_UserCallback userCallback) {
+inline void __attribute__((deprecated("Use hal_spi_transfer_dma() instead"), always_inline))
+HAL_SPI_DMA_Transfer(hal_spi_interface_t spi, void* tx_buffer, void* rx_buffer, uint32_t length, HAL_SPI_DMA_UserCallback userCallback) {
     hal_spi_transfer_dma(spi, tx_buffer, rx_buffer, length, userCallback);
 }
 
-inline bool __attribute__((deprecated("Use hal_spi_is_enabled_deprecated() instead"))) HAL_SPI_Is_Enabled_Old() {
+inline bool __attribute__((deprecated("Use hal_spi_is_enabled_deprecated() instead"), always_inline))
+HAL_SPI_Is_Enabled_Old() {
     return hal_spi_is_enabled_deprecated();
 }
 
-inline bool __attribute__((deprecated("Use hal_spi_is_enabled() instead"))) HAL_SPI_Is_Enabled(hal_spi_interface_t spi) {
+inline bool __attribute__((deprecated("Use hal_spi_is_enabled() instead"), always_inline))
+HAL_SPI_Is_Enabled(hal_spi_interface_t spi) {
     return hal_spi_is_enabled(spi);
 }
 
-inline void __attribute__((deprecated("Use hal_spi_info() instead"))) HAL_SPI_Info(hal_spi_interface_t spi, hal_spi_info_t* info, void* reserved) {
+inline void __attribute__((deprecated("Use hal_spi_info() instead"), always_inline))
+HAL_SPI_Info(hal_spi_interface_t spi, hal_spi_info_t* info, void* reserved) {
     hal_spi_info(spi, info, reserved);
 }
 
-inline void __attribute__((deprecated("Use hal_spi_set_callback_on_selected() instead"))) HAL_SPI_Set_Callback_On_Select(hal_spi_interface_t spi, HAL_SPI_Select_UserCallback cb, void* reserved) {
+inline void __attribute__((deprecated("Use hal_spi_set_callback_on_selected() instead"), always_inline))
+HAL_SPI_Set_Callback_On_Select(hal_spi_interface_t spi, HAL_SPI_Select_UserCallback cb, void* reserved) {
     hal_spi_set_callback_on_selected(spi, cb, reserved);
 }
 
-inline void __attribute__((deprecated("Use hal_spi_transfer_dma_cancel() instead"))) HAL_SPI_DMA_Transfer_Cancel(hal_spi_interface_t spi) {
+inline void __attribute__((deprecated("Use hal_spi_transfer_dma_cancel() instead"), always_inline))
+HAL_SPI_DMA_Transfer_Cancel(hal_spi_interface_t spi) {
     hal_spi_transfer_dma_cancel(spi);
 }
 
-inline int32_t __attribute__((deprecated("Use hal_spi_transfer_dma_status() instead"))) HAL_SPI_DMA_Transfer_Status(hal_spi_interface_t spi, hal_spi_transfer_status_t* st) {
+inline int32_t __attribute__((deprecated("Use hal_spi_transfer_dma_status() instead"), always_inline))
+HAL_SPI_DMA_Transfer_Status(hal_spi_interface_t spi, hal_spi_transfer_status_t* st) {
     return hal_spi_transfer_dma_status(spi, st);
 }
 
-inline int32_t __attribute__((deprecated("Use hal_spi_set_settings() instead"))) HAL_SPI_Set_Settings(hal_spi_interface_t spi, uint8_t set_default, uint8_t clockdiv, uint8_t order, uint8_t mode, void* reserved) {
+inline int32_t __attribute__((deprecated("Use hal_spi_set_settings() instead"), always_inline))
+HAL_SPI_Set_Settings(hal_spi_interface_t spi, uint8_t set_default, uint8_t clockdiv, uint8_t order, uint8_t mode, void* reserved) {
     return hal_spi_set_settings(spi, set_default, clockdiv, order, mode, reserved);
 }
 
 #if HAL_PLATFORM_SPI_HAL_THREAD_SAFETY
 
-inline int32_t __attribute__((deprecated("Use hal_spi_acquire() instead"))) HAL_SPI_Acquire(hal_spi_interface_t spi, const hal_spi_acquire_config_t* conf) { 
+inline int32_t __attribute__((deprecated("Use hal_spi_acquire() instead"), always_inline))
+HAL_SPI_Acquire(hal_spi_interface_t spi, const hal_spi_acquire_config_t* conf) { 
     return hal_spi_acquire(spi, conf);
 }
 
-inline int32_t __attribute__((deprecated("Use hal_spi_release() instead"))) HAL_SPI_Release(hal_spi_interface_t spi, void* reserved) {
+inline int32_t __attribute__((deprecated("Use hal_spi_release() instead"), always_inline))
+HAL_SPI_Release(hal_spi_interface_t spi, void* reserved) {
     return hal_spi_release(spi, reserved);
 }
 

--- a/hal/inc/usart_hal_compat.h
+++ b/hal/inc/usart_hal_compat.h
@@ -23,63 +23,78 @@ typedef hal_usart_interface_t HAL_USART_Serial __attribute__((deprecated("Use ha
 typedef hal_usart_buffer_config_t HAL_USART_Buffer_Config __attribute__((deprecated("Use hal_usart_buffer_config_t instead")));
 
 // Deprecated *dynalib* APIs for backwards compatibility
-inline void __attribute__((deprecated("Use hal_usart_init() instead"))) HAL_USART_Init(hal_usart_interface_t serial, hal_usart_ring_buffer_t *rx_buffer, hal_usart_ring_buffer_t *tx_buffer) {
+inline void __attribute__((deprecated("Use hal_usart_init() instead"), always_inline))
+HAL_USART_Init(hal_usart_interface_t serial, hal_usart_ring_buffer_t *rx_buffer, hal_usart_ring_buffer_t *tx_buffer) {
     hal_usart_init(serial, rx_buffer, tx_buffer);
 }
 
-inline void __attribute__((deprecated("Use hal_usart_begin() instead"))) HAL_USART_Begin(hal_usart_interface_t serial, uint32_t baud) {
+inline void __attribute__((deprecated("Use hal_usart_begin() instead"), always_inline))
+HAL_USART_Begin(hal_usart_interface_t serial, uint32_t baud) {
     hal_usart_begin(serial, baud);
 }
 
-inline void __attribute__((deprecated("Use hal_usart_end() instead"))) HAL_USART_End(hal_usart_interface_t serial) {
+inline void __attribute__((deprecated("Use hal_usart_end() instead"), always_inline))
+HAL_USART_End(hal_usart_interface_t serial) {
     hal_usart_end(serial);
 }
 
-inline uint32_t __attribute__((deprecated("Use hal_usart_write() instead"))) HAL_USART_Write_Data(hal_usart_interface_t serial, uint8_t data) {
+inline uint32_t __attribute__((deprecated("Use hal_usart_write() instead"), always_inline))
+HAL_USART_Write_Data(hal_usart_interface_t serial, uint8_t data) {
     return hal_usart_write(serial, data);
 }
 
-inline int32_t __attribute__((deprecated("Use hal_usart_available_data_for_write() instead"))) HAL_USART_Available_Data_For_Write(hal_usart_interface_t serial) {
+inline int32_t __attribute__((deprecated("Use hal_usart_available_data_for_write() instead"), always_inline))
+HAL_USART_Available_Data_For_Write(hal_usart_interface_t serial) {
     return hal_usart_available_data_for_write(serial);
 }
 
-inline int32_t __attribute__((deprecated("Use hal_usart_available() instead"))) HAL_USART_Available_Data(hal_usart_interface_t serial) {
+inline int32_t __attribute__((deprecated("Use hal_usart_available() instead"), always_inline))
+HAL_USART_Available_Data(hal_usart_interface_t serial) {
     return hal_usart_available(serial);
 }
 
-inline int32_t __attribute__((deprecated("Use hal_usart_read() instead"))) HAL_USART_Read_Data(hal_usart_interface_t serial) {
+inline int32_t __attribute__((deprecated("Use hal_usart_read() instead"), always_inline))
+HAL_USART_Read_Data(hal_usart_interface_t serial) {
     return hal_usart_read(serial);
 }
 
-inline int32_t __attribute__((deprecated("Use hal_usart_peek() instead"))) HAL_USART_Peek_Data(hal_usart_interface_t serial) {
+inline int32_t __attribute__((deprecated("Use hal_usart_peek() instead"), always_inline))
+HAL_USART_Peek_Data(hal_usart_interface_t serial) {
     return hal_usart_peek(serial);
 }
 
-inline void __attribute__((deprecated("Use hal_usart_flush() instead"))) HAL_USART_Flush_Data(hal_usart_interface_t serial) {
+inline void __attribute__((deprecated("Use hal_usart_flush() instead"), always_inline))
+HAL_USART_Flush_Data(hal_usart_interface_t serial) {
     hal_usart_flush(serial);
 }
 
-inline bool __attribute__((deprecated("Use hal_usart_is_enabled() instead"))) HAL_USART_Is_Enabled(hal_usart_interface_t serial) {
+inline bool __attribute__((deprecated("Use hal_usart_is_enabled() instead"), always_inline))
+HAL_USART_Is_Enabled(hal_usart_interface_t serial) {
     return hal_usart_is_enabled(serial);
 }
 
-inline void __attribute__((deprecated("Use hal_usart_half_duplex() instead"))) HAL_USART_Half_Duplex(hal_usart_interface_t serial, bool Enable) {
+inline void __attribute__((deprecated("Use hal_usart_half_duplex() instead"), always_inline))
+HAL_USART_Half_Duplex(hal_usart_interface_t serial, bool Enable) {
     hal_usart_half_duplex(serial, Enable);
 }
 
-inline void __attribute__((deprecated("Use hal_usart_begin_config() instead"))) HAL_USART_BeginConfig(hal_usart_interface_t serial, uint32_t baud, uint32_t config, void* reserved) {
+inline void __attribute__((deprecated("Use hal_usart_begin_config() instead"), always_inline))
+HAL_USART_BeginConfig(hal_usart_interface_t serial, uint32_t baud, uint32_t config, void* reserved) {
     hal_usart_begin_config(serial, baud, config, reserved);
 }
 
-inline uint32_t __attribute__((deprecated("Use hal_usart_write_nine_bits() instead"))) HAL_USART_Write_NineBitData(hal_usart_interface_t serial, uint16_t data) {
+inline uint32_t __attribute__((deprecated("Use hal_usart_write_nine_bits() instead"), always_inline))
+HAL_USART_Write_NineBitData(hal_usart_interface_t serial, uint16_t data) {
     return hal_usart_write_nine_bits(serial, data);
 }
 
-inline void __attribute__((deprecated("Use hal_usart_send_break() instead"))) HAL_USART_Send_Break(hal_usart_interface_t serial, void* reserved) {
+inline void __attribute__((deprecated("Use hal_usart_send_break() instead"), always_inline))
+HAL_USART_Send_Break(hal_usart_interface_t serial, void* reserved) {
     hal_usart_send_break(serial, reserved);
 }
 
-inline uint8_t __attribute__((deprecated("Use hal_usart_break_detected() instead"))) HAL_USART_Break_Detected(hal_usart_interface_t serial) {
+inline uint8_t __attribute__((deprecated("Use hal_usart_break_detected() instead"), always_inline))
+HAL_USART_Break_Detected(hal_usart_interface_t serial) {
     return hal_usart_break_detected(serial);
 }
 


### PR DESCRIPTION
### Problem

If the deprecated APIs are invoked in c files, they might not be inlined by compiler actually, which would encounter "undefined reference xxxx" error.

### Solution

Add `always_inline` attribute for the deprecated functions.

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
