### PR TITLE
BLE: Scanned/Connected/Disconnected/Data Received callback in C++ style

### DIFF
--- a/user/tests/wiring/api/ble.cpp
+++ b/user/tests/wiring/api/ble.cpp
@@ -5,6 +5,23 @@
 
 using namespace std::placeholders;
 
+class Handlers {
+public:
+    void dataHandler(const uint8_t*, size_t) {
+    }
+
+    void scanHandler(const BleScanResult& result) {
+    }
+
+    void connectedHandler(const BlePeerDevice& peer) {
+    }
+
+    void disconnectedHandler(const BlePeerDevice& peer) {
+    }
+};
+
+Handlers handlerInstance;
+
 void dataHandlerFunc(const uint8_t* data, size_t len, const BlePeerDevice& peer, void* context) {
 }
 
@@ -326,6 +343,18 @@ test(ble_characteristic_class) {
     EnumFlags<BleCharacteristicProperty> props = BleCharacteristicProperty::BROADCAST;
 
     API_COMPILE(BleCharacteristic c(characteristic));
+    API_COMPILE(BleCharacteristic c(props, "1234"));
+    API_COMPILE(BleCharacteristic c(props, "1234", dataHandlerFunc));
+    API_COMPILE(BleCharacteristic c(props, "1234", dataHandlerFunc, nullptr));
+    API_COMPILE(BleCharacteristic c(props, String("1234")));
+    API_COMPILE(BleCharacteristic c(props, String("1234"), dataHandlerFunc));
+    API_COMPILE(BleCharacteristic c(props, String("1234"), dataHandlerFunc, nullptr));
+    API_COMPILE(BleCharacteristic c(props, "1234", [](const uint8_t*, size_t) {}));
+    API_COMPILE(BleCharacteristic c(props, String("1234"), [](const uint8_t*, size_t) {}));
+    API_COMPILE(BleCharacteristic c(props, "1234", &Handlers::dataHandler, &handlerInstance));
+    API_COMPILE(BleCharacteristic c(props, String("1234"), &Handlers::dataHandler, &handlerInstance));
+    API_COMPILE(BleCharacteristic c(props, "1234", std::bind(&Handlers::dataHandler, &handlerInstance, _1, _2)));
+    API_COMPILE(BleCharacteristic c(props, String("1234"), std::bind(&Handlers::dataHandler, &handlerInstance, _1, _2)));
 
     API_COMPILE(BleCharacteristic c("1234", props, charUuid, svcUuid));
     API_COMPILE(BleCharacteristic c(String("1234"), props, charUuid, svcUuid));
@@ -333,6 +362,12 @@ test(ble_characteristic_class) {
     API_COMPILE(BleCharacteristic c(String("1234"), props, charUuid, svcUuid, dataHandlerFunc));
     API_COMPILE(BleCharacteristic c("1234", props, charUuid, svcUuid, dataHandlerFunc, nullptr));
     API_COMPILE(BleCharacteristic c(String("1234"), props, charUuid, svcUuid, dataHandlerFunc, nullptr));
+    API_COMPILE(BleCharacteristic c("1234", props, charUuid, svcUuid, [](const uint8_t*, size_t) {}));
+    API_COMPILE(BleCharacteristic c(String("1234"), props, charUuid, svcUuid, [](const uint8_t*, size_t) {}));
+    API_COMPILE(BleCharacteristic c("1234", props, charUuid, svcUuid, &Handlers::dataHandler, &handlerInstance));
+    API_COMPILE(BleCharacteristic c(String("1234"), props, charUuid, svcUuid, &Handlers::dataHandler, &handlerInstance));
+    API_COMPILE(BleCharacteristic c("1234", props, charUuid, svcUuid, std::bind(&Handlers::dataHandler, &handlerInstance, _1, _2)));
+    API_COMPILE(BleCharacteristic c(String("1234"), props, charUuid, svcUuid, std::bind(&Handlers::dataHandler, &handlerInstance, _1, _2)));
 
     API_COMPILE({ BleCharacteristic c = characteristic; });
 
@@ -419,6 +454,9 @@ test(ble_characteristic_class) {
 
     API_COMPILE({ characteristic.onDataReceived(dataHandlerFunc); });
     API_COMPILE({ characteristic.onDataReceived(dataHandlerFunc, nullptr); });
+    API_COMPILE({ characteristic.onDataReceived([](const uint8_t*, size_t) {}); });
+    API_COMPILE({ characteristic.onDataReceived(&Handlers::dataHandler, &handlerInstance); });
+    API_COMPILE({ characteristic.onDataReceived(std::bind(&Handlers::dataHandler, &handlerInstance, _1, _2)); });
 
     API_COMPILE({ bool ret = characteristic; (void)ret; });
 }
@@ -626,13 +664,33 @@ test(ble_local_device_class) {
     API_COMPILE({ int ret = BLE.scan(scanHandlerFunc, nullptr); (void)ret; });
     API_COMPILE({ int ret = BLE.scan(scanHandlerFuncRef); (void)ret; });
     API_COMPILE({ int ret = BLE.scan(scanHandlerFuncRef, nullptr); (void)ret; });
+    API_COMPILE({ int ret = BLE.scan([](const BleScanResult& result) {}); (void)ret; });
+    API_COMPILE({ int ret = BLE.scan(&Handlers::scanHandler, &handlerInstance); (void)ret; });
+    API_COMPILE({ int ret = BLE.scan(std::bind(&Handlers::scanHandler, &handlerInstance, _1)); (void)ret; });
     API_COMPILE({ Vector<BleScanResult> results = BLE.scanWithFilter(BleScanFilter()); });
     API_COMPILE({ BleScanResult results[1]; int ret = BLE.scanWithFilter(BleScanFilter(), results, 0); (void)ret; });
     API_COMPILE({ int ret = BLE.scanWithFilter(BleScanFilter(), scanHandlerFunc); (void)ret; });
     API_COMPILE({ int ret = BLE.scanWithFilter(BleScanFilter(), scanHandlerFunc, nullptr); (void)ret; });
     API_COMPILE({ int ret = BLE.scanWithFilter(BleScanFilter(), scanHandlerFuncRef); (void)ret; });
     API_COMPILE({ int ret = BLE.scanWithFilter(BleScanFilter(), scanHandlerFuncRef, nullptr); (void)ret; });
+    API_COMPILE({ int ret = BLE.scanWithFilter(BleScanFilter(), [](const BleScanResult& result) {}); (void)ret; });
+    API_COMPILE({ int ret = BLE.scanWithFilter(BleScanFilter(), &Handlers::scanHandler, &handlerInstance); (void)ret; });
+    API_COMPILE({ int ret = BLE.scanWithFilter(BleScanFilter(), std::bind(&Handlers::scanHandler, &handlerInstance, _1)); (void)ret; });
     API_COMPILE({ int ret = BLE.stopScanning(); (void)ret; });
+
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(characteristic); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(props, "1234"); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(props, "1234", dataHandlerFunc); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(props, "1234", dataHandlerFunc, nullptr); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(props, String("1234")); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(props, String("1234"), dataHandlerFunc); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(props, String("1234"), dataHandlerFunc, nullptr); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(props, "1234", [](const uint8_t*, size_t) {}); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(props, String("1234"), [](const uint8_t*, size_t) {}); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(props, "1234", &Handlers::dataHandler, &handlerInstance); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(props, String("1234"), &Handlers::dataHandler, &handlerInstance); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(props, "1234", std::bind(&Handlers::dataHandler, &handlerInstance, _1, _2)); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(props, String("1234"), std::bind(&Handlers::dataHandler, &handlerInstance, _1, _2)); });
 
     API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic("1234", props, charUuid, svcUuid); });
     API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(String("1234"), props, charUuid, svcUuid); });
@@ -640,6 +698,12 @@ test(ble_local_device_class) {
     API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(String("1234"), props, charUuid, svcUuid, dataHandlerFunc); });
     API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic("1234", props, charUuid, svcUuid, dataHandlerFunc, nullptr); });
     API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(String("1234"), props, charUuid, svcUuid, dataHandlerFunc, nullptr); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic("1234", props, charUuid, svcUuid, [](const uint8_t*, size_t) {}); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(String("1234"), props, charUuid, svcUuid, [](const uint8_t*, size_t) {}); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic("1234", props, charUuid, svcUuid, &Handlers::dataHandler, &handlerInstance); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(String("1234"), props, charUuid, svcUuid, &Handlers::dataHandler, &handlerInstance); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic("1234", props, charUuid, svcUuid, std::bind(&Handlers::dataHandler, &handlerInstance, _1, _2)); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(String("1234"), props, charUuid, svcUuid, std::bind(&Handlers::dataHandler, &handlerInstance, _1, _2)); });
 
     API_COMPILE({ int ret = BLE.setPPCP(0, 0, 0, 0); (void)ret; });
 
