### PR TITLE
[Electron] Workaround for modem HAL relying on system networking code to re-attempt initialization

### DIFF
--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -56,6 +56,8 @@ std::recursive_mutex mdm_mutex;
 #define MDM_C_REG_POLL_INTERVAL_MS (30000) //!< CREG/CGREG/CEREG poll interval to check for unexpected modem reset
 #define MDM_SOCKET_SEND_RETRIES_R4_BUG (3)
 #define MDM_MAX_ERRORS (2) //!< max number of errors before action is taken to recover the modem
+#define MDM_RESET_FAILURE_TIMEOUT_MS (10000)
+#define MDM_RESET_FAILURE_MAX_ATTEMPTS (8)
 
 // ID of the PDP context used to configure the default EPS bearer when registering in an LTE network
 // Note: There are no PDP contexts in LTE, SARA-R4 uses this naming for the sake of simplicity
@@ -277,6 +279,8 @@ MDMParser::MDMParser(void)
 #ifdef MDM_DEBUG
     _debugLevel = 3;
 #endif
+    _resetFailureAttempts = 0;
+    _resetFailureTimestamp = 0;
 
     Hal_Pin_Info* pinMap = HAL_Pin_Map();
     RCC_AHB1PeriphClockCmd(RCC_AHB1Periph_GPIOB, ENABLE);
@@ -295,12 +299,16 @@ void MDMParser::setPowerMode(int mode) {
 }
 
 void MDMParser::cancel(void) {
-    MDM_INFO("\r\n[ Modem::cancel ] = = = = = = = = = = = = = = =");
+    if (!_cancel_all_operations) {
+        MDM_INFO("\r\n[ Modem::cancel ] = = = = = = = = = = = = = = =");
+    }
     _cancel_all_operations = true;
 }
 
 void MDMParser::resume(void) {
-    MDM_INFO("\r\n[ Modem::resume ] = = = = = = = = = = = = = = =");
+    if (_cancel_all_operations) {
+        MDM_INFO("\r\n[ Modem::resume ] = = = = = = = = = = = = = = =");
+    }
     _cancel_all_operations = false;
 }
 
@@ -916,11 +924,18 @@ failure:
 bool MDMParser::powerOn(const char* simpin)
 {
     LOCK();
+
     // The modem type won't change that easily
     auto device_type = _dev.dev;
     memset(&_dev, 0, sizeof(_dev));
     _dev.dev = device_type;
     bool retried_after_reset = false;
+
+    if (_resetFailureAttempts > 0) {
+        if (HAL_Timer_Get_Milli_Seconds() - _resetFailureTimestamp < MDM_RESET_FAILURE_TIMEOUT_MS) {
+            goto failure;
+        }
+    }
 
     _error = 0;
 
@@ -998,8 +1013,7 @@ failure:
 bool MDMParser::init(DevStatus* status)
 {
     LOCK();
-    static int resetFailureAttempts = 0;
-    MDM_INFO("\r\n[ Modem::init ] = = = = = = = = = = = = = = =");
+    MDM_INFO("\r\n[ Modem::init (attempt %u/%u) ] = = = = = = = = = =", (unsigned)_resetFailureAttempts + 1, (unsigned)MDM_RESET_FAILURE_MAX_ATTEMPTS);
 
     // Define all cstringhelpers up here, because "goto"s do not like bypassing inits
     CStringHelper str_imei(_dev.imei, sizeof(_dev.imei));
@@ -1193,7 +1207,7 @@ bool MDMParser::init(DevStatus* status)
             goto reset_failure;
         }
     } // if (_dev.dev == DEV_SARA_R410)
-    resetFailureAttempts = 0;
+    _resetFailureAttempts = 0;
     return true;
 
 failure:
@@ -1202,16 +1216,15 @@ failure:
 reset_failure:
     // Don't get stuck in a reset-retry loop
     // eDRX disables can take a couple or more resets, UMNOPROF requires 1 or 2 and UBANDMASK requires 1 or 2 worst case
