### PR TITLE
[Gen3] Fix LED behavior in case of network failure in Cloud Connecting state 

### DIFF
--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -325,6 +325,10 @@ void establish_cloud_connection()
             // the last error diagnostic is used only for communication errors since we cannot mix
             // HAL and communication error codes without specifying the category of an error
             WARN("Cloud socket connection failed: %d", connect_result);
+            if (connect_result == SYSTEM_ERROR_NETWORK) {
+                LED_SIGNAL_STOP(CLOUD_HANDSHAKE);
+                LED_SIGNAL_STOP(CLOUD_CONNECTING);
+            }
             SPARK_CLOUD_SOCKETED = 0;
 
             diag->status(CloudDiagnostics::DISCONNECTED);


### PR DESCRIPTION
### Problem

When cloud _connecting_, the RGB LED doesn't go back to (blinking) green when de-registered from network, or when having DNS test failures

### Solution

The cloud signaling procedure is correct, however, the LED doesn't reflect the same. The LED stays in blinking cyan, although the system state has backed off from "Cloud Connecting" state.

### Steps to Test

- Run any app that allows connecting to cloud, with serial logging enabled helpfully
- As soon as "Cloud connecting" is seen (device must have started blinking cyan), disconnect the module from network (probably by removing antenna). This needs to be done after "Cloud: Connecting" and before "Cloud socket connected" states
- The device struggles at that point to connect, and likely gets a `CEREG: x` deregistered URC
- The device should be blinking green (instead of blinking cyan)

### Example App

```c
void setup() {
}

void loop() {
}
```

### References

[ch64095](https://app.clubhouse.io/particle/story/64095/boron-lte-device-keeps-blinking-cyan-while-it-should-blink-green-with-cereg-2-urc)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