@@ -660,8 +724,14 @@ test(ble_local_device_class) {
 
     API_COMPILE({ BLE.onConnected(connectedHandlerFunc); });
     API_COMPILE({ BLE.onConnected(connectedHandlerFunc, nullptr); });
+    API_COMPILE({ BLE.onConnected([](const BlePeerDevice&) {}); });
+    API_COMPILE({ BLE.onConnected(&Handlers::connectedHandler, &handlerInstance); });
+    API_COMPILE({ BLE.onConnected(std::bind(&Handlers::connectedHandler, &handlerInstance, _1)); });
     API_COMPILE({ BLE.onDisconnected(disconnectedHandlerFunc); });
     API_COMPILE({ BLE.onDisconnected(disconnectedHandlerFunc, nullptr); });
+    API_COMPILE({ BLE.onDisconnected([](const BlePeerDevice&) {}); });
+    API_COMPILE({ BLE.onDisconnected(&Handlers::disconnectedHandler, &handlerInstance); });
+    API_COMPILE({ BLE.onDisconnected(std::bind(&Handlers::disconnectedHandler, &handlerInstance, _1)); });
 }
 
 #endif

--- a/user/tests/wiring/api/ble.cpp
+++ b/user/tests/wiring/api/ble.cpp
@@ -7,7 +7,7 @@ using namespace std::placeholders;
 
 class Handlers {
 public:
-    void dataHandler(const uint8_t*, size_t) {
+    void dataHandler(const uint8_t*, size_t, const BlePeerDevice& peer) {
     }
 
     void scanHandler(const BleScanResult& result) {
@@ -20,7 +20,7 @@ public:
     }
 };
 
-Handlers handlerInstance;
+Handlers bleHandlerInstance;
 
 void dataHandlerFunc(const uint8_t* data, size_t len, const BlePeerDevice& peer, void* context) {
 }
@@ -349,12 +349,12 @@ test(ble_characteristic_class) {
     API_COMPILE(BleCharacteristic c(props, String("1234")));
     API_COMPILE(BleCharacteristic c(props, String("1234"), dataHandlerFunc));
     API_COMPILE(BleCharacteristic c(props, String("1234"), dataHandlerFunc, nullptr));
-    API_COMPILE(BleCharacteristic c(props, "1234", [](const uint8_t*, size_t) {}));
-    API_COMPILE(BleCharacteristic c(props, String("1234"), [](const uint8_t*, size_t) {}));
-    API_COMPILE(BleCharacteristic c(props, "1234", &Handlers::dataHandler, &handlerInstance));
-    API_COMPILE(BleCharacteristic c(props, String("1234"), &Handlers::dataHandler, &handlerInstance));
-    API_COMPILE(BleCharacteristic c(props, "1234", std::bind(&Handlers::dataHandler, &handlerInstance, _1, _2)));
-    API_COMPILE(BleCharacteristic c(props, String("1234"), std::bind(&Handlers::dataHandler, &handlerInstance, _1, _2)));
+    API_COMPILE(BleCharacteristic c(props, "1234", [](const uint8_t*, size_t, const BlePeerDevice& peer) {}));
+    API_COMPILE(BleCharacteristic c(props, String("1234"), [](const uint8_t*, size_t, const BlePeerDevice& peer) {}));
+    API_COMPILE(BleCharacteristic c(props, "1234", &Handlers::dataHandler, &bleHandlerInstance));
+    API_COMPILE(BleCharacteristic c(props, String("1234"), &Handlers::dataHandler, &bleHandlerInstance));
+    API_COMPILE(BleCharacteristic c(props, "1234", std::bind(&Handlers::dataHandler, &bleHandlerInstance, _1, _2, _3)));
+    API_COMPILE(BleCharacteristic c(props, String("1234"), std::bind(&Handlers::dataHandler, &bleHandlerInstance, _1, _2, _3)));
 
     API_COMPILE(BleCharacteristic c("1234", props, charUuid, svcUuid));
     API_COMPILE(BleCharacteristic c(String("1234"), props, charUuid, svcUuid));
@@ -362,12 +362,12 @@ test(ble_characteristic_class) {
     API_COMPILE(BleCharacteristic c(String("1234"), props, charUuid, svcUuid, dataHandlerFunc));
     API_COMPILE(BleCharacteristic c("1234", props, charUuid, svcUuid, dataHandlerFunc, nullptr));
     API_COMPILE(BleCharacteristic c(String("1234"), props, charUuid, svcUuid, dataHandlerFunc, nullptr));
-    API_COMPILE(BleCharacteristic c("1234", props, charUuid, svcUuid, [](const uint8_t*, size_t) {}));
-    API_COMPILE(BleCharacteristic c(String("1234"), props, charUuid, svcUuid, [](const uint8_t*, size_t) {}));
-    API_COMPILE(BleCharacteristic c("1234", props, charUuid, svcUuid, &Handlers::dataHandler, &handlerInstance));
-    API_COMPILE(BleCharacteristic c(String("1234"), props, charUuid, svcUuid, &Handlers::dataHandler, &handlerInstance));
-    API_COMPILE(BleCharacteristic c("1234", props, charUuid, svcUuid, std::bind(&Handlers::dataHandler, &handlerInstance, _1, _2)));
-    API_COMPILE(BleCharacteristic c(String("1234"), props, charUuid, svcUuid, std::bind(&Handlers::dataHandler, &handlerInstance, _1, _2)));
+    API_COMPILE(BleCharacteristic c("1234", props, charUuid, svcUuid, [](const uint8_t*, size_t, const BlePeerDevice& peer) {}));
+    API_COMPILE(BleCharacteristic c(String("1234"), props, charUuid, svcUuid, [](const uint8_t*, size_t, const BlePeerDevice& peer) {}));
+    API_COMPILE(BleCharacteristic c("1234", props, charUuid, svcUuid, &Handlers::dataHandler, &bleHandlerInstance));
+    API_COMPILE(BleCharacteristic c(String("1234"), props, charUuid, svcUuid, &Handlers::dataHandler, &bleHandlerInstance));
+    API_COMPILE(BleCharacteristic c("1234", props, charUuid, svcUuid, std::bind(&Handlers::dataHandler, &bleHandlerInstance, _1, _2, _3)));
+    API_COMPILE(BleCharacteristic c(String("1234"), props, charUuid, svcUuid, std::bind(&Handlers::dataHandler, &bleHandlerInstance, _1, _2, _3)));
 
     API_COMPILE({ BleCharacteristic c = characteristic; });
 
@@ -454,9 +454,9 @@ test(ble_characteristic_class) {
 
     API_COMPILE({ characteristic.onDataReceived(dataHandlerFunc); });
     API_COMPILE({ characteristic.onDataReceived(dataHandlerFunc, nullptr); });
-    API_COMPILE({ characteristic.onDataReceived([](const uint8_t*, size_t) {}); });
-    API_COMPILE({ characteristic.onDataReceived(&Handlers::dataHandler, &handlerInstance); });
-    API_COMPILE({ characteristic.onDataReceived(std::bind(&Handlers::dataHandler, &handlerInstance, _1, _2)); });
+    API_COMPILE({ characteristic.onDataReceived([](const uint8_t*, size_t, const BlePeerDevice& peer) {}); });
+    API_COMPILE({ characteristic.onDataReceived(&Handlers::dataHandler, &bleHandlerInstance); });
+    API_COMPILE({ characteristic.onDataReceived(std::bind(&Handlers::dataHandler, &bleHandlerInstance, _1, _2, _3)); });
 
     API_COMPILE({ bool ret = characteristic; (void)ret; });
 }
@@ -665,8 +665,8 @@ test(ble_local_device_class) {
     API_COMPILE({ int ret = BLE.scan(scanHandlerFuncRef); (void)ret; });
     API_COMPILE({ int ret = BLE.scan(scanHandlerFuncRef, nullptr); (void)ret; });
     API_COMPILE({ int ret = BLE.scan([](const BleScanResult& result) {}); (void)ret; });
-    API_COMPILE({ int ret = BLE.scan(&Handlers::scanHandler, &handlerInstance); (void)ret; });
-    API_COMPILE({ int ret = BLE.scan(std::bind(&Handlers::scanHandler, &handlerInstance, _1)); (void)ret; });
+    API_COMPILE({ int ret = BLE.scan(&Handlers::scanHandler, &bleHandlerInstance); (void)ret; });
+    API_COMPILE({ int ret = BLE.scan(std::bind(&Handlers::scanHandler, &bleHandlerInstance, _1)); (void)ret; });
     API_COMPILE({ Vector<BleScanResult> results = BLE.scanWithFilter(BleScanFilter()); });
     API_COMPILE({ BleScanResult results[1]; int ret = BLE.scanWithFilter(BleScanFilter(), results, 0); (void)ret; });
     API_COMPILE({ int ret = BLE.scanWithFilter(BleScanFilter(), scanHandlerFunc); (void)ret; });
@@ -674,8 +674,8 @@ test(ble_local_device_class) {
     API_COMPILE({ int ret = BLE.scanWithFilter(BleScanFilter(), scanHandlerFuncRef); (void)ret; });
     API_COMPILE({ int ret = BLE.scanWithFilter(BleScanFilter(), scanHandlerFuncRef, nullptr); (void)ret; });
     API_COMPILE({ int ret = BLE.scanWithFilter(BleScanFilter(), [](const BleScanResult& result) {}); (void)ret; });
-    API_COMPILE({ int ret = BLE.scanWithFilter(BleScanFilter(), &Handlers::scanHandler, &handlerInstance); (void)ret; });
-    API_COMPILE({ int ret = BLE.scanWithFilter(BleScanFilter(), std::bind(&Handlers::scanHandler, &handlerInstance, _1)); (void)ret; });
+    API_COMPILE({ int ret = BLE.scanWithFilter(BleScanFilter(), &Handlers::scanHandler, &bleHandlerInstance); (void)ret; });
+    API_COMPILE({ int ret = BLE.scanWithFilter(BleScanFilter(), std::bind(&Handlers::scanHandler, &bleHandlerInstance, _1)); (void)ret; });
     API_COMPILE({ int ret = BLE.stopScanning(); (void)ret; });
 
     API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(characteristic); });
@@ -685,12 +685,12 @@ test(ble_local_device_class) {
     API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(props, String("1234")); });
     API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(props, String("1234"), dataHandlerFunc); });
     API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(props, String("1234"), dataHandlerFunc, nullptr); });
