### PR TITLE
[gen3] Allow UMNOPROF SIM_SELECT to default back to SW_DEFAULT

### DIFF
--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1083,12 +1083,21 @@ bool MDMParser::init(DevStatus* status)
                 }
             }
             int p = UBLOX_SARA_UMNOPROF_SIM_SELECT;
+            bool continueInit = false;
             if (netProv == CELLULAR_NETPROV_TWILIO) {
                 p = UBLOX_SARA_UMNOPROF_STANDARD_EUROPE;
+            } else {
+                // continue on with init if we are trying to set SIM_SELECT a second time
+                if (resetFailureAttempts >= 1) {
+                    LOG(WARN, "UMNOPROF=1 did not resolve a built-in profile, please check if UMNOPROF=100 is required!");
+                    continueInit = true;
+                }
             }
-            sendFormated("AT+UMNOPROF=%d\r\n", p);
-            waitFinalResp(nullptr, nullptr, UMNOPROF_TIMEOUT);
-            goto reset_failure; // Not checking for errors above since we will reset either way
+            if (!continueInit) {
+                sendFormated("AT+UMNOPROF=%d\r\n", p);
+                waitFinalResp(nullptr, nullptr, UMNOPROF_TIMEOUT);
+                goto reset_failure; // Not checking for errors above since we will reset either way
+            }
         } else if (umnoprof == UBLOX_SARA_UMNOPROF_STANDARD_EUROPE) {
             sendFormated("AT+UBANDMASK?\r\n");
             uint64_t ubandUint64 = 0;


### PR DESCRIPTION
### Problem

3rd party SIMs that are not detected with a UMNOPROF, do not default to the SW_DEFAULT profile (0), but get stuck in an init loop in Gen 3.

On Gen 2, it will default to SW_DEFAULT profile, but it will take 8 tries before it does taking up unnecessary time.

### Solution

- [gen2] A repeated UMNOPROF SIM_SELECT allows MDMParser::init to continue early [ch64292]
- [gen3] Allow UMNOPROF SIM_SELECT to default back to SW_DEFAULT [ch64292]

### Steps to Test

- Run the example app
- Let the device connect to the cloud with a Particle SIM
- Triple tap the Mode button and wait for "Cold boot for a Factory Boot Experience!"
- Power off the device
- Switch the SIM for a 3rd party SIM
- Power on the device and it should connect quickly using the SW_DEFAULT profile.

NOTE: You will see a log that says the following if this happens:
> UMNOPROF=1 did not resolve a built-in profile, please check if UMNOPROF=100 is required!

This is up to the user to research and implement.  YMMV on the exact configuration needed.  Please contact your SIM provider.

### Example App

```c
#include "Particle.h"
Serial1LogHandler logHandler(115200, LOG_LEVEL_ALL);
SYSTEM_MODE(SEMI_AUTOMATIC);
bool reset_umnoprof = false;
void button_handler(system_event_t event, int clicks)
{
    if (event == button_final_click) {
        if (clicks == 3) {
            reset_umnoprof = true;
        }
    }
}
void setup() {
    System.on(button_final_click, button_handler);
    // Cellular.setActiveSim(EXTERNAL_SIM); // you might need this
    // Cellular.setActiveSim(INTERNAL_SIM);
    Particle.connect();
}

void loop() {
    if (reset_umnoprof) {
        reset_umnoprof = false;

        // System.reset();
        Cellular.command(60000, "AT+CFUN=0\r\n");
        Cellular.command(1000, "AT+UMNOPROF=0\r\n");
        Cellular.command(1000, "AT+UMNOPROF?\r\n");
        Cellular.command(1000, "AT+CFUN=15\r\n");
        Log.info("\r\n\r\nCold boot for a Factory Boot Experience!\r\n\r\n");
    }
}

```

### References

ch64292

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] N/A Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
