### PR TITLE
Gen3: Network management improvement

### DIFF
--- a/hal/network/lwip/basenetif.h
+++ b/hal/network/lwip/basenetif.h
@@ -50,12 +50,6 @@ private:
     static void netifEventCb(netif* iface, netif_nsc_reason_t reason, const netif_ext_callback_args_t* args);
 
 protected:
-    enum NetifState {
-        NETIF_STATE_OFF,
-        NETIF_STATE_ON_DOWN,
-        NETIF_STATE_UP
-    };
-
     netif netif_ = {};
 
 private:

--- a/hal/network/lwip/basenetif.h
+++ b/hal/network/lwip/basenetif.h
@@ -50,6 +50,12 @@ private:
     static void netifEventCb(netif* iface, netif_nsc_reason_t reason, const netif_ext_callback_args_t* args);
 
 protected:
+    enum NetifState {
+        NETIF_STATE_OFF,
+        NETIF_STATE_ON_DOWN,
+        NETIF_STATE_UP
+    };
+
     netif netif_ = {};
 
 private:

--- a/hal/network/lwip/cellular/pppncpnetif.cpp
+++ b/hal/network/lwip/cellular/pppncpnetif.cpp
@@ -119,6 +119,8 @@ void PppNcpNetif::loop(void* arg) {
         self->celMan_->ncpClient()->enable(); // Make sure the client is enabled
         os_semaphore_take(self->netifSemaphore_, timeout, false);
 
+        self->setExpectedInternalState(self->lastNetifEvent_);
+
         if (self->expectedNcpState_ == NcpState::ON && self->celMan_->ncpClient()->ncpState() != NcpState::ON) {
             auto r = self->celMan_->ncpClient()->on();
             if (r != SYSTEM_ERROR_NONE && r != SYSTEM_ERROR_ALREADY_EXISTS) {
@@ -169,7 +171,6 @@ int PppNcpNetif::up() {
         return SYSTEM_ERROR_NONE;
     }
     lastNetifEvent_ = NetifEvent::Up;
-    setExpectedInternalState(lastNetifEvent_);
     // It's fine even if we failed to give the semaphore, as we specify a timeout taking the semaphore.
     os_semaphore_give(netifSemaphore_, false);
     return SYSTEM_ERROR_NONE;
@@ -190,7 +191,6 @@ int PppNcpNetif::down() {
         // Disable the client to interrupt its current operation
         client->disable();
     }
-    setExpectedInternalState(lastNetifEvent_);
     // It's fine even if we failed to give the semaphore, as we specify a timeout taking the semaphore.
     os_semaphore_give(netifSemaphore_, false);
     return SYSTEM_ERROR_NONE;
@@ -201,7 +201,6 @@ int PppNcpNetif::powerUp() {
         return SYSTEM_ERROR_NONE;
     }
     lastNetifEvent_ = NetifEvent::PowerOn;
-    setExpectedInternalState(lastNetifEvent_);
     // It's fine even if we failed to give the semaphore, as we specify a timeout taking the semaphore.
     os_semaphore_give(netifSemaphore_, false);
     return SYSTEM_ERROR_NONE;
@@ -216,7 +215,7 @@ int PppNcpNetif::powerDown() {
      * or hardware pins will fail in some case, which will result a hardreset of the modem. That takes
      * longer to turn off the modem. Simply let the NCP initialization complete and then execute the power
      * off sequence. */
-    setExpectedInternalState(lastNetifEvent_);
+
     // It's fine even if we failed to give the semaphore, as we specify a timeout taking the semaphore.
     os_semaphore_give(netifSemaphore_, false);
     return SYSTEM_ERROR_NONE;

--- a/hal/network/lwip/cellular/pppncpnetif.cpp
+++ b/hal/network/lwip/cellular/pppncpnetif.cpp
@@ -119,8 +119,6 @@ void PppNcpNetif::loop(void* arg) {
         self->celMan_->ncpClient()->enable(); // Make sure the client is enabled
         os_semaphore_take(self->netifSemaphore_, timeout, false);
 
-        self->setExpectedInternalState(self->lastNetifEvent_);
-
         if (self->expectedNcpState_ == NcpState::ON && self->celMan_->ncpClient()->ncpState() != NcpState::ON) {
             auto r = self->celMan_->ncpClient()->on();
             if (r != SYSTEM_ERROR_NONE && r != SYSTEM_ERROR_ALREADY_EXISTS) {
@@ -170,7 +168,11 @@ int PppNcpNetif::up() {
     if (lastNetifEvent_ == NetifEvent::Up) {
         return SYSTEM_ERROR_NONE;
     }
+    // FIXME:
+    // The following separate sequential atomic operations do not make the whole change atomic.
+    // We may end up in an inconsistent state. Same to wherever the changes being made.
     lastNetifEvent_ = NetifEvent::Up;
+    setExpectedInternalState(lastNetifEvent_);
     // It's fine even if we failed to give the semaphore, as we specify a timeout taking the semaphore.
     os_semaphore_give(netifSemaphore_, false);
     return SYSTEM_ERROR_NONE;
@@ -191,6 +193,7 @@ int PppNcpNetif::down() {
         // Disable the client to interrupt its current operation
         client->disable();
     }
+    setExpectedInternalState(lastNetifEvent_);
     // It's fine even if we failed to give the semaphore, as we specify a timeout taking the semaphore.
     os_semaphore_give(netifSemaphore_, false);
     return SYSTEM_ERROR_NONE;
@@ -201,6 +204,7 @@ int PppNcpNetif::powerUp() {
         return SYSTEM_ERROR_NONE;
     }
     lastNetifEvent_ = NetifEvent::PowerOn;
+    setExpectedInternalState(lastNetifEvent_);
     // It's fine even if we failed to give the semaphore, as we specify a timeout taking the semaphore.
     os_semaphore_give(netifSemaphore_, false);
     return SYSTEM_ERROR_NONE;
@@ -215,7 +219,7 @@ int PppNcpNetif::powerDown() {
      * or hardware pins will fail in some case, which will result a hardreset of the modem. That takes
      * longer to turn off the modem. Simply let the NCP initialization complete and then execute the power
      * off sequence. */
-
+    setExpectedInternalState(lastNetifEvent_);
     // It's fine even if we failed to give the semaphore, as we specify a timeout taking the semaphore.
     os_semaphore_give(netifSemaphore_, false);
     return SYSTEM_ERROR_NONE;

--- a/hal/network/lwip/cellular/pppncpnetif.h
+++ b/hal/network/lwip/cellular/pppncpnetif.h
@@ -58,11 +58,22 @@ protected:
     virtual void netifEventHandler(netif_nsc_reason_t reason, const netif_ext_callback_args_t* args) override;
 
 private:
+    enum class NetifEvent {
+        None = 0,
+        Up = 1,
+        Down = 2,
+        Exit = 3,
+        PowerOff = 4,
+        PowerOn = 5
+    };
+
     int up();
     int down();
 
     int upImpl();
     int downImpl();
+
+    void setExpectedInternalState(NetifEvent ev);
 
     static void loop(void* arg);
 
@@ -73,10 +84,12 @@ private:
 
 private:
     os_thread_t thread_ = nullptr;
-    os_queue_t queue_ = nullptr;
+    os_semaphore_t netifSemaphore_ = nullptr;
     std::atomic_bool exit_;
     particle::net::ppp::Client client_;
-    std::atomic<NetifState> expectedNetifState_;
+    std::atomic<NetifEvent> lastNetifEvent_;
+    std::atomic<NcpState> expectedNcpState_;
+    std::atomic<NcpConnectionState> expectedConnectionState_;
     CellularNetworkManager* celMan_ = nullptr;
     volatile system_tick_t connectStart_ = 0;
 };

--- a/hal/network/lwip/cellular/pppncpnetif.h
+++ b/hal/network/lwip/cellular/pppncpnetif.h
@@ -72,12 +72,6 @@ private:
     static void mempEventHandler(memp_t type, unsigned available, unsigned size, void* ctx);
 
 private:
-    enum NetifState {
-        NETIF_STATE_OFF,
-        NETIF_STATE_ON_DOWN,
-        NETIF_STATE_UP
-    };
-
     os_thread_t thread_ = nullptr;
     os_queue_t queue_ = nullptr;
     std::atomic_bool exit_;

--- a/hal/network/lwip/cellular/pppncpnetif.h
+++ b/hal/network/lwip/cellular/pppncpnetif.h
@@ -72,11 +72,17 @@ private:
     static void mempEventHandler(memp_t type, unsigned available, unsigned size, void* ctx);
 
 private:
+    enum NetifState {
+        NETIF_STATE_OFF,
+        NETIF_STATE_ON_DOWN,
+        NETIF_STATE_UP
+    };
+
     os_thread_t thread_ = nullptr;
     os_queue_t queue_ = nullptr;
     std::atomic_bool exit_;
     particle::net::ppp::Client client_;
-    volatile bool up_ = false;
+    std::atomic<NetifState> expectedNetifState_;
     CellularNetworkManager* celMan_ = nullptr;
     volatile system_tick_t connectStart_ = 0;
 };

--- a/hal/network/lwip/esp32/esp32ncpnetif.cpp
+++ b/hal/network/lwip/esp32/esp32ncpnetif.cpp
@@ -204,13 +204,12 @@ void Esp32NcpNetif::loop(void* arg) {
 }
 
 int Esp32NcpNetif::up() {
-    if (lastNetifEvent_ == NetifEvent::Up) {
-        return SYSTEM_ERROR_NONE;
-    }
     // FIXME:
     // The following separate sequential atomic operations do not make the whole change atomic.
     // We may end up in an inconsistent state. Same to wherever the changes being made.
-    lastNetifEvent_ = NetifEvent::Up;
+    if (lastNetifEvent_.exchange(NetifEvent::Up, std::memory_order_acq_rel) == NetifEvent::Up) {
+        return SYSTEM_ERROR_NONE;
+    }
     setExpectedInternalState(lastNetifEvent_);
     // It's fine even if we failed to give the semaphore, as we specify a timeout taking the semaphore.
     os_semaphore_give(netifSemaphore_, false);
@@ -218,10 +217,9 @@ int Esp32NcpNetif::up() {
 }
 
 int Esp32NcpNetif::down() {
-    if (lastNetifEvent_ == NetifEvent::Down) {
+    if (lastNetifEvent_.exchange(NetifEvent::Down, std::memory_order_acq_rel) == NetifEvent::Down) {
         return SYSTEM_ERROR_NONE;
     }
-    lastNetifEvent_ = NetifEvent::Down;
     const auto client = wifiMan_->ncpClient();
     if (client->connectionState() != NcpConnectionState::CONNECTED) {
         // Disable the client to interrupt its current operation
@@ -234,10 +232,9 @@ int Esp32NcpNetif::down() {
 }
 
 int Esp32NcpNetif::powerUp() {
-    if (lastNetifEvent_ == NetifEvent::PowerOn) {
+    if (lastNetifEvent_.exchange(NetifEvent::PowerOn, std::memory_order_acq_rel) == NetifEvent::PowerOn) {
         return SYSTEM_ERROR_NONE;
     }
-    lastNetifEvent_ = NetifEvent::PowerOn;
     setExpectedInternalState(lastNetifEvent_);
     // It's fine even if we failed to give the semaphore, as we specify a timeout taking the semaphore.
     os_semaphore_give(netifSemaphore_, false);
@@ -245,10 +242,9 @@ int Esp32NcpNetif::powerUp() {
 }
 
 int Esp32NcpNetif::powerDown() {
-    if (lastNetifEvent_ == NetifEvent::PowerOff) {
+    if (lastNetifEvent_.exchange(NetifEvent::PowerOff, std::memory_order_acq_rel) == NetifEvent::PowerOff) {
         return SYSTEM_ERROR_NONE;
     }
-    lastNetifEvent_ = NetifEvent::PowerOff;
     setExpectedInternalState(lastNetifEvent_);
     // It's fine even if we failed to give the semaphore, as we specify a timeout taking the semaphore.
     os_semaphore_give(netifSemaphore_, false);

--- a/hal/network/lwip/esp32/esp32ncpnetif.h
+++ b/hal/network/lwip/esp32/esp32ncpnetif.h
@@ -77,7 +77,7 @@ private:
     os_thread_t thread_ = nullptr;
     os_queue_t queue_ = nullptr;
     std::atomic_bool exit_;
-    volatile bool up_ = false;
+    std::atomic<NetifState> expectedNetifState_;
     particle::WifiNetworkManager* wifiMan_ = nullptr;
     std::unique_ptr<char[]> hostname_;
 };

--- a/hal/network/lwip/esp32/esp32ncpnetif.h
+++ b/hal/network/lwip/esp32/esp32ncpnetif.h
@@ -53,11 +53,22 @@ protected:
     virtual void netifEventHandler(netif_nsc_reason_t reason, const netif_ext_callback_args_t* args) override;
 
 private:
+    enum class NetifEvent {
+        None = 0,
+        Up = 1,
+        Down = 2,
+        Exit = 3,
+        PowerOff = 4,
+        PowerOn = 5
+    };
+
     int up();
     int down();
 
     int upImpl();
     int downImpl();
+
+    void setExpectedInternalState(NetifEvent ev);
 
     /* LwIP netif init callback */
     static err_t initCb(netif *netif);
@@ -75,9 +86,11 @@ private:
 
 private:
     os_thread_t thread_ = nullptr;
-    os_queue_t queue_ = nullptr;
+    os_semaphore_t netifSemaphore_ = nullptr;
     std::atomic_bool exit_;
-    std::atomic<NetifState> expectedNetifState_;
+    std::atomic<NetifEvent> lastNetifEvent_;
+    std::atomic<NcpState> expectedNcpState_;
+    std::atomic<NcpConnectionState> expectedConnectionState_;
     particle::WifiNetworkManager* wifiMan_ = nullptr;
     std::unique_ptr<char[]> hostname_;
 };

--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -368,7 +368,7 @@ int QuectelNcpClient::off() {
         // WARN: We assume that the modem can turn off itself reliably.
     } else {
         // Power down using hardware
-        modemPowerOff();
+        CHECK(modemPowerOff());
         // FIXME: There is power leakage still if powering off the modem failed.
     }
 

--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -363,7 +363,9 @@ int SaraNcpClient::off() {
         // WARN: We assume that the modem can turn off itself reliably.
     } else {
         // Power down using hardware
-        CHECK(modemPowerOff());
+        if (modemPowerOff() != SYSTEM_ERROR_NONE) {
+            LOG(ERROR, "Failed to turn off the modem.");
+        }
         // FIXME: There is power leakage still if powering off the modem failed.
     }
 

--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -363,7 +363,7 @@ int SaraNcpClient::off() {
         // WARN: We assume that the modem can turn off itself reliably.
     } else {
         // Power down using hardware
-        modemPowerOff();
+        CHECK(modemPowerOff());
         // FIXME: There is power leakage still if powering off the modem failed.
     }
 


### PR DESCRIPTION
This PR improves the network connection and modem power management for Gen3 platforms. Whenever a network API is called, the final network state intends to be consistent with the final call. And it gracefully transits network state according to the sequence that network APIs are called.

## Example App

```c
#include "Particle.h"

SYSTEM_MODE(MANUAL);
SYSTEM_THREAD(ENABLED);

SerialLogHandler log(115200, LOG_LEVEL_ALL);

void setup() {
    while (!Serial.isConnected());

    Log.info("Type 'o', 'f', 'c', 'd', 'p' to test.");
    Log.info("'o' -- WiFi/Cellular.on()");
    Log.info("'f' -- WiFi/Cellular.off()");
    Log.info("'c' -- WiFi/Cellular.connect()");
    Log.info("'d' -- WiFi/Cellular.disconnect()");
    Log.info("'p' -- Particle.connect()");
    Log.info("'q' -- Particle.disconnect()");
}

void loop() {
    if (Serial.available()) {
        char cmd = Serial.read();
        switch (cmd) {
            case 'o': {
                #if HAL_PLATFORM_CELLULAR
                Log.info("Cellular.on()");
                Cellular.on();
                #else
                Log.info("WiFi.on()");
                WiFi.on();
                #endif
                break;
            }
            case 'f': {
                #if HAL_PLATFORM_CELLULAR
                Log.info("Cellular.off()");
                Cellular.off();
                #else
                Log.info("WiFi.off()");
                WiFi.off();
                #endif
                break;
            }
            case 'c': {
                #if HAL_PLATFORM_CELLULAR
                Log.info("Cellular.connect()");
                Cellular.connect();
                #else
                Log.info("WiFi.connect()");
                WiFi.connect();
                #endif
                break;
            }
            case 'd': {
                #if HAL_PLATFORM_CELLULAR
                Log.info("Cellular.disconnect()");
                Cellular.disconnect();
                #else
                Log.info("WiFi.disconnect()");
                WiFi.disconnect();
                #endif
                break;
            }
            case 'p': {
                Log.info("Particle.connect()");
                Particle.connect();
                break;
            }
            case 'q': {
                Log.info("Particle.disconnect()");
                Particle.disconnect();
                break;
            }
            default: break;
        }
    }
}

```

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
