### PR TITLE
[Wiring] Remove warning for publish scope deprecation

### DIFF
--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -41,9 +41,6 @@
 #include <functional>
 #include <type_traits>
 
-#define PARTICLE_DEPRECATED_API_DEFAULT_SUBSCRIBE_SCOPE \
-        PARTICLE_DEPRECATED_API("Beginning with 0.8.0 release, Particle.subscribe() will require event scope to be specified explicitly.");
-
 typedef std::function<user_function_int_str_t> user_std_function_int_str_t;
 typedef std::function<void (const char*, const char*)> wiring_event_handler_t;
 
@@ -319,11 +316,10 @@ public:
         return subscribe(eventName, std::bind(handler, instance, _1, _2), deviceID);
     }
 
-    // Deprecated methods
-    bool subscribe(const char* name, EventHandler handler) PARTICLE_DEPRECATED_API_DEFAULT_SUBSCRIBE_SCOPE;
-    bool subscribe(const char* name, wiring_event_handler_t handler) PARTICLE_DEPRECATED_API_DEFAULT_SUBSCRIBE_SCOPE;
+    bool subscribe(const char* name, EventHandler handler);
+    bool subscribe(const char* name, wiring_event_handler_t handler);
     template<typename T>
-    bool subscribe(const char* name, void (T::*handler)(const char*, const char*), T* instance) PARTICLE_DEPRECATED_API_DEFAULT_SUBSCRIBE_SCOPE;
+    bool subscribe(const char* name, void (T::*handler)(const char*, const char*), T* instance);
 
     void unsubscribe()
     {
@@ -558,7 +554,6 @@ inline bool CloudDisconnectOptions::isTimeoutSet() const {
     return (flags_ & OptionFlag::TIMEOUT);
 }
 
-// Deprecated methods
 inline particle::Future<bool> CloudClass::publish(const char* name) {
     return publish(name, PUBLIC);
 }

--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -41,9 +41,6 @@
 #include <functional>
 #include <type_traits>
 
-#define PARTICLE_DEPRECATED_API_DEFAULT_PUBLISH_SCOPE \
-        PARTICLE_DEPRECATED_API("Beginning with 0.8.0 release, Particle.publish() will require event scope to be specified explicitly.");
-
 #define PARTICLE_DEPRECATED_API_DEFAULT_SUBSCRIBE_SCOPE \
         PARTICLE_DEPRECATED_API("Beginning with 0.8.0 release, Particle.subscribe() will require event scope to be specified explicitly.");
 
@@ -259,10 +256,9 @@ public:
         return publish_event(eventName, eventData, ttl, flags1 | flags2);
     }
 
-    // Deprecated methods
-    particle::Future<bool> publish(const char* name) PARTICLE_DEPRECATED_API_DEFAULT_PUBLISH_SCOPE;
-    particle::Future<bool> publish(const char* name, const char* data) PARTICLE_DEPRECATED_API_DEFAULT_PUBLISH_SCOPE;
-    particle::Future<bool> publish(const char* name, const char* data, int ttl) PARTICLE_DEPRECATED_API_DEFAULT_PUBLISH_SCOPE;
+    particle::Future<bool> publish(const char* name);
+    particle::Future<bool> publish(const char* name, const char* data);
+    particle::Future<bool> publish(const char* name, const char* data, int ttl);
 
     /**
      * @brief Publish vitals information


### PR DESCRIPTION
### Problem

Deprecation notice exists on Particle.publish without a scope, although there is no need for a scope now.

### Solution

Remove the deprecation notice on Particle.publish without a scope, since there is only one event stream. 

### Steps to Test

### Example App

Compile the following code, and you should **no longer** see warning of deprecation notice like this
```
warning: 'particle::Future<bool> CloudClass::publish(const char*)' is deprecated: Beginning with 0.8.0 release, Particle.publish() will require event scope to be specified explicitly. Define PARTICLE_USING_DEPRECATED_API macro to avoid this warning. [-Wdeprecated-declarations]
```
or
```
warning: 'bool CloudClass::subscribe(const char*, EventHandler)' is deprecated: Beginning with 0.8.0 release, Particle.subscribe() will require event scope to be specified explicitly. Define PARTICLE_USING_DEPRECATED_API macro to avoid this warning. [-Wdeprecated-declarations]
```

```c
#include "application.h"

void myHandler(const char *event, const char *data)
{
 // code
}

void setup() {
    Particle.publish("msg");
    Particle.subscribe("temp", myHandler);
}

void loop() {
}
```

### References

[ch61262](https://app.clubhouse.io/particle/story/61262/remove-deprecation-notice-for-particle-publish-without-a-scope)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