-    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(props, "1234", [](const uint8_t*, size_t) {}); });
-    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(props, String("1234"), [](const uint8_t*, size_t) {}); });
-    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(props, "1234", &Handlers::dataHandler, &handlerInstance); });
-    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(props, String("1234"), &Handlers::dataHandler, &handlerInstance); });
-    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(props, "1234", std::bind(&Handlers::dataHandler, &handlerInstance, _1, _2)); });
-    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(props, String("1234"), std::bind(&Handlers::dataHandler, &handlerInstance, _1, _2)); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(props, "1234", [](const uint8_t*, size_t, const BlePeerDevice& peer) {}); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(props, String("1234"), [](const uint8_t*, size_t, const BlePeerDevice& peer) {}); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(props, "1234", &Handlers::dataHandler, &bleHandlerInstance); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(props, String("1234"), &Handlers::dataHandler, &bleHandlerInstance); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(props, "1234", std::bind(&Handlers::dataHandler, &bleHandlerInstance, _1, _2, _3)); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(props, String("1234"), std::bind(&Handlers::dataHandler, &bleHandlerInstance, _1, _2, _3)); });
 
     API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic("1234", props, charUuid, svcUuid); });
     API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(String("1234"), props, charUuid, svcUuid); });
@@ -698,12 +698,12 @@ test(ble_local_device_class) {
     API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(String("1234"), props, charUuid, svcUuid, dataHandlerFunc); });
     API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic("1234", props, charUuid, svcUuid, dataHandlerFunc, nullptr); });
     API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(String("1234"), props, charUuid, svcUuid, dataHandlerFunc, nullptr); });
-    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic("1234", props, charUuid, svcUuid, [](const uint8_t*, size_t) {}); });
-    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(String("1234"), props, charUuid, svcUuid, [](const uint8_t*, size_t) {}); });
-    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic("1234", props, charUuid, svcUuid, &Handlers::dataHandler, &handlerInstance); });
-    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(String("1234"), props, charUuid, svcUuid, &Handlers::dataHandler, &handlerInstance); });
-    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic("1234", props, charUuid, svcUuid, std::bind(&Handlers::dataHandler, &handlerInstance, _1, _2)); });
-    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(String("1234"), props, charUuid, svcUuid, std::bind(&Handlers::dataHandler, &handlerInstance, _1, _2)); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic("1234", props, charUuid, svcUuid, [](const uint8_t*, size_t, const BlePeerDevice& peer) {}); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(String("1234"), props, charUuid, svcUuid, [](const uint8_t*, size_t, const BlePeerDevice& peer) {}); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic("1234", props, charUuid, svcUuid, &Handlers::dataHandler, &bleHandlerInstance); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(String("1234"), props, charUuid, svcUuid, &Handlers::dataHandler, &bleHandlerInstance); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic("1234", props, charUuid, svcUuid, std::bind(&Handlers::dataHandler, &bleHandlerInstance, _1, _2, _3)); });
+    API_COMPILE({ BleCharacteristic c = BLE.addCharacteristic(String("1234"), props, charUuid, svcUuid, std::bind(&Handlers::dataHandler, &bleHandlerInstance, _1, _2, _3)); });
 
     API_COMPILE({ int ret = BLE.setPPCP(0, 0, 0, 0); (void)ret; });
 
@@ -725,13 +725,13 @@ test(ble_local_device_class) {
     API_COMPILE({ BLE.onConnected(connectedHandlerFunc); });
     API_COMPILE({ BLE.onConnected(connectedHandlerFunc, nullptr); });
     API_COMPILE({ BLE.onConnected([](const BlePeerDevice&) {}); });
-    API_COMPILE({ BLE.onConnected(&Handlers::connectedHandler, &handlerInstance); });
-    API_COMPILE({ BLE.onConnected(std::bind(&Handlers::connectedHandler, &handlerInstance, _1)); });
+    API_COMPILE({ BLE.onConnected(&Handlers::connectedHandler, &bleHandlerInstance); });
+    API_COMPILE({ BLE.onConnected(std::bind(&Handlers::connectedHandler, &bleHandlerInstance, _1)); });
     API_COMPILE({ BLE.onDisconnected(disconnectedHandlerFunc); });
     API_COMPILE({ BLE.onDisconnected(disconnectedHandlerFunc, nullptr); });
     API_COMPILE({ BLE.onDisconnected([](const BlePeerDevice&) {}); });
-    API_COMPILE({ BLE.onDisconnected(&Handlers::disconnectedHandler, &handlerInstance); });
-    API_COMPILE({ BLE.onDisconnected(std::bind(&Handlers::disconnectedHandler, &handlerInstance, _1)); });
+    API_COMPILE({ BLE.onDisconnected(&Handlers::disconnectedHandler, &bleHandlerInstance); });
+    API_COMPILE({ BLE.onDisconnected(std::bind(&Handlers::disconnectedHandler, &bleHandlerInstance, _1)); });
 }
 
 #endif

