### PR TITLE
Wiring BLE APIs consistency improvements

### DIFF
--- a/hal/src/nRF52840/ble_hal.cpp
+++ b/hal/src/nRF52840/ble_hal.cpp
@@ -3750,6 +3750,7 @@ int hal_ble_gap_connect_cancel(const hal_ble_addr_t* address, void* reserved) {
 }
 
 int hal_ble_gap_disconnect(hal_ble_conn_handle_t conn_handle, void* reserved) {
+    BleLock lk;
     LOG_DEBUG(TRACE, "hal_ble_gap_disconnect().");
     CHECK_TRUE(BleObject::getInstance().initialized(), SYSTEM_ERROR_INVALID_STATE);
     hal_ble_conn_info_t info = {};

--- a/hal/src/nRF52840/ble_hal.cpp
+++ b/hal/src/nRF52840/ble_hal.cpp
@@ -3750,7 +3750,6 @@ int hal_ble_gap_connect_cancel(const hal_ble_addr_t* address, void* reserved) {
 }
 
 int hal_ble_gap_disconnect(hal_ble_conn_handle_t conn_handle, void* reserved) {
-    BleLock lk;
     LOG_DEBUG(TRACE, "hal_ble_gap_disconnect().");
     CHECK_TRUE(BleObject::getInstance().initialized(), SYSTEM_ERROR_INVALID_STATE);
     hal_ble_conn_info_t info = {};

--- a/user/tests/app/ble/scanner/application.cpp
+++ b/user/tests/app/ble/scanner/application.cpp
@@ -35,9 +35,6 @@ void loop() {
     int count = BLE.scan(results, SCAN_RESULT_COUNT);
 
     if (count > 0) {
-        uint8_t buf[BLE_MAX_ADV_DATA_LEN];
-        size_t len;
-
         Log.info("%d devices are found:", count);
         for (int i = 0; i < count; i++) {
             Log.info(" -------- MAC: %s | RSSI: %dBm --------", results[i].address().toString().c_str(), results[i].rssi());
@@ -51,20 +48,20 @@ void loop() {
                 Log.info("Local name: %s", name.c_str());
             }
 
-            len = results[i].advertisingData().get(buf, sizeof(buf));
-            if (len > 0) {
+            const BleAdvertisingData& advData = results[i].advertisingData();
+            if (advData.length() > 0) {
                 Serial1.print("Advertising data: ");
-                for (size_t j = 0; j < len; j++) {
-                    Serial1.printf("0x%02x,", buf[j]);
+                for (size_t j = 0; j < advData.length(); j++) {
+                    Serial1.printf("0x%02x,", advData[j]);
                 }
                 Serial1.println("\r\n");
             }
 
-            len = results[i].scanResponse().get(buf, sizeof(buf));
-            if (len > 0) {
+            const BleAdvertisingData& srData = results[i].scanResponse();
+            if (srData.length() > 0) {
                 Serial1.print("Scan response data: ");
-                for (size_t j = 0; j < len; j++) {
-                    Serial1.printf("0x%02x,", buf[j]);
+                for (size_t j = 0; j < srData.length(); j++) {
+                    Serial1.printf("0x%02x,", srData[j]);
                 }
                 Serial1.println("\r\n");
             }

--- a/user/tests/app/ble/scanner/application.cpp
+++ b/user/tests/app/ble/scanner/application.cpp
@@ -40,19 +40,18 @@ void loop() {
 
         LOG(TRACE, "%d devices are found:", count);
         for (int i = 0; i < count; i++) {
-            BleAddress address = results[i].address;
-            LOG(TRACE, " -------- MAC: %s | RSSI: %dBm --------", address.toString().c_str(), results[i].rssi);
+            LOG(TRACE, " -------- MAC: %s | RSSI: %dBm --------", results[i].address().toString().c_str(), results[i].rssi());
 
-            String name = results[i].advertisingData.deviceName();
+            String name = results[i].advertisingData().deviceName();
             if (name.length() > 0) {
                 LOG(TRACE, "Local name: %s", name.c_str());
             }
-            name = results[i].scanResponse.deviceName();
+            name = results[i].scanResponse().deviceName();
             if (name.length() > 0) {
                 LOG(TRACE, "Local name: %s", name.c_str());
             }
 
-            len = results[i].advertisingData(buf, sizeof(buf));
+            len = results[i].advertisingData().get(buf, sizeof(buf));
             if (len > 0) {
                 Serial1.print("Advertising data: ");
                 for (size_t j = 0; j < len; j++) {
@@ -61,7 +60,7 @@ void loop() {
                 Serial1.println("\r\n");
             }
 
-            len = results[i].scanResponse(buf, sizeof(buf));
+            len = results[i].scanResponse().get(buf, sizeof(buf));
             if (len > 0) {
                 Serial1.print("Scan response data: ");
                 for (size_t j = 0; j < len; j++) {

--- a/user/tests/app/ble/scanner/application.cpp
+++ b/user/tests/app/ble/scanner/application.cpp
@@ -38,17 +38,17 @@ void loop() {
         uint8_t buf[BLE_MAX_ADV_DATA_LEN];
         size_t len;
 
-        LOG(TRACE, "%d devices are found:", count);
+        Log.info("%d devices are found:", count);
         for (int i = 0; i < count; i++) {
-            LOG(TRACE, " -------- MAC: %s | RSSI: %dBm --------", results[i].address().toString().c_str(), results[i].rssi());
+            Log.info(" -------- MAC: %s | RSSI: %dBm --------", results[i].address().toString().c_str(), results[i].rssi());
 
             String name = results[i].advertisingData().deviceName();
             if (name.length() > 0) {
-                LOG(TRACE, "Local name: %s", name.c_str());
+                Log.info("Local name: %s", name.c_str());
             }
             name = results[i].scanResponse().deviceName();
             if (name.length() > 0) {
-                LOG(TRACE, "Local name: %s", name.c_str());
+                Log.info("Local name: %s", name.c_str());
             }
 
             len = results[i].advertisingData().get(buf, sizeof(buf));

--- a/user/tests/app/ble/uart_central/application.cpp
+++ b/user/tests/app/ble/uart_central/application.cpp
@@ -61,9 +61,9 @@ void loop() {
         if (count > 0) {
             for (uint8_t i = 0; i < count; i++) {
                 BleUuid foundServiceUUID;
-                size_t svcCount = results[i].advertisingData.serviceUUID(&foundServiceUUID, 1);
+                size_t svcCount = results[i].advertisingData().serviceUUID(&foundServiceUUID, 1);
                 if (svcCount > 0 && foundServiceUUID == "6E400001-B5A3-F393-E0A9-E50E24DCCA9E") {
-                    peer = BLE.connect(results[i].address);
+                    peer = BLE.connect(results[i].address());
                     if (peer.connected()) {
                         peer.getCharacteristicByDescription(peerTxCharacteristic, "tx");
                         peer.getCharacteristicByUUID(peerRxCharacteristic, "6E400002-B5A3-F393-E0A9-E50E24DCCA9E");

--- a/user/tests/wiring/api/ble.cpp
+++ b/user/tests/wiring/api/ble.cpp
@@ -241,6 +241,8 @@ test(ble_uuid_class) {
     API_COMPILE({ bool ret = uuid != String("1234"); (void)ret; });
     API_COMPILE({ bool ret = uuid != 0x1234; (void)ret; });
     API_COMPILE({ bool ret = uuid != uuidArray; (void)ret; });
+
+    API_COMPILE({ uint8_t ret = uuid[0]; (void)ret; });
 }
 
 test(ble_ibeacon_class) {
@@ -309,6 +311,8 @@ test(ble_advertising_data_class) {
     API_COMPILE({ uint8_t buf[1]; size_t ret = data(buf, 0); (void)ret; });
 
     API_COMPILE({ bool ret = data.contains(BleAdvertisingDataType::FLAGS); (void)ret; });
+
+    API_COMPILE({ uint8_t ret = data[0]; (void)ret; });
 }
 
 test(ble_characteristic_class) {

--- a/user/tests/wiring/api/ble.cpp
+++ b/user/tests/wiring/api/ble.cpp
@@ -186,7 +186,9 @@ test(ble_address_class) {
     API_COMPILE({ bool ret = addr != String("123"); (void)ret; });
     API_COMPILE({ bool ret = addr != addrArray; (void)ret; });
 
-    API_COMPILE({ bool ret = addr.valid(); (void)ret; });
+    API_COMPILE({ bool ret = addr; (void)ret; });
+
+    API_COMPILE({ bool ret = addr.isValid(); (void)ret; });
     API_COMPILE({ int ret = addr.clear(); (void)ret; });
 }
 
@@ -241,6 +243,8 @@ test(ble_uuid_class) {
     API_COMPILE({ bool ret = uuid != String("1234"); (void)ret; });
     API_COMPILE({ bool ret = uuid != 0x1234; (void)ret; });
     API_COMPILE({ bool ret = uuid != uuidArray; (void)ret; });
+
+    API_COMPILE({ bool ret = uuid; (void)ret; });
 
     API_COMPILE({ uint8_t ret = uuid[0]; (void)ret; });
 }
@@ -333,6 +337,7 @@ test(ble_characteristic_class) {
     API_COMPILE({ BleCharacteristic c = characteristic; });
 
     API_COMPILE({ bool ret = characteristic.valid(); (void)ret; });
+    API_COMPILE({ bool ret = characteristic.isValid(); (void)ret; });
 
     API_COMPILE({ BleUuid uuid = characteristic.UUID(); });
 
@@ -413,6 +418,8 @@ test(ble_characteristic_class) {
     API_COMPILE({ int ret = characteristic.subscribe(true); (void)ret; });
 
     API_COMPILE({ characteristic.onDataReceived(dataHandlerFunc, nullptr); });
+
+    API_COMPILE({ bool ret = characteristic; (void)ret; });
 }
 
 test(ble_service_class) {
@@ -493,8 +500,12 @@ test(ble_peer_device) {
 
     API_COMPILE({ BleAddress a = peer.address(); });
 
+    API_COMPILE({ bool ret = peer.isValid(); (void)ret; });
+
     API_COMPILE({ bool ret = peer == BlePeerDevice(); (void)ret; });
     API_COMPILE({ bool ret = peer != BlePeerDevice(); (void)ret; });
+
+    API_COMPILE({ bool ret = peer; (void)ret; });
 
     API_COMPILE({ BlePeerDevice p = peer; });
 }
@@ -600,6 +611,8 @@ test(ble_local_device_class) {
     API_COMPILE({ int ret = BLE.disconnect(peer); (void)ret; });
     API_COMPILE({ int ret = BLE.disconnectAll(); (void)ret; });
     API_COMPILE({ bool ret = BLE.connected(); (void)ret; });
+
+    API_COMPILE({ BlePeerDevice p = BLE.peerCentral(); });
 
     API_COMPILE({ BLE.onConnected(connectedHandlerFunc, nullptr); });
     API_COMPILE({ BLE.onDisconnected(disconnectedHandlerFunc, nullptr); });

--- a/user/tests/wiring/api/ble.cpp
+++ b/user/tests/wiring/api/ble.cpp
@@ -11,6 +11,9 @@ void dataHandlerFunc(const uint8_t* data, size_t len, const BlePeerDevice& peer,
 void scanHandlerFunc(const BleScanResult* result, void* context) {
 }
 
+void scanHandlerFuncRef(const BleScanResult& result, void* context) {
+}
+
 void connectedHandlerFunc(const BlePeerDevice& peer, void* context) {
 }
 
@@ -182,6 +185,9 @@ test(ble_address_class) {
     API_COMPILE({ bool ret = addr != "123"; (void)ret; });
     API_COMPILE({ bool ret = addr != String("123"); (void)ret; });
     API_COMPILE({ bool ret = addr != addrArray; (void)ret; });
+
+    API_COMPILE({ bool ret = addr.valid(); (void)ret; });
+    API_COMPILE({ int ret = addr.clear(); (void)ret; });
 }
 
 test(ble_uuid_class) {
@@ -243,10 +249,16 @@ test(ble_ibeacon_class) {
 
     API_COMPILE(iBeacon beacon(0, 0, uuid, 0));
 
-    API_COMPILE({ uint16_t val = beacon.major; (void)val; });
-    API_COMPILE({ uint16_t val = beacon.minor; (void)val; });
-    API_COMPILE({ BleUuid u = beacon.uuid;});
-    API_COMPILE({ int8_t val = beacon.measurePower; (void)val; });
+    API_COMPILE({ iBeacon b = beacon.major(0); });
+    API_COMPILE({ iBeacon b = beacon.minor(0); });
+    API_COMPILE({ iBeacon b = beacon.UUID(uuid); });
+    API_COMPILE({ iBeacon b = beacon.measurePower(-1); });
+
+    API_COMPILE({ uint16_t val = beacon.major(); (void)val; });
+    API_COMPILE({ uint16_t val = beacon.minor(); (void)val; });
+    API_COMPILE({ BleUuid u = beacon.UUID(); (void)u; });
+    API_COMPILE({ const BleUuid& u = beacon.UUID(); (void)u; });
+    API_COMPILE({ int8_t val = beacon.measurePower(); (void)val; });
 
     API_COMPILE({ uint16_t id = iBeacon::APPLE_COMPANY_ID; (void)id; });
     API_COMPILE({ uint16_t type = iBeacon::BEACON_TYPE_IBEACON; (void)type; });
@@ -289,6 +301,8 @@ test(ble_advertising_data_class) {
     API_COMPILE({ char buf[1]; size_t ret = data.deviceName(buf, 0); (void)ret; });
 
     API_COMPILE({ BleUuid u[1]; size_t ret = data.serviceUUID(u, 0); (void)ret; });
+    API_COMPILE({ Vector<BleUuid> u = data.serviceUUID(); });
+    API_COMPILE({ const Vector<BleUuid>& u = data.serviceUUID(); });
 
     API_COMPILE({ uint8_t buf[1]; size_t ret = data.customData(buf, 0); (void)ret; });
 
@@ -408,10 +422,26 @@ test(ble_service_class) {
     API_COMPILE({ BleService s = service; });
 
     API_COMPILE({ bool ret = service == BleService(uuid); (void)ret; });
+    API_COMPILE({ bool ret = service != BleService(uuid); (void)ret; });
 }
 
 test(ble_scan_result) {
+    BleScanResult result;
 
+    API_COMPILE({ BleScanResult r = result.address(BleAddress()); (void)r; });
+    API_COMPILE({ BleScanResult r = result.advertisingData(BleAdvertisingData()); (void)r; });
+    API_COMPILE({ uint8_t buf[1]; BleScanResult r = result.advertisingData(buf, 0); (void)r; });
+    API_COMPILE({ BleScanResult r = result.scanResponse(BleAdvertisingData()); (void)r; });
+    API_COMPILE({ uint8_t buf[1]; BleScanResult r = result.scanResponse(buf, 0); (void)r; });
+    API_COMPILE({ BleScanResult r = result.rssi(-8); (void)r; });
+
+    API_COMPILE({ BleAddress addr = result.address(); (void)addr; });
+    API_COMPILE({ const BleAddress& addr = result.address(); (void)addr; });
+    API_COMPILE({ BleAdvertisingData adv = result.advertisingData(); (void)adv; });
+    API_COMPILE({ const BleAdvertisingData& adv = result.advertisingData(); (void)adv; });
+    API_COMPILE({ BleAdvertisingData sr = result.scanResponse(); (void)sr; });
+    API_COMPILE({ const BleAdvertisingData& sr = result.scanResponse(); (void)sr; });
+    API_COMPILE({ int8_t ret = result.rssi(); (void)ret; });
 }
 
 test(ble_peer_device) {
@@ -440,12 +470,16 @@ test(ble_peer_device) {
     API_COMPILE({ int ret = peer.connect(addr, false); (void)ret; });
     API_COMPILE({ int ret = peer.connect(addr, &params); (void)ret; });
     API_COMPILE({ int ret = peer.connect(addr, &params, false); (void)ret; });
+    API_COMPILE({ int ret = peer.connect(addr, params); (void)ret; });
+    API_COMPILE({ int ret = peer.connect(addr, params, false); (void)ret; });
     API_COMPILE({ int ret = peer.connect(addr, 0 , 0, 0); (void)ret; });
     API_COMPILE({ int ret = peer.connect(addr, 0, 0, 0, false); (void)ret; });
     API_COMPILE({ int ret = peer.connect(); (void)ret; });
     API_COMPILE({ int ret = peer.connect(false); (void)ret; });
     API_COMPILE({ int ret = peer.connect(&params); (void)ret; });
     API_COMPILE({ int ret = peer.connect(&params, false); (void)ret; });
+    API_COMPILE({ int ret = peer.connect(params); (void)ret; });
+    API_COMPILE({ int ret = peer.connect(params, false); (void)ret; });
     API_COMPILE({ int ret = peer.connect(0 , 0, 0); (void)ret; });
     API_COMPILE({ int ret = peer.connect(0, 0, 0, false); (void)ret; });
     API_COMPILE({ int ret = peer.disconnect(); (void)ret; });
@@ -456,6 +490,7 @@ test(ble_peer_device) {
     API_COMPILE({ BleAddress a = peer.address(); });
 
     API_COMPILE({ bool ret = peer == BlePeerDevice(); (void)ret; });
+    API_COMPILE({ bool ret = peer != BlePeerDevice(); (void)ret; });
 
     API_COMPILE({ BlePeerDevice p = peer; });
 }
@@ -484,6 +519,7 @@ test(ble_local_device_class) {
 
     API_COMPILE({ int ret = BLE.setTxPower(-8); (void)ret; });
     API_COMPILE({ int8_t p; int ret = BLE.txPower(&p); (void)ret; });
+    API_COMPILE({ int8_t p = BLE.txPower(); (void)p; });
 
     API_COMPILE({ int ret = BLE.selectAntenna(BleAntennaType::DEFAULT); (void)ret; });
 
@@ -504,28 +540,39 @@ test(ble_local_device_class) {
     API_COMPILE({ int ret = BLE.setAdvertisingTimeout(0); (void)ret; });
     API_COMPILE({ int ret = BLE.setAdvertisingType(BleAdvertisingEventType::CONNECTABLE_SCANNABLE_UNDIRECRED); (void)ret; });
     API_COMPILE({ int ret = BLE.setAdvertisingParameters(&params); (void)ret; });
+    API_COMPILE({ int ret = BLE.setAdvertisingParameters(params); (void)ret; });
     API_COMPILE({ int ret = BLE.setAdvertisingParameters(0, 0, BleAdvertisingEventType::CONNECTABLE_SCANNABLE_UNDIRECRED); (void)ret; });
     API_COMPILE({ int ret = BLE.getAdvertisingParameters(&params); (void)ret; });
+    API_COMPILE({ int ret = BLE.getAdvertisingParameters(params); (void)ret; });
 
     API_COMPILE({ int ret = BLE.setAdvertisingData(&advData); (void)ret; });
+    API_COMPILE({ int ret = BLE.setAdvertisingData(advData); (void)ret; });
     API_COMPILE({ int ret = BLE.setScanResponseData(&srData); (void)ret; });
+    API_COMPILE({ int ret = BLE.setScanResponseData(srData); (void)ret; });
     API_COMPILE({ size_t ret = BLE.getAdvertisingData(&advData); (void)ret; });
+    API_COMPILE({ size_t ret = BLE.getAdvertisingData(advData); (void)ret; });
     API_COMPILE({ size_t ret = BLE.getScanResponseData(&srData); (void)ret; });
+    API_COMPILE({ size_t ret = BLE.getScanResponseData(srData); (void)ret; });
 
     API_COMPILE({ int ret = BLE.advertise(); (void)ret; });
     API_COMPILE({ int ret = BLE.advertise(&advData); (void)ret; });
+    API_COMPILE({ int ret = BLE.advertise(advData); (void)ret; });
     API_COMPILE({ int ret = BLE.advertise(&advData, &srData); (void)ret; });
+    API_COMPILE({ int ret = BLE.advertise(advData, srData); (void)ret; });
     API_COMPILE({ int ret = BLE.advertise(beacon); (void)ret; });
     API_COMPILE({ int ret = BLE.stopAdvertising(); (void)ret; });
     API_COMPILE({ bool ret = BLE.advertising(); (void)ret; });
 
     API_COMPILE({ int ret = BLE.setScanTimeout(0); (void)ret; });
     API_COMPILE({ int ret = BLE.setScanParameters(&scanParams); (void)ret; });
+    API_COMPILE({ int ret = BLE.setScanParameters(scanParams); (void)ret; });
     API_COMPILE({ int ret = BLE.getScanParameters(&scanParams); (void)ret; });
+    API_COMPILE({ int ret = BLE.getScanParameters(scanParams); (void)ret; });
 
     API_COMPILE({ Vector<BleScanResult> results = BLE.scan(); });
     API_COMPILE({ BleScanResult results[1]; int ret = BLE.scan(results, 0); (void)ret; });
     API_COMPILE({ int ret = BLE.scan(scanHandlerFunc, nullptr); (void)ret; });
+    API_COMPILE({ int ret = BLE.scan(scanHandlerFuncRef, nullptr); (void)ret; });
     API_COMPILE({ int ret = BLE.stopScanning(); (void)ret; });
 
     API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic("1234", props, charUuid, svcUuid); });
@@ -541,6 +588,8 @@ test(ble_local_device_class) {
     API_COMPILE({ BlePeerDevice p = BLE.connect(addr, false); });
     API_COMPILE({ BlePeerDevice p = BLE.connect(addr, &connectParams); });
     API_COMPILE({ BlePeerDevice p = BLE.connect(addr, &connectParams, false); });
+    API_COMPILE({ BlePeerDevice p = BLE.connect(addr, connectParams); });
+    API_COMPILE({ BlePeerDevice p = BLE.connect(addr, connectParams, false); });
     API_COMPILE({ BlePeerDevice p = BLE.connect(addr, 0 , 0, 0); });
     API_COMPILE({ BlePeerDevice p = BLE.connect(addr, 0, 0, 0, false); });
     API_COMPILE({ int ret = BLE.disconnect(); (void)ret; });

--- a/user/tests/wiring/ble_central_peripheral/ble_central/central.cpp
+++ b/user/tests/wiring/ble_central_peripheral/ble_central/central.cpp
@@ -67,9 +67,9 @@ test(BLE_01_Central_Scan_And_Connect) {
         if (count > 0) {
             for (uint8_t i = 0; i < count; i++) {
                 BleUuid foundServiceUUID;
-                size_t svcCount = results[i].advertisingData.serviceUUID(&foundServiceUUID, 1);
+                size_t svcCount = results[i].advertisingData().serviceUUID(&foundServiceUUID, 1);
                 if (svcCount > 0 && foundServiceUUID == "6E400000-B5A3-F393-E0A9-E50E24DCCA9E") {
-                    peer = BLE.connect(results[i].address);
+                    peer = BLE.connect(results[i].address());
                     if (peer.connected()) {
                         assertTrue(peer.getCharacteristicByDescription(peerCharRead, "read"));
                         assertTrue(peer.getCharacteristicByDescription(peerCharWrite, "write"));

--- a/user/tests/wiring/ble_scanner_broadcaster/ble_scanner/scanner.cpp
+++ b/user/tests/wiring/ble_scanner_broadcaster/ble_scanner/scanner.cpp
@@ -18,6 +18,13 @@ static void bleOnScanResultCallback(const BleScanResult* result, void* context) 
     assertEqual(ret, 0);
 }
 
+static void bleOnScanResultCallbackRef(const BleScanResult& result, void* context) {
+    INFO("  > On BLE device scanned callback.\r\n");
+    INFO("  > Stop scanning...\r\n");
+    int ret = BLE.stopScanning();
+    assertEqual(ret, 0);
+}
+
 test(00_BLE_Scanning_Blocked_Timeout_Simulate) {
     int ret;
 
@@ -61,6 +68,10 @@ test(01_BLE_Scanning_Control) {
 
     INFO("  > Testing BLE scanning for 3 seconds...\r\n");
     ret = BLE.scan(bleOnScanResultCallback, nullptr);
+    assertTrue(ret > 0);
+
+    INFO("  > Testing BLE scanning for 3 seconds...\r\n");
+    ret = BLE.scan(bleOnScanResultCallbackRef, nullptr);
     assertTrue(ret > 0);
 
     INFO("  > Testing BLE scanning for 3 seconds...\r\n");

--- a/user/tests/wiring/no_fixture_ble/ble.cpp
+++ b/user/tests/wiring/no_fixture_ble/ble.cpp
@@ -441,66 +441,66 @@ test(BLE_11_BLE_UUID_Conversion) {
 
 test(BLE_12_BLE_Address_Validation) {
     BleAddress address;
-    assertFalse(address.valid());
+    assertFalse(address.isValid());
 
     // Public address
     address = "44:14:0A:9F:F2:96";
-    assertTrue(address.valid());
+    assertTrue(address.isValid());
     address = "00:00:00:00:00:00"; // At least 1 bit is set
-    assertFalse(address.valid());
+    assertFalse(address.isValid());
     address = "FF:FF:FF:FF:FF:FF"; // At least 1 bit is cleared
-    assertFalse(address.valid());
+    assertFalse(address.isValid());
 
     // Static address. Two most significant bits should be 0b11 and
     // the reset of bits should at least have 1 bit set and cleared.
     address.type(BleAddressType::RANDOM_STATIC);
     address = "30:12:34:56:78:9a"; // 0b00
-    assertFalse(address.valid());
+    assertFalse(address.isValid());
     address = "40:12:34:56:78:9a"; // 0b01
-    assertFalse(address.valid());
+    assertFalse(address.isValid());
     address = "80:12:34:56:78:9a:"; // 0b10
-    assertFalse(address.valid());
+    assertFalse(address.isValid());
     address = "C0:00:00:00:00:00"; // At least 1 bit is set
-    assertFalse(address.valid());
+    assertFalse(address.isValid());
     address = "FF:FF:FF:FF:FF:FF"; // At least 1 bit is clear
-    assertFalse(address.valid());
+    assertFalse(address.isValid());
     address = "C0:12:34:56:78:9a";
-    assertTrue(address.valid()); 
+    assertTrue(address.isValid()); 
 
     // Non-resolvable address.  Two most significant bits should be 0b00 and
     // the reset of bits should at least have 1 bit set and cleared.
     address.type(BleAddressType::RANDOM_PRIVATE_NON_RESOLVABLE);
     address = "40:12:34:56:78:9a"; // 0b01
-    assertFalse(address.valid());
+    assertFalse(address.isValid());
     address = "80:12:34:56:78:9a"; // 0b10
-    assertFalse(address.valid());
+    assertFalse(address.isValid());
     address = "C0:12:34:56:78:9a"; // 0b11
-    assertFalse(address.valid());
+    assertFalse(address.isValid());
     address = "00:00:00:00:00:00"; // At least 1 bit is set
-    assertFalse(address.valid());
+    assertFalse(address.isValid());
     address = "3F:FF:FF:FF:FF:FF"; // At least 1 bit is clear
-    assertFalse(address.valid());
+    assertFalse(address.isValid());
     address = "3F:12:34:56:78:9a";
-    assertTrue(address.valid()); 
+    assertTrue(address.isValid()); 
 
     // Resolvable address. Two most significant bits should be 0b01 and
     // bit24 ~ bit45 should at least have 1 bit set and cleared.
     address.type(BleAddressType::RANDOM_PRIVATE_RESOLVABLE);
     address = "30:12:34:56:78:9a"; // 0b00
-    assertFalse(address.valid());
+    assertFalse(address.isValid());
     address = "80:12:34:56:78:9a"; // 0b10
-    assertFalse(address.valid());
+    assertFalse(address.isValid());
     address = "C0:12:34:56:78:9a"; // 0b11
-    assertFalse(address.valid());
+    assertFalse(address.isValid());
     address = "40:00:00:12:34:56"; // At least 1 bit is set
-    assertFalse(address.valid());
+    assertFalse(address.isValid());
     address = "7F:FF:FF:12:34:56:"; // At least 1 bit is cleared
-    assertFalse(address.valid());
+    assertFalse(address.isValid());
     address = "4F:12:34:56:78:9a";
-    assertTrue(address.valid()); 
+    assertTrue(address.isValid()); 
 
     address.clear();
-    assertFalse(address.valid());
+    assertFalse(address.isValid());
 }
 
 #endif // #if Wiring_BLE == 1

--- a/user/tests/wiring/no_fixture_ble/ble.cpp
+++ b/user/tests/wiring/no_fixture_ble/ble.cpp
@@ -439,5 +439,69 @@ test(BLE_11_BLE_UUID_Conversion) {
     assertTrue(!memcmp(pUuid, extendedShortUUID, BLE_SIG_UUID_128BIT_LEN));
 }
 
+test(BLE_12_BLE_Address_Validation) {
+    BleAddress address;
+    assertFalse(address.valid());
+
+    // Public address
+    address = "44:14:0A:9F:F2:96";
+    assertTrue(address.valid());
+    address = "00:00:00:00:00:00"; // At least 1 bit is set
+    assertFalse(address.valid());
+    address = "FF:FF:FF:FF:FF:FF"; // At least 1 bit is cleared
+    assertFalse(address.valid());
+
+    // Static address. Two most significant bits should be 0b11 and
+    // the reset of bits should at least have 1 bit set and cleared.
+    address.type(BleAddressType::RANDOM_STATIC);
+    address = "30:12:34:56:78:9a"; // 0b00
+    assertFalse(address.valid());
+    address = "40:12:34:56:78:9a"; // 0b01
+    assertFalse(address.valid());
+    address = "80:12:34:56:78:9a:"; // 0b10
+    assertFalse(address.valid());
+    address = "C0:00:00:00:00:00"; // At least 1 bit is set
+    assertFalse(address.valid());
+    address = "FF:FF:FF:FF:FF:FF"; // At least 1 bit is clear
+    assertFalse(address.valid());
+    address = "C0:12:34:56:78:9a";
+    assertTrue(address.valid()); 
+
+    // Non-resolvable address.  Two most significant bits should be 0b00 and
+    // the reset of bits should at least have 1 bit set and cleared.
+    address.type(BleAddressType::RANDOM_PRIVATE_NON_RESOLVABLE);
+    address = "40:12:34:56:78:9a"; // 0b01
+    assertFalse(address.valid());
+    address = "80:12:34:56:78:9a"; // 0b10
+    assertFalse(address.valid());
+    address = "C0:12:34:56:78:9a"; // 0b11
+    assertFalse(address.valid());
+    address = "00:00:00:00:00:00"; // At least 1 bit is set
+    assertFalse(address.valid());
+    address = "3F:FF:FF:FF:FF:FF"; // At least 1 bit is clear
+    assertFalse(address.valid());
+    address = "3F:12:34:56:78:9a";
+    assertTrue(address.valid()); 
+
+    // Resolvable address. Two most significant bits should be 0b01 and
+    // bit24 ~ bit45 should at least have 1 bit set and cleared.
+    address.type(BleAddressType::RANDOM_PRIVATE_RESOLVABLE);
+    address = "30:12:34:56:78:9a"; // 0b00
+    assertFalse(address.valid());
+    address = "80:12:34:56:78:9a"; // 0b10
+    assertFalse(address.valid());
+    address = "C0:12:34:56:78:9a"; // 0b11
+    assertFalse(address.valid());
+    address = "40:00:00:12:34:56"; // At least 1 bit is set
+    assertFalse(address.valid());
+    address = "7F:FF:FF:12:34:56:"; // At least 1 bit is cleared
+    assertFalse(address.valid());
+    address = "4F:12:34:56:78:9a";
+    assertTrue(address.valid()); 
+
+    address.clear();
+    assertFalse(address.valid());
+}
+
 #endif // #if Wiring_BLE == 1
 

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -146,6 +146,7 @@ typedef hal_ble_attr_handle_t BleAttributeHandle;
 
 typedef void (*BleOnDataReceivedCallback)(const uint8_t* data, size_t len, const BlePeerDevice& peer, void* context);
 typedef void (*BleOnScanResultCallback)(const BleScanResult* device, void* context);
+typedef void (*BleOnScanResultCallbackRef)(const BleScanResult& device, void* context);
 typedef void (*BleOnConnectedCallback)(const BlePeerDevice& peer, void* context);
 typedef void (*BleOnDisconnectedCallback)(const BlePeerDevice& peer, void* context);
 
@@ -577,6 +578,7 @@ public:
 
     // Scanning control
     int scan(BleOnScanResultCallback callback, void* context) const;
+    int scan(BleOnScanResultCallbackRef callback, void* context) const;
     int scan(BleScanResult* results, size_t resultCount) const;
     Vector<BleScanResult> scan() const;
     int stopScanning() const;

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -220,7 +220,11 @@ public:
     bool operator!=(const char* address) const;
     bool operator!=(const String& address) const;
 
-    bool valid() const;
+    operator bool() const {
+        return isValid();
+    }
+
+    bool isValid() const;
     int clear();
 
 private:
@@ -242,8 +246,7 @@ public:
     BleUuid(const char* uuid);
     ~BleUuid() = default;
 
-    bool __attribute__((deprecated("Use BleUuid::valid() instead"))) isValid() const;
-    bool valid() const;
+    bool isValid() const;
 
     BleUuidType type() const;
 
@@ -275,6 +278,10 @@ public:
     }
 
     uint8_t operator[](uint8_t i) const;
+
+    operator bool() const {
+        return isValid();
+    }
 
 private:
     void construct(const char* uuid);
@@ -412,7 +419,7 @@ public:
     bool contains(BleAdvertisingDataType type) const;
 
 private:
-    size_t serviceUUID(BleAdvertisingDataType type, Vector<BleUuid>& uuids) const;
+    Vector<BleUuid> serviceUUID(BleAdvertisingDataType type) const;
     static size_t locate(const uint8_t* buf, size_t len, BleAdvertisingDataType type, size_t* offset);
 
     uint8_t selfData_[BLE_MAX_ADV_DATA_LEN];
@@ -444,7 +451,8 @@ public:
 
     BleCharacteristic& operator=(const BleCharacteristic& characteristic);
 
-    bool valid() const;
+    bool __attribute__((deprecated("Use BleCharacteristic::isValid() instead"))) valid() const;
+    bool isValid() const;
 
     BleUuid UUID() const;
     EnumFlags<BleCharacteristicProperty> properties() const;
@@ -476,6 +484,10 @@ public:
     int subscribe(bool enable) const;
 
     void onDataReceived(BleOnDataReceivedCallback callback, void* context);
+
+    operator bool() const {
+        return isValid();
+    }
 
     BleCharacteristicImpl* impl() const {
         return impl_.get();
@@ -614,10 +626,14 @@ public:
     void bind(const BleAddress& address) const;
     BleAddress address() const;
 
-    bool valid() const;
+    bool isValid() const;
 
     bool operator==(const BlePeerDevice& device) const;
     bool operator!=(const BlePeerDevice& device) const;
+
+    operator bool() const {
+        return isValid();
+    }
 
     BlePeerDevice& operator=(const BlePeerDevice& peer);
 

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -274,6 +274,8 @@ public:
         return !(*this == BleUuid(uuid));
     }
 
+    uint8_t operator[](uint8_t i) const;
+
 private:
     void construct(const char* uuid);
     void toBigEndian(uint8_t buf[BLE_SIG_UUID_128BIT_LEN]) const;
@@ -404,6 +406,8 @@ public:
     size_t operator()(uint8_t* buf, size_t len) const {
         return get(buf, len);
     }
+
+    uint8_t operator[](uint8_t i) const;
 
     bool contains(BleAdvertisingDataType type) const;
 

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -614,6 +614,8 @@ public:
     void bind(const BleAddress& address) const;
     BleAddress address() const;
 
+    bool valid() const;
+
     bool operator==(const BlePeerDevice& device) const;
     bool operator!=(const BlePeerDevice& device) const;
 
@@ -730,6 +732,8 @@ public:
     bool connected() const;
     void onConnected(BleOnConnectedCallback callback, void* context) const;
     void onDisconnected(BleOnDisconnectedCallback callback, void* context) const;
+
+    BlePeerDevice peerCentral() const;
 
     static BleLocalDevice& getInstance();
 

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -219,6 +219,9 @@ public:
     bool operator!=(const char* address) const;
     bool operator!=(const String& address) const;
 
+    bool valid() const;
+    int clear();
+
 private:
     void toBigEndian(uint8_t buf[BLE_SIG_ADDR_LEN]) const;
 
@@ -238,7 +241,8 @@ public:
     BleUuid(const char* uuid);
     ~BleUuid() = default;
 
-    bool isValid() const;
+    bool __attribute__((deprecated("Use BleUuid::valid() instead"))) isValid() const;
+    bool valid() const;
 
     BleUuidType type() const;
 

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -145,8 +145,8 @@ typedef hal_ble_conn_handle_t BleConnectionHandle;
 typedef hal_ble_attr_handle_t BleAttributeHandle;
 
 typedef void (*BleOnDataReceivedCallback)(const uint8_t* data, size_t len, const BlePeerDevice& peer, void* context);
-typedef void (*BleOnScanResultCallback)(const BleScanResult* device, void* context);
-typedef void (*BleOnScanResultCallbackRef)(const BleScanResult& device, void* context);
+typedef void (*BleOnScanResultCallback)(const BleScanResult* result, void* context);
+typedef void (*BleOnScanResultCallbackRef)(const BleScanResult& result, void* context);
 typedef void (*BleOnConnectedCallback)(const BlePeerDevice& peer, void* context);
 typedef void (*BleOnDisconnectedCallback)(const BlePeerDevice& peer, void* context);
 
@@ -466,10 +466,52 @@ private:
 
 class BleScanResult {
 public:
-    BleAddress address;
-    BleAdvertisingData advertisingData;
-    BleAdvertisingData scanResponse;
-    int8_t rssi;
+    BleScanResult& address(const BleAddress& addr) {
+        address_ = addr;
+        return *this;
+    }
+
+    BleScanResult& advertisingData(const BleAdvertisingData& advData) {
+        advertisingData_ = advData;
+        return *this;
+    }
+
+    BleScanResult& advertisingData(const uint8_t* buf, size_t len) {
+        advertisingData_.set(buf, len);
+        return *this;
+    }
+
+    BleScanResult& scanResponse(const uint8_t* buf, size_t len) {
+        scanResponse_.set(buf, len);
+        return *this;
+    }
+
+    BleScanResult& rssi(int8_t value) {
+        rssi_ = value;
+        return *this;
+    }
+
+    const BleAddress& address() const {
+        return address_;
+    }
+
+    const BleAdvertisingData& advertisingData() const {
+        return advertisingData_;
+    }
+
+    const BleAdvertisingData& scanResponse() const {
+        return scanResponse_;
+    }
+
+    int8_t rssi() const {
+        return rssi_;
+    }
+
+private:
+    BleAddress address_;
+    BleAdvertisingData advertisingData_;
+    BleAdvertisingData scanResponse_;
+    int8_t rssi_;
 };
 
 

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -466,6 +466,10 @@ private:
 
 class BleScanResult {
 public:
+    BleScanResult()
+            : rssi_(0xFF) {
+    }
+
     BleScanResult& address(const BleAddress& addr) {
         address_ = addr;
         return *this;

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -510,6 +510,13 @@ bool BleUuid::operator==(const BleUuid& uuid) const {
     return ((type_ == uuid.type_) && !memcmp(uuid128_, uuid.uuid128_, BLE_SIG_UUID_128BIT_LEN));
 }
 
+uint8_t BleUuid::operator[](uint8_t i) const {
+    if (i >= BLE_SIG_UUID_128BIT_LEN) {
+        return 0;
+    }
+    return uuid128_[i];
+}
+
 void BleUuid::construct(const char* uuid) {
     type_ = BleUuidType::LONG;
     memcpy(uuid128_, BASE_UUID, BLE_SIG_UUID_128BIT_LEN);
@@ -763,6 +770,13 @@ Vector<BleUuid> BleAdvertisingData::serviceUUID() const {
 
 size_t BleAdvertisingData::customData(uint8_t* buf, size_t len) const {
     return get(BleAdvertisingDataType::MANUFACTURER_SPECIFIC_DATA, buf, len);
+}
+
+uint8_t BleAdvertisingData::operator[](uint8_t i) const {
+    if (i >= selfLen_) {
+        return 0;
+    }
+    return selfData_[i];
 }
 
 bool BleAdvertisingData::contains(BleAdvertisingDataType type) const {

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -111,6 +111,7 @@ RecursiveMutex WiringBleLock::mutex_;
  */
 BleAddress::BleAddress()
         : address_{} {
+    clear();
     address_.addr_type = BLE_SIG_ADDR_TYPE_PUBLIC;
 }
 
@@ -324,9 +325,9 @@ bool BleAddress::valid() const {
         memcpy(temp, address_.addr, BLE_SIG_ADDR_LEN);
         if (address_.addr_type == BLE_SIG_ADDR_TYPE_RANDOM_STATIC || address_.addr_type == BLE_SIG_ADDR_TYPE_RANDOM_PRIVATE_NON_RESOLVABLE) {
             temp[5] &= 0x3F; // Clear the two most significant bits
-            CHECK_TRUE(memcmp(address_.addr, bitsClear, BLE_SIG_ADDR_LEN), false);
+            CHECK_TRUE(memcmp(temp, bitsClear, BLE_SIG_ADDR_LEN), false);
             temp[5] |= 0xC0; // Set the two most significant bits
-            CHECK_TRUE(memcmp(address_.addr, bitsSet, BLE_SIG_ADDR_LEN), false);
+            CHECK_TRUE(memcmp(temp, bitsSet, BLE_SIG_ADDR_LEN), false);
             if (address_.addr_type == BLE_SIG_ADDR_TYPE_RANDOM_STATIC) {
                 return (address_.addr[5] & 0xC0) == 0xC0;
             } else {
@@ -334,9 +335,9 @@ bool BleAddress::valid() const {
             }
         } else if (address_.addr_type == BLE_SIG_ADDR_TYPE_RANDOM_PRIVATE_RESOLVABLE) {
             temp[5] &= 0x3F;
-            CHECK_TRUE(memcmp(&address_.addr[3], &bitsClear[3], 3), false);
+            CHECK_TRUE(memcmp(&temp[3], &bitsClear[3], 3), false);
             temp[5] |= 0xC0;
-            CHECK_TRUE(memcmp(&address_.addr[3], &bitsSet[3], 3), false);
+            CHECK_TRUE(memcmp(&temp[3], &bitsSet[3], 3), false);
             return (address_.addr[5] & 0xC0) == 0x40;
         }
     }
@@ -1898,6 +1899,7 @@ public:
               targetCount_(0),
               foundCount_(0),
               callback_(nullptr),
+              callbackRef_(nullptr),
               context_(nullptr) {
         resultsVector_.clear();
     }

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -1944,10 +1944,9 @@ private:
         delegator->foundCount_++;
 
         BleScanResult result = {};
-        result.address = event->peer_addr;
-        result.rssi = event->rssi;
-        result.scanResponse.set(event->sr_data, event->sr_data_len);
-        result.advertisingData.set(event->adv_data, event->adv_data_len);
+        result.address(event->peer_addr).rssi(event->rssi)
+              .scanResponse(event->sr_data, event->sr_data_len)
+              .advertisingData(event->adv_data, event->adv_data_len);
         if (delegator->callback_) {
             delegator->callback_(&result, delegator->context_);
             return;


### PR DESCRIPTION
**This PR is targeting to feature/ip_ble_address**

### Problem

1. `BleAddress` doesn't support validity check and invalidating object.
2. Scanning callback doesn't pass scanned result in reference manner.
3. `BleScanResult` should not access members directly

### References

https://github.com/particle-iot/device-os/issues/2005

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
