### PR TITLE
[wiring] Network: introduce isOn() and isOff() APIs to enquiry the modem power state

### DIFF
--- a/hal/inc/cellular_hal.h
+++ b/hal/inc/cellular_hal.h
@@ -56,6 +56,11 @@ cellular_result_t  cellular_init(void* reserved);
 cellular_result_t  cellular_off(void* reserved);
 
 /**
+ * Check if the cellular module is powered.
+ */
+bool cellular_powered(void* reserved);
+
+/**
  * Wait for the cellular module to register on the GSM network.
  */
 cellular_result_t  cellular_register(void* reserved);

--- a/hal/inc/hal_dynalib_cellular.h
+++ b/hal/inc/hal_dynalib_cellular.h
@@ -93,6 +93,8 @@ DYNALIB_FN(BASE_CELL_IDX + 2, hal_cellular, cellular_process, cellular_result_t(
 #define BASE_CELL_IDX1 (BASE_CELL_IDX + 2)
 #endif // !HAL_PLATFORM_NCP
 
+DYNALIB_FN(BASE_CELL_IDX1 + 0, hal_cellular, cellular_powered, bool(void*))
+
 DYNALIB_END(hal_cellular)
 
 #endif  // PLATFORM_ID == 10 || HAL_PLATFORM_CELLULAR

--- a/hal/inc/hal_dynalib_cellular.h
+++ b/hal/inc/hal_dynalib_cellular.h
@@ -88,12 +88,11 @@ DYNALIB_FN(BASE_CELL_IDX + 1, hal_cellular, cellular_registration_timeout_set, c
 
 #if !HAL_PLATFORM_NCP
 DYNALIB_FN(BASE_CELL_IDX + 2, hal_cellular, cellular_process, cellular_result_t(void*, void*))
-#define BASE_CELL_IDX1 (BASE_CELL_IDX + 3)
+DYNALIB_FN(BASE_CELL_IDX + 3, hal_cellular, cellular_powered, bool(void*))
+#define BASE_CELL_IDX1 (BASE_CELL_IDX + 4)
 #else
 #define BASE_CELL_IDX1 (BASE_CELL_IDX + 2)
 #endif // !HAL_PLATFORM_NCP
-
-DYNALIB_FN(BASE_CELL_IDX1 + 0, hal_cellular, cellular_powered, bool(void*))
 
 DYNALIB_END(hal_cellular)
 

--- a/hal/network/api/ifapi.h
+++ b/hal/network/api/ifapi.h
@@ -60,7 +60,9 @@ typedef enum if_xflags_t {
     IFXF_DHCP6        = 0x20000,
     IFXF_AUTOIP       = 0x40000,
 
-    IFXF_CANTCHANGE   = 0
+    IFXF_READY        = 0x100000,
+
+    IFXF_CANTCHANGE   = (IFXF_READY)
 } if_xflags_t;
 
 #ifndef IF_NAMESIZE
@@ -141,7 +143,8 @@ typedef enum if_event_type_t {
     IF_EVENT_LINK                 = 0x04,
     IF_EVENT_ADDR                 = 0x05,
     IF_EVENT_LLADDR               = 0x06,
-    IF_EVENT_POWER_STATE          = 0x07
+    IF_EVENT_POWER_STATE          = 0x07,
+    IF_EVENT_PHY_STATE            = 0x08,
 } if_event_type_t;
 
 typedef enum if_state_t {
@@ -164,10 +167,11 @@ typedef enum if_power_state_t {
     IF_POWER_STATE_POWERING_UP = 0x04,
 } if_power_state_t;
 
-typedef enum if_ncp_state_t {
-    IF_NCP_STATE_OFF = 0x00,
-    IF_NCP_STATE_ON = 0x01
-} if_ncp_state_t;
+typedef enum if_phy_state_t {
+    IF_PHY_STATE_UNKNOWN = 0x00,
+    IF_PHY_STATE_OFF = 0x01,
+    IF_PHY_STATE_ON = 0x02
+} if_phy_state_t;
 
 struct if_event_state {
     uint8_t state;
@@ -178,6 +182,10 @@ struct if_event_link_state {
 };
 
 struct if_event_power_state {
+    uint8_t state;
+};
+
+struct if_event_phy_state {
     uint8_t state;
 };
 
@@ -201,6 +209,7 @@ struct if_event {
         struct if_event_addr* ev_if_addr;
         struct if_event_lladdr* ev_if_lladdr;
         struct if_event_power_state* ev_power_state;
+        struct if_event_phy_state* ev_phy_state;
     };
 };
 
@@ -264,7 +273,6 @@ int if_request(if_t iface, int type, void* req, size_t reqsize, void* reserved);
 void if_notify_event(if_t iface, const struct if_event* evt, void* reserved);
 
 int if_get_power_state(if_t iface, if_power_state_t* state);
-int if_get_ncp_state(if_t iface, if_ncp_state_t* state);
 
 #ifdef __cplusplus
 }

--- a/hal/network/api/ifapi.h
+++ b/hal/network/api/ifapi.h
@@ -164,6 +164,11 @@ typedef enum if_power_state_t {
     IF_POWER_STATE_POWERING_UP = 0x04,
 } if_power_state_t;
 
+typedef enum if_ncp_state_t {
+    IF_NCP_STATE_OFF = 0x00,
+    IF_NCP_STATE_ON = 0x01
+} if_ncp_state_t;
+
 struct if_event_state {
     uint8_t state;
 };
@@ -259,6 +264,7 @@ int if_request(if_t iface, int type, void* req, size_t reqsize, void* reserved);
 void if_notify_event(if_t iface, const struct if_event* evt, void* reserved);
 
 int if_get_power_state(if_t iface, if_power_state_t* state);
+int if_get_ncp_state(if_t iface, if_ncp_state_t* state);
 
 #ifdef __cplusplus
 }

--- a/hal/network/lwip/basenetif.h
+++ b/hal/network/lwip/basenetif.h
@@ -37,7 +37,7 @@ public:
     virtual int powerDown() = 0;
 
     virtual int getPowerState(if_power_state_t* state) const = 0;
-    virtual int getNcpState(if_ncp_state_t* state) const = 0;
+    virtual int getNcpState(unsigned int* state) const = 0;
 
 protected:
     void registerHandlers();

--- a/hal/network/lwip/basenetif.h
+++ b/hal/network/lwip/basenetif.h
@@ -37,6 +37,7 @@ public:
     virtual int powerDown() = 0;
 
     virtual int getPowerState(if_power_state_t* state) const = 0;
+    virtual int getNcpState(if_ncp_state_t* state) const = 0;
 
 protected:
     void registerHandlers();

--- a/hal/network/lwip/cellular/pppncpnetif.cpp
+++ b/hal/network/lwip/cellular/pppncpnetif.cpp
@@ -203,6 +203,17 @@ int PppNcpNetif::getPowerState(if_power_state_t* state) const {
     return SYSTEM_ERROR_NONE;
 }
 
+int PppNcpNetif::getNcpState(if_ncp_state_t* state) const {
+    auto s = celMan_->ncpClient()->ncpState();
+    if (s == NcpState::ON) {
+        *state = IF_NCP_STATE_ON;
+    } else {
+        // NcpState::OFF or NcpState::DISABLED
+        *state = IF_NCP_STATE_OFF;
+    }
+    return SYSTEM_ERROR_NONE;
+}
+
 int PppNcpNetif::upImpl() {
     up_ = true;
     auto r = celMan_->ncpClient()->on();

--- a/hal/network/lwip/cellular/pppncpnetif.cpp
+++ b/hal/network/lwip/cellular/pppncpnetif.cpp
@@ -203,13 +203,13 @@ int PppNcpNetif::getPowerState(if_power_state_t* state) const {
     return SYSTEM_ERROR_NONE;
 }
 
-int PppNcpNetif::getNcpState(if_ncp_state_t* state) const {
+int PppNcpNetif::getNcpState(unsigned int* state) const {
     auto s = celMan_->ncpClient()->ncpState();
     if (s == NcpState::ON) {
-        *state = IF_NCP_STATE_ON;
+        *state = 1;
     } else {
         // NcpState::OFF or NcpState::DISABLED
-        *state = IF_NCP_STATE_OFF;
+        *state = 0;
     }
     return SYSTEM_ERROR_NONE;
 }
@@ -351,6 +351,21 @@ void PppNcpNetif::ncpEventHandlerCb(const NcpEvent& ev, void* ctx) {
         } else {
             LOG(ERROR, "NCP power state unknown");
         }
+    } else if (ev.type == NcpEvent::NCP_STATE_CHANGED) {
+        const auto& cev = static_cast<const NcpStateChangedEvent&>(ev);
+        if_event evt = {};
+        struct if_event_phy_state ev_if_phy_state = {};
+        evt.ev_len = sizeof(if_event);
+        evt.ev_type = IF_EVENT_PHY_STATE;
+        evt.ev_phy_state = &ev_if_phy_state;
+        if (cev.state == NcpState::ON) {
+            evt.ev_phy_state->state = IF_PHY_STATE_ON;
+        } else if (cev.state == NcpState::OFF) {
+            evt.ev_phy_state->state = IF_PHY_STATE_OFF;
+        } else {
+            evt.ev_phy_state->state = IF_PHY_STATE_UNKNOWN;
+        }
+        if_notify_event(self->interface(), &evt, nullptr);
     }
 }
 

--- a/hal/network/lwip/cellular/pppncpnetif.h
+++ b/hal/network/lwip/cellular/pppncpnetif.h
@@ -48,6 +48,7 @@ public:
     virtual int powerDown() override;
 
     virtual int getPowerState(if_power_state_t* state) const override;
+    virtual int getNcpState(if_ncp_state_t* state) const override;
 
     static int ncpDataHandlerCb(int id, const uint8_t* data, size_t size, void* ctx);
     static void ncpEventHandlerCb(const NcpEvent& ev, void* ctx);

--- a/hal/network/lwip/cellular/pppncpnetif.h
+++ b/hal/network/lwip/cellular/pppncpnetif.h
@@ -48,7 +48,7 @@ public:
     virtual int powerDown() override;
 
     virtual int getPowerState(if_power_state_t* state) const override;
-    virtual int getNcpState(if_ncp_state_t* state) const override;
+    virtual int getNcpState(unsigned int* state) const override;
 
     static int ncpDataHandlerCb(int id, const uint8_t* data, size_t size, void* ctx);
     static void ncpEventHandlerCb(const NcpEvent& ev, void* ctx);

--- a/hal/network/lwip/esp32/esp32ncpnetif.cpp
+++ b/hal/network/lwip/esp32/esp32ncpnetif.cpp
@@ -256,13 +256,13 @@ int Esp32NcpNetif::getPowerState(if_power_state_t* state) const {
     return SYSTEM_ERROR_NONE;
 }
 
-int Esp32NcpNetif::getNcpState(if_ncp_state_t* state) const {
+int Esp32NcpNetif::getNcpState(unsigned int* state) const {
     auto s = wifiMan_->ncpClient()->ncpState();
     if (s == NcpState::ON) {
-        *state = IF_NCP_STATE_ON;
+        *state = 1;
     } else {
         // NcpState::OFF or NcpState::DISABLED
-        *state = IF_NCP_STATE_OFF;
+        *state = 0;
     }
     return SYSTEM_ERROR_NONE;
 }

--- a/hal/network/lwip/esp32/esp32ncpnetif.cpp
+++ b/hal/network/lwip/esp32/esp32ncpnetif.cpp
@@ -256,6 +256,17 @@ int Esp32NcpNetif::getPowerState(if_power_state_t* state) const {
     return SYSTEM_ERROR_NONE;
 }
 
+int Esp32NcpNetif::getNcpState(if_ncp_state_t* state) const {
+    auto s = wifiMan_->ncpClient()->ncpState();
+    if (s == NcpState::ON) {
+        *state = IF_NCP_STATE_ON;
+    } else {
+        // NcpState::OFF or NcpState::DISABLED
+        *state = IF_NCP_STATE_OFF;
+    }
+    return SYSTEM_ERROR_NONE;
+}
+
 int Esp32NcpNetif::upImpl() {
     up_ = true;
     auto r = queryMacAddress();

--- a/hal/network/lwip/esp32/esp32ncpnetif.h
+++ b/hal/network/lwip/esp32/esp32ncpnetif.h
@@ -43,6 +43,7 @@ public:
     virtual int powerDown() override;
 
     virtual int getPowerState(if_power_state_t* state) const override;
+    virtual int getNcpState(if_ncp_state_t* state) const override;
 
     static int ncpDataHandlerCb(int id, const uint8_t* data, size_t size, void* ctx);
     static void ncpEventHandlerCb(const NcpEvent& ev, void* ctx);

--- a/hal/network/lwip/esp32/esp32ncpnetif.h
+++ b/hal/network/lwip/esp32/esp32ncpnetif.h
@@ -43,7 +43,7 @@ public:
     virtual int powerDown() override;
 
     virtual int getPowerState(if_power_state_t* state) const override;
-    virtual int getNcpState(if_ncp_state_t* state) const override;
+    virtual int getNcpState(unsigned int* state) const override;
 
     static int ncpDataHandlerCb(int id, const uint8_t* data, size_t size, void* ctx);
     static void ncpEventHandlerCb(const NcpEvent& ev, void* ctx);

--- a/hal/network/lwip/ifapi.cpp
+++ b/hal/network/lwip/ifapi.cpp
@@ -1188,3 +1188,15 @@ int if_get_power_state(if_t iface, if_power_state_t* state) {
     CHECK_TRUE(bnetif, -1);
     return bnetif->getPowerState(state);
 }
+
+int if_get_ncp_state(if_t iface, if_ncp_state_t* state) {
+    LwipTcpIpCoreLock lk;
+
+    if (!netif_validate(iface)) {
+        return -1;
+    }
+
+    auto bnetif = getBaseNetif(iface);
+    CHECK_TRUE(bnetif, -1);
+    return bnetif->getNcpState(state);
+}

--- a/hal/network/lwip/ifapi.cpp
+++ b/hal/network/lwip/ifapi.cpp
@@ -644,6 +644,16 @@ int if_get_xflags(if_t iface, unsigned int* xflags) {
 
     /* TODO: WOL */
 
+    ifxf &= ~IFXF_READY;
+    auto bnetif = getBaseNetif(iface);
+    if (bnetif) {
+        unsigned int state;
+        bnetif->getNcpState(&state);
+        if (state) {
+            ifxf |= IFXF_READY;
+        }
+    }
+
     *xflags = ifxf;
 
     return 0;
@@ -1187,16 +1197,4 @@ int if_get_power_state(if_t iface, if_power_state_t* state) {
     auto bnetif = getBaseNetif(iface);
     CHECK_TRUE(bnetif, -1);
     return bnetif->getPowerState(state);
-}
-
-int if_get_ncp_state(if_t iface, if_ncp_state_t* state) {
-    LwipTcpIpCoreLock lk;
-
-    if (!netif_validate(iface)) {
-        return -1;
-    }
-
-    auto bnetif = getBaseNetif(iface);
-    CHECK_TRUE(bnetif, -1);
-    return bnetif->getNcpState(state);
 }

--- a/hal/network/lwip/wiznet/wiznetif.cpp
+++ b/hal/network/lwip/wiznet/wiznetif.cpp
@@ -431,6 +431,11 @@ int WizNetif::getPowerState(if_power_state_t* state) const {
     return SYSTEM_ERROR_NOT_SUPPORTED;
 }
 
+int WizNetif::getNcpState(if_ncp_state_t* state) const {
+    // TODO: implement it
+    return SYSTEM_ERROR_NOT_SUPPORTED;
+}
+
 int WizNetif::openRaw() {
     LwipTcpIpCoreLock lk;
 

--- a/hal/network/lwip/wiznet/wiznetif.cpp
+++ b/hal/network/lwip/wiznet/wiznetif.cpp
@@ -431,7 +431,7 @@ int WizNetif::getPowerState(if_power_state_t* state) const {
     return SYSTEM_ERROR_NOT_SUPPORTED;
 }
 
-int WizNetif::getNcpState(if_ncp_state_t* state) const {
+int WizNetif::getNcpState(unsigned int* state) const {
     // TODO: implement it
     return SYSTEM_ERROR_NOT_SUPPORTED;
 }

--- a/hal/network/lwip/wiznet/wiznetif.h
+++ b/hal/network/lwip/wiznet/wiznetif.h
@@ -41,6 +41,7 @@ public:
     virtual int powerDown() override;
 
     virtual int getPowerState(if_power_state_t* state) const override;
+    virtual int getNcpState(if_ncp_state_t* state) const override;
 
     static WizNetif* instance() {
         return instance_;

--- a/hal/network/lwip/wiznet/wiznetif.h
+++ b/hal/network/lwip/wiznet/wiznetif.h
@@ -41,7 +41,7 @@ public:
     virtual int powerDown() override;
 
     virtual int getPowerState(if_power_state_t* state) const override;
-    virtual int getNcpState(if_ncp_state_t* state) const override;
+    virtual int getNcpState(unsigned int* state) const override;
 
     static WizNetif* instance() {
         return instance_;

--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -1739,11 +1739,14 @@ int QuectelNcpClient::modemPowerOff() {
 
 int QuectelNcpClient::modemSoftPowerOff() {
     if (modemPowerState()) {
+        ncpPowerState(NcpPowerState::TRANSIENT_OFF);
+        
         LOG(TRACE, "Try powering modem off using AT command");
         if (!ready_) {
             LOG(ERROR, "NCP client is not ready");
             return SYSTEM_ERROR_INVALID_STATE;
         }
+        
         // Delay 1s in case that the modem is just powered up and refuse to execute the power down command.
         HAL_Delay_Milliseconds(1000);
         int r = CHECK_PARSER(parser_.execCommand("AT+QPOWD"));
@@ -1751,7 +1754,6 @@ int QuectelNcpClient::modemSoftPowerOff() {
             LOG(ERROR, "AT+QPOWD command is not responding");
             return SYSTEM_ERROR_AT_NOT_OK;
         }
-        ncpPowerState(NcpPowerState::TRANSIENT_OFF);
         system_tick_t now = HAL_Timer_Get_Milli_Seconds();
         LOG(TRACE, "Waiting the modem to be turned off...");
         // Verify that the module was powered down by checking the VINT pin up to 30 sec
@@ -1786,11 +1788,10 @@ int QuectelNcpClient::modemHardReset(bool powerOff) {
 
     // The modem restarts automatically after hard reset.
     if (powerOff) {
-        // Need to delay at least 5s, otherwise, the modem cannot be powered off.
-        HAL_Delay_Milliseconds(5000);
-
         ncpPowerState(NcpPowerState::TRANSIENT_OFF);
 
+        // Need to delay at least 5s, otherwise, the modem cannot be powered off.
+        HAL_Delay_Milliseconds(5000);
         LOG(TRACE, "Powering modem off");
         // Power off, power off pulse >= 650ms
         // NOTE: The BGPWR pin is inverted

--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -2100,6 +2100,7 @@ int SaraNcpClient::modemPowerOff() {
 
 int SaraNcpClient::modemSoftPowerOff() {
     if (modemPowerState()) {
+        ncpPowerState(NcpPowerState::TRANSIENT_OFF);
         LOG(TRACE, "Try powering modem off using AT command");
         if (!ready_) {
             LOG(ERROR, "NCP client is not ready");
@@ -2110,7 +2111,6 @@ int SaraNcpClient::modemSoftPowerOff() {
             LOG(ERROR, "AT+CPWROFF command is not responding");
             return SYSTEM_ERROR_AT_NOT_OK;
         }
-        ncpPowerState(NcpPowerState::TRANSIENT_OFF);
         system_tick_t now = HAL_Timer_Get_Milli_Seconds();
         LOG(TRACE, "Waiting the modem to be turned off...");
         // Verify that the module was powered down by checking the VINT pin up to 10 sec

--- a/hal/src/electron/cellular_hal.cpp
+++ b/hal/src/electron/cellular_hal.cpp
@@ -111,6 +111,11 @@ cellular_result_t  cellular_off(void* reserved)
     return 0;
 }
 
+bool cellular_powered(void* reserved)
+{
+    return electronMDM.powerState();
+}
+
 cellular_result_t  cellular_register(void* reserved)
 {
     CHECK_SUCCESS(electronMDM.registerNet());

--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -493,6 +493,10 @@ public:
 
     int process();
 
+    /** Detects the modem power state
+    */
+    bool powerState(void);
+
 protected:
     /** Write bytes to the physical interface. This function should be
         implemented in a inherited class.
@@ -533,10 +537,6 @@ protected:
         \param index the index of the received SMS
     */
     void SMSreceived(int index);
-
-    /** Detects the modem power state
-    */
-    bool powerState(void);
 
 protected:
     // String helper to prevent buffer overrun

--- a/system/inc/system_dynalib_net.h
+++ b/system/inc/system_dynalib_net.h
@@ -48,6 +48,8 @@ DYNALIB_FN(12, system_net, network_set_listen_timeout, void(network_handle_t, ui
 DYNALIB_FN(13, system_net, network_get_listen_timeout, uint16_t(network_handle_t, uint32_t, void*))
 DYNALIB_FN(14, system_net, network_set_hostname, int(network_handle_t, uint32_t, const char*, void*))
 DYNALIB_FN(15, system_net, network_get_hostname, int(network_handle_t, uint32_t, char*, size_t, void*))
+DYNALIB_FN(16, system_net, network_is_on, bool(network_handle_t, void*))
+DYNALIB_FN(17, system_net, network_is_off, bool(network_handle_t, void*))
 
 DYNALIB_END(system_net)
 

--- a/system/inc/system_network.h
+++ b/system/inc/system_network.h
@@ -58,6 +58,8 @@ void network_disconnect(network_handle_t network, uint32_t reason, void* reserve
 bool network_ready(network_handle_t network, uint32_t type, void* reserved);
 void network_on(network_handle_t network, uint32_t flags, uint32_t param1, void* reserved);
 void network_off(network_handle_t network, uint32_t flags, uint32_t param1, void* reserved);
+bool network_is_on(network_handle_t network, void* reserved);
+bool network_is_off(network_handle_t network, void* reserved);
 int network_connect_cancel(network_handle_t network, uint32_t flags, uint32_t param1, void* reserved);
 
 #define NETWORK_LISTEN_EXIT (1<<0)

--- a/system/src/system_network_cellular.h
+++ b/system/src/system_network_cellular.h
@@ -101,6 +101,10 @@ protected:
         cellular_off(nullptr);
     }
 
+    bool is_powered() override {
+        return cellular_powered(nullptr);
+    }
+
     void disconnect_now() override {
         cellular_disconnect(nullptr);
     }

--- a/system/src/system_network_compat.cpp
+++ b/system/src/system_network_compat.cpp
@@ -134,6 +134,14 @@ void network_on(network_handle_t network, uint32_t flags, uint32_t param, void* 
     SYSTEM_THREAD_CONTEXT_ASYNC_CALL(nif(network).on());
 }
 
+bool network_is_on(network_handle_t network, void* reserved) {
+    return nif(network).isOn();
+}
+
+bool network_is_off(network_handle_t network, void* reserved) {
+    return nif(network).isOff();
+}
+
 bool network_has_credentials(network_handle_t network, uint32_t param, void* reserved)
 {
     SYSTEM_THREAD_CONTEXT_SYNC_CALL_RESULT(nif(network).has_credentials());

--- a/system/src/system_network_internal.h
+++ b/system/src/system_network_internal.h
@@ -376,6 +376,7 @@ protected:
 
     virtual int on_now()=0;
     virtual void off_now()=0;
+    virtual bool is_powered()=0;
 
     virtual int process_now()=0;
 
@@ -620,7 +621,7 @@ public:
 
     bool isOff() override
     {
-        return WLAN_INITIALIZED && !SPARK_WLAN_STARTED;
+        return !SPARK_WLAN_STARTED && !is_powered();
     }
 
     void off(bool disconnect_cloud=false) override

--- a/system/src/system_network_internal.h
+++ b/system/src/system_network_internal.h
@@ -141,8 +141,14 @@ struct NetworkInterface
     virtual network_interface_t network_interface()=0;
     virtual void setup()=0;
 
+<<<<<<< HEAD
     virtual int on()=0;
+=======
+    virtual int on()=0;
+    virtual bool isOn()=0;
+>>>>>>> [wiring] Network: introduce isOn() and isOff() APIs to enquiry the modem power state.
     virtual void off(bool disconnect_cloud=false)=0;
+    virtual bool isOff()=0;
     virtual void connect(bool listen_enabled=true)=0;
     virtual bool connecting()=0;
     virtual void connect_cancel(bool cancel)=0;
@@ -609,6 +615,24 @@ public:
             return ret;
         }
         return 0;
+    }
+
+    bool isOn() override
+    {
+#if PLATFORM_ID == PLATFORM_ELECTRON // Electron
+        return !WLAN_INITIALIZED || SPARK_WLAN_STARTED;
+#else
+        return SPARK_WLAN_STARTED;
+#endif
+    }
+
+    bool isOff() override
+    {
+#if PLATFORM_ID == PLATFORM_ELECTRON // Electron
+        return WLAN_INITIALIZED && !SPARK_WLAN_STARTED;
+#else
+        return !SPARK_WLAN_STARTED;
+#endif
     }
 
     void off(bool disconnect_cloud=false) override

--- a/system/src/system_network_internal.h
+++ b/system/src/system_network_internal.h
@@ -141,12 +141,8 @@ struct NetworkInterface
     virtual network_interface_t network_interface()=0;
     virtual void setup()=0;
 
-<<<<<<< HEAD
-    virtual int on()=0;
-=======
     virtual int on()=0;
     virtual bool isOn()=0;
->>>>>>> [wiring] Network: introduce isOn() and isOff() APIs to enquiry the modem power state.
     virtual void off(bool disconnect_cloud=false)=0;
     virtual bool isOff()=0;
     virtual void connect(bool listen_enabled=true)=0;
@@ -619,20 +615,12 @@ public:
 
     bool isOn() override
     {
-#if PLATFORM_ID == PLATFORM_ELECTRON // Electron
-        return !WLAN_INITIALIZED || SPARK_WLAN_STARTED;
-#else
-        return SPARK_WLAN_STARTED;
-#endif
+        return WLAN_INITIALIZED && SPARK_WLAN_STARTED;
     }
 
     bool isOff() override
     {
-#if PLATFORM_ID == PLATFORM_ELECTRON // Electron
         return WLAN_INITIALIZED && !SPARK_WLAN_STARTED;
-#else
-        return !SPARK_WLAN_STARTED;
-#endif
     }
 
     void off(bool disconnect_cloud=false) override

--- a/system/src/system_network_manager.cpp
+++ b/system/src/system_network_manager.cpp
@@ -830,6 +830,28 @@ NetworkManager::InterfaceRuntimeState* NetworkManager::getInterfaceRuntimeState(
     return nullptr;
 }
 
+bool NetworkManager::isInterfacePowerState(if_t iface, if_power_state_t state) const {
+    bool ret = false;
+    if_power_state_t pwr = IF_POWER_STATE_NONE;
+    if (!iface) {
+        for_each_iface([&](if_t iface, unsigned int curFlags) {
+            if (if_get_power_state(iface, &pwr) != SYSTEM_ERROR_NONE) {
+                return;
+            }
+            if (pwr == state) {
+                ret = true;
+            }
+        });
+        return ret;
+    } else {
+        if (if_get_power_state(iface, &pwr) != SYSTEM_ERROR_NONE) {
+            return false;
+        }
+        ret = (pwr == state) ? true : false;
+    }
+    return ret;
+}
+
 bool NetworkManager::isInterfaceEnabled(if_t iface) const {
     auto state = getInterfaceRuntimeState(iface);
     if (state) {

--- a/system/src/system_network_manager.cpp
+++ b/system/src/system_network_manager.cpp
@@ -852,6 +852,28 @@ bool NetworkManager::isInterfacePowerState(if_t iface, if_power_state_t state) c
     return ret;
 }
 
+bool NetworkManager::isInterfaceNcpState(if_t iface, if_ncp_state_t state) const {
+    bool ret = false;
+    if_ncp_state_t ncpState = IF_NCP_STATE_OFF;
+    if (!iface) {
+        for_each_iface([&](if_t iface, unsigned int curFlags) {
+            if (if_get_ncp_state(iface, &ncpState) != SYSTEM_ERROR_NONE) {
+                return;
+            }
+            if (ncpState == state) {
+                ret = true;
+            }
+        });
+        return ret;
+    } else {
+        if (if_get_ncp_state(iface, &ncpState) != SYSTEM_ERROR_NONE) {
+            return false;
+        }
+        ret = (ncpState == state) ? true : false;
+    }
+    return ret;
+}
+
 bool NetworkManager::isInterfaceEnabled(if_t iface) const {
     auto state = getInterfaceRuntimeState(iface);
     if (state) {

--- a/system/src/system_network_manager.cpp
+++ b/system/src/system_network_manager.cpp
@@ -109,6 +109,7 @@ NetworkManager::NetworkManager() {
     ip6State_ = ProtocolState::UNCONFIGURED;
     dns4State_ = DnsState::UNCONFIGURED;
     dns6State_ = DnsState::UNCONFIGURED;
+    networkStatus_ = NetworkStatus::NETWORK_STATUS_OFF;
 }
 
 NetworkManager::~NetworkManager() {
@@ -374,10 +375,10 @@ void NetworkManager::transition(State state) {
     /* To */
     switch (state) {
         case State::DISABLED: {
+            networkStatus_ = NetworkStatus::NETWORK_STATUS_POWERING_OFF;
             LED_SIGNAL_START(NETWORK_OFF, BACKGROUND);
             // FIXME: turning-off events/diagnostics
             system_notify_event(network_status, network_status_powering_off);
-            system_notify_event(network_status, network_status_off);
             NetworkDiagnostics::instance()->status(NetworkDiagnostics::TURNED_OFF);
             break;
         }
@@ -385,15 +386,17 @@ void NetworkManager::transition(State state) {
             LED_SIGNAL_START(NETWORK_ON, BACKGROUND);
             NetworkDiagnostics::instance()->status(NetworkDiagnostics::DISCONNECTED);
             if (state_ == State::IFACE_REQUEST_DOWN) {
+                networkStatus_ = NetworkStatus::NETWORK_STATUS_DISCONNECTED;
                 system_notify_event(network_status, network_status_disconnected);
             } else if (state_ == State::DISABLED) {
+                networkStatus_ = NetworkStatus::NETWORK_STATUS_POWERING_ON;
                 // FIXME:
                 system_notify_event(network_status, network_status_powering_on);
-                system_notify_event(network_status, network_status_on);
             }
             break;
         }
         case State::IFACE_REQUEST_DOWN: {
+            networkStatus_ = NetworkStatus::NETWORK_STATUS_DISCONNECTING;
             if (state_ == State::IP_CONFIGURED) {
                 NetworkDiagnostics::instance()->resetConnectionAttempts();
             }
@@ -407,6 +410,7 @@ void NetworkManager::transition(State state) {
             break;
         }
         case State::IFACE_UP: {
+            networkStatus_ = NetworkStatus::NETWORK_STATUS_CONNECTING;
             if (state_ == State::IP_CONFIGURED) {
                 NetworkDiagnostics::instance()->disconnectionReason(NETWORK_DISCONNECT_REASON_ERROR);
                 NetworkDiagnostics::instance()->disconnectedUnexpectedly();
@@ -422,6 +426,7 @@ void NetworkManager::transition(State state) {
             break;
         }
         case State::IP_CONFIGURED: {
+            networkStatus_ = NetworkStatus::NETWORK_STATUS_CONNECTED;
             LED_SIGNAL_START(NETWORK_CONNECTED, BACKGROUND);
             NetworkDiagnostics::instance()->status(NetworkDiagnostics::CONNECTED);
             if (state_ != State::IP_CONFIGURED) {
@@ -469,6 +474,10 @@ void NetworkManager::ifEventHandler(if_t iface, const struct if_event* ev) {
         }
         case IF_EVENT_POWER_STATE: {
             handleIfPowerState(iface, ev);
+            break;
+        }
+        case IF_EVENT_PHY_STATE: {
+            handleIfPhyState(iface, ev);
             break;
         }
     }
@@ -574,6 +583,14 @@ void NetworkManager::handleIfPowerState(if_t iface, const struct if_event* ev) {
         uint8_t index;
         if_get_index(iface, &index);
         LOG(TRACE, "Interface %d power state changed: %d", index, state->pwrState.load());
+    }
+}
+
+void NetworkManager::handleIfPhyState(if_t iface, const struct if_event* ev) {
+    if (networkStatus_ == NetworkStatus::NETWORK_STATUS_POWERING_ON && ev->ev_phy_state->state == IF_PHY_STATE_ON) {
+        system_notify_event(network_status, network_status_on);
+    } else if (networkStatus_ == NetworkStatus::NETWORK_STATUS_POWERING_OFF && ev->ev_phy_state->state == IF_PHY_STATE_OFF) {
+        system_notify_event(network_status, network_status_off);
     }
 }
 
@@ -852,24 +869,25 @@ bool NetworkManager::isInterfacePowerState(if_t iface, if_power_state_t state) c
     return ret;
 }
 
-bool NetworkManager::isInterfaceNcpState(if_t iface, if_ncp_state_t state) const {
+bool NetworkManager::isInterfaceReady(if_t iface) const {
     bool ret = false;
-    if_ncp_state_t ncpState = IF_NCP_STATE_OFF;
+    unsigned int xflags = 0;
     if (!iface) {
         for_each_iface([&](if_t iface, unsigned int curFlags) {
-            if (if_get_ncp_state(iface, &ncpState) != SYSTEM_ERROR_NONE) {
+            xflags = 0;
+            if (if_get_xflags(iface, &xflags) != SYSTEM_ERROR_NONE) {
                 return;
             }
-            if (ncpState == state) {
+            if (xflags & IFXF_READY) {
                 ret = true;
             }
         });
         return ret;
     } else {
-        if (if_get_ncp_state(iface, &ncpState) != SYSTEM_ERROR_NONE) {
+        if (if_get_xflags(iface, &xflags) != SYSTEM_ERROR_NONE) {
             return false;
         }
-        ret = (ncpState == state) ? true : false;
+        ret = (xflags & IFXF_READY) ? true : false;
     }
     return ret;
 }

--- a/system/src/system_network_manager.h
+++ b/system/src/system_network_manager.h
@@ -63,7 +63,9 @@ public:
     ProtocolState getInterfaceIp6State(if_t iface) const;
 
     bool isInterfacePowerState(if_t iface = nullptr, if_power_state_t state = IF_POWER_STATE_NONE) const;
-    bool isInterfaceReady(if_t iface = nullptr) const;
+    bool isInterfacePhyReady(if_t iface = nullptr) const;
+    bool isInterfaceOn(if_t iface = nullptr) const;
+    bool isInterfaceOff(if_t iface = nullptr) const;
 
     bool isConfigured(if_t iface = nullptr) const;
     int clearConfiguration(if_t iface = nullptr);

--- a/system/src/system_network_manager.h
+++ b/system/src/system_network_manager.h
@@ -63,6 +63,7 @@ public:
     ProtocolState getInterfaceIp6State(if_t iface) const;
 
     bool isInterfacePowerState(if_t iface = nullptr, if_power_state_t state = IF_POWER_STATE_NONE) const;
+    bool isInterfaceNcpState(if_t iface = nullptr, if_ncp_state_t state = IF_NCP_STATE_OFF) const;
 
     bool isConfigured(if_t iface = nullptr) const;
     int clearConfiguration(if_t iface = nullptr);

--- a/system/src/system_network_manager.h
+++ b/system/src/system_network_manager.h
@@ -62,6 +62,8 @@ public:
     ProtocolState getInterfaceIp4State(if_t iface) const;
     ProtocolState getInterfaceIp6State(if_t iface) const;
 
+    bool isInterfacePowerState(if_t iface = nullptr, if_power_state_t state = IF_POWER_STATE_NONE) const;
+
     bool isConfigured(if_t iface = nullptr) const;
     int clearConfiguration(if_t iface = nullptr);
 

--- a/system/src/system_network_manager.h
+++ b/system/src/system_network_manager.h
@@ -63,7 +63,7 @@ public:
     ProtocolState getInterfaceIp6State(if_t iface) const;
 
     bool isInterfacePowerState(if_t iface = nullptr, if_power_state_t state = IF_POWER_STATE_NONE) const;
-    bool isInterfaceNcpState(if_t iface = nullptr, if_ncp_state_t state = IF_NCP_STATE_OFF) const;
+    bool isInterfaceReady(if_t iface = nullptr) const;
 
     bool isConfigured(if_t iface = nullptr) const;
     int clearConfiguration(if_t iface = nullptr);
@@ -110,6 +110,17 @@ private:
         CONFIGURED
     };
 
+    enum class NetworkStatus {
+        NETWORK_STATUS_POWERING_OFF,
+        NETWORK_STATUS_OFF,
+        NETWORK_STATUS_POWERING_ON,
+        NETWORK_STATUS_ON,
+        NETWORK_STATUS_CONNECTING,
+        NETWORK_STATUS_CONNECTED,
+        NETWORK_STATUS_DISCONNECTING,
+        NETWORK_STATUS_DISCONNECTED
+    };
+
     struct InterfaceRuntimeState {
         InterfaceRuntimeState()
                 : ip4State(ProtocolState::UNCONFIGURED),
@@ -135,6 +146,7 @@ private:
     void handleIfAddr(if_t iface, const struct if_event* ev);
     void handleIfLinkLayerAddr(if_t iface, const struct if_event* ev);
     void handleIfPowerState(if_t iface, const struct if_event* ev);
+    void handleIfPhyState(if_t iface, const struct if_event* ev);
 
     unsigned int countIfacesWithFlags(unsigned int flags) const;
     void refreshIpState();
@@ -159,6 +171,7 @@ private:
     std::atomic<ProtocolState> ip6State_;
     std::atomic<DnsState> dns4State_;
     std::atomic<DnsState> dns6State_;
+    std::atomic<NetworkStatus> networkStatus_;
 
     IntrusiveList<InterfaceRuntimeState> runState_;
 };

--- a/system/src/system_network_manager_api.cpp
+++ b/system/src/system_network_manager_api.cpp
@@ -263,13 +263,11 @@ void network_on(network_handle_t network, uint32_t flags, uint32_t param, void* 
 
 bool network_is_on(network_handle_t network, void* reserved) {
     if (network == NETWORK_INTERFACE_ALL) {
-        return (NetworkManager::instance()->isInterfacePowerState(nullptr, IF_POWER_STATE_UP) &&
-                NetworkManager::instance()->isInterfaceReady(nullptr));
+        return NetworkManager::instance()->isInterfaceOn(nullptr);
     } else {
         if_t iface;
         if (!if_get_by_index(network, &iface)) {
-            return (NetworkManager::instance()->isInterfacePowerState(iface, IF_POWER_STATE_UP) &&
-                    NetworkManager::instance()->isInterfaceReady(iface));
+            return NetworkManager::instance()->isInterfaceOn(iface);
         }
     }
 
@@ -278,13 +276,11 @@ bool network_is_on(network_handle_t network, void* reserved) {
 
 bool network_is_off(network_handle_t network, void* reserved) {
     if (network == NETWORK_INTERFACE_ALL) {
-        return (NetworkManager::instance()->isInterfacePowerState(nullptr, IF_POWER_STATE_DOWN) &&
-                !NetworkManager::instance()->isInterfaceReady(nullptr));
+        return NetworkManager::instance()->isInterfaceOff(nullptr);
     } else {
         if_t iface;
         if (!if_get_by_index(network, &iface)) {
-            return (NetworkManager::instance()->isInterfacePowerState(iface, IF_POWER_STATE_DOWN) &&
-                    !NetworkManager::instance()->isInterfaceReady(iface));
+            return NetworkManager::instance()->isInterfaceOff(iface);
         }
     }
 

--- a/system/src/system_network_manager_api.cpp
+++ b/system/src/system_network_manager_api.cpp
@@ -263,11 +263,13 @@ void network_on(network_handle_t network, uint32_t flags, uint32_t param, void* 
 
 bool network_is_on(network_handle_t network, void* reserved) {
     if (network == NETWORK_INTERFACE_ALL) {
-        return NetworkManager::instance()->isInterfacePowerState(nullptr, IF_POWER_STATE_UP);
+        return (NetworkManager::instance()->isInterfacePowerState(nullptr, IF_POWER_STATE_UP) &&
+                NetworkManager::instance()->isInterfaceNcpState(nullptr, IF_NCP_STATE_ON));
     } else {
         if_t iface;
         if (!if_get_by_index(network, &iface)) {
-            return NetworkManager::instance()->isInterfacePowerState(iface, IF_POWER_STATE_UP);
+            return (NetworkManager::instance()->isInterfacePowerState(iface, IF_POWER_STATE_UP) &&
+                    NetworkManager::instance()->isInterfaceNcpState(iface, IF_NCP_STATE_ON));
         }
     }
 
@@ -276,11 +278,13 @@ bool network_is_on(network_handle_t network, void* reserved) {
 
 bool network_is_off(network_handle_t network, void* reserved) {
     if (network == NETWORK_INTERFACE_ALL) {
-        return NetworkManager::instance()->isInterfacePowerState(nullptr, IF_POWER_STATE_DOWN);
+        return (NetworkManager::instance()->isInterfacePowerState(nullptr, IF_POWER_STATE_DOWN) &&
+                NetworkManager::instance()->isInterfaceNcpState(nullptr, IF_NCP_STATE_OFF));
     } else {
         if_t iface;
         if (!if_get_by_index(network, &iface)) {
-            return NetworkManager::instance()->isInterfacePowerState(iface, IF_POWER_STATE_DOWN);
+            return (NetworkManager::instance()->isInterfacePowerState(iface, IF_POWER_STATE_DOWN) &&
+                    NetworkManager::instance()->isInterfaceNcpState(iface, IF_NCP_STATE_OFF));
         }
     }
 

--- a/system/src/system_network_manager_api.cpp
+++ b/system/src/system_network_manager_api.cpp
@@ -264,12 +264,12 @@ void network_on(network_handle_t network, uint32_t flags, uint32_t param, void* 
 bool network_is_on(network_handle_t network, void* reserved) {
     if (network == NETWORK_INTERFACE_ALL) {
         return (NetworkManager::instance()->isInterfacePowerState(nullptr, IF_POWER_STATE_UP) &&
-                NetworkManager::instance()->isInterfaceNcpState(nullptr, IF_NCP_STATE_ON));
+                NetworkManager::instance()->isInterfaceReady(nullptr));
     } else {
         if_t iface;
         if (!if_get_by_index(network, &iface)) {
             return (NetworkManager::instance()->isInterfacePowerState(iface, IF_POWER_STATE_UP) &&
-                    NetworkManager::instance()->isInterfaceNcpState(iface, IF_NCP_STATE_ON));
+                    NetworkManager::instance()->isInterfaceReady(iface));
         }
     }
 
@@ -279,12 +279,12 @@ bool network_is_on(network_handle_t network, void* reserved) {
 bool network_is_off(network_handle_t network, void* reserved) {
     if (network == NETWORK_INTERFACE_ALL) {
         return (NetworkManager::instance()->isInterfacePowerState(nullptr, IF_POWER_STATE_DOWN) &&
-                NetworkManager::instance()->isInterfaceNcpState(nullptr, IF_NCP_STATE_OFF));
+                !NetworkManager::instance()->isInterfaceReady(nullptr));
     } else {
         if_t iface;
         if (!if_get_by_index(network, &iface)) {
             return (NetworkManager::instance()->isInterfacePowerState(iface, IF_POWER_STATE_DOWN) &&
-                    NetworkManager::instance()->isInterfaceNcpState(iface, IF_NCP_STATE_OFF));
+                    !NetworkManager::instance()->isInterfaceReady(iface));
         }
     }
 

--- a/system/src/system_network_manager_api.cpp
+++ b/system/src/system_network_manager_api.cpp
@@ -261,6 +261,32 @@ void network_on(network_handle_t network, uint32_t flags, uint32_t param, void* 
     }());
 }
 
+bool network_is_on(network_handle_t network, void* reserved) {
+    if (network == NETWORK_INTERFACE_ALL) {
+        return NetworkManager::instance()->isInterfacePowerState(nullptr, IF_POWER_STATE_UP);
+    } else {
+        if_t iface;
+        if (!if_get_by_index(network, &iface)) {
+            return NetworkManager::instance()->isInterfacePowerState(iface, IF_POWER_STATE_UP);
+        }
+    }
+
+    return false;
+}
+
+bool network_is_off(network_handle_t network, void* reserved) {
+    if (network == NETWORK_INTERFACE_ALL) {
+        return NetworkManager::instance()->isInterfacePowerState(nullptr, IF_POWER_STATE_DOWN);
+    } else {
+        if_t iface;
+        if (!if_get_by_index(network, &iface)) {
+            return NetworkManager::instance()->isInterfacePowerState(iface, IF_POWER_STATE_DOWN);
+        }
+    }
+
+    return false;
+}
+
 bool network_has_credentials(network_handle_t network, uint32_t param, void* reserved) {
     if (network == NETWORK_INTERFACE_ALL) {
         return NetworkManager::instance()->isConfigured();

--- a/system/src/system_network_wifi.h
+++ b/system/src/system_network_wifi.h
@@ -128,8 +128,23 @@ protected:
         wlan_disconnect_now();
     }
 
-    int on_now() override { return wlan_activate(); }
-    void off_now() override { wlan_deactivate(); }
+    int on_now() override {
+        int ret = wlan_activate();
+        if (ret == 0) {
+            powered = true; 
+        }
+        return ret;
+    }
+
+    void off_now() override {
+        if (wlan_deactivate() == 0) {
+            powered = false;
+        }
+    }
+
+    bool is_powered() override {
+        return powered;
+    }
 
     void on_setup_cleanup() override { wlan_smart_config_cleanup(); }
 
@@ -139,7 +154,6 @@ protected:
     }
 
 public:
-
 
     virtual void start_listening() override
     {
@@ -151,7 +165,6 @@ public:
 
         ManagedNetworkInterface::start_listening(console);
     }
-
 
     void connect_cancel(bool cancel) override
     {
@@ -223,6 +236,11 @@ public:
         return wlan_get_hostname(buf, buf_len, NULL);
     }
 
+private:
+    // It's tricky to detect the modem power state.
+    // We assume that every time the device being powered up, the module is powered on.
+    // The the power state then be tracked by the on_now() and off_now() APIs.
+    bool powered = true;
 };
 
 #endif /* !HAL_PLATFORM_IFAPI */

--- a/user/tests/unit/stubs/system_network.cpp
+++ b/user/tests/unit/stubs/system_network.cpp
@@ -23,6 +23,14 @@ void network_on(network_handle_t network, uint32_t flags, uint32_t param1, void*
 void network_off(network_handle_t network, uint32_t flags, uint32_t param1, void* reserved) {
 }
 
+bool network_is_on(network_handle_t network, void* reserved) {
+    return false;
+}
+
+bool network_is_off(network_handle_t network, void* reserved) {
+    return false;
+}
+
 void network_connect(network_handle_t network, uint32_t flags, uint32_t param1, void* reserved) {
 }
 

--- a/user/tests/wiring/api/cellular.cpp
+++ b/user/tests/wiring/api/cellular.cpp
@@ -53,6 +53,12 @@ test (api_cellular_on_off)
     API_COMPILE(Cellular.off());
 }
 
+test (api_cellular_is_on_off)
+{
+    API_COMPILE(Cellular.isOn());
+    API_COMPILE(Cellular.isOff());
+}
+
 test (api_cellular_listen)
 {
     bool result;

--- a/user/tests/wiring/api/wifi.cpp
+++ b/user/tests/wiring/api/wifi.cpp
@@ -47,6 +47,18 @@ test(api_wifi_resolve)
     API_COMPILE(WiFi.resolve("abc.def.com"));
 }
 
+test (api_wifi_on_off)
+{
+    API_COMPILE(WiFi.on());
+    API_COMPILE(WiFi.off());
+}
+
+test (api_wifi_is_on_off)
+{
+    API_COMPILE(WiFi.isOn());
+    API_COMPILE(WiFi.isOff());
+}
+
 test (api_wifi_connect) {
     bool result;
     API_COMPILE(WiFi.connect());

--- a/user/tests/wiring/no_fixture/cellular.cpp
+++ b/user/tests/wiring/no_fixture/cellular.cpp
@@ -157,6 +157,43 @@ test(CELLULAR_05_sigstr_is_valid) {
     assertTrue(values_in_range);
 }
 
+test(CELLULAR_06_on_off_validity_check) {
+    connect_to_cloud(6*60*1000);
+    assertTrue(Cellular.isOn());
+    assertFalse(Cellular.isOff());
+
+    Particle.disconnect();
+    waitFor(Particle.disconnected, 30000);
+    assertTrue(Cellular.isOn());
+    assertFalse(Cellular.isOff());
+
+    Cellular.disconnect();
+    waitFor([]{ return !Cellular.ready(); }, 30000);
+    assertTrue(Cellular.isOn());
+    assertFalse(Cellular.isOff());
+
+    int ret = Cellular.command("AT\r\n");
+    assertEqual(ret, (int)RESP_OK);
+
+    Cellular.off();
+    waitFor(Cellular.isOff, 30000);
+    assertFalse(Cellular.isOn());
+    assertTrue(Cellular.isOff());
+
+    ret = Cellular.command("AT\r\n");
+    assertNotEqual(ret, (int)RESP_OK);
+
+    Cellular.on();
+    waitFor(Cellular.isOn, 30000);
+    assertTrue(Cellular.isOn());
+    assertFalse(Cellular.isOff());
+
+    ret = Cellular.command("AT\r\n");
+    assertEqual(ret, (int)RESP_OK);
+
+    connect_to_cloud(6*60*1000);
+}
+
 test(MDM_01_socket_writes_with_length_more_than_1023_work_correctly) {
 
 #if HAL_PLATFORM_NCP

--- a/wiring/inc/spark_wiring_cellular.h
+++ b/wiring/inc/spark_wiring_cellular.h
@@ -50,12 +50,6 @@ public:
     void off() {
         network_off(*this, 0, 0, NULL);
     }
-    bool isOn() {
-        return network_is_on(*this, NULL);
-    }
-    bool isOff() {
-        return network_is_off(*this, NULL);
-    }
     void connect(unsigned flags=0) {
         network_connect(*this, flags, 0, NULL);
     }

--- a/wiring/inc/spark_wiring_cellular.h
+++ b/wiring/inc/spark_wiring_cellular.h
@@ -50,6 +50,12 @@ public:
     void off() {
         network_off(*this, 0, 0, NULL);
     }
+    bool isOn() {
+        return network_is_on(*this, NULL);
+    }
+    bool isOff() {
+        return network_is_off(*this, NULL);
+    }
     void connect(unsigned flags=0) {
         network_connect(*this, flags, 0, NULL);
     }

--- a/wiring/inc/spark_wiring_network.h
+++ b/wiring/inc/spark_wiring_network.h
@@ -55,6 +55,8 @@ public:
 
     virtual void on();
     virtual void off();
+    virtual bool isOn();
+    virtual bool isOff();
     virtual void listen(bool begin = true);
     virtual void setListenTimeout(uint16_t timeout);
     virtual uint16_t getListenTimeout();

--- a/wiring/inc/spark_wiring_wifi.h
+++ b/wiring/inc/spark_wiring_wifi.h
@@ -156,15 +156,7 @@ public:
     void off(void) {
         network_off(*this, 0, 0, NULL);
     }
-
-    bool isOn() {
-        return network_is_on(*this, NULL);
-    }
-
-    bool isOff() {
-        return network_is_off(*this, NULL);
-    }
-
+    
     void listen(bool begin=true) {
         network_listen(*this, begin ? 0 : 1, NULL);
     }

--- a/wiring/inc/spark_wiring_wifi.h
+++ b/wiring/inc/spark_wiring_wifi.h
@@ -157,6 +157,14 @@ public:
         network_off(*this, 0, 0, NULL);
     }
 
+    bool isOn() {
+        return network_is_on(*this, NULL);
+    }
+
+    bool isOff() {
+        return network_is_off(*this, NULL);
+    }
+
     void listen(bool begin=true) {
         network_listen(*this, begin ? 0 : 1, NULL);
     }

--- a/wiring/src/spark_wiring_network.cpp
+++ b/wiring/src/spark_wiring_network.cpp
@@ -74,6 +74,14 @@ void NetworkClass::off() {
     network_off(*this, 0, 0, nullptr);
 }
 
+bool NetworkClass::isOn() {
+    return network_is_on(*this, nullptr);
+}
+
+bool NetworkClass::isOff() {
+    return network_is_off(*this, nullptr);
+}
+
 void NetworkClass::listen(bool begin) {
     network_listen(*this, begin ? 0 : 1, nullptr);
 }


### PR DESCRIPTION
As the title describes.

### Example App

```c
#include "Particle.h"

SYSTEM_MODE(MANUAL);
SYSTEM_THREAD(ENABLED);

SerialLogHandler log(115200, LOG_LEVEL_ALL);

void onNetworkStatusUpdated(system_event_t event, int param) {
    if (event == network_status) {
        switch (param) {
            case network_status_on: {
                Log.info("network_status_on");
                break;
            }
            case network_status_off: {
                Log.info("network_status_off");
                break;
            }
            case network_status_connected: {
                Log.info("network_status_connected");
                break;
            }
        }
    }
}

void setup() {
    System.on(network_status, onNetworkStatusUpdated);

    while (!Serial.isConnected());
    delay(1000);

    Log.info("Application started.");

    if (Cellular.isOn()) {
        Log.info("Modem is on.");
    } else if (Cellular.isOff()) {
        Log.info("Modem is off.");
    } else {
        Log.info("Modem is in an unknown state.");
    }

    Log.info("Turning on the modem...");
    Cellular.on();

    while (Cellular.isOff()) {
        Log.info("modem is off.");
    }
    while (!Cellular.isOn()) {
        Log.info("powering on...");
        delay(500);
    }
    Log.info("Modem is turned on.");

    delay(3s);

    Log.info("Turning off the modem...");
    Cellular.off();

    while (Cellular.isOn()) {
        Log.info("modem is on.");
    }
    while (!Cellular.isOff()) {
        Log.info("powering off...");
        delay(500);
    }
    Log.info("Modem is turned off.");
}

void loop() {
}
```
---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