--- a/user/tests/wiring/no_fixture_ble/ble.cpp
+++ b/user/tests/wiring/no_fixture_ble/ble.cpp
@@ -385,13 +385,13 @@ test(BLE_09_Set_BLE_Scanning_Parameters) {
 }
 
 test(BLE_10_Add_BLE_Local_Characteristics) {
-    BleCharacteristic characteristic("char1", BleCharacteristicProperty::NOTIFY);
+    BleCharacteristic characteristic(BleCharacteristicProperty::NOTIFY, "char1");
     BleCharacteristic char1 = BLE.addCharacteristic(characteristic);
     assertTrue(char1.UUID() == "F5720001-13A9-49DD-AC15-F87B7427E37B"); // Default particle assigned UUID
     assertTrue(char1.properties() == BleCharacteristicProperty::NOTIFY);
     assertTrue(char1.description() == "char1");
 
-    BleCharacteristic char2 = BLE.addCharacteristic("char2", BleCharacteristicProperty::READ);
+    BleCharacteristic char2 = BLE.addCharacteristic(BleCharacteristicProperty::READ, "char2");
     assertTrue(char2.UUID() == "F5720002-13A9-49DD-AC15-F87B7427E37B");
     assertTrue(char2.properties() == BleCharacteristicProperty::READ);
     assertTrue(char2.description() == "char2");

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -446,22 +446,33 @@ class BleCharacteristic {
 public:
     BleCharacteristic();
     BleCharacteristic(const BleCharacteristic& characteristic);
+
+    __attribute__((deprecated("The order of the first argument and second argument need to be swapped")))
+    BleCharacteristic(const char* desc, EnumFlags<BleCharacteristicProperty> properties, BleOnDataReceivedCallback callback = nullptr, void* context = nullptr)
+            : BleCharacteristic(properties, desc, callback, context) {
+    }
+    
+    __attribute__((deprecated("The order of the first argument and second argument need to be swapped")))
+    BleCharacteristic(const String& desc, EnumFlags<BleCharacteristicProperty> properties, BleOnDataReceivedCallback callback = nullptr, void* context = nullptr)
+            : BleCharacteristic(properties, desc, callback, context) {
+    }
+
     BleCharacteristic(EnumFlags<BleCharacteristicProperty> properties,  const char* desc, BleOnDataReceivedCallback callback = nullptr, void* context = nullptr);
     BleCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const String& desc, BleOnDataReceivedCallback callback = nullptr, void* context = nullptr)
             : BleCharacteristic(properties, desc.c_str(), callback, context) {
     }
-    BleCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const char* desc, std::function<void(const uint8_t*, size_t)> callback);
-    BleCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const String& desc, std::function<void(const uint8_t*, size_t)> callback)
+    BleCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const char* desc, std::function<void(const uint8_t*, size_t, const BlePeerDevice& peer)> callback);
+    BleCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const String& desc, std::function<void(const uint8_t*, size_t, const BlePeerDevice& peer)> callback)
             : BleCharacteristic(properties, desc.c_str(), callback) {
     }
 
     template<typename T>
-    BleCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const String& desc, void(T::*callback)(const uint8_t*, size_t), T* instance)
+    BleCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const String& desc, void(T::*callback)(const uint8_t*, size_t, const BlePeerDevice& peer), T* instance)
             : BleCharacteristic(properties, desc, std::bind(callback, instance, _1, _2)) {
     }
 
     template<typename T>
-    BleCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const char* desc, void(T::*callback)(const uint8_t*, size_t), T* instance)
+    BleCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const char* desc, void(T::*callback)(const uint8_t*, size_t, const BlePeerDevice& peer), T* instance)
             : BleCharacteristic(properties, desc, std::bind(callback, instance, _1, _2)) {
     }
 
@@ -478,24 +489,24 @@ public:
     }
 
     template<typename T1, typename T2>
-    BleCharacteristic(const char* desc, EnumFlags<BleCharacteristicProperty> properties, T1 charUuid, T2 svcUuid, std::function<void(const uint8_t*, size_t)> callback) {
+    BleCharacteristic(const char* desc, EnumFlags<BleCharacteristicProperty> properties, T1 charUuid, T2 svcUuid, std::function<void(const uint8_t*, size_t, const BlePeerDevice& peer)> callback) {
         BleUuid cUuid(charUuid);
         BleUuid sUuid(svcUuid);
         construct(desc, properties, cUuid, sUuid, callback);
     }
 
     template<typename T1, typename T2>
-    BleCharacteristic(const String& desc, EnumFlags<BleCharacteristicProperty> properties, T1 charUuid, T2 svcUuid, std::function<void(const uint8_t*, size_t)> callback)
+    BleCharacteristic(const String& desc, EnumFlags<BleCharacteristicProperty> properties, T1 charUuid, T2 svcUuid, std::function<void(const uint8_t*, size_t, const BlePeerDevice& peer)> callback)
             : BleCharacteristic(desc.c_str(), properties, charUuid, svcUuid, callback) {
     }
 
     template<typename T1, typename T2, typename T3>
-    BleCharacteristic(const char* desc, EnumFlags<BleCharacteristicProperty> properties, T1 charUuid, T2 svcUuid, void(T3::*callback)(const uint8_t*, size_t), T3* instance)
+    BleCharacteristic(const char* desc, EnumFlags<BleCharacteristicProperty> properties, T1 charUuid, T2 svcUuid, void(T3::*callback)(const uint8_t*, size_t, const BlePeerDevice& peer), T3* instance)
             : BleCharacteristic(desc, properties, charUuid, svcUuid, std::bind(callback, instance, _1, _2)) {
     }
 
     template<typename T1, typename T2, typename T3>
-    BleCharacteristic(const String& desc, EnumFlags<BleCharacteristicProperty> properties, T1 charUuid, T2 svcUuid, void(T3::*callback)(const uint8_t*, size_t), T3* instance)
+    BleCharacteristic(const String& desc, EnumFlags<BleCharacteristicProperty> properties, T1 charUuid, T2 svcUuid, void(T3::*callback)(const uint8_t*, size_t, const BlePeerDevice& peer), T3* instance)
             : BleCharacteristic(desc, properties, charUuid, svcUuid, std::bind(callback, instance, _1, _2)) {
     }
 
@@ -540,10 +551,10 @@ public:
     }
 
     void onDataReceived(BleOnDataReceivedCallback callback, void* context = nullptr);
-    void onDataReceived(std::function<void(const uint8_t*, size_t)> callback);
+    void onDataReceived(std::function<void(const uint8_t*, size_t, const BlePeerDevice& peer)> callback);
 
     template<typename T>
-    void onDataReceived(void(T::*callback)(const uint8_t*, size_t), T* instance) {
+    void onDataReceived(void(T::*callback)(const uint8_t*, size_t, const BlePeerDevice& peer), T* instance) {
         onDataReceived(std::bind(callback, instance, _1, _2));
     }
 
@@ -557,7 +568,7 @@ private:
             BleOnDataReceivedCallback callback, void* context);
 
     void construct(const char* desc, EnumFlags<BleCharacteristicProperty> properties,
-            BleUuid& charUuid, BleUuid& svcUuid, std::function<void(const uint8_t*, size_t)> callback);
+            BleUuid& charUuid, BleUuid& svcUuid, std::function<void(const uint8_t*, size_t, const BlePeerDevice& peer)> callback);
 
     std::shared_ptr<BleCharacteristicImpl> impl_;
 };
@@ -911,18 +922,29 @@ public:
 
     // Access local characteristics
     BleCharacteristic addCharacteristic(const BleCharacteristic& characteristic);
+    
+    BleCharacteristic __attribute__((deprecated("The order of the first argument and second argument need to be swapped")))
+    addCharacteristic(const char* desc, EnumFlags<BleCharacteristicProperty> properties, BleOnDataReceivedCallback callback = nullptr, void* context = nullptr) {
+        return addCharacteristic(properties, desc, callback, context);
+    }
+
+    BleCharacteristic __attribute__((deprecated("The order of the first argument and second argument need to be swapped")))
+    addCharacteristic(const String& desc, EnumFlags<BleCharacteristicProperty> properties, BleOnDataReceivedCallback callback = nullptr, void* context = nullptr) {
+        return addCharacteristic(properties, desc, callback, context);
+    }
+
     BleCharacteristic addCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const char* desc, BleOnDataReceivedCallback callback = nullptr, void* context = nullptr);
     BleCharacteristic addCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const String& desc, BleOnDataReceivedCallback callback = nullptr, void* context = nullptr);
-    BleCharacteristic addCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const char* desc, std::function<void(const uint8_t*, size_t)> callback);
-    BleCharacteristic addCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const String& desc, std::function<void(const uint8_t*, size_t)> callback);
+    BleCharacteristic addCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const char* desc, std::function<void(const uint8_t*, size_t, const BlePeerDevice& peer)> callback);
+    BleCharacteristic addCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const String& desc, std::function<void(const uint8_t*, size_t, const BlePeerDevice& peer)> callback);
 
     template<typename T>
-    BleCharacteristic addCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const char* desc, void(T::*callback)(const uint8_t*, size_t), T* instance) {
+    BleCharacteristic addCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const char* desc, void(T::*callback)(const uint8_t*, size_t, const BlePeerDevice& peer), T* instance) {
         return addCharacteristic(properties, desc, std::bind(callback, instance, _1, _2));
     }
 
     template<typename T>
