### PR TITLE
Signal values to percentage mapping

### DIFF
--- a/hal/inc/cellular_hal.h
+++ b/hal/inc/cellular_hal.h
@@ -29,6 +29,7 @@
 #include "cellular_hal_constants.h"
 #include "cellular_hal_utilities.h"
 #include "cellular_hal_cellular_global_identity.h"
+#include "cellular_sig_perc_mapping.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/hal/network/ncp/cellular/cellular_hal.cpp
+++ b/hal/network/ncp/cellular/cellular_hal.cpp
@@ -310,6 +310,7 @@ int cellular_signal(void* deprecated, cellular_signal_t* signalExt) {
 
     if (signalExt) {
         signalExt->rat = fromCellularAccessTechnology(s.accessTechnology());
+
         // Signal strength
         switch (s.strengthUnits()) {
         case CellularStrengthUnits::RXLEV: {
@@ -317,7 +318,7 @@ int cellular_signal(void* deprecated, cellular_signal_t* signalExt) {
             // Reported multiplied by 100
             signalExt->rssi = (strn != 99) ? (strn - 111) * 100 : std::numeric_limits<int32_t>::min();
             // RSSI in % [0, 100] based on [-111, -48] range mapped to [0, 65535] integer range
-            signalExt->strength = (strn != 99) ? strn * 65535 / 63 : std::numeric_limits<int32_t>::min();
+            signalExt->strength = (strn != 99) ? get_scaled_strn(signalExt->rssi, static_cast<hal_net_access_tech_t>(signalExt->rat)) : std::numeric_limits<int32_t>::min();
             break;
         }
         case CellularStrengthUnits::RSCP: {
@@ -325,7 +326,7 @@ int cellular_signal(void* deprecated, cellular_signal_t* signalExt) {
             // Reported multiplied by 100
             signalExt->rscp = (strn != 255) ? (strn - 121) * 100 : std::numeric_limits<int32_t>::min();
             // RSCP in % [0, 100] based on [-121, -25] range mapped to [0, 65535] integer range
-            signalExt->strength = (strn != 255) ? strn * 65535 / 96 : std::numeric_limits<int32_t>::min();
+            signalExt->strength = (strn != 255) ? get_scaled_strn(signalExt->rscp, static_cast<hal_net_access_tech_t>(signalExt->rat)) : std::numeric_limits<int32_t>::min();
             break;
         }
         case CellularStrengthUnits::RSRP: {
@@ -333,7 +334,7 @@ int cellular_signal(void* deprecated, cellular_signal_t* signalExt) {
             // Reported multiplied by 100
             signalExt->rsrp = (strn != 255) ? (strn - 141) * 100 : std::numeric_limits<int32_t>::min();
             // RSRP in % [0, 100] based on [-141, -44] range mapped to [0, 65535] integer range
-            signalExt->strength = (strn != 255) ? strn * 65535 / 97 : std::numeric_limits<int32_t>::min();
+            signalExt->strength = (strn != 255) ? get_scaled_strn(signalExt->rsrp, static_cast<hal_net_access_tech_t>(signalExt->rat)) : std::numeric_limits<int32_t>::min();
             break;
         }
         default:
@@ -381,7 +382,7 @@ int cellular_signal(void* deprecated, cellular_signal_t* signalExt) {
             // Report multiplied by 100
             signalExt->rsrq = (qual != 255) ? qual * 50 - 2000 : std::numeric_limits<int32_t>::min();
             // Quality based on RSRQ in % [0, 100] mapped to [0,65535] integer range
-            signalExt->quality = (qual != 255) ? qual * 65535 / 34 : std::numeric_limits<int32_t>::min();
+            signalExt->quality = (qual != 255) ? get_scaled_qual(signalExt->rsrq, static_cast<hal_net_access_tech_t>(signalExt->rat)) : std::numeric_limits<int32_t>::min();
             break;
         }
         default:

--- a/hal/network/ncp/cellular/cellular_hal.cpp
+++ b/hal/network/ncp/cellular/cellular_hal.cpp
@@ -319,7 +319,7 @@ int cellular_signal(void* deprecated, cellular_signal_t* signalExt) {
             signalExt->rssi = (strn != 99) ? (strn - 111) * 100 : std::numeric_limits<int32_t>::min();
             // RSSI in % [0, 100] based on [-111, -48] range mapped to [0, 65535] integer range
             // signalExt->strength = (strn != 99) ? strn * 65535 / 63 : std::numeric_limits<int32_t>::min();
-            signalExt->strength = (strn != 99) ? get_scaled_strn(signalExt->rssi, static_cast<hal_net_access_tech_t>(signalExt->rat)) : std::numeric_limits<int32_t>::min();
+            signalExt->strength = (strn != 99) ? cellular_get_scaled_strn(signalExt->rssi, static_cast<hal_net_access_tech_t>(signalExt->rat)) : std::numeric_limits<int32_t>::min();
             break;
         }
         case CellularStrengthUnits::RSCP: {
@@ -328,7 +328,7 @@ int cellular_signal(void* deprecated, cellular_signal_t* signalExt) {
             signalExt->rscp = (strn != 255) ? (strn - 121) * 100 : std::numeric_limits<int32_t>::min();
             // RSCP in % [0, 100] based on [-121, -25] range mapped to [0, 65535] integer range
             // signalExt->strength = (strn != 255) ? strn * 65535 / 96 : std::numeric_limits<int32_t>::min();
-            signalExt->strength = (strn != 255) ? get_scaled_strn(signalExt->rscp, static_cast<hal_net_access_tech_t>(signalExt->rat)) : std::numeric_limits<int32_t>::min();
+            signalExt->strength = (strn != 255) ? cellular_get_scaled_strn(signalExt->rscp, static_cast<hal_net_access_tech_t>(signalExt->rat)) : std::numeric_limits<int32_t>::min();
             break;
         }
         case CellularStrengthUnits::RSRP: {
@@ -337,7 +337,7 @@ int cellular_signal(void* deprecated, cellular_signal_t* signalExt) {
             signalExt->rsrp = (strn != 255) ? (strn - 141) * 100 : std::numeric_limits<int32_t>::min();
             // RSRP in % [0, 100] based on [-141, -44] range mapped to [0, 65535] integer range
             // signalExt->strength = (strn != 255) ? strn * 65535 / 97 : std::numeric_limits<int32_t>::min();
-            signalExt->strength = (strn != 255) ? get_scaled_strn(signalExt->rsrp, static_cast<hal_net_access_tech_t>(signalExt->rat)) : std::numeric_limits<int32_t>::min();
+            signalExt->strength = (strn != 255) ? cellular_get_scaled_strn(signalExt->rsrp, static_cast<hal_net_access_tech_t>(signalExt->rat)) : std::numeric_limits<int32_t>::min();
             break;
         }
         default:
@@ -377,7 +377,8 @@ int cellular_signal(void* deprecated, cellular_signal_t* signalExt) {
             // Report multiplied by 100
             signalExt->ecno = (qual != 255) ? qual * 50 - 2450 : std::numeric_limits<int32_t>::min();
             // Quality based on Ec/Io in % [0, 100] mapped to [0,65535] integer range
-            signalExt->quality = (qual != 255) ? qual * 65535 / 49 : std::numeric_limits<int32_t>::min();
+            // signalExt->quality = (qual != 255) ? qual * 65535 / 49 : std::numeric_limits<int32_t>::min();
+            signalExt->quality = (qual != 255) ? cellular_get_scaled_qual(signalExt->ecno, static_cast<hal_net_access_tech_t>(signalExt->rat)) : std::numeric_limits<int32_t>::min();
             break;
         }
         case CellularQualityUnits::RSRQ: {
@@ -386,7 +387,7 @@ int cellular_signal(void* deprecated, cellular_signal_t* signalExt) {
             signalExt->rsrq = (qual != 255) ? qual * 50 - 2000 : std::numeric_limits<int32_t>::min();
             // Quality based on RSRQ in % [0, 100] mapped to [0,65535] integer range
             // signalExt->quality = (qual != 255) ? qual * 65535 / 34 : std::numeric_limits<int32_t>::min();
-            signalExt->quality = (qual != 255) ? get_scaled_qual(signalExt->rsrq, static_cast<hal_net_access_tech_t>(signalExt->rat)) : std::numeric_limits<int32_t>::min();
+            signalExt->quality = (qual != 255) ? cellular_get_scaled_qual(signalExt->rsrq, static_cast<hal_net_access_tech_t>(signalExt->rat)) : std::numeric_limits<int32_t>::min();
             break;
         }
         default:

--- a/hal/network/ncp/cellular/cellular_hal.cpp
+++ b/hal/network/ncp/cellular/cellular_hal.cpp
@@ -318,6 +318,7 @@ int cellular_signal(void* deprecated, cellular_signal_t* signalExt) {
             // Reported multiplied by 100
             signalExt->rssi = (strn != 99) ? (strn - 111) * 100 : std::numeric_limits<int32_t>::min();
             // RSSI in % [0, 100] based on [-111, -48] range mapped to [0, 65535] integer range
+            // signalExt->strength = (strn != 99) ? strn * 65535 / 63 : std::numeric_limits<int32_t>::min();
             signalExt->strength = (strn != 99) ? get_scaled_strn(signalExt->rssi, static_cast<hal_net_access_tech_t>(signalExt->rat)) : std::numeric_limits<int32_t>::min();
             break;
         }
@@ -326,6 +327,7 @@ int cellular_signal(void* deprecated, cellular_signal_t* signalExt) {
             // Reported multiplied by 100
             signalExt->rscp = (strn != 255) ? (strn - 121) * 100 : std::numeric_limits<int32_t>::min();
             // RSCP in % [0, 100] based on [-121, -25] range mapped to [0, 65535] integer range
+            // signalExt->strength = (strn != 255) ? strn * 65535 / 96 : std::numeric_limits<int32_t>::min();
             signalExt->strength = (strn != 255) ? get_scaled_strn(signalExt->rscp, static_cast<hal_net_access_tech_t>(signalExt->rat)) : std::numeric_limits<int32_t>::min();
             break;
         }
@@ -334,6 +336,7 @@ int cellular_signal(void* deprecated, cellular_signal_t* signalExt) {
             // Reported multiplied by 100
             signalExt->rsrp = (strn != 255) ? (strn - 141) * 100 : std::numeric_limits<int32_t>::min();
             // RSRP in % [0, 100] based on [-141, -44] range mapped to [0, 65535] integer range
+            // signalExt->strength = (strn != 255) ? strn * 65535 / 97 : std::numeric_limits<int32_t>::min();
             signalExt->strength = (strn != 255) ? get_scaled_strn(signalExt->rsrp, static_cast<hal_net_access_tech_t>(signalExt->rat)) : std::numeric_limits<int32_t>::min();
             break;
         }
@@ -382,6 +385,7 @@ int cellular_signal(void* deprecated, cellular_signal_t* signalExt) {
             // Report multiplied by 100
             signalExt->rsrq = (qual != 255) ? qual * 50 - 2000 : std::numeric_limits<int32_t>::min();
             // Quality based on RSRQ in % [0, 100] mapped to [0,65535] integer range
+            // signalExt->quality = (qual != 255) ? qual * 65535 / 34 : std::numeric_limits<int32_t>::min();
             signalExt->quality = (qual != 255) ? get_scaled_qual(signalExt->rsrq, static_cast<hal_net_access_tech_t>(signalExt->rat)) : std::numeric_limits<int32_t>::min();
             break;
         }

--- a/hal/shared/cellular_sig_perc_mapping.cpp
+++ b/hal/shared/cellular_sig_perc_mapping.cpp
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2019 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cellular_sig_perc_mapping.h"
+
+// Cellular signal values and mapping
+
+// XXX: Must change the mapping tables associated with region categorization
+typedef enum {
+    CELLULAR_HAL_SIG_REGION_POOR = 0,
+    CELLULAR_HAL_SIG_REGION_BAD = 1,
+    CELLULAR_HAL_SIG_REGION_FAIR = 2,
+    CELLULAR_HAL_SIG_REGION_GOOD = 3,
+    CELLULAR_HAL_SIG_REGION_GREAT = 4,
+    MAX_NUM_OF_REGION_THRESHOLDS
+} SignalMappingRegions;
+
+const int sig_strn_perc_thres = 100 / (MAX_NUM_OF_REGION_THRESHOLDS - 1);
+
+const int catm1_strn_map[] = {
+    -141,   /* CELLULAR_HAL_SIG_REGION_POOR */
+    -122,   /* CELLULAR_HAL_SIG_REGION_BAD */
+    -116,   /* CELLULAR_HAL_SIG_REGION_FAIR */
+    -107,   /* CELLULAR_HAL_SIG_REGION_GOOD */
+    -95,    /* CELLULAR_HAL_SIG_REGION_GREAT */
+    //-44     /* MAX */
+};
+
+const int catm1_qual_map[] = {
+    -20,   /* CELLULAR_HAL_SIG_REGION_POOR */
+    -19,   /* CELLULAR_HAL_SIG_REGION_BAD */
+    -17,   /* CELLULAR_HAL_SIG_REGION_FAIR */
+    -14,   /* CELLULAR_HAL_SIG_REGION_GOOD */
+    -12,   /* CELLULAR_HAL_SIG_REGION_GREAT */
+    //-3     /* MAX */
+};
+
+const int cat1_strn_map[] = {
+    -141,   /* CELLULAR_HAL_SIG_REGION_POOR */
+    -115,   /* CELLULAR_HAL_SIG_REGION_BAD */
+    -105,   /* CELLULAR_HAL_SIG_REGION_FAIR */
+    -95,    /* CELLULAR_HAL_SIG_REGION_GOOD */
+    -85,    /* CELLULAR_HAL_SIG_REGION_GREAT */
+    //-44     /* MAX */
+};
+
+const int cat1_qual_map[] = {
+    -20,   /* CELLULAR_HAL_SIG_REGION_POOR */
+    -19,   /* CELLULAR_HAL_SIG_REGION_BAD */
+    -17,   /* CELLULAR_HAL_SIG_REGION_FAIR */
+    -14,   /* CELLULAR_HAL_SIG_REGION_GOOD */
+    -12,   /* CELLULAR_HAL_SIG_REGION_GREAT */
+    //-3     /* MAX */
+};
+
+const int utran_strn_map[] = {
+    -121,   /* CELLULAR_HAL_SIG_REGION_POOR */
+    -115,   /* CELLULAR_HAL_SIG_REGION_BAD */
+    -105,   /* CELLULAR_HAL_SIG_REGION_FAIR */
+    -95,    /* CELLULAR_HAL_SIG_REGION_GOOD */
+    -85,    /* CELLULAR_HAL_SIG_REGION_GREAT */
+    //-24     /* MAX */
+};
+
+const int gsm_strn_map[] = {
+    -111,   /* CELLULAR_HAL_SIG_REGION_POOR */
+    -107,   /* CELLULAR_HAL_SIG_REGION_BAD */
+    -103,   /* CELLULAR_HAL_SIG_REGION_FAIR */
+    -97,    /* CELLULAR_HAL_SIG_REGION_GOOD */
+    -89,    /* CELLULAR_HAL_SIG_REGION_GREAT */
+    //-48     /* MAX */
+};
+
+int get_scaled_strn(int strn_value, hal_net_access_tech_t access_tech) {
+    int res = 0;
+    int region = -1;
+
+    // The strength value obtained is a number multiplied by 100. Get the original value.
+    strn_value = strn_value / 100;
+
+
+    int gen_strn_map[MAX_NUM_OF_REGION_THRESHOLDS] = {0};
+
+    // Get the mapping data according to the RAT
+    switch (access_tech) {
+        case NET_ACCESS_TECHNOLOGY_GSM:
+        case NET_ACCESS_TECHNOLOGY_EDGE: {
+            memcpy(gen_strn_map,gsm_strn_map, sizeof(gen_strn_map));
+            break;
+        }
+        case NET_ACCESS_TECHNOLOGY_UTRAN: {
+            memcpy(gen_strn_map,utran_strn_map, sizeof(gen_strn_map));
+            break;
+        }
+        case NET_ACCESS_TECHNOLOGY_LTE: {
+            memcpy(gen_strn_map,cat1_strn_map, sizeof(gen_strn_map));
+            break;
+        }
+        case NET_ACCESS_TECHNOLOGY_LTE_CAT_M1:
+        case NET_ACCESS_TECHNOLOGY_LTE_CAT_NB1: {
+            memcpy(gen_strn_map,catm1_strn_map, sizeof(gen_strn_map));
+            break;
+        }
+        default: {
+            res = std::numeric_limits<int32_t>::min();
+            break;
+        }
+    }
+
+    // If RAT was not selected, return
+    if (res == std::numeric_limits<int32_t>::min()) {
+        return res;
+    }
+
+    // Check which region the value falls into. Convert into percetages, but scale it to [0,65535]
+    if (strn_value < gen_strn_map[CELLULAR_HAL_SIG_REGION_POOR]) {
+        return 0*65535;
+    } else if (strn_value >= gen_strn_map[MAX_NUM_OF_REGION_THRESHOLDS-1]) {
+        return 65535;
+    } else {
+        for (int i=MAX_NUM_OF_REGION_THRESHOLDS-2; i>=CELLULAR_HAL_SIG_REGION_POOR; i--) {
+            if (strn_value >= gen_strn_map[i]) {
+                region = i;
+                break;
+            }
+        }
+        // Covert dBm to percetange based on that region and the value from mapping table
+        int new_range = sig_strn_perc_thres;
+        int old_range = gen_strn_map[region+1] - gen_strn_map[region];
+        res = ((((strn_value - gen_strn_map[region])*new_range*65535)/old_range) +
+                                        (sig_strn_perc_thres*region*65535))/100;
+    }
+    return res;
+}
+
+int get_scaled_qual(int qual_value, hal_net_access_tech_t access_tech) {
+    int res = 0;
+    int region = -1;
+
+    // The quality value obtained is a number multiplied by 100. Get the original value.
+    qual_value = qual_value / 100;
+
+    int gen_qual_map[MAX_NUM_OF_REGION_THRESHOLDS] = {0};
+
+    // Quality conversion considered only for LTE RAT in this impl
+    switch (access_tech) {
+        case NET_ACCESS_TECHNOLOGY_LTE: {
+            memcpy(gen_qual_map,cat1_qual_map, sizeof(gen_qual_map));
+            break;
+        }
+        case NET_ACCESS_TECHNOLOGY_LTE_CAT_M1:
+        case NET_ACCESS_TECHNOLOGY_LTE_CAT_NB1: {
+            memcpy(gen_qual_map,catm1_qual_map, sizeof(gen_qual_map));
+            break;
+        }
+        default: {
+            res = std::numeric_limits<int32_t>::min();
+            break;
+        }
+    }
+
+    if (res == std::numeric_limits<int32_t>::min()) {
+        return res;
+    }
+
+    // Check which region the value falls into. Convert into percetages, but scale it to [0,65535]
+    if (qual_value < gen_qual_map[CELLULAR_HAL_SIG_REGION_POOR]) {
+        return 0;
+    } else if (qual_value >= gen_qual_map[MAX_NUM_OF_REGION_THRESHOLDS-1]) {
+        return 65535;
+    } else {
+        for (int i=MAX_NUM_OF_REGION_THRESHOLDS-2; i>=CELLULAR_HAL_SIG_REGION_POOR; i--) {
+            if (qual_value >= gen_qual_map[i]) {
+                region = i;
+                break;
+            }
+        }
+        // Covert dBm to percetange based on that region and the value from mapping table
+        int new_range = sig_strn_perc_thres;
+        int old_range = gen_qual_map[region+1] - gen_qual_map[region];
+        res = ((((qual_value - gen_qual_map[region])*new_range*65535)/old_range) +
+                                        (sig_strn_perc_thres*region*65535))/100;
+    }
+    return res;
+}

--- a/hal/shared/cellular_sig_perc_mapping.h
+++ b/hal/shared/cellular_sig_perc_mapping.h
@@ -16,7 +16,7 @@
  */
 
 #ifndef CELLULAR_SIG_MAPPING_HAL_H
-#define	CELLULAR_SIG_MAPPING_HAL_H
+#define CELLULAR_SIG_MAPPING_HAL_H
 
 #include "logging.h"
 #include "net_hal.h"

--- a/hal/shared/cellular_sig_perc_mapping.h
+++ b/hal/shared/cellular_sig_perc_mapping.h
@@ -18,11 +18,8 @@
 #ifndef CELLULAR_SIG_MAPPING_HAL_H
 #define CELLULAR_SIG_MAPPING_HAL_H
 
-#include "logging.h"
+
 #include "net_hal.h"
-#include "string.h"
-#include <stdlib.h>
-#include <limits>
 
 #ifdef __cplusplus
 extern "C" {
@@ -31,12 +28,12 @@ extern "C" {
 /*
 *   Convert strength in dBm into percetage
 */
-int get_scaled_strn(int strn_value, hal_net_access_tech_t access_tech);
+int cellular_get_scaled_strn(int strn_value, hal_net_access_tech_t access_tech);
 
 /*
 *   Conver quality in dBm into percetage
 */
-int get_scaled_qual(int qual_value, hal_net_access_tech_t access_tech);
+int cellular_get_scaled_qual(int qual_value, hal_net_access_tech_t access_tech);
 
 #ifdef __cplusplus
 }

--- a/hal/shared/cellular_sig_perc_mapping.h
+++ b/hal/shared/cellular_sig_perc_mapping.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2019 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef CELLULAR_SIG_MAPPING_HAL_H
+#define	CELLULAR_SIG_MAPPING_HAL_H
+
+#include "logging.h"
+#include "net_hal.h"
+#include "string.h"
+#include <stdlib.h>
+#include <limits>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+*   Convert strength in dBm into percetage
+*/
+int get_scaled_strn(int strn_value, hal_net_access_tech_t access_tech);
+
+/*
+*   Conver quality in dBm into percetage
+*/
+int get_scaled_qual(int qual_value, hal_net_access_tech_t access_tech);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CELLULAR_SIG_MAPPING_HAL_H

--- a/hal/src/electron/cellular_internal.cpp
+++ b/hal/src/electron/cellular_internal.cpp
@@ -75,7 +75,7 @@ cellular_result_t cellular_signal_impl(cellular_signal_t* signalext, bool streng
             }
 
             // RSSI in % [0, 100] based on [-111, -48] range mapped to [0, 65535] integer range
-            signalext->strength = (status.rxlev != 99) ? status.rxlev * 65535 / 63 : std::numeric_limits<int32_t>::min();
+            signalext->strength = (status.rxlev != 99) ? get_scaled_strn(signalext->rssi, static_cast<hal_net_access_tech_t>(signalext->rat)) : std::numeric_limits<int32_t>::min();
             // Quality based on RXQUAL in % [0, 100] mapped to [0, 65535] integer range
             signalext->quality = (status.rxqual != 99) ? (7 - status.rxqual) * 65535 / 7 : std::numeric_limits<int32_t>::min();
             break;
@@ -88,7 +88,7 @@ cellular_result_t cellular_signal_impl(cellular_signal_t* signalext, bool streng
             signalext->ecno = (status.ecno != 255) ? status.ecno * 50 - 2450 : std::numeric_limits<int32_t>::min();
 
             // RSCP in % [0, 100] based on [-121, -25] range mapped to [0, 65535] integer range
-            signalext->strength = (status.rscp != 255) ? status.rscp * 65535 / 96 : std::numeric_limits<int32_t>::min();
+            signalext->strength = (status.rscp != 255) ? get_scaled_strn(signalext->rscp, static_cast<hal_net_access_tech_t>(signalext->rat)) : std::numeric_limits<int32_t>::min();
             // Quality based on Ec/Io in % [0, 100] mapped to [0,65535] integer range
             signalext->quality = (status.ecno != 255) ? status.ecno * 65535 / 49 : std::numeric_limits<int32_t>::min();
             break;
@@ -103,9 +103,9 @@ cellular_result_t cellular_signal_impl(cellular_signal_t* signalext, bool streng
             signalext->rsrq = (status.rsrq != 255) ? status.rsrq * 50 - 2000 : std::numeric_limits<int32_t>::min();
 
             // RSRP in % [0, 100] based on [-141, -44] range mapped to [0, 65535] integer range
-            signalext->strength = (status.rsrp != 255) ? status.rsrp * 65535 / 97 : std::numeric_limits<int32_t>::min();
+            signalext->strength = (status.rsrp != 255) ? get_scaled_strn(signalext->rsrp, static_cast<hal_net_access_tech_t>(signalext->rat)) : std::numeric_limits<int32_t>::min();
             // Quality based on Ec/Io in % [0, 100] mapped to [0,65535] integer range
-            signalext->quality = (status.rsrq != 255) ? status.rsrq * 65535 / 34 : std::numeric_limits<int32_t>::min();
+            signalext->quality = (status.rsrq != 255) ? get_scaled_qual(signalext->rsrq, static_cast<hal_net_access_tech_t>(signalext->rat)) : std::numeric_limits<int32_t>::min();
             break;
         default:
             res = SYSTEM_ERROR_UNKNOWN;

--- a/hal/src/electron/cellular_internal.cpp
+++ b/hal/src/electron/cellular_internal.cpp
@@ -75,6 +75,7 @@ cellular_result_t cellular_signal_impl(cellular_signal_t* signalext, bool streng
             }
 
             // RSSI in % [0, 100] based on [-111, -48] range mapped to [0, 65535] integer range
+            // signalext->strength = (status.rxlev != 99) ? status.rxlev * 65535 / 63 : std::numeric_limits<int32_t>::min();
             signalext->strength = (status.rxlev != 99) ? get_scaled_strn(signalext->rssi, static_cast<hal_net_access_tech_t>(signalext->rat)) : std::numeric_limits<int32_t>::min();
             // Quality based on RXQUAL in % [0, 100] mapped to [0, 65535] integer range
             signalext->quality = (status.rxqual != 99) ? (7 - status.rxqual) * 65535 / 7 : std::numeric_limits<int32_t>::min();
@@ -88,6 +89,7 @@ cellular_result_t cellular_signal_impl(cellular_signal_t* signalext, bool streng
             signalext->ecno = (status.ecno != 255) ? status.ecno * 50 - 2450 : std::numeric_limits<int32_t>::min();
 
             // RSCP in % [0, 100] based on [-121, -25] range mapped to [0, 65535] integer range
+            // signalext->strength = (status.rscp != 255) ? status.rscp * 65535 / 96 : std::numeric_limits<int32_t>::min();
             signalext->strength = (status.rscp != 255) ? get_scaled_strn(signalext->rscp, static_cast<hal_net_access_tech_t>(signalext->rat)) : std::numeric_limits<int32_t>::min();
             // Quality based on Ec/Io in % [0, 100] mapped to [0,65535] integer range
             signalext->quality = (status.ecno != 255) ? status.ecno * 65535 / 49 : std::numeric_limits<int32_t>::min();
@@ -103,8 +105,10 @@ cellular_result_t cellular_signal_impl(cellular_signal_t* signalext, bool streng
             signalext->rsrq = (status.rsrq != 255) ? status.rsrq * 50 - 2000 : std::numeric_limits<int32_t>::min();
 
             // RSRP in % [0, 100] based on [-141, -44] range mapped to [0, 65535] integer range
+            // signalext->strength = (status.rsrp != 255) ? status.rsrp * 65535 / 97 : std::numeric_limits<int32_t>::min();
             signalext->strength = (status.rsrp != 255) ? get_scaled_strn(signalext->rsrp, static_cast<hal_net_access_tech_t>(signalext->rat)) : std::numeric_limits<int32_t>::min();
             // Quality based on Ec/Io in % [0, 100] mapped to [0,65535] integer range
+            // signalext->quality = (status.rsrq != 255) ? status.rsrq * 65535 / 34 : std::numeric_limits<int32_t>::min();
             signalext->quality = (status.rsrq != 255) ? get_scaled_qual(signalext->rsrq, static_cast<hal_net_access_tech_t>(signalext->rat)) : std::numeric_limits<int32_t>::min();
             break;
         default:

--- a/hal/src/electron/cellular_internal.cpp
+++ b/hal/src/electron/cellular_internal.cpp
@@ -76,7 +76,7 @@ cellular_result_t cellular_signal_impl(cellular_signal_t* signalext, bool streng
 
             // RSSI in % [0, 100] based on [-111, -48] range mapped to [0, 65535] integer range
             // signalext->strength = (status.rxlev != 99) ? status.rxlev * 65535 / 63 : std::numeric_limits<int32_t>::min();
-            signalext->strength = (status.rxlev != 99) ? get_scaled_strn(signalext->rssi, static_cast<hal_net_access_tech_t>(signalext->rat)) : std::numeric_limits<int32_t>::min();
+            signalext->strength = (status.rxlev != 99) ? cellular_get_scaled_strn(signalext->rssi, static_cast<hal_net_access_tech_t>(signalext->rat)) : std::numeric_limits<int32_t>::min();
             // Quality based on RXQUAL in % [0, 100] mapped to [0, 65535] integer range
             signalext->quality = (status.rxqual != 99) ? (7 - status.rxqual) * 65535 / 7 : std::numeric_limits<int32_t>::min();
             break;
@@ -90,9 +90,10 @@ cellular_result_t cellular_signal_impl(cellular_signal_t* signalext, bool streng
 
             // RSCP in % [0, 100] based on [-121, -25] range mapped to [0, 65535] integer range
             // signalext->strength = (status.rscp != 255) ? status.rscp * 65535 / 96 : std::numeric_limits<int32_t>::min();
-            signalext->strength = (status.rscp != 255) ? get_scaled_strn(signalext->rscp, static_cast<hal_net_access_tech_t>(signalext->rat)) : std::numeric_limits<int32_t>::min();
+            signalext->strength = (status.rscp != 255) ? cellular_get_scaled_strn(signalext->rscp, static_cast<hal_net_access_tech_t>(signalext->rat)) : std::numeric_limits<int32_t>::min();
             // Quality based on Ec/Io in % [0, 100] mapped to [0,65535] integer range
-            signalext->quality = (status.ecno != 255) ? status.ecno * 65535 / 49 : std::numeric_limits<int32_t>::min();
+            // signalext->quality = (status.ecno != 255) ? status.ecno * 65535 / 49 : std::numeric_limits<int32_t>::min();
+            signalext->quality = (status.rsrq != 255) ? cellular_get_scaled_qual(signalext->ecno, static_cast<hal_net_access_tech_t>(signalext->rat)) : std::numeric_limits<int32_t>::min();
             break;
         case ACT_LTE:
         case ACT_LTE_CAT_M1:
@@ -106,10 +107,10 @@ cellular_result_t cellular_signal_impl(cellular_signal_t* signalext, bool streng
 
             // RSRP in % [0, 100] based on [-141, -44] range mapped to [0, 65535] integer range
             // signalext->strength = (status.rsrp != 255) ? status.rsrp * 65535 / 97 : std::numeric_limits<int32_t>::min();
-            signalext->strength = (status.rsrp != 255) ? get_scaled_strn(signalext->rsrp, static_cast<hal_net_access_tech_t>(signalext->rat)) : std::numeric_limits<int32_t>::min();
+            signalext->strength = (status.rsrp != 255) ? cellular_get_scaled_strn(signalext->rsrp, static_cast<hal_net_access_tech_t>(signalext->rat)) : std::numeric_limits<int32_t>::min();
             // Quality based on Ec/Io in % [0, 100] mapped to [0,65535] integer range
             // signalext->quality = (status.rsrq != 255) ? status.rsrq * 65535 / 34 : std::numeric_limits<int32_t>::min();
-            signalext->quality = (status.rsrq != 255) ? get_scaled_qual(signalext->rsrq, static_cast<hal_net_access_tech_t>(signalext->rat)) : std::numeric_limits<int32_t>::min();
+            signalext->quality = (status.rsrq != 255) ? cellular_get_scaled_qual(signalext->rsrq, static_cast<hal_net_access_tech_t>(signalext->rat)) : std::numeric_limits<int32_t>::min();
             break;
         default:
             res = SYSTEM_ERROR_UNKNOWN;

--- a/hal/src/electron/cellular_internal.h
+++ b/hal/src/electron/cellular_internal.h
@@ -22,6 +22,7 @@
 
 #include "cellular_enums_hal.h"
 #include "cellular_hal_constants.h"
+#include "cellular_sig_perc_mapping.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/modules/electron/system-part1/src/cellular_hal.cpp
+++ b/modules/electron/system-part1/src/cellular_hal.cpp
@@ -7,3 +7,4 @@
 #include "../src/electron/cellular_internal.cpp"
 #include "../src/electron/inet_hal_new.cpp"
 #include "../src/electron/socket_hal.cpp"
+#include "../shared/cellular_sig_perc_mapping.cpp"

--- a/test/unit_tests/cellular/CMakeLists.txt
+++ b/test/unit_tests/cellular/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable( ${target_name}
   ${DEVICE_OS_DIR}/wiring/src/spark_wiring_cellular_printable.cpp
   ${DEVICE_OS_DIR}/wiring/src/spark_wiring_print.cpp
   ${DEVICE_OS_DIR}/hal/network/ncp/cellular/network_config_db.cpp
+  ${DEVICE_OS_DIR}/hal/shared/cellular_sig_perc_mapping.cpp
   cellular.cpp
 )
 

--- a/test/unit_tests/cellular/cellular.cpp
+++ b/test/unit_tests/cellular/cellular.cpp
@@ -542,16 +542,16 @@ TEST_CASE("cellular_signal()") {
 
         SECTION("middle RSCP and ECNO") {
             status.rscp = 16;
-            status.ecno = 24;
+            status.ecno = 28;
 
             cellular_signal_t sig = {};
             sig.size = sizeof(sig);
             REQUIRE(cellular_signal_impl(&sig, true, status) == SYSTEM_ERROR_NONE);
             REQUIRE(sig.rat == NET_ACCESS_TECHNOLOGY_UTRAN);
             REQUIRE(std::abs(sig.strength - 32767) == 0);
-            REQUIRE(std::abs(sig.quality - 32767) <= 655 * 2);
+            REQUIRE(std::abs(sig.quality - 32767) == 0);
             REQUIRE(sig.rscp == -10500);
-            REQUIRE(sig.ecno == -1250);
+            REQUIRE(sig.ecno == -1050);
 
             SECTION("CellularSignal") {
                 CellularSignal cs;
@@ -559,8 +559,8 @@ TEST_CASE("cellular_signal()") {
                 REQUIRE(cs.getAccessTechnology() == NET_ACCESS_TECHNOLOGY_UTRAN);
                 REQUIRE(std::abs(cs.getStrength()) <= 50.0f);
                 REQUIRE(cs.getStrengthValue() == -105.0f);
-                REQUIRE(std::abs(cs.getQuality() - 50.0f) <= 2.0f);
-                REQUIRE(cs.getQualityValue() == -12.5f);
+                REQUIRE(std::abs(cs.getQuality()) <= 50.0f);
+                REQUIRE(cs.getQualityValue() == -10.5f);
             }
         }
 

--- a/test/unit_tests/cellular/cellular.cpp
+++ b/test/unit_tests/cellular/cellular.cpp
@@ -524,7 +524,7 @@ TEST_CASE("cellular_signal()") {
 
             cellular_signal_t sig = {};
             sig.size = sizeof(sig);
-            REQUIRE(cellular_signal_impl(nullptr, &sig, true, status) == SYSTEM_ERROR_NONE);
+            REQUIRE(cellular_signal_impl(&sig, true, status) == SYSTEM_ERROR_NONE);
             REQUIRE(sig.rat == NET_ACCESS_TECHNOLOGY_UTRAN);
             REQUIRE(sig.rscp == -11800);
             REQUIRE(sig.ecno == -2300);
@@ -605,7 +605,7 @@ TEST_CASE("cellular_signal()") {
 
             cellular_signal_t sig = {};
             sig.size = sizeof(sig);
-            REQUIRE(cellular_signal_impl(nullptr, &sig, true, status) == SYSTEM_ERROR_NONE);
+            REQUIRE(cellular_signal_impl(&sig, true, status) == SYSTEM_ERROR_NONE);
             REQUIRE(sig.rat == data.expected_act);
             REQUIRE(sig.strength < 0);
             REQUIRE(sig.quality < 0);
@@ -629,7 +629,7 @@ TEST_CASE("cellular_signal()") {
 
             cellular_signal_t sig = {};
             sig.size = sizeof(sig);
-            REQUIRE(cellular_signal_impl(nullptr, &sig, true, status) == SYSTEM_ERROR_NONE);
+            REQUIRE(cellular_signal_impl(&sig, true, status) == SYSTEM_ERROR_NONE);
             REQUIRE(sig.rat == data.expected_act);
             REQUIRE(sig.strength == 0);
             REQUIRE(sig.quality == 0);
@@ -653,7 +653,7 @@ TEST_CASE("cellular_signal()") {
 
             cellular_signal_t sig = {};
             sig.size = sizeof(sig);
-            REQUIRE(cellular_signal_impl(nullptr, &sig, true, status) == SYSTEM_ERROR_NONE);
+            REQUIRE(cellular_signal_impl(&sig, true, status) == SYSTEM_ERROR_NONE);
             REQUIRE(sig.rat == data.expected_act);
             REQUIRE(std::abs(sig.strength - 32767) == 0);
             REQUIRE(std::abs(sig.quality - 32767) == 0);
@@ -677,7 +677,7 @@ TEST_CASE("cellular_signal()") {
 
             cellular_signal_t sig = {};
             sig.size = sizeof(sig);
-            REQUIRE(cellular_signal_impl(nullptr, &sig, true, status) == SYSTEM_ERROR_NONE);
+            REQUIRE(cellular_signal_impl(&sig, true, status) == SYSTEM_ERROR_NONE);
             REQUIRE(sig.rat == data.expected_act);
             REQUIRE(sig.strength == 65535);
             REQUIRE(sig.quality == 65535);
@@ -761,7 +761,7 @@ TEST_CASE("cellular_signal()") {
 
             cellular_signal_t sig = {};
             sig.size = sizeof(sig);
-            REQUIRE(cellular_signal_impl(nullptr, &sig, true, status) == SYSTEM_ERROR_NONE);
+            REQUIRE(cellular_signal_impl(&sig, true, status) == SYSTEM_ERROR_NONE);
             REQUIRE(sig.rat == data.expected_act);
             REQUIRE(sig.rsrp == -13000);
             REQUIRE(sig.rsrq == -1900);

--- a/test/unit_tests/cellular/cellular.cpp
+++ b/test/unit_tests/cellular/cellular.cpp
@@ -281,24 +281,24 @@ TEST_CASE("cellular_signal()") {
         }
 
         SECTION("middle RXLEV and RXQUAL") {
-            status.rxlev = 31;
+            status.rxlev = 8;
             status.rxqual = 4;
 
             cellular_signal_t sig = {};
             sig.size = sizeof(sig);
             REQUIRE(cellular_signal_impl(&sig, true, status) == SYSTEM_ERROR_NONE);
             REQUIRE(sig.rat == NET_ACCESS_TECHNOLOGY_GSM);
-            REQUIRE(std::abs(sig.strength - 32767) <= 655);
+            REQUIRE(std::abs(sig.strength - 32767) == 0);
             REQUIRE(std::abs(sig.quality - 32767) <= 6553);
-            REQUIRE(sig.rssi == -8000);
+            REQUIRE(sig.rssi == -10300);
             REQUIRE(sig.ber == 226);
 
             SECTION("CellularSignal") {
                 CellularSignal cs;
                 REQUIRE(cs.fromHalCellularSignal(sig) == true);
                 REQUIRE(cs.getAccessTechnology() == NET_ACCESS_TECHNOLOGY_GSM);
-                REQUIRE(std::abs(cs.getStrength() - 50.0f) <= 1.0f);
-                REQUIRE(cs.getStrengthValue() == -80.0f);
+                REQUIRE(std::abs(cs.getStrength()) <= 50.0f);
+                REQUIRE(cs.getStrengthValue() == -103.0f);
                 REQUIRE(std::abs(cs.getQuality() - 50.0f) <= 10.0f);
                 REQUIRE(cs.getQualityValue() == 2.26f);
             }
@@ -417,24 +417,24 @@ TEST_CASE("cellular_signal()") {
         }
 
         SECTION("middle RXLEV and RXQUAL") {
-            status.rxlev = 31;
+            status.rxlev = 8;
             status.rxqual = 4;
 
             cellular_signal_t sig = {};
             sig.size = sizeof(sig);
             REQUIRE(cellular_signal_impl(&sig, true, status) == SYSTEM_ERROR_NONE);
             REQUIRE(sig.rat == NET_ACCESS_TECHNOLOGY_EDGE);
-            REQUIRE(std::abs(sig.strength - 32767) <= 655);
+            REQUIRE(std::abs(sig.strength - 32767) == 0);
             REQUIRE(std::abs(sig.quality - 32767) <= 6553);
-            REQUIRE(sig.rssi == -8000);
+            REQUIRE(sig.rssi == -10300);
             REQUIRE(sig.ber == -190);
 
             SECTION("CellularSignal") {
                 CellularSignal cs;
                 REQUIRE(cs.fromHalCellularSignal(sig) == true);
                 REQUIRE(cs.getAccessTechnology() == NET_ACCESS_TECHNOLOGY_EDGE);
-                REQUIRE(std::abs(cs.getStrength() - 50.0f) <= 1.0f);
-                REQUIRE(cs.getStrengthValue() == -80.0f);
+                REQUIRE(std::abs(cs.getStrength()) <= 50.0f);
+                REQUIRE(cs.getStrengthValue() == -103.0f);
                 REQUIRE(std::abs(cs.getQuality() - 50.0f) <= 10.0f);
                 REQUIRE(cs.getQualityValue() == -1.9f);
             }
@@ -518,25 +518,47 @@ TEST_CASE("cellular_signal()") {
             }
         }
 
+        SECTION("poor RSCP and ECNO") {
+            status.rscp = 3;
+            status.ecno = 3;
+
+            cellular_signal_t sig = {};
+            sig.size = sizeof(sig);
+            REQUIRE(cellular_signal_impl(nullptr, &sig, true, status) == SYSTEM_ERROR_NONE);
+            REQUIRE(sig.rat == NET_ACCESS_TECHNOLOGY_UTRAN);
+            REQUIRE(sig.rscp == -11800);
+            REQUIRE(sig.ecno == -2300);
+
+            SECTION("CellularSignal") {
+                CellularSignal cs;
+                REQUIRE(cs.fromHalCellularSignal(sig) == true);
+                REQUIRE(cs.getAccessTechnology() == NET_ACCESS_TECHNOLOGY_UTRAN);
+                REQUIRE(std::abs(cs.getStrength()) <= 25.0f);
+                REQUIRE(cs.getStrengthValue() == -118.0f);
+                REQUIRE(std::abs(cs.getQuality()) <= 25.0f);
+                REQUIRE(cs.getQualityValue() == -23.0f);
+            }
+        }
+
         SECTION("middle RSCP and ECNO") {
-            status.rscp = 48;
+            status.rscp = 16;
             status.ecno = 24;
 
             cellular_signal_t sig = {};
             sig.size = sizeof(sig);
             REQUIRE(cellular_signal_impl(&sig, true, status) == SYSTEM_ERROR_NONE);
             REQUIRE(sig.rat == NET_ACCESS_TECHNOLOGY_UTRAN);
-            REQUIRE(sig.strength == 32767);
+            REQUIRE(std::abs(sig.strength - 32767) == 0);
             REQUIRE(std::abs(sig.quality - 32767) <= 655 * 2);
-            REQUIRE(sig.rscp == -7300);
+            REQUIRE(sig.rscp == -10500);
             REQUIRE(sig.ecno == -1250);
 
             SECTION("CellularSignal") {
                 CellularSignal cs;
                 REQUIRE(cs.fromHalCellularSignal(sig) == true);
                 REQUIRE(cs.getAccessTechnology() == NET_ACCESS_TECHNOLOGY_UTRAN);
-                REQUIRE(std::abs(cs.getStrength() - 50.0f) <= 1.0f);
-                REQUIRE(cs.getStrengthValue() == -73.0f);
+                REQUIRE(std::abs(cs.getStrength()) <= 50.0f);
+                REQUIRE(cs.getStrengthValue() == -105.0f);
                 REQUIRE(std::abs(cs.getQuality() - 50.0f) <= 2.0f);
                 REQUIRE(cs.getQualityValue() == -12.5f);
             }
@@ -567,13 +589,119 @@ TEST_CASE("cellular_signal()") {
         }
     }
 
-    SECTION("LTE/LTE_CAT_M1/LTE_CAT_NB1") {
+    SECTION("LTE") {
         NetStatus status = {};
 
         // Expected { input, output } data table
         struct DataTable { AcT input_act; hal_net_access_tech_t expected_act; };
         auto data = GENERATE( values<DataTable>({
             { AcT::ACT_LTE, hal_net_access_tech_t::NET_ACCESS_TECHNOLOGY_LTE },
+        }));
+        status.act = data.input_act;
+
+        SECTION("error values reported by the modem") {
+            status.rsrp = 255;
+            status.rsrq = 255;
+
+            cellular_signal_t sig = {};
+            sig.size = sizeof(sig);
+            REQUIRE(cellular_signal_impl(nullptr, &sig, true, status) == SYSTEM_ERROR_NONE);
+            REQUIRE(sig.rat == data.expected_act);
+            REQUIRE(sig.strength < 0);
+            REQUIRE(sig.quality < 0);
+            REQUIRE(sig.rsrp == std::numeric_limits<int32_t>::min());
+            REQUIRE(sig.rsrq == std::numeric_limits<int32_t>::min());
+
+            SECTION("CellularSignal") {
+                CellularSignal cs;
+                REQUIRE(cs.fromHalCellularSignal(sig) == true);
+                REQUIRE(cs.getAccessTechnology() == data.expected_act);
+                REQUIRE(cs.getStrength() < 0.0f);
+                REQUIRE(cs.getStrengthValue() == 0.0f);
+                REQUIRE(cs.getQuality() < 0.0f);
+                REQUIRE(cs.getQualityValue() == 0.0f);
+            }
+        }
+
+        SECTION("minimum RSRP and RSRQ") {
+            status.rsrp = 0;
+            status.rsrq = 0;
+
+            cellular_signal_t sig = {};
+            sig.size = sizeof(sig);
+            REQUIRE(cellular_signal_impl(nullptr, &sig, true, status) == SYSTEM_ERROR_NONE);
+            REQUIRE(sig.rat == data.expected_act);
+            REQUIRE(sig.strength == 0);
+            REQUIRE(sig.quality == 0);
+            REQUIRE(sig.rsrp == -14100);
+            REQUIRE(sig.rsrq == -2000);
+
+            SECTION("CellularSignal") {
+                CellularSignal cs;
+                REQUIRE(cs.fromHalCellularSignal(sig) == true);
+                REQUIRE(cs.getAccessTechnology() == data.expected_act);
+                REQUIRE(cs.getStrength() == 0.0f);
+                REQUIRE(cs.getStrengthValue() == -141.0f);
+                REQUIRE(cs.getQuality() == 0.0f);
+                REQUIRE(cs.getQualityValue() == -20.0f);
+            }
+        }
+
+        SECTION("middle RSRP and RSRQ") {
+            status.rsrp = 36;
+            status.rsrq = 6;
+
+            cellular_signal_t sig = {};
+            sig.size = sizeof(sig);
+            REQUIRE(cellular_signal_impl(nullptr, &sig, true, status) == SYSTEM_ERROR_NONE);
+            REQUIRE(sig.rat == data.expected_act);
+            REQUIRE(std::abs(sig.strength - 32767) == 0);
+            REQUIRE(std::abs(sig.quality - 32767) == 0);
+            REQUIRE(sig.rsrp == -10500);
+            REQUIRE(sig.rsrq == -1700);
+
+            SECTION("CellularSignal") {
+                CellularSignal cs;
+                REQUIRE(cs.fromHalCellularSignal(sig) == true);
+                REQUIRE(cs.getAccessTechnology() == data.expected_act);
+                REQUIRE(std::abs(cs.getStrength()) <= 50.0f);
+                REQUIRE(cs.getStrengthValue() == -105.0f);
+                REQUIRE(std::abs(cs.getQuality()) <= 50.0f);
+                REQUIRE(cs.getQualityValue() == -17.0f);
+            }
+        }
+
+        SECTION("max RSRP and RSRQ") {
+            status.rsrp = 97;
+            status.rsrq = 34;
+
+            cellular_signal_t sig = {};
+            sig.size = sizeof(sig);
+            REQUIRE(cellular_signal_impl(nullptr, &sig, true, status) == SYSTEM_ERROR_NONE);
+            REQUIRE(sig.rat == data.expected_act);
+            REQUIRE(sig.strength == 65535);
+            REQUIRE(sig.quality == 65535);
+            REQUIRE(sig.rsrp == -4400);
+            REQUIRE(sig.rsrq == -300);
+
+            SECTION("CellularSignal") {
+                CellularSignal cs;
+                REQUIRE(cs.fromHalCellularSignal(sig) == true);
+                REQUIRE(cs.getAccessTechnology() == data.expected_act);
+                REQUIRE(cs.getStrength() == 100.0f);
+                REQUIRE(cs.getStrengthValue() == -44.0f);
+                REQUIRE(cs.getQuality() == 100.0f);
+                REQUIRE(cs.getQualityValue() == -3.0f);
+            }
+        }
+    }
+
+    SECTION("LTE_CAT_M1/LTE_CAT_NB1") {
+        NetStatus status = {};
+
+        // Expected { input, output } data table
+        struct DataTable { AcT input_act; hal_net_access_tech_t expected_act; };
+        auto data = GENERATE( values<DataTable>({
             { AcT::ACT_LTE_CAT_M1, hal_net_access_tech_t::NET_ACCESS_TECHNOLOGY_LTE_CAT_M1 },
             { AcT::ACT_LTE_CAT_NB1, hal_net_access_tech_t::NET_ACCESS_TECHNOLOGY_LTE_CAT_NB1 }
         }));
@@ -627,27 +755,49 @@ TEST_CASE("cellular_signal()") {
             }
         }
 
-        SECTION("middle RSRP and RSRQ") {
-            status.rsrp = 48;
-            status.rsrq = 17;
+        SECTION("poor RSRP and RSRQ") {
+            status.rsrp = 11;
+            status.rsrq = 2;
 
             cellular_signal_t sig = {};
             sig.size = sizeof(sig);
-            REQUIRE(cellular_signal_impl(&sig, true, status) == SYSTEM_ERROR_NONE);
+            REQUIRE(cellular_signal_impl(nullptr, &sig, true, status) == SYSTEM_ERROR_NONE);
             REQUIRE(sig.rat == data.expected_act);
-            REQUIRE(sig.strength == 32429);
-            REQUIRE(std::abs(sig.quality - 32767) <= 655 * 2);
-            REQUIRE(sig.rsrp == -9300);
-            REQUIRE(sig.rsrq == -1150);
+            REQUIRE(sig.rsrp == -13000);
+            REQUIRE(sig.rsrq == -1900);
 
             SECTION("CellularSignal") {
                 CellularSignal cs;
                 REQUIRE(cs.fromHalCellularSignal(sig) == true);
                 REQUIRE(cs.getAccessTechnology() == data.expected_act);
-                REQUIRE(std::abs(cs.getStrength() - 50.0f) <= 1.0f);
-                REQUIRE(cs.getStrengthValue() == -93.0f);
-                REQUIRE(std::abs(cs.getQuality() - 50.0f) <= 2.0f);
-                REQUIRE(cs.getQualityValue() == -11.5f);
+                REQUIRE(std::abs(cs.getStrength()) <= 25.0f);
+                REQUIRE(cs.getStrengthValue() == -130.0f);
+                REQUIRE(std::abs(cs.getQuality()) <= 25.0f);
+                REQUIRE(cs.getQualityValue() == -19.0f);
+            }
+        }
+
+        SECTION("middle RSRP and RSRQ") {
+            status.rsrp = 25;
+            status.rsrq = 6;
+
+            cellular_signal_t sig = {};
+            sig.size = sizeof(sig);
+            REQUIRE(cellular_signal_impl(&sig, true, status) == SYSTEM_ERROR_NONE);
+            REQUIRE(sig.rat == data.expected_act);
+            REQUIRE(std::abs(sig.strength - 32767) == 0);
+            REQUIRE(std::abs(sig.quality - 32767) == 0);
+            REQUIRE(sig.rsrp == -11600);
+            REQUIRE(sig.rsrq == -1700);
+
+            SECTION("CellularSignal") {
+                CellularSignal cs;
+                REQUIRE(cs.fromHalCellularSignal(sig) == true);
+                REQUIRE(cs.getAccessTechnology() == data.expected_act);
+                REQUIRE(std::abs(cs.getStrength()) <= 50.0f);
+                REQUIRE(cs.getStrengthValue() == -116.0f);
+                REQUIRE(std::abs(cs.getQuality()) <= 50.0f);
+                REQUIRE(cs.getQualityValue() == -17.0f);
             }
         }
 

--- a/user/tests/unit/makefile
+++ b/user/tests/unit/makefile
@@ -84,6 +84,7 @@ CPPSRC += $(call target_files,$(HAL)src/gcc,deviceid_hal.cpp)
 CPPSRC += $(call target_files,$(HAL)src/gcc,interrupts_hal.cpp)
 CPPSRC += $(call target_files,$(HAL)src/electron,cellular_internal.cpp)
 CPPSRC += $(call target_files,$(HAL)src/template,i2c_hal.cpp)
+CPPSRC += $(call target_files,$(HAL)shared,cellular_sig_perc_mapping.cpp)
 
 # Paths to dependent projects, referenced from root of this project
 LIB_SERVICES = services/


### PR DESCRIPTION
### Problem

Current signal values to percentage conversion is incorrect depending on the values.

### Solution

Changing the signal percentages reported to the cloud such that they render an accurate representation of the cellular signal.

### References

- [ch66635](https://app.clubhouse.io/particle/story/66635/change-the-how-device-os-signal-quality-percentages-are-calculated-in-device-os)

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
