### PR TITLE
Query cellular signal while module tries to register

### DIFF
--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -1604,6 +1604,9 @@ int QuectelNcpClient::processEventsImpl() {
     CHECK_PARSER_OK(parser_.execCommand("AT+CREG?"));
     CHECK_PARSER_OK(parser_.execCommand("AT+CGREG?"));
     CHECK_PARSER_OK(parser_.execCommand("AT+CEREG?"));
+    // Check the signal seen by the module while trying to register
+    // Do not need to check for an OK, as this is just for debugging purpose
+    CHECK_PARSER(parser_.execCommand("AT+QCSQ"));
 
     if (connState_ == NcpConnectionState::CONNECTING && millis() - regStartTime_ >= registrationTimeout_) {
         LOG(WARN, "Resetting the modem due to the network registration timeout");

--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -1928,8 +1928,16 @@ int SaraNcpClient::processEventsImpl() {
         CHECK_PARSER(parser_.execCommand("AT+CEER"));
         CHECK_PARSER_OK(parser_.execCommand("AT+CREG?"));
         CHECK_PARSER_OK(parser_.execCommand("AT+CGREG?"));
+        // Check the signal seen by the module while trying to register
+        // Do not need to check for an OK, as this is just for debugging purpose
+        CHECK_PARSER(parser_.execCommand("AT+CSQ"));
     } else {
         CHECK_PARSER_OK(parser_.execCommand("AT+CEREG?"));
+        // Check the signal seen by the module while trying to register
+        // Do not need to check for an OK, as this is just for debugging purpose,
+        // and UCGED may sometimes return CME ERROR with low signal
+        CHECK_PARSER(parser_.execCommand("AT+UCGED=5"));
+        CHECK_PARSER(parser_.execCommand("AT+UCGED?"));
     }
 
     if (connState_ == NcpConnectionState::CONNECTING &&

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1713,12 +1713,25 @@ bool MDMParser::checkNetStatus(NetStatus* status /*= NULL*/)
     _net.cgi.location_area_code = 0xFFFF;
     _net.cgi.cell_id = 0xFFFFFFFF;
     if (_dev.dev == DEV_SARA_R410) {
+        // Check the signal seen by the module while trying to register
+        // Do not need to check for an OK, as this is just for debugging purpose,
+        // and UCGED may sometimes return CME ERROR with low signal
+        sendFormated("AT+UCGED=5\r\n");
+        waitFinalResp(nullptr, nullptr, UCGED_TIMEOUT);
+        sendFormated("AT+UCGED?\r\n");
+        waitFinalResp(nullptr, nullptr, UCGED_TIMEOUT);
+
         // check EPS registration (LTE)
         sendFormated("AT+CEREG?\r\n");
         if (RESP_OK != waitFinalResp(nullptr, nullptr, CEREG_TIMEOUT)) {
             goto failure;
         }
     } else {
+        // Check the signal seen by the module while trying to register
+        // Do not need to check for an OK, as this is just for debugging purpose
+        sendFormated("AT+CSQ\r\n");
+        waitFinalResp(nullptr, nullptr, CSQ_TIMEOUT);
+
         // check CSD registration (GSM)
         sendFormated("AT+CREG?\r\n");
         if (RESP_OK != waitFinalResp(nullptr, nullptr, CREG_TIMEOUT)) {

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1717,9 +1717,13 @@ bool MDMParser::checkNetStatus(NetStatus* status /*= NULL*/)
         // Do not need to check for an OK, as this is just for debugging purpose,
         // and UCGED may sometimes return CME ERROR with low signal
         sendFormated("AT+UCGED=5\r\n");
-        waitFinalResp(nullptr, nullptr, UCGED_TIMEOUT);
+        if (WAIT == waitFinalResp(nullptr, nullptr, UCGED_TIMEOUT)) {
+            goto failure;
+        }
         sendFormated("AT+UCGED?\r\n");
-        waitFinalResp(nullptr, nullptr, UCGED_TIMEOUT);
+        if (WAIT == waitFinalResp(nullptr, nullptr, UCGED_TIMEOUT)) {
+            goto failure;
+        }
 
         // check EPS registration (LTE)
         sendFormated("AT+CEREG?\r\n");
@@ -1730,7 +1734,9 @@ bool MDMParser::checkNetStatus(NetStatus* status /*= NULL*/)
         // Check the signal seen by the module while trying to register
         // Do not need to check for an OK, as this is just for debugging purpose
         sendFormated("AT+CSQ\r\n");
-        waitFinalResp(nullptr, nullptr, CSQ_TIMEOUT);
+        if (WAIT == waitFinalResp(nullptr, nullptr, CSQ_TIMEOUT)) {
+            goto failure;
+        }
 
         // check CSD registration (GSM)
         sendFormated("AT+CREG?\r\n");


### PR DESCRIPTION
### Problem

The device, at times, do not register and instead stay in "searching" mode. In this case, it's unclear to tell if the device is even receiving a cellular signal which is useful for debugging purposes.

### Solution

Query cellular signal as a part of periodically checking the status of registration. 
- Not checking for an `OK` for the signal queries as sometimes these queries can return `ERROR` while the module is not having cellular coverage 

### Steps to Test

- Watch logs with antenna removed

### References

- [ch64153](https://app.clubhouse.io/particle/story/64153/query-signal-strength-as-a-part-of-registration-intervention-process)

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] n/a Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
