### PR TITLE
Set pin mode for PMIC and fuel gauge interrupts

### DIFF
--- a/system/src/system_power_manager.cpp
+++ b/system/src/system_power_manager.cpp
@@ -302,8 +302,10 @@ void PowerManager::loop(void* arg) {
 
     // IMPORTANT: attach the interrupt handler first
 #if HAL_PLATFORM_PMIC_INT_PIN_PRESENT
+    HAL_Pin_Mode(PMIC_INT, INPUT_PULLUP);
     attachInterrupt(PMIC_INT, &PowerManager::isrHandler, FALLING);
 #endif
+    HAL_Pin_Mode(LOW_BAT_UC, INPUT_PULLUP);
     attachInterrupt(LOW_BAT_UC, &PowerManager::isrHandler, FALLING);
     self->initDefault();
     FuelGauge fuel(true);


### PR DESCRIPTION
### Problem

Interrupts for the fuel gauge device were not firing after attaching handlers, mainly on the tracker platform.  An MCP23S17 GPIO expander is used to receive the input from the fuel gauge and it's defaults were not set for the interrupt pins to accept inputs with pullup.

### Solution

The PMIC and fuel gauge interrupt pins were explicitly configured for input source with pullups.

### Steps to Test

1. A battery with charge greater than 10% should be powering the device.
2. Flash the application
3. Unplug any cabled power sources (VIN or USB)
4. Allow the battery to discharge
5. Check if the handler print statement prints when the SOC (not normalized) value decreases and crosses 8%.

### Example App

```c
void lowBatteryHandler(system_event_t event, int data) {
  Serial1.println("Battery charge low handler");
}

void setup() {
  Serial1.begin(115200);
  FuelGauge().setAlertThreshold(8); // percent
  FuelGauge().clearAlert();
  delay(100);
  System.on(low_battery, lowBatteryHandler);
}

void loop() {
  static unsigned int loopCount = 0;
  if (System.uptime() - loopCount >= 10) {
    loopCount = System.uptime();
    Serial1.printlnf("voltage = %0.3f, normal SOC = %0.3f%%, SOC = %0.3f%%, state = %d, source = %d",
      FuelGauge().getVCell(),
      FuelGauge().getNormalizedSoC(),
      FuelGauge().getSoC(),
      System.batteryState(),
      System.powerSource());
  }
}
```

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
