### PR TITLE
[u-blox] older modem firmware does not have UMNOPROF=100 available [ch64670]

### DIFF
--- a/hal/network/ncp_client/sara/sara_ncp_client.h
+++ b/hal/network/ncp_client/sara/sara_ncp_client.h
@@ -107,7 +107,8 @@ private:
     system_tick_t registeredTime_;
     system_tick_t powerOnTime_;
     unsigned int fwVersion_ = 0;
-    bool memoryIssuePresent_ = false;
+    bool memoryIssuePresent_;
+    bool oldFirmwarePresent_;
     unsigned registrationTimeout_;
     unsigned registrationInterventions_;
     volatile bool inFlowControl_ = false;

--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -616,7 +616,8 @@ protected:
     // variables
     DevStatus   _dev; //!< collected device information
     char _verExtended[32]; //!< collected modem and application version string (ATI9)
-    bool _memoryIssuePresent = true; //!< flag to add specific delays when the firmware version with memory issue is present
+    bool _memoryIssuePresent; //!< flag to add specific delays when the firmware version with memory issue is present
+    bool _oldFirmwarePresent; //!< flag to add indicate specific issues present with older firmware versions
     system_tick_t _timePowerOn; //!< timestamp when unit was powered on (to be used in conjunction with _memoryIssuePresent)
     system_tick_t _timeRegistered; //!< timestamp when unit was registered on (to be used in conjunction with _memoryIssuePresent)
     NetStatus   _net; //!< collected network information


### PR DESCRIPTION
### Problem

- R410 - Gets stuck in loop where UMNOPROF=100 was not sticking, but erroring out instead, on older modem firmware
- R410 - Mostly an issue for Gen 3 with external SIM support on Boron/B SoM, switching between Kore AT&T vs. Twilio Super vs. 3rd Party SIMs could get stuck on the wrong UMNOPROF.
- Gen 3 Modem version detection was running too late for where it needed to be used, and could potentially return an invalid version number instead of 0.

### Solution

- Allow modem to continue with SW_DEFAULT (UMNOPROF=0) when older modem firmware detected.
- Allow UMNOPROF to be switched accordingly between Kore AT&T vs. Twilio Super vs. 3rd Party SIMs.
- Run Gen 3 modem detection earlier, and use temporary variables to ensure if an error occurs, we don't return the error code as the firmware version.

### Steps to Test

- Make sure your R410 modem has older modem firmware < 05.08
- Run the example app
- Let the device connect to the cloud with a Particle SIM
- Triple tap the Mode button and wait for "Cold boot for a Factory Boot Experience!"
- Power off the device
- Make sure the SIM is a Twilio Super SIM
- Power on the device and it should connect quickly using the SW_DEFAULT profile.
- I also ran through the following Test Matrix, but it is not required to do the same as it will take a long time (spot check if you wish):

```
Boron Old Modem Firmware
- 3rd party SIM tries to connect: OK
- Twilio: OK
- Kore AT&T: OK
- Factory Reset Kore AT&T: OK
- Twilio Again: OK
- Factory Reset Twilio: OK

Boron New Modem Firmware
- 3rd party SIM tries to connect: OK
- Twilio: OK
- Kore AT&T: OK
- Factory Reset Kore AT&T: OK
- Twilio Again: OK
- Factory Reset Twilio: OK

Electron LTE Old Modem Firmware
- 3rd party SIM tries to connect: OK
- Twilio: OK
- Kore AT&T: OK
- Factory Reset Kore AT&T: OK
- Twilio Again: OK
- Factory Reset Twilio: OK

Electron LTE New Modem Firmware
- Kore AT&T: OK
- Factory Reset Kore AT&T: OK
```


### Example App

```c
#include "Particle.h"
Serial1LogHandler logHandler(115200, LOG_LEVEL_ALL);
SYSTEM_MODE(SEMI_AUTOMATIC);
bool reset_umnoprof = false;
void button_handler(system_event_t event, int clicks)
{
    if (event == button_final_click) {
        if (clicks == 3) {
            reset_umnoprof = true;
        }
    }
}
void setup() {
    System.on(button_final_click, button_handler);
    // Cellular.setActiveSim(EXTERNAL_SIM); // you might need this
    // Cellular.setActiveSim(INTERNAL_SIM);
    Particle.connect();
}

void loop() {
    if (reset_umnoprof) {
        reset_umnoprof = false;

        // System.reset();
        Cellular.command(60000, "AT+CFUN=0\r\n");
        Cellular.command(1000, "AT+UMNOPROF=0\r\n");
        Cellular.command(1000, "AT+UMNOPROF?\r\n");
        Cellular.command(1000, "AT+CFUN=15\r\n");
        Log.info("\r\n\r\nCold boot for a Factory Boot Experience!\r\n\r\n");
    }
}
```

### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] N/A - Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
