### PR TITLE
[wiring] BLE: implement BLE scanning filter.

### DIFF
--- a/user/tests/wiring/api/ble.cpp
+++ b/user/tests/wiring/api/ble.cpp
@@ -417,6 +417,7 @@ test(ble_characteristic_class) {
 
     API_COMPILE({ int ret = characteristic.subscribe(true); (void)ret; });
 
+    API_COMPILE({ characteristic.onDataReceived(dataHandlerFunc); });
     API_COMPILE({ characteristic.onDataReceived(dataHandlerFunc, nullptr); });
 
     API_COMPILE({ bool ret = characteristic; (void)ret; });
@@ -453,6 +454,41 @@ test(ble_scan_result) {
     API_COMPILE({ BleAdvertisingData sr = result.scanResponse(); (void)sr; });
     API_COMPILE({ const BleAdvertisingData& sr = result.scanResponse(); (void)sr; });
     API_COMPILE({ int8_t ret = result.rssi(); (void)ret; });
+}
+
+test(ble_scan_filter) {
+    BleScanFilter filter;
+
+    API_COMPILE({ BleScanFilter f = filter.clear(); (void)f; });
+
+    API_COMPILE({ BleScanFilter f = filter.deviceName("1234"); (void)f; });
+    API_COMPILE({ BleScanFilter f = filter.deviceName(String("1234")); (void)f; });
+    API_COMPILE({ BleScanFilter f = filter.deviceNames(Vector<String>()); (void)f; });
+    API_COMPILE({ Vector<String> names = filter.deviceNames(); (void)names; });
+    API_COMPILE({ const Vector<String>& names = filter.deviceNames(); (void)names; });
+
+    API_COMPILE({ BleScanFilter f = filter.serviceUUID(BleUuid()); (void)f; });
+    API_COMPILE({ BleScanFilter f = filter.serviceUUIDs(Vector<BleUuid>()); (void)f; });
+    API_COMPILE({ Vector<BleUuid> uuids = filter.serviceUUIDs(); (void)uuids; });
+    API_COMPILE({ const Vector<BleUuid>& uuids = filter.serviceUUIDs(); (void)uuids; });
+
+    API_COMPILE({ BleScanFilter f = filter.address("1234"); (void)f; });
+    API_COMPILE({ BleScanFilter f = filter.addresses(Vector<BleAddress>()); (void)f; });
+    API_COMPILE({ Vector<BleAddress> addrs = filter.addresses(); (void)addrs; });
+    API_COMPILE({ const Vector<BleAddress>& addrs = filter.addresses(); (void)addrs; });
+
+    API_COMPILE({ BleScanFilter f = filter.appearance(BLE_SIG_APPEARANCE_GENERIC_PHONE); (void)f; });
+    API_COMPILE({ BleScanFilter f = filter.appearances(Vector<ble_sig_appearance_t>()); (void)f; });
+    API_COMPILE({ Vector<ble_sig_appearance_t> apprs = filter.appearances(); (void)apprs; });
+    API_COMPILE({ const Vector<ble_sig_appearance_t>& apprs = filter.appearances(); (void)apprs; });
+
+    API_COMPILE({ BleScanFilter f = filter.minRssi(0); (void)f; });
+    API_COMPILE({ BleScanFilter f = filter.maxRssi(0); (void)f; });
+    API_COMPILE({ int8_t ret = filter.minRssi(); (void)ret; });
+    API_COMPILE({ int8_t ret = filter.maxRssi(); (void)ret; });
+
+    API_COMPILE({ uint8_t buf[1]; BleScanFilter f = filter.customData(buf, 0); (void)f; });
+    API_COMPILE({ size_t len; const uint8_t* buf = filter.customData(&len); (void)len; (void)buf; });
 }
 
 test(ble_peer_device) {
@@ -586,8 +622,16 @@ test(ble_local_device_class) {
 
     API_COMPILE({ Vector<BleScanResult> results = BLE.scan(); });
     API_COMPILE({ BleScanResult results[1]; int ret = BLE.scan(results, 0); (void)ret; });
+    API_COMPILE({ int ret = BLE.scan(scanHandlerFunc); (void)ret; });
     API_COMPILE({ int ret = BLE.scan(scanHandlerFunc, nullptr); (void)ret; });
+    API_COMPILE({ int ret = BLE.scan(scanHandlerFuncRef); (void)ret; });
     API_COMPILE({ int ret = BLE.scan(scanHandlerFuncRef, nullptr); (void)ret; });
+    API_COMPILE({ Vector<BleScanResult> results = BLE.scanWithFilter(BleScanFilter()); });
+    API_COMPILE({ BleScanResult results[1]; int ret = BLE.scanWithFilter(BleScanFilter(), results, 0); (void)ret; });
+    API_COMPILE({ int ret = BLE.scanWithFilter(BleScanFilter(), scanHandlerFunc); (void)ret; });
+    API_COMPILE({ int ret = BLE.scanWithFilter(BleScanFilter(), scanHandlerFunc, nullptr); (void)ret; });
+    API_COMPILE({ int ret = BLE.scanWithFilter(BleScanFilter(), scanHandlerFuncRef); (void)ret; });
+    API_COMPILE({ int ret = BLE.scanWithFilter(BleScanFilter(), scanHandlerFuncRef, nullptr); (void)ret; });
     API_COMPILE({ int ret = BLE.stopScanning(); (void)ret; });
 
     API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic("1234", props, charUuid, svcUuid); });
@@ -614,7 +658,9 @@ test(ble_local_device_class) {
 
     API_COMPILE({ BlePeerDevice p = BLE.peerCentral(); });
 
+    API_COMPILE({ BLE.onConnected(connectedHandlerFunc); });
     API_COMPILE({ BLE.onConnected(connectedHandlerFunc, nullptr); });
+    API_COMPILE({ BLE.onDisconnected(disconnectedHandlerFunc); });
     API_COMPILE({ BLE.onDisconnected(disconnectedHandlerFunc, nullptr); });
 }
 

--- a/user/tests/wiring/ble_central_peripheral/ble_peripheral/peripheral.cpp
+++ b/user/tests/wiring/ble_central_peripheral/ble_peripheral/peripheral.cpp
@@ -63,21 +63,21 @@ test(BLE_01_Peripheral_Advertising) {
     BleCharacteristic temp;
 
     temp = BLE.addCharacteristic(charRead);
-    assertTrue(temp.valid());
+    assertTrue(temp.isValid());
     ret = charRead.setValue("6dd902629e1d");
     assertEqual(ret, 12);
     temp = BLE.addCharacteristic(charWrite);
-    assertTrue(temp.valid());
+    assertTrue(temp.isValid());
     temp = BLE.addCharacteristic(charWriteWoRsp);
-    assertTrue(temp.valid());
+    assertTrue(temp.isValid());
     temp = BLE.addCharacteristic(charWriteAndWriteWoRsp);
-    assertTrue(temp.valid());
+    assertTrue(temp.isValid());
     temp = BLE.addCharacteristic(charNotify);
-    assertTrue(temp.valid());
+    assertTrue(temp.isValid());
     temp = BLE.addCharacteristic(charIndicate);
-    assertTrue(temp.valid());
+    assertTrue(temp.isValid());
     temp = BLE.addCharacteristic(charNotifyAndIndicate);
-    assertTrue(temp.valid());
+    assertTrue(temp.isValid());
 
     BleAdvertisingData data;
     data.appendServiceUUID(serviceUuid);

--- a/user/tests/wiring/ble_scanner_broadcaster/ble_broadcaster/application.cpp
+++ b/user/tests/wiring/ble_scanner_broadcaster/ble_broadcaster/application.cpp
@@ -1,0 +1,6 @@
+#include "Particle.h"
+#include "unit-test/unit-test.h"
+
+SYSTEM_MODE(SEMI_AUTOMATIC);
+
+UNIT_TEST_APP();

--- a/user/tests/wiring/ble_scanner_broadcaster/ble_broadcaster/broadcaster.cpp
+++ b/user/tests/wiring/ble_scanner_broadcaster/ble_broadcaster/broadcaster.cpp
@@ -1,16 +1,121 @@
 #include "Particle.h"
+#include "unit-test/unit-test.h"
 
 #if Wiring_BLE == 1
 
-SYSTEM_MODE(MANUAL);
+const char* peerServiceUuid = "6E400000-B5A3-F393-E0A9-E50E24DCCA9E";
+const char* peerCharacteristicUuid = "6E400001-B5A3-F393-E0A9-E50E24DCCA9E";
 
-void setup() {
-    iBeacon beacon(1, 2, "9c1b8bdc-5548-4e32-8a78-b9f524131206", -55);
-    BLE.advertise(beacon);
+void onDataReceived(const uint8_t* data, size_t len, const BlePeerDevice& peer, void* context);
+
+BleCharacteristic charWriteWoRsp("", BleCharacteristicProperty::WRITE_WO_RSP,
+                                 peerCharacteristicUuid, peerServiceUuid, onDataReceived, nullptr);
+
+typedef enum {
+    CMD_UNKNOWN,
+    CMD_RESTART_ADV,
+    CMD_ADV_DEVICE_NAME,
+    CMD_ADV_APPEARANCE,
+    CMD_ADV_CUSTOM_DATA
+} TestCommand;
+TestCommand cmd = CMD_UNKNOWN;
+
+void onDataReceived(const uint8_t* data, size_t len, const BlePeerDevice& peer, void* context) {
+    cmd = (TestCommand)(*data);
 }
 
-void loop() {
+test(BLE_Broadcaster_01_Connect_By_Scanner) {
+    Serial.println("This is BLE broadcaster.");
 
+    BleCharacteristic temp;
+    temp = BLE.addCharacteristic(charWriteWoRsp);
+    assertTrue(temp.valid());
+
+    BleAdvertisingData data;
+    data.appendServiceUUID(peerServiceUuid);
+    int ret = BLE.advertise(&data);
+    assertEqual(ret, 0);
+    assertTrue(BLE.advertising());
+
+    Serial.println("BLE starts advertising...");
+    size_t wait = 200; // Wait 20s for establishing connection.
+    while (!BLE.connected() && wait > 0) {
+        delay(100);
+        wait--;
+    }
+    assertTrue(wait > 0);
+}
+
+test(BLE_Broadcaster_02_Restart_Advertising) {
+    assertTrue(BLE.connected());
+
+    size_t wait = 600;
+    while (cmd != CMD_RESTART_ADV && wait > 0) {
+        delay(100);
+        wait--;
+    }
+    assertTrue(wait > 0);
+
+    int ret = BLE.advertise();
+    assertEqual(ret, 0);
+    assertTrue(BLE.advertising());
+}
+
+test(BLE_Broadcaster_03_Advertise_Device_Name) {
+    assertTrue(BLE.connected());
+
+    size_t wait = 600;
+    while (cmd != CMD_ADV_DEVICE_NAME && wait > 0) {
+        delay(100);
+        wait--;
+    }
+    assertTrue(wait > 0);
+
+    BleAdvertisingData data;
+    data.appendLocalName("PARTICLE_TEST");
+    assertEqual(data.deviceName(), String("PARTICLE_TEST"));
+    int ret = BLE.advertise(&data);
+    assertEqual(ret, 0);
+    assertTrue(BLE.advertising());
+}
+
+test(BLE_Broadcaster_04_Advertise_Appearance) {
+    assertTrue(BLE.connected());
+
+    size_t wait = 600;
+    while (cmd != CMD_ADV_APPEARANCE && wait > 0) {
+        delay(100);
+        wait--;
+    }
+    assertTrue(wait > 0);
+
+    BleAdvertisingData data;
+    data.appendAppearance(BLE_SIG_APPEARANCE_GENERIC_DISPLAY);
+    assertEqual(data.appearance(), BLE_SIG_APPEARANCE_GENERIC_DISPLAY);
+    int ret = BLE.advertise(&data);
+    assertEqual(ret, 0);
+    assertTrue(BLE.advertising());
+}
+
+test(BLE_Broadcaster_05_Advertise_Custom_Data) {
+    assertTrue(BLE.connected());
+
+    size_t wait = 600;
+    while (cmd != CMD_ADV_CUSTOM_DATA && wait > 0) {
+        delay(100);
+        wait--;
+    }
+    assertTrue(wait > 0);
+
+    BleAdvertisingData data;
+    constexpr uint8_t buf[] = {0xde, 0xad, 0xbe, 0xef};
+    uint8_t read[4];
+    data.appendCustomData(buf, sizeof(buf));
+    data.customData(read, sizeof(read));
+    assertEqual(memcmp(buf, read, sizeof(buf)), 0);
+    int ret = BLE.advertise(&data);
+    assertEqual(ret, 0);
+    assertTrue(BLE.advertising());
 }
 
 #endif // #if Wiring_BLE == 1

--- a/user/tests/wiring/ble_scanner_broadcaster/ble_broadcaster/broadcaster.cpp
+++ b/user/tests/wiring/ble_scanner_broadcaster/ble_broadcaster/broadcaster.cpp
@@ -29,7 +29,7 @@ test(BLE_Broadcaster_01_Connect_By_Scanner) {
 
     BleCharacteristic temp;
     temp = BLE.addCharacteristic(charWriteWoRsp);
-    assertTrue(temp.valid());
+    assertTrue(temp.isValid());
 
     BleAdvertisingData data;
     data.appendServiceUUID(peerServiceUuid);

--- a/user/tests/wiring/ble_scanner_broadcaster/ble_broadcaster/broadcaster.cpp
+++ b/user/tests/wiring/ble_scanner_broadcaster/ble_broadcaster/broadcaster.cpp
@@ -38,23 +38,12 @@ test(BLE_Broadcaster_01_Connect_By_Scanner) {
     assertTrue(BLE.advertising());
 
     Serial.println("BLE starts advertising...");
-    size_t wait = 200; // Wait 20s for establishing connection.
-    while (!BLE.connected() && wait > 0) {
-        delay(100);
-        wait--;
-    }
-    assertTrue(wait > 0);
+    assertTrue(waitFor(BLE.connected, 20000));
 }
 
 test(BLE_Broadcaster_02_Restart_Advertising) {
     assertTrue(BLE.connected());
-
-    size_t wait = 600;
-    while (cmd != CMD_RESTART_ADV && wait > 0) {
-        delay(100);
-        wait--;
-    }
-    assertTrue(wait > 0);
+    assertTrue(waitFor([&]{ return cmd == CMD_RESTART_ADV; }, 60000));
 
     int ret = BLE.advertise();
     assertEqual(ret, 0);
@@ -63,13 +52,7 @@ test(BLE_Broadcaster_02_Restart_Advertising) {
 
 test(BLE_Broadcaster_03_Advertise_Device_Name) {
     assertTrue(BLE.connected());
-
-    size_t wait = 600;
-    while (cmd != CMD_ADV_DEVICE_NAME && wait > 0) {
-        delay(100);
-        wait--;
-    }
-    assertTrue(wait > 0);
+    assertTrue(waitFor([&]{ return cmd == CMD_ADV_DEVICE_NAME; }, 60000));
 
     BleAdvertisingData data;
     data.appendLocalName("PARTICLE_TEST");
@@ -81,13 +64,7 @@ test(BLE_Broadcaster_03_Advertise_Device_Name) {
 
 test(BLE_Broadcaster_04_Advertise_Appearance) {
     assertTrue(BLE.connected());
-
-    size_t wait = 600;
-    while (cmd != CMD_ADV_APPEARANCE && wait > 0) {
-        delay(100);
-        wait--;
-    }
-    assertTrue(wait > 0);
+    assertTrue(waitFor([&]{ return cmd == CMD_ADV_APPEARANCE; }, 60000));
 
     BleAdvertisingData data;
     data.appendAppearance(BLE_SIG_APPEARANCE_GENERIC_DISPLAY);
@@ -99,13 +76,7 @@ test(BLE_Broadcaster_04_Advertise_Appearance) {
 
 test(BLE_Broadcaster_05_Advertise_Custom_Data) {
     assertTrue(BLE.connected());
-
-    size_t wait = 600;
-    while (cmd != CMD_ADV_CUSTOM_DATA && wait > 0) {
-        delay(100);
-        wait--;
-    }
-    assertTrue(wait > 0);
+    assertTrue(waitFor([&]{ return cmd == CMD_ADV_CUSTOM_DATA; }, 60000));
 
     BleAdvertisingData data;
     constexpr uint8_t buf[] = {0xde, 0xad, 0xbe, 0xef};

--- a/user/tests/wiring/ble_scanner_broadcaster/ble_scanner/scanner.cpp
+++ b/user/tests/wiring/ble_scanner_broadcaster/ble_scanner/scanner.cpp
@@ -79,9 +79,9 @@ test(BLE_Scanner_01_Connects_To_Broadcaster) {
         if (results.size() > 0) {
             for (const auto& result : results) {
                 BleUuid foundServiceUUID;
-                size_t svcCount = result.advertisingData.serviceUUID(&foundServiceUUID, 1);
+                size_t svcCount = result.advertisingData().serviceUUID(&foundServiceUUID, 1);
                 if (svcCount > 0 && foundServiceUUID == peerServiceUuid) {
-                    BlePeerDevice peer = BLE.connect(result.address);
+                    BlePeerDevice peer = BLE.connect(result.address());
                     if (peer.connected()) {
                         assertTrue(peer.getCharacteristicByUUID(peerCharWriteWoRsp, peerCharacteristicUuid));
                         peerAddress = peer.address();
@@ -133,8 +133,8 @@ test(BLE_Scanner_05_Scan_With_Filter_Rssi) {
     Vector<BleScanResult> results = BLE.scanWithFilter(BleScanFilter().minRssi(MIN_RSSI).maxRssi(MAX_RSSI));
     assertTrue(results.size() > 0);
     for (const auto& result : results) {
-        assertMoreOrEqual(result.rssi, MIN_RSSI);
-        assertLessOrEqual(result.rssi, MAX_RSSI);
+        assertMoreOrEqual(result.rssi(), MIN_RSSI);
+        assertLessOrEqual(result.rssi(), MAX_RSSI);
     }
 }
 

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -378,7 +378,7 @@ public:
     // According to the Bluetooth CSS, Local Name shall not appear more than once in a block.
     size_t appendLocalName(const char* name);
     size_t appendLocalName(const String& name);
-    
+
     size_t appendAppearance(ble_sig_appearance_t appearance);
 
     template<typename T>
@@ -487,7 +487,7 @@ public:
     // Valid for peer characteristic only. Manually enable the characteristic notification or indication.
     int subscribe(bool enable) const;
 
-    void onDataReceived(BleOnDataReceivedCallback callback, void* context);
+    void onDataReceived(BleOnDataReceivedCallback callback, void* context = nullptr);
 
     operator bool() const {
         return isValid();
@@ -828,12 +828,13 @@ public:
     int getScanParameters(BleScanParams& params) const;
 
     // Scanning control
-    int scan(BleOnScanResultCallback callback, void* context) const;
-    int scan(BleOnScanResultCallbackRef callback, void* context) const;
+    int scan(BleOnScanResultCallback callback, void* context = nullptr) const;
+    int scan(BleOnScanResultCallbackRef callback, void* context = nullptr) const;
     int scan(BleScanResult* results, size_t resultCount) const;
     Vector<BleScanResult> scan() const;
-    int scanWithFilter(BleOnScanResultCallback callback, void* context, const BleScanFilter& filter) const;
-    int scanWithFilter(BleScanResult* results, size_t resultCount, const BleScanFilter& filter) const;
+    int scanWithFilter(const BleScanFilter& filter, BleOnScanResultCallback callback, void* context = nullptr) const;
+    int scanWithFilter(const BleScanFilter& filter, BleOnScanResultCallbackRef callback, void* context = nullptr) const;
+    int scanWithFilter(const BleScanFilter& filter, BleScanResult* results, size_t resultCount) const;
     Vector<BleScanResult> scanWithFilter(const BleScanFilter& filter) const;
     int stopScanning() const;
 
@@ -869,8 +870,8 @@ public:
     int disconnect(const BlePeerDevice& peer) const;
     int disconnectAll() const;
     bool connected() const;
-    void onConnected(BleOnConnectedCallback callback, void* context) const;
-    void onDisconnected(BleOnDisconnectedCallback callback, void* context) const;
+    void onConnected(BleOnConnectedCallback callback, void* context = nullptr) const;
+    void onDisconnected(BleOnDisconnectedCallback callback, void* context = nullptr) const;
 
     BlePeerDevice peerCentral() const;
 

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -378,6 +378,7 @@ public:
     // According to the Bluetooth CSS, Local Name shall not appear more than once in a block.
     size_t appendLocalName(const char* name);
     size_t appendLocalName(const String& name);
+    
     size_t appendAppearance(ble_sig_appearance_t appearance);
 
     template<typename T>
@@ -408,11 +409,9 @@ public:
 
     size_t serviceUUID(BleUuid* uuids, size_t count) const;
     Vector<BleUuid> serviceUUID() const;
-<<<<<<< HEAD
 
-=======
->>>>>>> [wiring] BLE: implement BLE scanning filter.
     size_t customData(uint8_t* buf, size_t len) const;
+
     ble_sig_appearance_t appearance() const;
 
     size_t operator()(uint8_t* buf, size_t len) const {

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -35,6 +35,9 @@
 
 namespace particle {
 
+constexpr int8_t BLE_RSSI_INVALID = 0x7F;
+constexpr int8_t BLE_TX_POWER_INVALID = 0x7F;
+
 class BleScanResult;
 class BlePeerDevice;
 
@@ -531,7 +534,7 @@ private:
 class BleScanResult {
 public:
     BleScanResult()
-            : rssi_(0x7F) {
+            : rssi_(BLE_RSSI_INVALID) {
     }
 
     BleScanResult& address(const BleAddress& addr) {
@@ -592,8 +595,8 @@ private:
 class BleScanFilter {
 public:
     BleScanFilter()
-            : minRssi_(0x7F),
-              maxRssi_(0x7F),
+            : minRssi_(BLE_RSSI_INVALID),
+              maxRssi_(BLE_RSSI_INVALID),
               customData_(nullptr),
               customDataLen_(0) {
     }
@@ -686,7 +689,7 @@ public:
         serviceUuids_.clear();
         addresses_.clear();
         appearances_.clear();
-        minRssi_ = maxRssi_ = 0xFF;
+        minRssi_ = maxRssi_ = BLE_RSSI_INVALID;
         customData_ = nullptr;
         customDataLen_ = 0;
         return *this;

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -2295,13 +2295,19 @@ Vector<BleScanResult> BleLocalDevice::scan() const {
     return scanner.start();
 }
 
-int BleLocalDevice::scanWithFilter(BleOnScanResultCallback callback, void* context, const BleScanFilter& filter) const {
+int BleLocalDevice::scanWithFilter(const BleScanFilter& filter, BleOnScanResultCallback callback, void* context) const {
     WiringBleLock lk;
     BleScanDelegator scanner;
     return scanner.setScanFilter(filter).start(callback, context);
 }
 
-int BleLocalDevice::scanWithFilter(BleScanResult* results, size_t resultCount, const BleScanFilter& filter) const {
+int BleLocalDevice::scanWithFilter(const BleScanFilter& filter, BleOnScanResultCallbackRef callback, void* context) const {
+    WiringBleLock lk;
+    BleScanDelegator scanner;
+    return scanner.setScanFilter(filter).start(callback, context);
+}
+
+int BleLocalDevice::scanWithFilter(const BleScanFilter& filter, BleScanResult* results, size_t resultCount) const {
     WiringBleLock lk;
     if (results == nullptr || resultCount == 0) {
         return SYSTEM_ERROR_INVALID_ARGUMENT;

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -2066,12 +2066,12 @@ public:
 
     bool filterByRssi(const BleScanResult& result) {
         int8_t filterRssi = filter_.minRssi();
-        if (filterRssi != 0x7F && result.rssi < filterRssi) {
+        if (filterRssi != 0x7F && result.rssi() < filterRssi) {
             LOG_DEBUG(TRACE, "Exceed min. RSSI");
             return false;
         }
         filterRssi = filter_.maxRssi();
-        if (filterRssi != 0x7F && result.rssi > filterRssi) {
+        if (filterRssi != 0x7F && result.rssi() > filterRssi) {
             LOG_DEBUG(TRACE, "Exceed max. RSSI.");
             return false;
         }
@@ -2082,7 +2082,7 @@ public:
         auto filerAddresses = filter_.addresses();
         if (filerAddresses.size() > 0) {
             for (const auto& address : filerAddresses) {
-                if (address == result.address) {
+                if (address == result.address()) {
                     return true;
                 }
             }
@@ -2095,8 +2095,8 @@ public:
     bool filterByDeviceName(const BleScanResult& result) {
         auto filterDeviceNames = filter_.deviceNames();
         if (filterDeviceNames.size() > 0) {
-            String srName = result.scanResponse.deviceName();
-            String advName = result.advertisingData.deviceName();
+            String srName = result.scanResponse().deviceName();
+            String advName = result.advertisingData().deviceName();
             if (srName.length() == 0 && advName.length() == 0) {
                 LOG_DEBUG(TRACE, "Device name mismatched.");
                 return false;
@@ -2115,8 +2115,8 @@ public:
     bool filterByServiceUUID(const BleScanResult& result) {
         auto filterServiceUuids = filter_.serviceUUIDs();
         if (filterServiceUuids.size() > 0) {
-            const Vector<BleUuid>& srUuids = result.scanResponse.serviceUUID();
-            const Vector<BleUuid>& advUuids = result.advertisingData.serviceUUID();
+            const Vector<BleUuid>& srUuids = result.scanResponse().serviceUUID();
+            const Vector<BleUuid>& advUuids = result.advertisingData().serviceUUID();
             if (srUuids.size() <= 0 && advUuids.size() <= 0) {
                 LOG_DEBUG(TRACE, "Service UUID mismatched.");
                 return false;
@@ -2142,8 +2142,8 @@ public:
     bool filterByAppearance(const BleScanResult& result) {
         auto filterAppearances = filter_.appearances();
         if (filterAppearances.size() > 0) {
-            ble_sig_appearance_t srAppearance = result.scanResponse.appearance();
-            ble_sig_appearance_t advAppearance = result.advertisingData.appearance();
+            ble_sig_appearance_t srAppearance = result.scanResponse().appearance();
+            ble_sig_appearance_t advAppearance = result.advertisingData().appearance();
             for (const auto& appearance : filterAppearances) {
                 if (appearance == srAppearance || appearance == advAppearance) {
                     return true;
@@ -2159,8 +2159,8 @@ public:
         size_t filterCustomDatalen;
         const uint8_t* filterCustomData = filter_.customData(&filterCustomDatalen);
         if (filterCustomData != nullptr && filterCustomDatalen > 0) {
-            size_t srLen = result.scanResponse.get(BleAdvertisingDataType::MANUFACTURER_SPECIFIC_DATA, nullptr, sizeof(size_t));
-            size_t advLen = result.advertisingData.get(BleAdvertisingDataType::MANUFACTURER_SPECIFIC_DATA, nullptr, sizeof(size_t));
+            size_t srLen = result.scanResponse().get(BleAdvertisingDataType::MANUFACTURER_SPECIFIC_DATA, nullptr, sizeof(size_t));
+            size_t advLen = result.advertisingData().get(BleAdvertisingDataType::MANUFACTURER_SPECIFIC_DATA, nullptr, sizeof(size_t));
             if (srLen != filterCustomDatalen && advLen != filterCustomDatalen) {
                 LOG_DEBUG(TRACE, "Custom data mismatched.");
                 return false;
@@ -2171,7 +2171,7 @@ public:
                     LOG(ERROR, "Failed to allocate memory!");
                     return false;
                 }
-                result.scanResponse.get(BleAdvertisingDataType::MANUFACTURER_SPECIFIC_DATA, buf, srLen);
+                result.scanResponse().get(BleAdvertisingDataType::MANUFACTURER_SPECIFIC_DATA, buf, srLen);
                 if (!memcmp(buf, filterCustomData, srLen)) {
                     return true;
                 }
@@ -2182,7 +2182,7 @@ public:
                     LOG(ERROR, "Failed to allocate memory!");
                     return false;
                 }
-                result.advertisingData.get(BleAdvertisingDataType::MANUFACTURER_SPECIFIC_DATA, buf, advLen);
+                result.advertisingData().get(BleAdvertisingDataType::MANUFACTURER_SPECIFIC_DATA, buf, advLen);
                 if (!memcmp(buf, filterCustomData, advLen)) {
                     return true;
                 }

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -665,6 +665,10 @@ size_t BleAdvertisingData::appendCustomData(const uint8_t* buf, size_t len, bool
     return append(BleAdvertisingDataType::MANUFACTURER_SPECIFIC_DATA, buf, len, force);
 }
 
+size_t BleAdvertisingData::appendAppearance(ble_sig_appearance_t appearance) {
+    return append(BleAdvertisingDataType::APPEARANCE, (const uint8_t*)&appearance, 2, false);
+}
+
 size_t BleAdvertisingData::resize(size_t size) {
     selfLen_ = std::min(size, (size_t)BLE_MAX_ADV_DATA_LEN);
     return selfLen_;
@@ -762,7 +766,7 @@ Vector<BleUuid> BleAdvertisingData::serviceUUID() const {
     foundUuids.append(serviceUUID(BleAdvertisingDataType::SERVICE_UUID_128BIT_MORE_AVAILABLE));
     foundUuids.append(serviceUUID(BleAdvertisingDataType::SERVICE_UUID_128BIT_COMPLETE));
     return foundUuids;
- }
+}
 
 size_t BleAdvertisingData::customData(uint8_t* buf, size_t len) const {
     return get(BleAdvertisingDataType::MANUFACTURER_SPECIFIC_DATA, buf, len);
@@ -773,6 +777,16 @@ uint8_t BleAdvertisingData::operator[](uint8_t i) const {
         return 0;
     }
     return selfData_[i];
+}
+
+ble_sig_appearance_t BleAdvertisingData::appearance() const {
+    uint8_t buf[2];
+    size_t len = get(BleAdvertisingDataType::APPEARANCE, buf, sizeof(buf));
+    if (len > 0) {
+        uint16_t temp = (uint16_t)buf[1] << 8 | buf[0];
+        return (ble_sig_appearance_t)temp;
+    }
+    return BLE_SIG_APPEARANCE_UNKNOWN;
 }
 
 bool BleAdvertisingData::contains(BleAdvertisingDataType type) const {
@@ -2045,6 +2059,140 @@ public:
         return resultsVector_;
     }
 
+    BleScanDelegator& setScanFilter(const BleScanFilter& filter) {
+        filter_ = filter;
+        return *this;
+    }
+
+    bool filterByRssi(const BleScanResult& result) {
+        int8_t filterRssi = filter_.minRssi();
+        if (filterRssi != 0x7F && result.rssi < filterRssi) {
+            LOG_DEBUG(TRACE, "Exceed min. RSSI");
+            return false;
+        }
+        filterRssi = filter_.maxRssi();
+        if (filterRssi != 0x7F && result.rssi > filterRssi) {
+            LOG_DEBUG(TRACE, "Exceed max. RSSI.");
+            return false;
+        }
+        return true;
+    }
+
+    bool filterByAddress(const BleScanResult& result) {
+        auto filerAddresses = filter_.addresses();
+        if (filerAddresses.size() > 0) {
+            for (const auto& address : filerAddresses) {
+                if (address == result.address) {
+                    return true;
+                }
+            }
+            LOG_DEBUG(TRACE, "Address mismatched.");
+            return false;
+        }
+        return true;
+    }
+
+    bool filterByDeviceName(const BleScanResult& result) {
+        auto filterDeviceNames = filter_.deviceNames();
+        if (filterDeviceNames.size() > 0) {
+            String srName = result.scanResponse.deviceName();
+            String advName = result.advertisingData.deviceName();
+            if (srName.length() == 0 && advName.length() == 0) {
+                LOG_DEBUG(TRACE, "Device name mismatched.");
+                return false;
+            }
+            for (const auto& name : filterDeviceNames) {
+                if (name == srName || name == advName) {
+                    return true;
+                }
+            }
+            LOG_DEBUG(TRACE, "Device name mismatched.");
+            return false;
+        }
+        return true;
+    }
+
+    bool filterByServiceUUID(const BleScanResult& result) {
+        auto filterServiceUuids = filter_.serviceUUIDs();
+        if (filterServiceUuids.size() > 0) {
+            const Vector<BleUuid>& srUuids = result.scanResponse.serviceUUID();
+            const Vector<BleUuid>& advUuids = result.advertisingData.serviceUUID();
+            if (srUuids.size() <= 0 && advUuids.size() <= 0) {
+                LOG_DEBUG(TRACE, "Service UUID mismatched.");
+                return false;
+            }
+            for (const auto& uuid : filterServiceUuids) {
+                for (const auto& found : srUuids) {
+                    if (uuid == found) {
+                        return true;
+                    }
+                }
+                for (const auto& found : advUuids) {
+                    if (uuid == found) {
+                        return true;
+                    }
+                }
+            }
+            LOG_DEBUG(TRACE, "Service UUID mismatched.");
+            return false;
+        }
+        return true;
+    }
+
+    bool filterByAppearance(const BleScanResult& result) {
+        auto filterAppearances = filter_.appearances();
+        if (filterAppearances.size() > 0) {
+            ble_sig_appearance_t srAppearance = result.scanResponse.appearance();
+            ble_sig_appearance_t advAppearance = result.advertisingData.appearance();
+            for (const auto& appearance : filterAppearances) {
+                if (appearance == srAppearance || appearance == advAppearance) {
+                    return true;
+                }
+            }
+            LOG_DEBUG(TRACE, "Appearance mismatched.");
+            return false;
+        }
+        return true;
+    }
+
+    bool filterByCustomData(const BleScanResult& result) {
+        size_t filterCustomDatalen;
+        const uint8_t* filterCustomData = filter_.customData(&filterCustomDatalen);
+        if (filterCustomData != nullptr && filterCustomDatalen > 0) {
+            size_t srLen = result.scanResponse.get(BleAdvertisingDataType::MANUFACTURER_SPECIFIC_DATA, nullptr, sizeof(size_t));
+            size_t advLen = result.advertisingData.get(BleAdvertisingDataType::MANUFACTURER_SPECIFIC_DATA, nullptr, sizeof(size_t));
+            if (srLen != filterCustomDatalen && advLen != filterCustomDatalen) {
+                LOG_DEBUG(TRACE, "Custom data mismatched.");
+                return false;
+            }
+            if (srLen == filterCustomDatalen) {
+                uint8_t* buf = (uint8_t*)malloc(srLen);
+                if (!buf) {
+                    LOG(ERROR, "Failed to allocate memory!");
+                    return false;
+                }
+                result.scanResponse.get(BleAdvertisingDataType::MANUFACTURER_SPECIFIC_DATA, buf, srLen);
+                if (!memcmp(buf, filterCustomData, srLen)) {
+                    return true;
+                }
+            }
+            if (advLen == filterCustomDatalen) {
+                uint8_t* buf = (uint8_t*)malloc(advLen);
+                if (!buf) {
+                    LOG(ERROR, "Failed to allocate memory!");
+                    return false;
+                }
+                result.advertisingData.get(BleAdvertisingDataType::MANUFACTURER_SPECIFIC_DATA, buf, advLen);
+                if (!memcmp(buf, filterCustomData, advLen)) {
+                    return true;
+                }
+            }
+            LOG_DEBUG(TRACE, "Custom data mismatched.");
+            return false;
+        }
+        return true;
+    }
+
 private:
     /*
      * WARN: This is executed from HAL ble thread. The current thread which starts the scanning procedure
@@ -2060,6 +2208,16 @@ private:
         result.address(event->peer_addr).rssi(event->rssi)
               .scanResponse(event->sr_data, event->sr_data_len)
               .advertisingData(event->adv_data, event->adv_data_len);
+
+        if (!delegator->filterByRssi(result) ||
+              !delegator->filterByAddress(result) ||
+              !delegator->filterByDeviceName(result) ||
+              !delegator->filterByServiceUUID(result) ||
+              !delegator->filterByAppearance(result) ||
+              !delegator->filterByCustomData(result)) {
+            return;
+        }
+
         if (delegator->callback_) {
             delegator->callback_(&result, delegator->context_);
             return;
@@ -2087,6 +2245,7 @@ private:
     BleOnScanResultCallback callback_;
     BleOnScanResultCallbackRef callbackRef_;
     void* context_;
+    BleScanFilter filter_;
 };
 
 int BleLocalDevice::setScanTimeout(uint16_t timeout) const {
@@ -2134,6 +2293,27 @@ int BleLocalDevice::scan(BleScanResult* results, size_t resultCount) const {
 Vector<BleScanResult> BleLocalDevice::scan() const {
     BleScanDelegator scanner;
     return scanner.start();
+}
+
+int BleLocalDevice::scanWithFilter(BleOnScanResultCallback callback, void* context, const BleScanFilter& filter) const {
+    WiringBleLock lk;
+    BleScanDelegator scanner;
+    return scanner.setScanFilter(filter).start(callback, context);
+}
+
+int BleLocalDevice::scanWithFilter(BleScanResult* results, size_t resultCount, const BleScanFilter& filter) const {
+    WiringBleLock lk;
+    if (results == nullptr || resultCount == 0) {
+        return SYSTEM_ERROR_INVALID_ARGUMENT;
+    }
+    BleScanDelegator scanner;
+    return scanner.setScanFilter(filter).start(results, resultCount);
+}
+
+Vector<BleScanResult> BleLocalDevice::scanWithFilter(const BleScanFilter& filter) const {
+    WiringBleLock lk;
+    BleScanDelegator scanner;
+    return scanner.setScanFilter(filter).start();
 }
 
 int BleLocalDevice::stopScanning() const {

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -2296,19 +2296,16 @@ Vector<BleScanResult> BleLocalDevice::scan() const {
 }
 
 int BleLocalDevice::scanWithFilter(const BleScanFilter& filter, BleOnScanResultCallback callback, void* context) const {
-    WiringBleLock lk;
     BleScanDelegator scanner;
     return scanner.setScanFilter(filter).start(callback, context);
 }
 
 int BleLocalDevice::scanWithFilter(const BleScanFilter& filter, BleOnScanResultCallbackRef callback, void* context) const {
-    WiringBleLock lk;
     BleScanDelegator scanner;
     return scanner.setScanFilter(filter).start(callback, context);
 }
 
 int BleLocalDevice::scanWithFilter(const BleScanFilter& filter, BleScanResult* results, size_t resultCount) const {
-    WiringBleLock lk;
     if (results == nullptr || resultCount == 0) {
         return SYSTEM_ERROR_INVALID_ARGUMENT;
     }
@@ -2317,7 +2314,6 @@ int BleLocalDevice::scanWithFilter(const BleScanFilter& filter, BleScanResult* r
 }
 
 Vector<BleScanResult> BleLocalDevice::scanWithFilter(const BleScanFilter& filter) const {
-    WiringBleLock lk;
     BleScanDelegator scanner;
     return scanner.setScanFilter(filter).start();
 }


### PR DESCRIPTION
**This PR is targeting to enhancement/ble_api_consistency/ch64120**

In the past, user application needs to implement a logic to filter the target devices to be connected. By introducing the scanning filter in Device OS, user can filter a bunch of desired target devices in the following manner for example:

```
void scan() {
    BleScanFilter filter;
    filter.deviceName("MyDevice").minRssi(-50).serviceUUID(0x1234);
    auto scanResult = BLE.scanWithFilter(filter);
}
```

The `scanResult` vector only contains the scanned devices those comply with all of the following conditions:

- The scanned device should be broadcasting device name `"MyDevice"`.
- The scanned device should be broadcasting service UUID `0x1234`.
- The RSSI of the scanned device should be large than -50 dBm.

### Example App

- user/tests/wiring/ble_scanner_broadcaster

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