-    BleCharacteristic addCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const String& desc, void(T::*callback)(const uint8_t*, size_t), T* instance) {
+    BleCharacteristic addCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const String& desc, void(T::*callback)(const uint8_t*, size_t, const BlePeerDevice& peer), T* instance) {
         return addCharacteristic(properties, desc, std::bind(callback, instance, _1, _2));
     }
 
@@ -939,24 +961,24 @@ public:
     }
 
     template<typename T1, typename T2>
-    BleCharacteristic addCharacteristic(const char* desc, EnumFlags<BleCharacteristicProperty> properties, T1 charUuid, T2 svcUuid, std::function<void(const uint8_t*, size_t)> callback) {
+    BleCharacteristic addCharacteristic(const char* desc, EnumFlags<BleCharacteristicProperty> properties, T1 charUuid, T2 svcUuid, std::function<void(const uint8_t*, size_t, const BlePeerDevice& peer)> callback) {
         BleCharacteristic characteristic(desc, properties, charUuid, svcUuid, callback);
         addCharacteristic(characteristic);
         return characteristic;
     }
 
     template<typename T1, typename T2>
-    BleCharacteristic addCharacteristic(const String& desc, EnumFlags<BleCharacteristicProperty> properties, T1 charUuid, T2 svcUuid, std::function<void(const uint8_t*, size_t)> callback) {
+    BleCharacteristic addCharacteristic(const String& desc, EnumFlags<BleCharacteristicProperty> properties, T1 charUuid, T2 svcUuid, std::function<void(const uint8_t*, size_t, const BlePeerDevice& peer)> callback) {
         return addCharacteristic(desc.c_str(), properties, charUuid, svcUuid, callback);
     }
 
     template<typename T1, typename T2, typename T3>
-    BleCharacteristic addCharacteristic(const char* desc, EnumFlags<BleCharacteristicProperty> properties, T1 charUuid, T2 svcUuid, void(T3::*callback)(const uint8_t*, size_t), T3* instance) {
+    BleCharacteristic addCharacteristic(const char* desc, EnumFlags<BleCharacteristicProperty> properties, T1 charUuid, T2 svcUuid, void(T3::*callback)(const uint8_t*, size_t, const BlePeerDevice& peer), T3* instance) {
         return addCharacteristic(desc, properties, charUuid, svcUuid, std::bind(callback, instance, _1, _2));
     }
 
     template<typename T1, typename T2, typename T3>
-    BleCharacteristic addCharacteristic(const String& desc, EnumFlags<BleCharacteristicProperty> properties, T1 charUuid, T2 svcUuid, void(T3::*callback)(const uint8_t*, size_t), T3* instance) {
+    BleCharacteristic addCharacteristic(const String& desc, EnumFlags<BleCharacteristicProperty> properties, T1 charUuid, T2 svcUuid, void(T3::*callback)(const uint8_t*, size_t, const BlePeerDevice& peer), T3* instance) {
         return addCharacteristic(desc, properties, charUuid, svcUuid, std::bind(callback, instance, _1, _2));
     }
 

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -904,7 +904,7 @@ public:
 
     template<typename T>
     int scanWithFilter(const BleScanFilter& filter, void(T::*callback)(const BleScanResult&), T* instance) {
-        return scan(filter, std::bind(callback, instance, _1));
+        return scanWithFilter(filter, std::bind(callback, instance, _1));
     }
 
     int stopScanning() const;

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -21,6 +21,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <string.h>
+#include <functional>
 #include "spark_wiring_platform.h"
 
 #if Wiring_BLE
@@ -838,6 +839,7 @@ public:
     // Scanning control
     int scan(BleOnScanResultCallback callback, void* context = nullptr) const;
     int scan(BleOnScanResultCallbackRef callback, void* context = nullptr) const;
+    int scan(const std::function<void(const BleScanResult&, void*)>& callback, void* context);
     int scan(BleScanResult* results, size_t resultCount) const;
     Vector<BleScanResult> scan() const;
     int scanWithFilter(const BleScanFilter& filter, BleOnScanResultCallback callback, void* context = nullptr) const;

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -386,8 +386,6 @@ public:
     size_t appendLocalName(const String& name);
     size_t appendAppearance(ble_sig_appearance_t appearance);
 
-    size_t appendAppearance(ble_sig_appearance_t appearance);
-
     template<typename T>
     size_t appendServiceUUID(T uuid, bool force = false) {
         BleUuid tempUUID(uuid);
@@ -416,12 +414,8 @@ public:
 
     size_t serviceUUID(BleUuid* uuids, size_t count) const;
     Vector<BleUuid> serviceUUID() const;
-<<<<<<< HEAD
 
-=======
->>>>>>> [wiring] BLE: implement BLE scanning filter.
     size_t customData(uint8_t* buf, size_t len) const;
-    ble_sig_appearance_t appearance() const;
 
     ble_sig_appearance_t appearance() const;
 
@@ -468,12 +462,12 @@ public:
 
     template<typename T>
     BleCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const String& desc, void(T::*callback)(const uint8_t*, size_t, const BlePeerDevice& peer), T* instance)
-            : BleCharacteristic(properties, desc, std::bind(callback, instance, _1, _2)) {
+            : BleCharacteristic(properties, desc, std::bind(callback, instance, _1, _2, _3)) {
     }
 
     template<typename T>
     BleCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const char* desc, void(T::*callback)(const uint8_t*, size_t, const BlePeerDevice& peer), T* instance)
-            : BleCharacteristic(properties, desc, std::bind(callback, instance, _1, _2)) {
+            : BleCharacteristic(properties, desc, std::bind(callback, instance, _1, _2, _3)) {
     }
 
     template<typename T1, typename T2>
@@ -502,12 +496,12 @@ public:
 
     template<typename T1, typename T2, typename T3>
     BleCharacteristic(const char* desc, EnumFlags<BleCharacteristicProperty> properties, T1 charUuid, T2 svcUuid, void(T3::*callback)(const uint8_t*, size_t, const BlePeerDevice& peer), T3* instance)
-            : BleCharacteristic(desc, properties, charUuid, svcUuid, std::bind(callback, instance, _1, _2)) {
+            : BleCharacteristic(desc, properties, charUuid, svcUuid, std::bind(callback, instance, _1, _2, _3)) {
     }
 
     template<typename T1, typename T2, typename T3>
     BleCharacteristic(const String& desc, EnumFlags<BleCharacteristicProperty> properties, T1 charUuid, T2 svcUuid, void(T3::*callback)(const uint8_t*, size_t, const BlePeerDevice& peer), T3* instance)
-            : BleCharacteristic(desc, properties, charUuid, svcUuid, std::bind(callback, instance, _1, _2)) {
+            : BleCharacteristic(desc, properties, charUuid, svcUuid, std::bind(callback, instance, _1, _2, _3)) {
     }
 
     ~BleCharacteristic();
@@ -555,7 +549,7 @@ public:
 
     template<typename T>
     void onDataReceived(void(T::*callback)(const uint8_t*, size_t, const BlePeerDevice& peer), T* instance) {
-        onDataReceived(std::bind(callback, instance, _1, _2));
+        onDataReceived(std::bind(callback, instance, _1, _2, _3));
     }
 
     BleCharacteristicImpl* impl() const {
@@ -940,12 +934,12 @@ public:
 
     template<typename T>
     BleCharacteristic addCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const char* desc, void(T::*callback)(const uint8_t*, size_t, const BlePeerDevice& peer), T* instance) {
-        return addCharacteristic(properties, desc, std::bind(callback, instance, _1, _2));
+        return addCharacteristic(properties, desc, std::bind(callback, instance, _1, _2, _3));
     }
 
     template<typename T>
     BleCharacteristic addCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const String& desc, void(T::*callback)(const uint8_t*, size_t, const BlePeerDevice& peer), T* instance) {
-        return addCharacteristic(properties, desc, std::bind(callback, instance, _1, _2));
+        return addCharacteristic(properties, desc, std::bind(callback, instance, _1, _2, _3));
     }
 
     template<typename T1, typename T2>
@@ -974,12 +968,12 @@ public:
 
     template<typename T1, typename T2, typename T3>
     BleCharacteristic addCharacteristic(const char* desc, EnumFlags<BleCharacteristicProperty> properties, T1 charUuid, T2 svcUuid, void(T3::*callback)(const uint8_t*, size_t, const BlePeerDevice& peer), T3* instance) {
-        return addCharacteristic(desc, properties, charUuid, svcUuid, std::bind(callback, instance, _1, _2));
+        return addCharacteristic(desc, properties, charUuid, svcUuid, std::bind(callback, instance, _1, _2, _3));
     }
 
     template<typename T1, typename T2, typename T3>
     BleCharacteristic addCharacteristic(const String& desc, EnumFlags<BleCharacteristicProperty> properties, T1 charUuid, T2 svcUuid, void(T3::*callback)(const uint8_t*, size_t, const BlePeerDevice& peer), T3* instance) {
-        return addCharacteristic(desc, properties, charUuid, svcUuid, std::bind(callback, instance, _1, _2));
+        return addCharacteristic(desc, properties, charUuid, svcUuid, std::bind(callback, instance, _1, _2, _3));
     }
 
     // Access connection parameters

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -448,6 +448,10 @@ public:
     BleCharacteristic(const String& desc, EnumFlags<BleCharacteristicProperty> properties, BleOnDataReceivedCallback callback = nullptr, void* context = nullptr)
             : BleCharacteristic(desc.c_str(), properties, callback, context) {
     }
+    BleCharacteristic(const char* desc, EnumFlags<BleCharacteristicProperty> properties, std::function<void(const uint8_t*, size_t)> callback);
+    BleCharacteristic(const String& desc, EnumFlags<BleCharacteristicProperty> properties, std::function<void(const uint8_t*, size_t)> callback)
+            : BleCharacteristic(desc.c_str(), properties, callback) {
+    }
 
     template<typename T1, typename T2>
     BleCharacteristic(const char* desc, EnumFlags<BleCharacteristicProperty> properties, T1 charUuid, T2 svcUuid, BleOnDataReceivedCallback callback = nullptr, void* context = nullptr) {
@@ -460,6 +464,19 @@ public:
     BleCharacteristic(const String& desc, EnumFlags<BleCharacteristicProperty> properties, T1 charUuid, T2 svcUuid, BleOnDataReceivedCallback callback = nullptr, void* context = nullptr)
             : BleCharacteristic(desc.c_str(), properties, charUuid, svcUuid, callback, context) {
     }
+
+    template<typename T1, typename T2>
+    BleCharacteristic(const char* desc, EnumFlags<BleCharacteristicProperty> properties, T1 charUuid, T2 svcUuid, std::function<void(const uint8_t*, size_t)> callback) {
+        BleUuid cUuid(charUuid);
+        BleUuid sUuid(svcUuid);
+        construct(desc, properties, cUuid, sUuid, callback);
+    }
+
+    template<typename T1, typename T2>
+    BleCharacteristic(const String& desc, EnumFlags<BleCharacteristicProperty> properties, T1 charUuid, T2 svcUuid, std::function<void(const uint8_t*, size_t)> callback)
+            : BleCharacteristic(desc.c_str(), properties, charUuid, svcUuid, callback) {
+    }
+
     ~BleCharacteristic();
 
     BleCharacteristic& operator=(const BleCharacteristic& characteristic);
@@ -497,6 +514,7 @@ public:
     int subscribe(bool enable) const;
 
     void onDataReceived(BleOnDataReceivedCallback callback, void* context = nullptr);
+    void onDataReceived(std::function<void(const uint8_t*, size_t)> callback);
 
     operator bool() const {
         return isValid();
@@ -510,6 +528,9 @@ private:
     void construct(const char* desc, EnumFlags<BleCharacteristicProperty> properties,
             BleUuid& charUuid, BleUuid& svcUuid,
             BleOnDataReceivedCallback callback, void* context);
+
+    void construct(const char* desc, EnumFlags<BleCharacteristicProperty> properties,
+            BleUuid& charUuid, BleUuid& svcUuid, std::function<void(const uint8_t*, size_t)> callback);
 
     std::shared_ptr<BleCharacteristicImpl> impl_;
 };
@@ -852,6 +873,8 @@ public:
     BleCharacteristic addCharacteristic(const BleCharacteristic& characteristic);
     BleCharacteristic addCharacteristic(const char* desc, EnumFlags<BleCharacteristicProperty> properties, BleOnDataReceivedCallback callback = nullptr, void* context = nullptr);
     BleCharacteristic addCharacteristic(const String& desc, EnumFlags<BleCharacteristicProperty> properties, BleOnDataReceivedCallback callback = nullptr, void* context = nullptr);
+    BleCharacteristic addCharacteristic(const char* desc, EnumFlags<BleCharacteristicProperty> properties, std::function<void(const uint8_t*, size_t)> callback);
+    BleCharacteristic addCharacteristic(const String& desc, EnumFlags<BleCharacteristicProperty> properties, std::function<void(const uint8_t*, size_t)> callback);
 
     template<typename T1, typename T2>
     BleCharacteristic addCharacteristic(const char* desc, EnumFlags<BleCharacteristicProperty> properties, T1 charUuid, T2 svcUuid, BleOnDataReceivedCallback callback = nullptr, void* context = nullptr) {
@@ -863,6 +886,20 @@ public:
     template<typename T1, typename T2>
     BleCharacteristic addCharacteristic(const String& desc, EnumFlags<BleCharacteristicProperty> properties, T1 charUuid, T2 svcUuid, BleOnDataReceivedCallback callback = nullptr, void* context = nullptr) {
         BleCharacteristic characteristic(desc.c_str(), properties, charUuid, svcUuid, callback, context);
+        addCharacteristic(characteristic);
+        return characteristic;
+    }
+
+    template<typename T1, typename T2>
+    BleCharacteristic addCharacteristic(const char* desc, EnumFlags<BleCharacteristicProperty> properties, T1 charUuid, T2 svcUuid, std::function<void(const uint8_t*, size_t)> callback) {
+        BleCharacteristic characteristic(desc, properties, charUuid, svcUuid, callback);
+        addCharacteristic(characteristic);
+        return characteristic;
+    }
+
+    template<typename T1, typename T2>
+    BleCharacteristic addCharacteristic(const String& desc, EnumFlags<BleCharacteristicProperty> properties, T1 charUuid, T2 svcUuid, std::function<void(const uint8_t*, size_t)> callback) {
+        BleCharacteristic characteristic(desc.c_str(), properties, charUuid, svcUuid, callback);
         addCharacteristic(characteristic);
         return characteristic;
     }

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -975,7 +975,7 @@ public:
     int disconnectAll() const;
 
     bool connected() const;
-
+    
     void onConnected(BleOnConnectedCallback callback, void* context = nullptr) const;
     void onConnected(const std::function<void(const BlePeerDevice& peer)>& callback) const;
 

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -381,6 +381,7 @@ public:
     // According to the Bluetooth CSS, Local Name shall not appear more than once in a block.
     size_t appendLocalName(const char* name);
     size_t appendLocalName(const String& name);
+    size_t appendAppearance(ble_sig_appearance_t appearance);
 
     size_t appendAppearance(ble_sig_appearance_t appearance);
 
@@ -412,8 +413,12 @@ public:
 
     size_t serviceUUID(BleUuid* uuids, size_t count) const;
     Vector<BleUuid> serviceUUID() const;
+<<<<<<< HEAD
 
+=======
+>>>>>>> [wiring] BLE: implement BLE scanning filter.
     size_t customData(uint8_t* buf, size_t len) const;
+    ble_sig_appearance_t appearance() const;
 
     ble_sig_appearance_t appearance() const;
 

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -839,7 +839,7 @@ public:
     // Scanning control
     int scan(BleOnScanResultCallback callback, void* context = nullptr) const;
     int scan(BleOnScanResultCallbackRef callback, void* context = nullptr) const;
-    int scan(const std::function<void(const BleScanResult&, void*)>& callback, void* context);
+    int scan(const std::function<void(const BleScanResult&)>& callback) const;
     int scan(BleScanResult* results, size_t resultCount) const;
     Vector<BleScanResult> scan() const;
     int scanWithFilter(const BleScanFilter& filter, BleOnScanResultCallback callback, void* context = nullptr) const;
@@ -875,13 +875,18 @@ public:
     BlePeerDevice connect(const BleAddress& addr, const BleConnectionParams& params, bool automatic = true) const;
     BlePeerDevice connect(const BleAddress& addr, uint16_t interval, uint16_t latency, uint16_t timeout, bool automatic = true) const;
     BlePeerDevice connect(const BleAddress& addr, bool automatic = true) const;
+
     // This only disconnect the peer Central device, i.e. when the local device is acting as BLE Peripheral.
     int disconnect() const;
     int disconnect(const BlePeerDevice& peer) const;
     int disconnectAll() const;
+
     bool connected() const;
+    
     void onConnected(BleOnConnectedCallback callback, void* context = nullptr) const;
+    void onConnected(const std::function<void(const BlePeerDevice& peer)>& callback) const;
     void onDisconnected(BleOnDisconnectedCallback callback, void* context = nullptr) const;
+    void onDisconnected(const std::function<void(const BlePeerDevice& peer)>& callback) const;
 
     BlePeerDevice peerCentral() const;
 

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -2332,7 +2332,6 @@ int BleLocalDevice::getScanParameters(BleScanParams& params) const {
 }
 
 int BleLocalDevice::scan(const std::function<void(const BleScanResult&)>& callback) const {
-    WiringBleLock lk;
     BleScanDelegator scanner;
     return scanner.start(callback);
 }
@@ -2361,7 +2360,6 @@ Vector<BleScanResult> BleLocalDevice::scan() const {
 }
 
 int BleLocalDevice::scanWithFilter(const BleScanFilter& filter, const std::function<void(const BleScanResult&)>& callback) const {
-    WiringBleLock lk;
     BleScanDelegator scanner;
     return scanner.setScanFilter(filter).start(callback);
 }

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -2102,7 +2102,8 @@ public:
               foundCount_(0),
               callback_(nullptr),
               callbackRef_(nullptr),
-              context_(nullptr) {
+              context_(nullptr),
+              wiringCallback_(nullptr) {
         resultsVector_.clear();
     }
 
@@ -2110,35 +2111,45 @@ public:
 
     int start(BleOnScanResultCallback callback, void* context) {
         callback_ = callback;
-        callbackRef_ = nullptr;
         context_ = context;
+        callbackRef_ = nullptr;
+        wiringCallback_ = nullptr;
         CHECK(hal_ble_gap_start_scan(onScanResultCallback, this, nullptr));
         return foundCount_;
     }
 
     int start(BleOnScanResultCallbackRef callback, void* context) {
         callbackRef_ = callback;
-        callback_ = nullptr;
         context_ = context;
-        CHECK(hal_ble_gap_start_scan(onScanResultCallbackV1, this, nullptr));
+        callback_ = nullptr;
+        wiringCallback_ = nullptr;
+        CHECK(hal_ble_gap_start_scan(onScanResultCallback, this, nullptr));
         return foundCount_;
     }
 
     int start(BleScanResult* results, size_t resultCount) {
+        callback_ = nullptr;
+        callbackRef_ = nullptr;
+        wiringCallback_ = nullptr;
         resultsPtr_ = results;
         targetCount_ = resultCount;
-        CHECK(hal_ble_gap_start_scan(onScanResultCallbackV2, this, nullptr));
+        CHECK(hal_ble_gap_start_scan(onScanResultCallback, this, nullptr));
         return foundCount_;
     }
 
     Vector<BleScanResult> start() {
-        hal_ble_gap_start_scan(onScanResultCallbackV3, this, nullptr);
+        callback_ = nullptr;
+        callbackRef_ = nullptr;
+        wiringCallback_ = nullptr;
+        hal_ble_gap_start_scan(onScanResultCallback, this, nullptr);
         return resultsVector_;
     }
 
     int start(const std::function<void(const BleScanResult&)>& callback) {
         wiringCallback_ = callback;
-        CHECK(hal_ble_gap_start_scan(onScanResultCallbackV4, this, nullptr));
+        callback_ = nullptr;
+        callbackRef_ = nullptr;
+        CHECK(hal_ble_gap_start_scan(onScanResultCallback, this, nullptr));
         return foundCount_;
     }
 
@@ -2327,8 +2338,8 @@ private:
     size_t foundCount_;
     BleOnScanResultCallback callback_;
     BleOnScanResultCallbackRef callbackRef_;
-    std::function<void(const BleScanResult&)> wiringCallback_;
     void* context_;
+    std::function<void(const BleScanResult&)> wiringCallback_;
     BleScanFilter filter_;
 };
 

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -2559,26 +2559,16 @@ BleCharacteristic BleLocalDevice::addCharacteristic(const BleCharacteristic& cha
     return characteristic;
 }
 
-<<<<<<< HEAD
-BleCharacteristic BleLocalDevice::addCharacteristic(const char* desc, EnumFlags<BleCharacteristicProperty> properties, BleOnDataReceivedCallback callback, void* context) {
-    BleCharacteristic characteristic(desc, properties, callback, context);
-=======
 BleCharacteristic BleLocalDevice::addCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const char* desc, BleOnDataReceivedCallback callback, void* context) {
     WiringBleLock lk;
     BleCharacteristic characteristic(properties, desc, callback, context);
->>>>>>> [wiring] BLE: callbacks can be class member function.
     addCharacteristic(characteristic);
     return characteristic;
 }
 
-<<<<<<< HEAD
-BleCharacteristic BleLocalDevice::addCharacteristic(const String& desc, EnumFlags<BleCharacteristicProperty> properties, BleOnDataReceivedCallback callback, void* context) {
-    return addCharacteristic(desc.c_str(), properties, callback, context);
-=======
 BleCharacteristic BleLocalDevice::addCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const String& desc, BleOnDataReceivedCallback callback, void* context) {
     WiringBleLock lk;
     return addCharacteristic(properties, desc.c_str(), callback, context);
->>>>>>> [wiring] BLE: callbacks can be class member function.
 }
 
 BleCharacteristic BleLocalDevice::addCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const char* desc, std::function<void(const uint8_t*, size_t)> callback) {

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -2132,8 +2132,6 @@ private:
      */
     static void onScanResultCallback(const hal_ble_scan_result_evt_t* event, void* context) {
         BleScanDelegator* delegator = static_cast<BleScanDelegator*>(context);
-        delegator->foundCount_++;
-
         BleScanResult result = {};
         result.address(event->peer_addr).rssi(event->rssi)
               .scanResponse(event->sr_data, event->sr_data_len)
@@ -2148,11 +2146,13 @@ private:
             return;
         }
 
-        if (delegator->callback_) {
-            delegator->callback_(&result, delegator->context_);
+        if (delegator->wiringCallback_) {
+            delegator->foundCount_++;
+            delegator->wiringCallback_(&result);
             return;
-        } else if (delegator->callbackRef_) {
-            delegator->callbackRef_(result, delegator->context_);
+        } else if (delegator->wiringCallbackRef_) {
+            delegator->foundCount_++;
+            delegator->wiringCallbackRef_(result);
             return;
         }
         if (delegator->resultsPtr_) {

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -860,7 +860,7 @@ public:
               context_(nullptr) {
     }
 
-    BleCharacteristicImpl(const char* desc, EnumFlags<BleCharacteristicProperty> properties, BleOnDataReceivedCallback callback, void* context)
+    BleCharacteristicImpl(EnumFlags<BleCharacteristicProperty> properties, const char* desc, BleOnDataReceivedCallback callback, void* context)
             : BleCharacteristicImpl() {
         properties_ = properties;
         description_ = desc;
@@ -869,7 +869,7 @@ public:
         wiringCallback_ = nullptr;
     }
 
-    BleCharacteristicImpl(const char* desc, EnumFlags<BleCharacteristicProperty> properties, std::function<void(const uint8_t*, size_t)> callback)
+    BleCharacteristicImpl(EnumFlags<BleCharacteristicProperty> properties, const char* desc, std::function<void(const uint8_t*, size_t)> callback)
             : BleCharacteristicImpl() {
         properties_ = properties;
         description_ = desc;
@@ -879,13 +879,13 @@ public:
     }
 
     BleCharacteristicImpl(const char* desc, EnumFlags<BleCharacteristicProperty> properties, BleUuid& charUuid, BleUuid& svcUuid, BleOnDataReceivedCallback callback, void* context)
-            : BleCharacteristicImpl(desc, properties, callback, context) {
+            : BleCharacteristicImpl(properties, desc, callback, context) {
         charUuid_ = charUuid;
         svcUuid_ = svcUuid;
     }
 
     BleCharacteristicImpl(const char* desc, EnumFlags<BleCharacteristicProperty> properties, BleUuid& charUuid, BleUuid& svcUuid, std::function<void(const uint8_t*, size_t)> callback)
-            : BleCharacteristicImpl(desc, properties, callback) {
+            : BleCharacteristicImpl(properties, desc, callback) {
         charUuid_ = charUuid;
         svcUuid_ = svcUuid;
     }
@@ -1251,16 +1251,16 @@ BleCharacteristic::BleCharacteristic(const BleCharacteristic& characteristic)
     DEBUG("BleCharacteristic(copy), 0x%08X => 0x%08X -> 0x%08X, count: %d", &characteristic, this, impl(), impl_.use_count());
 }
 
-BleCharacteristic::BleCharacteristic(const char* desc, EnumFlags<BleCharacteristicProperty> properties, BleOnDataReceivedCallback callback, void* context)
-        : impl_(std::make_shared<BleCharacteristicImpl>(desc, properties, callback, context)) {
+BleCharacteristic::BleCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const char* desc, BleOnDataReceivedCallback callback, void* context)
+        : impl_(std::make_shared<BleCharacteristicImpl>(properties, desc, callback, context)) {
     if (!impl()) {
         SPARK_ASSERT(false);
     }
     DEBUG("BleCharacteristic(...), 0x%08X -> 0x%08X, count: %d", this, impl(), impl_.use_count());
 }
 
-BleCharacteristic::BleCharacteristic(const char* desc, EnumFlags<BleCharacteristicProperty> properties, std::function<void(const uint8_t*, size_t)> callback)
-        : impl_(std::make_shared<BleCharacteristicImpl>(desc, properties, callback)) {
+BleCharacteristic::BleCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const char* desc, std::function<void(const uint8_t*, size_t)> callback)
+        : impl_(std::make_shared<BleCharacteristicImpl>(properties, desc, callback)) {
     if (!impl()) {
         SPARK_ASSERT(false);
     }
@@ -2385,6 +2385,12 @@ Vector<BleScanResult> BleLocalDevice::scan() const {
     return scanner.start();
 }
 
+int BleLocalDevice::scanWithFilter(const BleScanFilter& filter, const std::function<void(const BleScanResult&)>& callback) const {
+    WiringBleLock lk;
+    BleScanDelegator scanner;
+    return scanner.setScanFilter(filter).start(callback);
+}
+
 int BleLocalDevice::scanWithFilter(const BleScanFilter& filter, BleOnScanResultCallback callback, void* context) const {
     BleScanDelegator scanner;
     return scanner.setScanFilter(filter).start(callback, context);
@@ -2553,26 +2559,38 @@ BleCharacteristic BleLocalDevice::addCharacteristic(const BleCharacteristic& cha
     return characteristic;
 }
 
+<<<<<<< HEAD
 BleCharacteristic BleLocalDevice::addCharacteristic(const char* desc, EnumFlags<BleCharacteristicProperty> properties, BleOnDataReceivedCallback callback, void* context) {
     BleCharacteristic characteristic(desc, properties, callback, context);
+=======
+BleCharacteristic BleLocalDevice::addCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const char* desc, BleOnDataReceivedCallback callback, void* context) {
+    WiringBleLock lk;
+    BleCharacteristic characteristic(properties, desc, callback, context);
+>>>>>>> [wiring] BLE: callbacks can be class member function.
     addCharacteristic(characteristic);
     return characteristic;
 }
 
+<<<<<<< HEAD
 BleCharacteristic BleLocalDevice::addCharacteristic(const String& desc, EnumFlags<BleCharacteristicProperty> properties, BleOnDataReceivedCallback callback, void* context) {
     return addCharacteristic(desc.c_str(), properties, callback, context);
+=======
+BleCharacteristic BleLocalDevice::addCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const String& desc, BleOnDataReceivedCallback callback, void* context) {
+    WiringBleLock lk;
+    return addCharacteristic(properties, desc.c_str(), callback, context);
+>>>>>>> [wiring] BLE: callbacks can be class member function.
 }
 
-BleCharacteristic BleLocalDevice::addCharacteristic(const char* desc, EnumFlags<BleCharacteristicProperty> properties, std::function<void(const uint8_t*, size_t)> callback) {
+BleCharacteristic BleLocalDevice::addCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const char* desc, std::function<void(const uint8_t*, size_t)> callback) {
     WiringBleLock lk;
-    BleCharacteristic characteristic(desc, properties, callback);
+    BleCharacteristic characteristic(properties, desc, callback);
     addCharacteristic(characteristic);
     return characteristic;
 }
 
-BleCharacteristic BleLocalDevice::addCharacteristic(const String& desc, EnumFlags<BleCharacteristicProperty> properties, std::function<void(const uint8_t*, size_t)> callback) {
+BleCharacteristic BleLocalDevice::addCharacteristic(EnumFlags<BleCharacteristicProperty> properties, const String& desc, std::function<void(const uint8_t*, size_t)> callback) {
     WiringBleLock lk;
-    return addCharacteristic(desc.c_str(), properties, callback);
+    return addCharacteristic(properties, desc.c_str(), callback);
 }
 
 } /* namespace particle */


### PR DESCRIPTION
**This PR is targeting to the feature/ble_scan_filter/ch37224 branch.**

### Problem

The existing wiring BLE APIs only support c style callback.

### Solution

Using function wrapper to support c++ style callback.

### Example App

1. Central side:
```c
#include "Particle.h"

SYSTEM_MODE(MANUAL);

SerialLogHandler log(LOG_LEVEL_INFO);

BleCharacteristic peerTxChar;

void onBleScanCallbackWrapper(const BleScanResult& result) {
    Log.info("I'm a normal function.");
}

void onBleScanCallbackWithName(const char* name, const BleScanResult& result, void* context) {
    Log.info("I'm a normal function with context: %s", name);
}

class Test {
public:
    void scanHandler(const BleScanResult& result) {
        Log.info("Test::scanHandler()");
    }

    void dataHandler(const uint8_t* buf, size_t len) {
        Log.info("Test::dataHandler(), Data received:");
        for (uint8_t i = 0; i < len; i++) {
            Serial.printf("0x%02X ", buf[i]);
        }
        Serial.println("");
    }

    void disconnectHandler(const BlePeerDevice& peer) {
        Log.info("Test::disconnectHandler(), Disconnected by peer device.");
    }
};

Test test;

void setup() {
    while (!Serial.isConnected());
    delay(1s);

    Log.info("Start scanning...");
    BLE.scan(onBleScanCallbackWrapper);
    Log.info("Scan stopped\r\n");

    delay(3s);

    Log.info("Start scanning...");
    BLE.scan([](const BleScanResult& result) {
        Log.info("I'm a lambda.");
    });
    Log.info("Scan stopped\r\n");

    delay(3s);

    Log.info("Start scanning...");
    BLE.scan(std::bind(onBleScanCallbackWithName, "BindCallback", std::placeholders::_1, nullptr));
    Log.info("Scan stopped\r\n");

    Log.info("Start scanning...");
    BLE.scan(&Test::scanHandler, &test);
    Log.info("Scan stopped\r\n");

    delay(3s);

    // auto dataCb = [](const uint8_t* buf, size_t len, BleCharacteristic* characteristic) {
    //     Log.info("Data received from %s: ", characteristic->UUID().toString().c_str());
    //     for (uint8_t i = 0; i < len; i++) {
    //         Serial.printf("0x%02X ", buf[i]);
    //     }
    //     Serial.println("");
    // };
    // peerTxChar.onDataReceived(std::bind(dataCb, std::placeholders::_1, std::placeholders::_2, &peerTxChar));
    peerTxChar.onDataReceived(&Test::dataHandler, &test);

    // BLE.onDisconnected([](const BlePeerDevice& peer) {
    //     Log.info("Disconnected by peer device.");
    // });
    BLE.onDisconnected(&Test::disconnectHandler, &test);
}

void loop() {
    if (!BLE.connected()) {
        Log.info("Start scanning...");
        auto results = BLE.scan();
        for (const auto& result : results) {
            BleUuid foundServiceUUID;
            size_t svcCount = result.advertisingData.serviceUUID(&foundServiceUUID, 1);
            if (svcCount > 0 && foundServiceUUID == "6E400001-B5A3-F393-E0A9-E50E24DCCA9E") {
                Log.info("Connecting...");
                BlePeerDevice peer = BLE.connect(result.address);
                if (peer.connected()) {
                    Log.info("Connected.");
                    peer.getCharacteristicByUUID(peerTxChar, "6E400003-B5A3-F393-E0A9-E50E24DCCA9E");
                    if (!peerTxChar.valid()) {
                        Log.error("TX characteristic not found.");
                    }
                }
                break;
            }
        }
    }
}
```

2. Peripheral side:
- user/tests/app/ble/uart_peripheral

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
