### PR TITLE
Fixes the issue that BLE.scan() might hang the device.

### DIFF
--- a/hal/src/nRF52840/ble_hal_impl.h
+++ b/hal/src/nRF52840/ble_hal_impl.h
@@ -73,7 +73,7 @@
 #define BLE_DEFAULT_SCANNING_WINDOW                 BLE_MSEC_TO_UNITS(50, BLE_UNIT_0_625_MS)    /* The scan window: 50ms (in units of 0.625 ms). */
 #define BLE_DEFAULT_SCANNING_TIMEOUT                BLE_MSEC_TO_UNITS(BLE_DEFAULT_SCANNING_TIMEOUT_MS, BLE_UNIT_10_MS)     /* The timeout: 5000ms (in units of 10 ms. 0 for scanning forever). */
 // Extended timeout for the scanning timeout guard timer
-#define BLE_SCANNING_TIMEOUT_EXT                    1000
+#define BLE_SCANNING_TIMEOUT_EXT_MS                 1000
 
 /* Maximum length of advertising and scan response data */
 #define BLE_MAX_ADV_DATA_LEN                        BLE_GAP_ADV_SET_DATA_SIZE_MAX

--- a/hal/src/nRF52840/ble_hal_impl.h
+++ b/hal/src/nRF52840/ble_hal_impl.h
@@ -68,9 +68,12 @@
 #define BLE_MAX_TX_POWER                            (8)
 
 /* Default scanning parameters */
+#define BLE_DEFAULT_SCANNING_TIMEOUT_MS             5000
 #define BLE_DEFAULT_SCANNING_INTERVAL               BLE_MSEC_TO_UNITS(100, BLE_UNIT_0_625_MS)   /* The scan interval: 100ms (in units of 0.625 ms). */
 #define BLE_DEFAULT_SCANNING_WINDOW                 BLE_MSEC_TO_UNITS(50, BLE_UNIT_0_625_MS)    /* The scan window: 50ms (in units of 0.625 ms). */
-#define BLE_DEFAULT_SCANNING_TIMEOUT                BLE_MSEC_TO_UNITS(5000, BLE_UNIT_10_MS)     /* The timeout: 5000ms (in units of 10 ms. 0 for scanning forever). */
+#define BLE_DEFAULT_SCANNING_TIMEOUT                BLE_MSEC_TO_UNITS(BLE_DEFAULT_SCANNING_TIMEOUT_MS, BLE_UNIT_10_MS)     /* The timeout: 5000ms (in units of 10 ms. 0 for scanning forever). */
+// Extended timeout for the scanning timeout guard timer
+#define BLE_SCANNING_TIMEOUT_EXT                    1000
 
 /* Maximum length of advertising and scan response data */
 #define BLE_MAX_ADV_DATA_LEN                        BLE_GAP_ADV_SET_DATA_SIZE_MAX


### PR DESCRIPTION

### Problem

BLE may hang the thread that calls `BLE.scan()` due to unexpected scanning failure. Since the `BLE.scan()` is a blocking API waiting until a semaphore is given on scanning timeout event, in some condition the scanning procedure never timeout or a incorrect event is delivered from SoftDevice on scanning failure, in which case the semaphore cannot be taken any more.

### Solution

Introduce a timer to guard the scanning procedure. For example, if the scanning timeout is set to 5s and it starts scanning, the timer will expire after 6s to stop scanning actively. Normally BLE scanning can timeout by SoftDevice and the timer will be stopped by then.

### References

#1932 

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
