### PR TITLE
Disconnect from the cloud before going to sleep

### DIFF
--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -1234,16 +1234,6 @@ String bytes2hex(const uint8_t* buf, unsigned len)
     return result;
 }
 
-void Spark_Sleep(unsigned duration)
-{
-    cloud_disconnect(CLOUD_DISCONNECT_GRACEFULLY, CLOUD_DISCONNECT_REASON_SLEEP, NETWORK_DISCONNECT_REASON_NONE,
-            RESET_REASON_NONE, duration);
-}
-
-void Spark_Wake(void)
-{
-}
-
 CloudDiagnostics* CloudDiagnostics::instance() {
     return &g_cloudDiagnostics;
 }

--- a/system/src/system_cloud_internal.h
+++ b/system/src/system_cloud_internal.h
@@ -29,8 +29,6 @@
 
 void Spark_Signal(bool on, unsigned, void*);
 void Spark_SetTime(unsigned long dateTime);
-void Spark_Sleep(unsigned duration);
-void Spark_Wake();
 int Spark_Save(const void* buffer, size_t length, uint8_t type, void* reserved);
 int Spark_Restore(void* buffer, size_t max_length, uint8_t type, void* reserved);
 


### PR DESCRIPTION
### Problem

By default, the Sleep 2.0 API leaves the protocol layer in whatever state it was before going to sleep and continues to use it after waking up from sleep without checking whether the session with the server is still valid.

### Solution

Always disconnect from the cloud before going to sleep unless the network interface is used as a wake-up source. In the latter case, send a PING message to the server after waking up from sleep.

### Steps to Test

1. Verify that a sleepy device that doesn't use its network interface as a wake-up source successfully resumes its session when reconnecting to the cloud from a different address.
2. Using one of the network interfaces as a wake-up source, verify that the device sends a ping message to the cloud after waking up from sleep.

### References

- [ch64208]
