### PR TITLE
[hal] electron: use AT+CPWROFF to turn off the modem completely

### DIFF
--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1282,7 +1282,7 @@ bool MDMParser::softPowerOff(void) {
         }
     }
     for (uint8_t i = 0; i < 3; i++) {
-        if (!_error && _atOk()) {
+        if (_atOk()) {
             // We can talk to the modem getting here.
             MDM_INFO("\r\n[ Modem::softPowerOff ] Powering down the modem using AT+CPWROFF....");
             sendFormated("AT+CPWROFF\r\n");
@@ -1347,7 +1347,7 @@ bool MDMParser::powerOff(void)
             }
         }
         // Skip power off sequence if power is already off
-        if (powerState() && _dev.dev != DEV_SARA_G350 && _dev.dev != DEV_UNKNOWN) {
+        if (powerState() && _dev.dev != DEV_SARA_G350) {
             MDM_INFO("%s Modem not responsive, trying PWR_UC...", POWER_OFF_MSG);
             HAL_GPIO_Write(PWR_UC, 0);
             // >1.5 seconds on SARA R410M

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -834,13 +834,26 @@ bool MDMParser::_powerOn(void)
 
     int i = 10;
     while (i--) {
-        // SARA-U2/LISA-U2 50..80us
-        HAL_GPIO_Write(PWR_UC, 0); HAL_Delay_Milliseconds(50);
-        HAL_GPIO_Write(PWR_UC, 1); HAL_Delay_Milliseconds(10);
+        if (powerState()) {
+            MDM_INFO("\r\n[ Modem::powerOn ] Modem is already on");
+        } else {
+            // SARA-U2/LISA-U2 50..80us
+            HAL_GPIO_Write(PWR_UC, 0); HAL_Delay_Milliseconds(50);
+            HAL_GPIO_Write(PWR_UC, 1); HAL_Delay_Milliseconds(10);
 
-        // SARA-G35 >5ms, LISA-C2 > 150ms, LEON-G2 >5ms, SARA-R4 >= 150ms
-        HAL_GPIO_Write(PWR_UC, 0); HAL_Delay_Milliseconds(150);
-        HAL_GPIO_Write(PWR_UC, 1); HAL_Delay_Milliseconds(100);
+            if (powerState()) {
+                MDM_INFO("\r\n[ Modem::powerOn ] Modem is powered on");
+            } else {
+                // SARA-G35 >5ms, LISA-C2 > 150ms, LEON-G2 >5ms, SARA-R4 >= 150ms
+                HAL_GPIO_Write(PWR_UC, 0); HAL_Delay_Milliseconds(150);
+                HAL_GPIO_Write(PWR_UC, 1); HAL_Delay_Milliseconds(100);
+                if (powerState()) {
+                    MDM_INFO("\r\n[ Modem::powerOn ] Modem is powered on");
+                } else {
+                    MDM_ERROR("\r\n[ Modem::powerOn ] Failed to power on the modem.");
+                }
+            }
+        }
 
         // purge any messages
         purge();
@@ -871,7 +884,6 @@ bool MDMParser::_powerOn(void)
             i = 10;
             reset();
         }
-
     }
     if (i < 0) {
         MDM_ERROR("[ No Reply from Modem ]\r\n");
@@ -960,13 +972,20 @@ bool MDMParser::powerOn(const char* simpin)
             goto failure;
         }
         else if (i==4 && (RESP_OK != ret) && !retried_after_reset) {
-            retried_after_reset = true; // only perform reset & retry sequence once
-            i = 0;
-            if(!powerOff())
-                reset();
-            /* Power on the modem and perform basic initialization again */
-            if (!_powerOn())
+            if (_dev.sim == SIM_MISSING) {
+                // No need to try again in a short time.
                 goto failure;
+            } else {
+                retried_after_reset = true; // only perform reset & retry sequence once
+                i = 0;
+                if(!powerOff()) {
+                    reset();
+                }
+                /* Power on the modem and perform basic initialization again */
+                if (!_powerOn()) {
+                    goto failure;
+                }
+            }
         }
         // Enter PIN if needed
         if (_dev.sim == SIM_PIN) {
@@ -1271,84 +1290,89 @@ bool MDMParser::powerOff(void)
     bool ok = false;
     bool continue_cancel = false;
     bool check_ri = false;
-    if (_init && _pwr) {
-        MDM_INFO("%s = = = = = = = = = = = = = =", POWER_OFF_MSG);
-        if (_cancel_all_operations) {
-            continue_cancel = true;
-            resume(); // make sure we can use the AT parser
-        }
-        check_ri = true;
-        // Try to power off
-        for (int i=0; i<3; i++) { // try 3 times
-            if (_error || !_atOk()) {
-                if (_dev.dev == DEV_SARA_R410) {
-                    // If memory issue is present, ensure we don't force a power off too soon
-                    // to avoid hitting the 124 day memory housekeeping issue, AT+CPWROFF will
-                    // handle this delay automatically, or timeout after 40s.
-                    if (_memoryIssuePresent) {
-                        MDM_INFO("%s Modem not responsive, waiting up to 30s to power off with PWR_UC...", POWER_OFF_MSG);
-                        system_tick_t now = HAL_Timer_Get_Milli_Seconds();
-                        if (_timePowerOn == 0) {
-                            // fallback to max timeout of 30s to be safe
-                            _timePowerOn = now;
-                        }
-                        // check for timeout (VINT == LOW, Powered on 30s ago, Registered 20s ago)
-                        do {
-                            now = HAL_Timer_Get_Milli_Seconds();
-                            // prefer to timeout 20s after registration if we are registered
-                            if (_timeRegistered) {
-                                if (now - _timeRegistered >= 20000UL) {
-                                    break;
-                                }
-                            } else if (_timePowerOn && now - _timePowerOn >= 30000UL) {
-                                break;
-                            }
-                            HAL_Delay_Milliseconds(100); // just wait
-                        } while ( powerState() );
-                        // reset timers
-                        _timeRegistered = 0;
-                        _timePowerOn = 0;
-                    }
-                }
-                MDM_INFO("%s Modem not responsive, trying PWR_UC...", POWER_OFF_MSG);
-                // Skip power off sequence if power is already off
-                if (!powerState()) {
-                    break;
-                }
-                HAL_GPIO_Write(PWR_UC, 0);
-                // >1.5 seconds on SARA R410M
-                // >1 second on SARA U2
-                // plus a little extra for good luck
-                HAL_Delay_Milliseconds(1600);
-                HAL_GPIO_Write(PWR_UC, 1);
+
+    MDM_INFO("%s = = = = = = = = = = = = = =", POWER_OFF_MSG);
+
+    if (!powerState() && !_init && !_pwr) {
+        MDM_INFO("%s Modem is off already", POWER_OFF_MSG);
+        return true;
+    }
+
+    // Make sure we can use the AT parser.
+    // For SARA-G35 it doesn't support powering off the modem using the PWR_ON pin.
+    // But it shares the same code base with other modem, thus, we use AT+CPWROFF generally.
+    if (!(_init && _pwr)) {
+        MDM_INFO("%s Powering on to use AT parser...", POWER_OFF_MSG);
+        resume();
+        uint8_t i = 0;
+        for (i = 0; i < 3; i++) {
+            if (_powerOn()) {
                 break;
-            } else {
-                sendFormated("AT+CPWROFF\r\n");
-                int ret = waitFinalResp(nullptr, nullptr, CPWROFF_TIMEOUT);
-                if (RESP_OK == ret) {
-                    if (_dev.dev == DEV_SARA_R410) {
-                        check_ri = true;
-                    }
-                    break;
-                } else if (RESP_ABORTED == ret) {
-                    MDM_INFO("%s found ABORTED, retrying...", POWER_OFF_MSG);
-                } else {
-                    MDM_INFO("%s timeout, retrying...", POWER_OFF_MSG);
-                }
             }
         }
-    } else {
-        if (powerState()) {
-            check_ri = true;
-            MDM_INFO("%s modem is on unexpectedly. Turning it off...", POWER_OFF_MSG);
-            // Delay this long period so that the modem is fully on to accept the power-off sequence.
-            HAL_Delay_Milliseconds(12000);
+        if (i >= 3) {
+            // Failed to power on the modem.
+            MDM_INFO("%s Failed to power on the modem", POWER_OFF_MSG);
+            return false;
+        }
+    }
 
-            HAL_GPIO_Write(PWR_UC, 0);
-            // >1.5 seconds on SARA R410M
-            // >1 second on SARA U2
-            // plus a little extra for good luck
-            HAL_Delay_Milliseconds(2000);
+    if (_cancel_all_operations) {
+        continue_cancel = true;
+        resume(); // make sure we can use the AT parser
+    }
+    check_ri = true;
+
+    for (uint8_t i = 0; i < 3; i++) {
+        if (_error || !_atOk()) {
+            if (_dev.dev == DEV_SARA_R410) {
+                // If memory issue is present, ensure we don't force a power off too soon
+                // to avoid hitting the 124 day memory housekeeping issue, AT+CPWROFF will
+                // handle this delay automatically, or timeout after 40s.
+                if (_memoryIssuePresent) {
+                    MDM_INFO("%s Modem not responsive, waiting up to 30s to power off with PWR_UC...", POWER_OFF_MSG);
+                    system_tick_t now = HAL_Timer_Get_Milli_Seconds();
+                    if (_timePowerOn == 0) {
+                        // fallback to max timeout of 30s to be safe
+                        _timePowerOn = now;
+                    }
+                    // check for timeout (VINT == LOW, Powered on 30s ago, Registered 20s ago)
+                    do {
+                        now = HAL_Timer_Get_Milli_Seconds();
+                        // prefer to timeout 20s after registration if we are registered
+                        if (_timeRegistered) {
+                            if (now - _timeRegistered >= 20000UL) {
+                                break;
+                            }
+                        } else if (_timePowerOn && now - _timePowerOn >= 30000UL) {
+                            break;
+                        }
+                        HAL_Delay_Milliseconds(100); // just wait
+                    } while ( powerState() );
+                    // reset timers
+                    _timeRegistered = 0;
+                    _timePowerOn = 0;
+                }
+            }
+            // Skip power off sequence if power is already off
+            if (!powerState()) {
+                MDM_INFO("%s Modem is powered down.", POWER_OFF_MSG);
+                break;
+            }
+        } else {
+            MDM_INFO("%s Powering down the modem using AT+CPWROFF....", POWER_OFF_MSG);
+            sendFormated("AT+CPWROFF\r\n");
+            int ret = waitFinalResp(nullptr, nullptr, CPWROFF_TIMEOUT);
+            if (RESP_OK == ret) {
+                if (_dev.dev == DEV_SARA_R410) {
+                    check_ri = true;
+                }
+                break;
+            } else if (RESP_ABORTED == ret) {
+                MDM_INFO("%s found ABORTED, retrying...", POWER_OFF_MSG);
+            } else {
+                MDM_INFO("%s timeout, retrying...", POWER_OFF_MSG);
+            }
         }
     }
 
@@ -1362,8 +1386,6 @@ bool MDMParser::powerOff(void)
         // if V_INT is low, indicate power is off
         if (!power_state) {
             _pwr = false;
-        }
-        if (!power_state) {
             MDM_INFO("%s took %lu ms", POWER_OFF_MSG, HAL_Timer_Get_Milli_Seconds() - t0);
         } else {
             MDM_INFO("%s failed", POWER_OFF_MSG);

--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -154,6 +154,12 @@ public:
     */
     int getModemStateChangeCount(void);
 
+    /** Power on the MT if necessary and then try powering off using AT command. This function has to be called prior to
+        switching off the supply.
+        \return true if successfully, false otherwise
+    */
+    bool powerOnOffGracefully(void);
+
     /** Power off the MT, This function has to be called prior to
         switching off the supply.
         \return true if successfully, false otherwise

--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -158,7 +158,7 @@ public:
         switching off the supply.
         \return true if successfully, false otherwise
     */
-    bool powerOnOffGracefully(void);
+    bool softPowerOff(void);
 
     /** Power off the MT, This function has to be called prior to
         switching off the supply.

--- a/services/inc/services2_dynalib.h
+++ b/services/inc/services2_dynalib.h
@@ -68,6 +68,7 @@ DYNALIB_FN(22, services2, localtime_r, struct tm*(const time_t*, struct tm*))
 DYNALIB_FN(23, services2, mktime, time_t(struct tm*))
 DYNALIB_FN(24, services2, gmtime_r, struct tm*(const time_t*, struct tm*))
 DYNALIB_FN(25, services2, strftime, size_t(char* __restrict, size_t, const char* __restrict, const struct tm* __restrict))
+DYNALIB_FN(26, services2, _svfprintf_r, int(struct _reent*, FILE*, const char*, va_list))
 
 DYNALIB_END(services2)
 


### PR DESCRIPTION

### Problem

The Electron with SARA-G350 doesn't support powering off using the PWR_ON pin. The low level pulse of the PWR_ON pin being performed in current powerOff() will actually power on the modem.

### Solution

Use `AT+CPWROFF` completely to power off the modem.

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