-    if (resetFailureAttempts++ < 8) {
+    if (_resetFailureAttempts++ <= MDM_RESET_FAILURE_MAX_ATTEMPTS) {
         if (_atOk()) {
             sendFormated("AT+CFUN=15,0\r\n");
             waitFinalResp(nullptr, nullptr, CFUN_TIMEOUT);
-            _init = false; // invalidate init and prevent cellular registration
-            _pwr = false;  //   |
             // When this exits false, ARM_WLAN_WD 1 will fire and timeout after 30s.
             // MDMParser::powerOn and MDMParser::init will then be retried by the system.
             _incModemStateChangeCount();
         }
+        _resetFailureTimestamp = HAL_Timer_Get_Milli_Seconds();
     } else {
         // stop resetting, and try to register.
         // Preventing cellular registration gets us back to retrying init() faster,
@@ -1219,10 +1232,9 @@ reset_failure:
         // connect even with an error, since that error is persisting and might just
         // be a fluke or bug in the modem. Allowing to continue on eventually helps
         // the device recover in odd situations we can't predict.
-        resetFailureAttempts = 0;
-        return true;
+        _resetFailureAttempts = 0;
     }
-    return false;
+    return !_resetFailureAttempts;
 }
 
 void MDMParser::_incModemStateChangeCount(void) {
@@ -1262,6 +1274,8 @@ bool MDMParser::powerOff(void)
 {
     LOCK();
     const char * POWER_OFF_MSG = "\r\n[ Modem::powerOff ]";
+    _resetFailureAttempts = 0;
+    _resetFailureTimestamp = 0;
     bool ok = false;
     bool continue_cancel = false;
     bool check_ri = false;

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -927,8 +927,6 @@ bool MDMParser::powerOn(const char* simpin)
 
     // The modem type won't change that easily
     auto device_type = _dev.dev;
-    memset(&_dev, 0, sizeof(_dev));
-    _dev.dev = device_type;
     bool retried_after_reset = false;
 
     if (_resetFailureAttempts > 0) {
@@ -936,6 +934,9 @@ bool MDMParser::powerOn(const char* simpin)
             goto failure;
         }
     }
+
+    memset(&_dev, 0, sizeof(_dev));
+    _dev.dev = device_type;
 
     _error = 0;
 
@@ -961,6 +962,7 @@ bool MDMParser::powerOn(const char* simpin)
     for (int i = 0; (i < 5) && (_dev.sim != SIM_READY) && !_cancel_all_operations; i++) {
         sendFormated("AT+CPIN?\r\n");
         int ret = waitFinalResp(_cbCPIN, &_dev.sim);
+
         // having an error here is ok (sim may still be initializing)
         if ((RESP_OK != ret) && (RESP_ERROR != ret)) {
             goto failure;

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -56,7 +56,6 @@ std::recursive_mutex mdm_mutex;
 #define MDM_C_REG_POLL_INTERVAL_MS (30000) //!< CREG/CGREG/CEREG poll interval to check for unexpected modem reset
 #define MDM_SOCKET_SEND_RETRIES_R4_BUG (3)
 #define MDM_MAX_ERRORS (2) //!< max number of errors before action is taken to recover the modem
-#define MDM_RESET_FAILURE_TIMEOUT_MS (10000)
 #define MDM_RESET_FAILURE_MAX_ATTEMPTS (8)
 
 // ID of the PDP context used to configure the default EPS bearer when registering in an LTE network

--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -668,6 +668,8 @@ protected:
     int _debugLevel;
     void _debugPrint(int level, const char* color, const char* format, ...) __attribute__((format(printf, 4, 5)));
 #endif
+    uint32_t _resetFailureAttempts;
+    system_tick_t _resetFailureTimestamp;
 };
 
 // -----------------------------------------------------------------------

--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -669,7 +669,6 @@ protected:
     void _debugPrint(int level, const char* color, const char* format, ...) __attribute__((format(printf, 4, 5)));
 #endif
     uint32_t _resetFailureAttempts;
-    system_tick_t _resetFailureTimestamp;
 };
 
 // -----------------------------------------------------------------------

--- a/system/src/system_network_cellular.h
+++ b/system/src/system_network_cellular.h
@@ -144,11 +144,17 @@ public:
     bool has_credentials() override
     {
         bool rv = cellular_sim_ready(NULL);
-        LOG(INFO,"%s", (rv)?"Sim Ready":"SIM/modem not responsive or SIM not inserted/requires a PIN.");
+        // Suppress logs and only report errors
+        if (!rv) {
+            LOG(INFO,"%s", (rv)?"Sim Ready":"SIM/modem not responsive or SIM not inserted/requires a PIN.");
+        }
         if (!rv) {
             cellular_on(NULL);
             rv = cellular_sim_ready(NULL);
-            LOG(INFO,"%s", (rv)?"Sim Ready":"SIM/modem not responsive or SIM not inserted/requires a PIN.");
+            // Suppress logs and only report errors
+            if (!rv) {
+                LOG(INFO,"%s", (rv)?"Sim Ready":"SIM/modem not responsive or SIM not inserted/requires a PIN.");
+            }
         }
         return rv;
     }

--- a/system/src/system_network_cellular.h
+++ b/system/src/system_network_cellular.h
@@ -145,9 +145,7 @@ public:
     {
         bool rv = cellular_sim_ready(NULL);
         if (!rv) {
-            LOG(INFO, "SIM/modem not responsive or SIM not inserted/requires a PIN.");
-        }
-        if (!rv) {
+            LOG(INFO, "Retrying SIM check");
             cellular_on(NULL);
             rv = cellular_sim_ready(NULL);
             if (!rv) {

--- a/system/src/system_network_cellular.h
+++ b/system/src/system_network_cellular.h
@@ -145,13 +145,13 @@ public:
     {
         bool rv = cellular_sim_ready(NULL);
         if (!rv) {
-            LOG(INFO, "%s", "SIM/modem not responsive or SIM not inserted/requires a PIN.");
+            LOG(INFO, "SIM/modem not responsive or SIM not inserted/requires a PIN.");
         }
         if (!rv) {
             cellular_on(NULL);
             rv = cellular_sim_ready(NULL);
             if (!rv) {
-                LOG(INFO, "%s", "SIM/modem not responsive or SIM not inserted/requires a PIN.");
+                LOG(INFO, "SIM/modem not responsive or SIM not inserted/requires a PIN.");
             }
         }
         return rv;

--- a/system/src/system_network_cellular.h
+++ b/system/src/system_network_cellular.h
@@ -144,16 +144,14 @@ public:
     bool has_credentials() override
     {
         bool rv = cellular_sim_ready(NULL);
-        // Suppress logs and only report errors
         if (!rv) {
-            LOG(INFO,"%s", (rv)?"Sim Ready":"SIM/modem not responsive or SIM not inserted/requires a PIN.");
+            LOG(INFO, "%s", "SIM/modem not responsive or SIM not inserted/requires a PIN.");
         }
         if (!rv) {
             cellular_on(NULL);
             rv = cellular_sim_ready(NULL);
-            // Suppress logs and only report errors
             if (!rv) {
-                LOG(INFO,"%s", (rv)?"Sim Ready":"SIM/modem not responsive or SIM not inserted/requires a PIN.");
+                LOG(INFO, "%s", "SIM/modem not responsive or SIM not inserted/requires a PIN.");
             }
         }
         return rv;

--- a/system/src/system_network_internal.h
+++ b/system/src/system_network_internal.h
@@ -534,6 +534,11 @@ public:
             {
                 // On cellular platforms we'll also get here if modem is not responsive or
                 // there is no SIM card or it has a PIN.
+
+                // FIXME: going into listening mode will cancel an ongoing connection
+                // attempt and unless there is cloud auto-connect flag is set,
+                // a manual call to connect() will have to be made by the application.
+                // This needs to be revisited along with was_sleeping behavior
                 if (listen_enabled) {
                     CLR_WLAN_WD();
                     listen();

--- a/system/src/system_network_internal.h
+++ b/system/src/system_network_internal.h
@@ -38,7 +38,7 @@ enum eWanTimings
 {
     CONNECT_TO_ADDRESS_MAX = S2M(30),
     DISCONNECT_TO_RECONNECT = S2M(2),
-    POWER_ON_WD = S2M(300)
+    POWER_ON_WD = S2M(600) // 10 mins
 };
 
 extern volatile uint8_t SPARK_WLAN_RESET;


### PR DESCRIPTION
### Problem

There are two problems which have some common roots. If the power-on sequence on Electrons fails (and there are two stages in it: power on and SIM initialization, additional initialization), a specific set of actions needs to be taken by the _system networking layer_ to get the modem HAL into a proper state.

1. We are relying on a hack to get the system layer to restart poweron initialization when `MDMParser::init()` fails to initialize and requires a modem reset e.g. to set UMNO profile. This used to work somewhat until we've introduced reliable modem power off in one of the Sleep 2.0 PRs, which now causes the modem to be hard powercycled almost immediately after we've reset it through an AT command.

```
   219.818 AT send      14 "AT+CFUN=15,0\r\n"
   219.828 AT read OK    6 "\r\nOK\r\n"
0000219828 [system] INFO: Sim Ready
0000219829 [system] INFO: ARM_WLAN_WD 1
0000249833 [system] WARN: Resetting WLAN due to WLAN_WD_TO()
0000249833 [system] INFO: Clearing WLAN WD in disconnect()
0000249838 [system] INFO: Clearing WLAN WD in disconnect()
0000249843 [system] INFO: OFF 1
[ Modem::powerOff ] modem is on unexpectedly. Turning it off...

[ Modem::powerOff ] failed
[ ElectronSerialPipe::end ] pipeTx=0 pipeRx=0

[ Modem::resume ] = = = = = = = = = = = = = = =
[ ElectronSerialPipe::begin ] pipeTx=0 pipeRx=0

[ Modem::powerOn ] = = = = = = = = = = = = = =
   280.173 AT send       4 "AT\r\n"
   283.484 AT send       4 "AT\r\n"
```

2. The second step in poweron (`MDMParser::init()`) was skipped whenever initial SIM initialization in `MDMParser::powerOn()` failed, because for some reason reinitialization is happening in `has_credentials()`

```
0000321278 [system] INFO: OFF 1
[ Modem::powerOff ] modem is on unexpectedly. Turning it off...

[ Modem::powerOff ] failed
[ ElectronSerialPipe::end ] pipeTx=0 pipeRx=0

[ Modem::resume ] = = = = = = = = = = = = = = =
[ ElectronSerialPipe::begin ] pipeTx=0 pipeRx=0

[ Modem::powerOn ] = = = = = = = = = = = = = =
   351.608 AT send       4 "AT\r\n"
   351.613 AT read UNK   3 "AT\r"
   351.614 AT read OK    6 "\r\nOK\r\n"
   351.614 AT send       9 "AT+CGMM\r\n"
   361.819 AT send       6 "ATE0\r\n"
0000371820 [system] INFO: SIM/modem not responsive or SIM not inserted/requires a PIN.

[ Modem::powerOn ] = = = = = = = = = = = = = =
   372.136 AT send       4 "AT\r\n"
   375.447 AT send       4 "AT\r\n"
   378.758 AT send       4 "AT\r\n"
   378.764 AT read UNK   3 "AT\r"
   378.765 AT read OK    6 "\r\nOK\r\n"
   378.765 AT send       9 "AT+CGMM\r\n"
   378.778 AT read UNK   8 "AT+CGMM\r"
   378.779 AT read UNK  18 "\r\nSARA-R410M-02B\r\n"
   378.781 AT read OK    6 "\r\nOK\r\n"
   378.985 AT send       6 "ATE0\r\n"
   378.992 AT read UNK   5 "ATE0\r"
   378.993 AT read OK    6 "\r\nOK\r\n"
   378.993 AT send      11 "AT+CMEE=2\r\n"
   379.003 AT read OK    6 "\r\nOK\r\n"
   379.003 AT send      19 "AT+CMER=1,0,0,2,1\r\n"
   379.012 AT read OK    6 "\r\nOK\r\n"
   379.012 AT send      15 "AT+IPR=115200\r\n"
   379.021 AT read OK    6 "\r\nOK\r\n"
   379.121 AT send      10 "AT+CPIN?\r\n"
   379.129 AT read  +   16 "\r\n+CPIN: READY\r\n"
   379.130 AT read OK    6 "\r\nOK\r\n"
0000379131 [system] INFO: Sim Ready
0000379135 [system] INFO: ARM_WLAN_WD 1
   379.138 AT send       4 "AT\r\n"
   379.148 AT read OK    6 "\r\nOK\r\n"

[ Modem::register ] = = = = = = = = = = = = = =
   379.150 AT send      10 "AT+CFUN?\r\n"
   379.162 AT read  +   12 "\r\n+CFUN: 1\r\n"
   379.163 AT read OK    6 "\r\nOK\r\n"
   379.164 AT send      12 "AT+CEREG=2\r\n"
   379.175 AT read OK    6 "\r\nOK\r\n"
   379.175 AT send      11 "AT+CEREG?\r\n"
   379.186 AT read  +   34 "\r\n+CEREG: 2,1,\"4118\",\"3376211\",8\r\n"
   379.188 AT read OK    6 "\r\nOK\r\n"
   379.190 AT send       4 "AT\r\n"
   379.200 AT read OK    6 "\r\nOK\r\n"
   379.200 AT send       9 "AT+CIMI\r\n"
   379.210 AT read UNK  19 "\r\n732123200003356\r\n"
   379.211 AT read OK    6 "\r\nOK\r\n"
```

(see https://app.clubhouse.io/particle/story/64669, https://app.clubhouse.io/particle/story/64668)

### Solution

Add even more hacks! Ideally all these retries should be contained with the modem code and spread through multiple subsystems but this potentially brings some behavior changes, which we shouldn't be making so far along into LTS.

The main idea behind this PR is to check whether power-on succeeded and if not, rely on [`network_connect()`] (https://github.com/particle-iot/device-os/blob/develop/system/src/system_network_compat.cpp#L262) to trigger reinitialization.

### Steps to Test

Here are a few patches to trigger a particular issue:

1. `MDMParser::init()` failing, to emulate a case where we need a reset to set e.g. a correct UMNO profile:
```diff
diff --git a/hal/src/electron/modem/mdm_hal.cpp b/hal/src/electron/modem/mdm_hal.cpp
index f7c67672c..55edb6bb3 100644
--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1160,6 +1160,9 @@ bool MDMParser::init(DevStatus* status)
             goto reset_failure;
         }
     } // if (_dev.dev == DEV_SARA_R410)
+#if 1
+    goto reset_failure;
+#endif // 1
     _resetFailureAttempts = 0;
     return true;
```

There should be 8 attempts made to run `MDMParser::init()` and after that the system should continue to attempt to register

2. `MDMParser::powerOn()` failing due to SIM failure
```diff
diff --git a/hal/src/electron/modem/mdm_hal.cpp b/hal/src/electron/modem/mdm_hal.cpp
index f7d08ec8d..42c15be37 100644
--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -935,6 +935,13 @@ bool MDMParser::powerOn(const char* simpin)
     for (int i = 0; (i < 5) && (_dev.sim != SIM_READY) && !_cancel_all_operations; i++) {
         sendFormated("AT+CPIN?\r\n");
         int ret = waitFinalResp(_cbCPIN, &_dev.sim);
+#if 1
+        static int counter = 0;
+        if (counter++ <= 2) {
+            _dev.sim = SIM_MISSING;
+            goto failure;
+        }
+#endif // 1
         // having an error here is ok (sim may still be initializing)
         if ((RESP_OK != ret) && (RESP_ERROR != ret)) {
             goto failure;
```

This should trigger the system to enter listening mode as if the SIM card is not present and after 5 minutes (default listening mode timeout), the device should connect to the network.

3. `MDMParser::powerOn()` failing due to SIM failure (similar to the previous one, but we fail only once)
```diff
diff --git a/hal/src/electron/modem/mdm_hal.cpp b/hal/src/electron/modem/mdm_hal.cpp
index f7d08ec8d..42c15be37 100644
--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -935,6 +935,13 @@ bool MDMParser::powerOn(const char* simpin)
     for (int i = 0; (i < 5) && (_dev.sim != SIM_READY) && !_cancel_all_operations; i++) {
         sendFormated("AT+CPIN?\r\n");
         int ret = waitFinalResp(_cbCPIN, &_dev.sim);
+#if 1
+        static int counter = 0;
+        if (counter++ <= 1) {
+            _dev.sim = SIM_MISSING;
+            goto failure;
+        }
+#endif // 1
         // having an error here is ok (sim may still be initializing)
         if ((RESP_OK != ret) && (RESP_ERROR != ret)) {
             goto failure;
```

The device should report SIM failure once and then go through `MDMParser::init()` and successfully connect.

4. Same thing as 1, but with a simulated failure preventing us from completing initailization entirely

```diff
diff --git a/hal/src/electron/modem/mdm_hal.cpp b/hal/src/electron/modem/mdm_hal.cpp
index f7c67672c..9a14d6d5d 100644
--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -55,7 +55,7 @@ std::recursive_mutex mdm_mutex;
 #define MDM_URC_POLL_INTERVAL_MS (1000) //!< URC poll interval
 #define MDM_SOCKET_SEND_RETRIES_R4_BUG (3)
 #define MDM_RESET_FAILURE_TIMEOUT_MS (10000)
-#define MDM_RESET_FAILURE_MAX_ATTEMPTS (8)
+#define MDM_RESET_FAILURE_MAX_ATTEMPTS (9999)
 
 // ID of the PDP context used to configure the default EPS bearer when registering in an LTE network
 // Note: There are no PDP contexts in LTE, SARA-R4 uses this naming for the sake of simplicity
@@ -1161,6 +1161,9 @@ bool MDMParser::init(DevStatus* status)
         }
     } // if (_dev.dev == DEV_SARA_R410)
     _resetFailureAttempts = 0;
+#if 1
+    goto reset_failure;
+#endif // 1
     return true;
 
 failure:
```

This should cause a modem reset in 5 minutes and restart the initialization again.

5. These changes should not affect Photon/P1.

### Example App

N/A

### References

- [CH64668]
- [CH64669]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
