### PR TITLE
Fix CellularSignal deprecation messages

### DIFF
--- a/wiring/inc/spark_wiring_cellular_printable.h
+++ b/wiring/inc/spark_wiring_cellular_printable.h
@@ -36,8 +36,8 @@
  */
 class CellularSignal : public particle::Signal, public Printable {
 public:
-    int rssi __attribute__((deprecated("Use getSignalStrengthValue() instead"))) = 0;
-    int qual __attribute__((deprecated("Use getSignalQualityValue() instead"))) = 0;
+    int rssi __attribute__((deprecated("Use getStrengthValue() instead"))) = 0;
+    int qual __attribute__((deprecated("Use getQualityValue() instead"))) = 0;
 
 // TODO: remove once rssi/qual are removed
 #pragma GCC diagnostic push


### PR DESCRIPTION
### Problem

Compile warnings for CellularSignal class public member variables `rssi` and `qual` report the incorrect member function to use.
```c
int rssi __attribute__((deprecated("Use getSignalStrengthValue() instead"))) = 0;
int qual __attribute__((deprecated("Use getSignalQualityValue() instead"))) = 0;
```
Existing member functions are instead `getStrengthValue()` and `getQualityValue()`.

### Solution

Change the deprecated attribute warnings to the following.
```c
int rssi __attribute__((deprecated("Use getStrengthValue() instead"))) = 0;
int qual __attribute__((deprecated("Use getQualityValue() instead"))) = 0;
```

### Steps to Test

Implement the deprecated member variables and observe compile warnings.
```
main.cpp: In member function 'void loop()':
main.cpp:30:47: warning: 'CellularSignal::rssi' is deprecated: Use getSignalStrengthValue() instead [-Wdeprecated-declarations]
   30 |     Log.info("Signal strength is %d dBm", rssi.rssi);
```

### Example Code

```c
CellularSignal rssi = Cellular.RSSI();
Log.info("Signal strength is %d dBm", rssi.rssi);
```

### References

N/A
---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
