### PR TITLE
[hal] sleep: restore waleup sources' interrupt priority appropriately

### DIFF
--- a/hal/src/nRF52840/sleep_hal.cpp
+++ b/hal/src/nRF52840/sleep_hal.cpp
@@ -49,20 +49,24 @@
 #include "spark_wiring_vector.h"
 
 
-#define INVALID_INT_PRIORITY        (0xFFFFFFFF)
-
 using namespace particle;
 
 namespace {
 
-typedef struct WakeupSourcePriorityCache {
+struct WakeupSourcePriorityCache {
+    WakeupSourcePriorityCache() {
+        memset((uint8_t*)this, 0xFF, sizeof(WakeupSourcePriorityCache));
+    }
+
     uint32_t gpiotePriority;
     uint32_t rtc2Priority;
     uint32_t blePriority;
     uint32_t lpcompPriority;
     uint32_t usart0Priority;
     uint32_t usart1Priority;
-} WakeupSourcePriorityCache;
+};
+
+constexpr uint32_t INVALID_INT_PRIORITY = 0xFFFFFFFF;
 
 }
 
@@ -869,8 +873,7 @@ static int enterStopBasedSleep(const hal_sleep_config_t* config, hal_wakeup_sour
         __disable_irq();
 
         // Bump the priority
-        WakeupSourcePriorityCache priorityCache;
-        memset((uint8_t*)&priorityCache, 0xFF, sizeof(WakeupSourcePriorityCache));
+        WakeupSourcePriorityCache priorityCache = {};
         bumpWakeupSourcesPriority(config->wakeup_sources, &priorityCache, 0);
 
         __DSB();

--- a/hal/src/stm32f2xx/sleep_hal.cpp
+++ b/hal/src/stm32f2xx/sleep_hal.cpp
@@ -55,6 +55,33 @@ static constexpr uint8_t GPIO_IRQn[extiChannelNum] = {
     EXTI15_10_IRQn  //15
 };
 
+uint8_t exti0Bumped = false;
+uint8_t exti1Bumped = false;
+uint8_t exti2Bumped = false;
+uint8_t exti3Bumped = false;
+uint8_t exti4Bumped = false;
+uint8_t exti95Bumped = false;
+uint8_t exti1510Bumped = false;
+
+static uint8_t* const pExtiBump[extiChannelNum] = {
+    &exti0Bumped,
+    &exti1Bumped,
+    &exti2Bumped,
+    &exti3Bumped,
+    &exti4Bumped,
+    &exti95Bumped,
+    &exti95Bumped,
+    &exti95Bumped,
+    &exti95Bumped,
+    &exti95Bumped,
+    &exti1510Bumped,
+    &exti1510Bumped,
+    &exti1510Bumped,
+    &exti1510Bumped,
+    &exti1510Bumped,
+    &exti1510Bumped
+};
+
 };
 
 static int constructGpioWakeupReason(hal_wakeup_source_base_t** wakeupReason, pin_t pin) {
@@ -175,7 +202,10 @@ static int configGpioWakeupSource(const hal_wakeup_source_base_t* wakeupSources,
             
             Hal_Pin_Info* pinMap = HAL_Pin_Map();
             uint8_t pinSource = pinMap[gpioWakeup->pin].gpio_pin_source;
-            extiPriorities[pinSource] = NVIC_GetPriority(static_cast<IRQn_Type>(GPIO_IRQn[pinSource]));
+            if (!(*(pExtiBump[pinSource]))) {
+                extiPriorities[pinSource] = NVIC_GetPriority(static_cast<IRQn_Type>(GPIO_IRQn[pinSource]));
+                *(pExtiBump[pinSource]) = true;
+            }
             NVIC_SetPriority(static_cast<IRQn_Type>(GPIO_IRQn[pinSource]), 1);
         }
         source = source->next;
@@ -692,11 +722,10 @@ static int enterStopBasedSleep(const hal_sleep_config_t* config, hal_wakeup_sour
         } else if (wakeupSource->type == HAL_WAKEUP_SOURCE_TYPE_GPIO) {
             auto gpioWakeup = reinterpret_cast<hal_wakeup_source_gpio_t*>(wakeupSource);
             HAL_Interrupts_Detach_Ext(gpioWakeup->pin, 1, nullptr);
-
-            Hal_Pin_Info* pinMap = HAL_Pin_Map();
-            uint8_t pinSource = pinMap[gpioWakeup->pin].gpio_pin_source;
-            extiPriority[pinSource] = NVIC_GetPriority(static_cast<IRQn_Type>(GPIO_IRQn[pinSource]));
-            NVIC_SetPriority(static_cast<IRQn_Type>(GPIO_IRQn[pinSource]), extiPriority[pinSource]);
+            uint8_t pinSource = halPinMap[gpioWakeup->pin].gpio_pin_source;
+            if (*(pExtiBump[pinSource])) {
+                NVIC_SetPriority(static_cast<IRQn_Type>(GPIO_IRQn[pinSource]), extiPriority[pinSource]);
+            }
         } else if (wakeupSource->type == HAL_WAKEUP_SOURCE_TYPE_USART) {
             auto usartWakeup = reinterpret_cast<hal_wakeup_source_usart_t*>(wakeupSource);
             // Enabled unwanted interrupts and unbump the interrupt priority

--- a/hal/src/stm32f2xx/sleep_hal.cpp
+++ b/hal/src/stm32f2xx/sleep_hal.cpp
@@ -31,15 +31,15 @@
 #include "check.h"
 
 
-#define EXTI9_5_BITS_MASK       (0x03E0)
-#define EXTI15_10_BITS_MASK     (0xFC00)
-
 // anonymous namespace
 namespace {
 
-static constexpr uint8_t extiChannelNum = 16;
+constexpr uint16_t EXTI9_5_BITS_MASK = 0x03E0;
+constexpr uint16_t EXTI15_10_BITS_MASK = 0xFC00;
 
-static constexpr uint8_t GPIO_IRQn[extiChannelNum] = {
+constexpr uint8_t extiChannelNum = 16;
+
+constexpr uint8_t GPIO_IRQn[extiChannelNum] = {
     EXTI0_IRQn,     //0
     EXTI1_IRQn,     //1
     EXTI2_IRQn,     //2


### PR DESCRIPTION
## Problem

A wakeup source's interrupt priority is increased and never restored if it is duplicated in the wakeup source list or shares the same IRQ with other wakeup sources. Especially on Gen3, for critical SoftDevice region, a user application interrupt that would result in an error in SoftDevice.

### Solution

Bump a wakeup source's interrupt priority only if it hasn't been bumped previously.

### References

N/A

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
