### PR TITLE
[wiring] system: configure multiple pins as wakeup source at a time.

### DIFF
--- a/system/inc/system_sleep_configuration.h
+++ b/system/inc/system_sleep_configuration.h
@@ -26,9 +26,12 @@
 #include "system_error.h"
 #include "spark_wiring_network.h"
 #include "spark_wiring_usartserial.h"
+#include "spark_wiring_vector.h"
 #include "enumflags.h"
 
 #define SYSTEM_SLEEP_NETWORK_FLAG_SUPPORTED_VER     (3)
+
+using spark::Vector;
 
 namespace particle {
 
@@ -249,6 +252,27 @@ public:
             wakeupSource->pin = pin;
             wakeupSource->mode = mode;
             config_.wakeup_sources = reinterpret_cast<hal_wakeup_source_base_t*>(wakeupSource);
+        }
+        return *this;
+    }
+
+    SystemSleepConfiguration& gpios(const Vector<std::pair<pin_t, InterruptMode>>& pins) {
+        for (const auto& pin : pins) {
+            gpio(pin.first, pin.second);
+        }
+        return *this;
+    }
+
+    SystemSleepConfiguration& gpios(const Vector<pin_t>& pins, InterruptMode mode) {
+        for (const auto& pin : pins) {
+            gpio(pin, mode);
+        }
+        return *this;
+    }
+
+    SystemSleepConfiguration& gpios(const uint8_t* pins, size_t count, InterruptMode mode) {
+        for (size_t i = 0; i < count; i++) {
+            gpio(pins[i], mode);
         }
         return *this;
     }


### PR DESCRIPTION
As the title describes.

### Example App

```c
#include "Particle.h"

SYSTEM_MODE(MANUAL);

void setup() {
}

void loop() {
    delay(300);
    Vector<std::pair<pin_t, InterruptMode>> pins;
    pins.append(std::make_pair(D0, FALLING));
    pins.append(std::make_pair(D1, RISING));

    Vector<pin_t> altPins;
    altPins.append(D2);
    altPins.append(D3);

    uint8_t pinArray[2] = {D4, D5};

    System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::ULTRA_LOW_POWER)
                                           .gpios(pins)
                                           .gpios(altPins, FALLING)
                                           .gpios(pinArray, sizeof(pinArray), RISING));
}
```

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
