### PR TITLE
[u-blox][Boron / B SoM] PPP workaround for SARA R4 ConfReq behavior

### DIFF
--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -1689,8 +1689,11 @@ int SaraNcpClient::enterDataMode() {
 
     CHECK(waitAtResponse(dataParser_, 5000));
 
-    // Ignore response
-    CHECK(dataParser_.execCommand(20000, "ATH"));
+    if (ncpId() != PLATFORM_NCP_SARA_R410) {
+        // Ignore response
+        // SARA R4 does not support this, see above
+        CHECK(dataParser_.execCommand(20000, "ATH"));
+    }
 
     auto resp = dataParser_.sendCommand(3 * 60 * 1000, "ATD*99***1#");
     if (resp.hasNextLine()) {


### PR DESCRIPTION
## ~Update `third_party/lwip` submodule reference after https://github.com/particle-iot/lwip/pull/8 is merged, before merging this PR~

### Problem

SARA R4 PPP implementation is peculiar and for unknown reason after IPCP is already up, it sends up an _empty_ ConfReq. If we follow the standard to the T, we are supposed to bring IPCP down and restart negotiation. This increases warm bootup cloud connection times significantly.

### Solution

The solution is to utilize a new PPP option introduced in https://github.com/particle-iot/lwip/pull/8 to slightly go off standard and ACK these Configure-Requests in an already opened state if the protocol handler does not disagree with the options provided in them and we already in an appropriate state (authed, and it's not LCP protocol that we need to renegotiate)

This PR also disables `ATH` command on R4-based devices as it does not function anyway. See https://github.com/particle-iot/device-os/pull/2188

### Steps to Test

1. Build with PPP logs enabled
2. See logs from https://github.com/particle-iot/lwip/pull/8
3. Compare behavior and assess the connection times

### Example App

N/A

### References

- https://github.com/particle-iot/lwip/pull/8
- [CH64715]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
