### PR TITLE
[gen2][electron] modem brownout or unexpected reset causes system to think it still is connected [ch64465]

### DIFF
--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -649,6 +649,7 @@ protected:
     int _checkAtResponse(void);
     bool _atOk(void);
     bool _checkModem(bool force = true);
+    void _checkVerboseCxreg(void);
     bool _checkEpsReg(void);
     int _socketError(void);
     static MDMParser* inst;
@@ -662,6 +663,7 @@ protected:
     volatile bool _cancel_all_operations;
     volatile uint32_t _error;
     system_tick_t _lastProcess;
+    system_tick_t _lastVerboseCxregUpdate;
 #ifdef MDM_DEBUG
     int _debugLevel;
     void _debugPrint(int level, const char* color, const char* format, ...) __attribute__((format(printf, 4, 5)));


### PR DESCRIPTION
### Problem

Electron was found to suffer from a modem reset while antenna was disconnected in low signal environment on battery only (and also with USB and battery). This leads to `C*REG=2` verbose mode + URCS being reset to `C*REG=0` non-verbose mode + no URCs, which causes the system firmware to not be notified that the modem has deregistered. NO_ACK publishes can continue to be sent into the breeze, and a user's firmware will not know `Particle.connected()` or `Cellular.ready()` are `false`.

#2215 addresses the root cause of the problem, but just in case for unexpected reasons the following solution offers a recovery method.

### Solution

To periodically poll for `C*REG?` every 30 seconds look for changes to CREG verbosity. If there is a valid response, and we see `C*REG: 0,x`, URCs are disabled. Notify the system of disconnect immediately, which will reinitialize the modem.

### Steps to Test

Run unit tests: `TEST=wiring/no_fixture_long_running` CELLULAR_03 & CELLULAR_04

### References

ch64465
#2215 addresses the root cause of the problem
ch63632

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] N/A Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
