### PR TITLE
Gen2: platforms calling sleep20 API to enter stop/ulp mode may block user application.

### DIFF
--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -152,7 +152,7 @@ public:
         which can be used to invalidate previous assumptions about the state of the modem.
         \return _pwr_off_count value
     */
-    int getModemStateChangeCount(void);
+    int getModemStateChangeCount(void) const;
 
     /** Power on the MT if necessary and then try powering off using AT command. This function has to be called prior to
         switching off the supply.

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -55,6 +55,11 @@ static bool system_sleep_network_suspend(network_interface_index index) {
         network_disconnect(index, NETWORK_DISCONNECT_REASON_SLEEP, NULL);
         resume = true;
     }
+#if PLATFORM_GEN == 2
+    if (!SPARK_WLAN_SLEEP) {
+        resume = true;
+    }
+#endif
     // Turn off the modem
     network_off(index, 0, 0, NULL);
     LOG(TRACE, "Waiting interface to be off...");
@@ -64,8 +69,12 @@ static bool system_sleep_network_suspend(network_interface_index index) {
 }
 
 static int system_sleep_network_resume(network_interface_index index) {
+#if PLATFORM_GEN == 2
+    SPARK_WLAN_SLEEP = 0;
+#else
     network_on(index, 0, 0, nullptr);
     network_connect(index, 0, 0, nullptr);
+#endif
     return SYSTEM_ERROR_NONE;
 }
 

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -70,6 +70,10 @@ static bool system_sleep_network_suspend(network_interface_index index) {
 
 static int system_sleep_network_resume(network_interface_index index) {
 #if PLATFORM_GEN == 2
+    /* On Gen2, calling network_on() and network_connect() will block until the connection is established
+     * if single threaded, or this function is invoked synchronously by the system thread if system threading
+     * is enabled. In both case, that would block the user application. Setting a flag here to unblock the user
+     * application and restore the connection later. */
     SPARK_WLAN_SLEEP = 0;
 #else
     network_on(index, 0, 0, nullptr);

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -196,7 +196,6 @@ int system_sleep_ext(const hal_sleep_config_t* config, hal_wakeup_source_base_t*
 
 #if HAL_PLATFORM_WIFI
     if (wifiResume) {
-        SPARK_WLAN_SLEEP = 0;
         system_sleep_network_resume(NETWORK_INTERFACE_WIFI_STA);
     }
 #endif // HAL_PLATFORM_WIFI

--- a/system/src/system_sleep_compat.cpp
+++ b/system/src/system_sleep_compat.cpp
@@ -171,11 +171,15 @@ int system_sleep_impl(Spark_Sleep_TypeDef sleepMode, long seconds, uint32_t para
                 RESET_REASON_NONE, seconds);
     }
 
+#if HAL_PLATFORM_SETUP_BUTTON_UX
     bool networkTurnedOff = false;
+#endif // HAL_PLATFORM_SETUP_BUTTON_UX
 
     if (network_sleep_flag(param) || SLEEP_MODE_WLAN == sleepMode) {
         network_suspend();
+#if HAL_PLATFORM_SETUP_BUTTON_UX
         networkTurnedOff = true;
+#endif // HAL_PLATFORM_SETUP_BUTTON_UX
     }
 
     switch (sleepMode)

--- a/system/src/system_sleep_compat.cpp
+++ b/system/src/system_sleep_compat.cpp
@@ -171,8 +171,11 @@ int system_sleep_impl(Spark_Sleep_TypeDef sleepMode, long seconds, uint32_t para
                 RESET_REASON_NONE, seconds);
     }
 
+    bool networkTurnedOff = false;
+
     if (network_sleep_flag(param) || SLEEP_MODE_WLAN == sleepMode) {
         network_suspend();
+        networkTurnedOff = true;
     }
 
     switch (sleepMode)
@@ -193,17 +196,14 @@ int system_sleep_impl(Spark_Sleep_TypeDef sleepMode, long seconds, uint32_t para
             break;
 
         case SLEEP_MODE_DEEP:
-            if (network_sleep_flag(param))
-            {
-                network_disconnect(0, NETWORK_DISCONNECT_REASON_SLEEP, NULL);
-                network_off(0, 0, 0, NULL);
-            }
             return system_sleep_enter_standby_compat(seconds, param);
 
 #if HAL_PLATFORM_SETUP_BUTTON_UX
         case SLEEP_MODE_SOFTPOWEROFF:
-            network_disconnect(0, NETWORK_DISCONNECT_REASON_SLEEP, NULL);
-            network_off(0, 0, 0, NULL);
+            if (!networkTurnedOff) {
+                network_disconnect(0, NETWORK_DISCONNECT_REASON_SLEEP, NULL);
+                network_off(0, 0, 0, NULL);
+            }
             return system_sleep_enter_standby_compat(seconds, param);
 #endif
     }

--- a/user/tests/wiring/sleep20/sleep20.cpp
+++ b/user/tests/wiring/sleep20/sleep20.cpp
@@ -670,10 +670,9 @@ test(26_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_Wi
 #endif
 #endif // HAL_PLATFORM_WIFI
 
-#if HAL_PLATFORM_CELLULAR
-test(23_System_Sleep_With_Configuration_Object_Stop_Mode_Execution_Time) {
-    constexpr uint32_t SLEEP_DURATION_MS = 1000;
-    Serial.printf("    >> Device enters stop mode. Please reconnect serial after %ld ms\r\n", SLEEP_DURATION_MS);
+test(27_System_Sleep_With_Configuration_Object_Stop_Mode_Execution_Time) {
+    constexpr uint32_t SLEEP_DURATION_S = 3;
+    Serial.printf("    >> Device enters stop mode. Please reconnect serial after %ld s\r\n", SLEEP_DURATION_S);
     Serial.println("    >> Press any key now");
     while(Serial.available() <= 0);
     while (Serial.available() > 0) {
@@ -681,32 +680,31 @@ test(23_System_Sleep_With_Configuration_Object_Stop_Mode_Execution_Time) {
     }
 
     Serial.println("    >> Connecting to the cloud");
-    Cellular.on();
+    Network.on();
     Particle.connect();
     waitUntil(Particle.connected);
     Serial.println("    >> Connected to the cloud. You'll see the RGB is turned on after waking up.");
 
     SystemSleepConfiguration config;
     config.mode(SystemSleepMode::STOP)
-          .duration(SLEEP_DURATION_MS);
+          .duration(SLEEP_DURATION_S * 1000);
 
-    system_tick_t enter = millis();
+    time32_t enter = Time.now();
     SystemSleepResult result = System.sleep(config);
-    system_tick_t exit = millis();
+    time32_t exit = Time.now();
 
     while (!Serial.isConnected());
     // It might wait for up to 120s to turn off the modem
-    assertLessOrEqual(exit - enter - SLEEP_DURATION_MS, 121000);
-    Serial.printf("Sleep execution time: %ld\r\n", (uint32_t)(exit - enter));
+    assertLessOrEqual(exit - enter, 120 + SLEEP_DURATION_S);
+    Serial.printf("Sleep execution time: %ld s\r\n", exit - enter);
 
     assertEqual(result.error(), SYSTEM_ERROR_NONE);
     assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_RTC);
 }
 
-#if HAL_PLATFORM_GEN == 3
-test(24_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_Execution_Time) {
-    constexpr uint32_t SLEEP_DURATION_MS = 1000;
-    Serial.printf("    >> Device enters ultra-low power mode. Please reconnect serial after %ld ms\r\n", SLEEP_DURATION_MS);
+test(28_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_Execution_Time) {
+    constexpr uint32_t SLEEP_DURATION_S = 3;
+    Serial.printf("    >> Device enters ultra-low power mode. Please reconnect serial after %ld s\r\n", SLEEP_DURATION_S);
     Serial.println("    >> Press any key now");
     while(Serial.available() <= 0);
     while (Serial.available() > 0) {
@@ -714,92 +712,24 @@ test(24_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_Execu
     }
 
     Serial.println("    >> Connecting to the cloud");
-    Cellular.on();
+    Network.on();
     Particle.connect();
     waitUntil(Particle.connected);
     Serial.println("    >> Connected to the cloud. You'll see the RGB is turned on after waking up.");
 
     SystemSleepConfiguration config;
     config.mode(SystemSleepMode::ULTRA_LOW_POWER)
-          .duration(SLEEP_DURATION_MS);
+          .duration(SLEEP_DURATION_S * 1000);
 
-    system_tick_t enter = millis();
+    time32_t enter = millis();
     SystemSleepResult result = System.sleep(config);
-    system_tick_t exit = millis();
+    time32_t exit = millis();
 
     while (!Serial.isConnected());
     // It might wait for up to 120s to turn off the modem
-    assertLessOrEqual(exit - enter - SLEEP_DURATION_MS, 121000);
-    Serial.printf("Sleep execution time: %ld\r\n", (uint32_t)(exit - enter));
+    assertLessOrEqual(exit - enter, 120 + SLEEP_DURATION_S);
+    Serial.printf("Sleep execution time: %ld s\r\n", exit - enter);
 
     assertEqual(result.error(), SYSTEM_ERROR_NONE);
     assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_RTC);
 }
-#endif
-#endif // HAL_PLATFORM_CELLULAR
-
-#if HAL_PLATFORM_WIFI
-test(25_System_Sleep_With_Configuration_Object_Stop_Mode_Execution_Time) {
-    constexpr uint32_t SLEEP_DURATION_MS = 1000;
-    Serial.printf("    >> Device enters stop mode. Please reconnect serial after %ld ms\r\n", SLEEP_DURATION_MS);
-    Serial.println("    >> Press any key now");
-    while(Serial.available() <= 0);
-    while (Serial.available() > 0) {
-        (void)Serial.read();
-    }
-
-    Serial.println("    >> Connecting to the cloud");
-    WiFi.on();
-    Particle.connect();
-    waitUntil(Particle.connected);
-    Serial.println("    >> Connected to the cloud. You'll see the RGB is turned on after waking up.");
-
-    SystemSleepConfiguration config;
-    config.mode(SystemSleepMode::STOP)
-          .duration(SLEEP_DURATION_MS);
-    
-    system_tick_t enter = millis();
-    SystemSleepResult result = System.sleep(config);
-    system_tick_t exit = millis();
-
-    while (!Serial.isConnected());
-    // It might wait for up to 120s to turn off the modem
-    assertLessOrEqual(exit - enter - SLEEP_DURATION_MS, 121000);
-    Serial.printf("Sleep execution time: %ld\r\n", (uint32_t)(exit - enter));
-
-    assertEqual(result.error(), SYSTEM_ERROR_NONE);
-    assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_RTC);
-}
-
-test(26_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_WiFi) {
-    constexpr uint32_t SLEEP_DURATION_MS = 1000;
-    Serial.printf("    >> Device enters stop mode. Please reconnect serial after %ld ms\r\n", SLEEP_DURATION_MS);
-    Serial.println("    >> Press any key now");
-    while(Serial.available() <= 0);
-    while (Serial.available() > 0) {
-        (void)Serial.read();
-    }
-
-    Serial.println("    >> Connecting to the cloud");
-    WiFi.on();
-    Particle.connect();
-    waitUntil(Particle.connected);
-    Serial.println("    >> Connected to the cloud. You'll see the RGB is turned on after waking up.");
-
-    SystemSleepConfiguration config;
-    config.mode(SystemSleepMode::ULTRA_LOW_POWER)
-          .duration(SLEEP_DURATION_MS);
-    
-    system_tick_t enter = millis();
-    SystemSleepResult result = System.sleep(config);
-    system_tick_t exit = millis();
-
-    while (!Serial.isConnected());
-    // It might wait for up to 120s to turn off the modem
-    assertLessOrEqual(exit - enter - SLEEP_DURATION_MS, 121000);
-    Serial.printf("Sleep execution time: %ld\r\n", (uint32_t)(exit - enter));
-
-    assertEqual(result.error(), SYSTEM_ERROR_NONE);
-    assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_RTC);
-}
-#endif // HAL_PLATFORM_WIFI

--- a/user/tests/wiring/sleep20/sleep20.cpp
+++ b/user/tests/wiring/sleep20/sleep20.cpp
@@ -22,9 +22,15 @@
 
 //TODO: Run user/tests/app/tracker_wakeup to verify the additional wakeup sources for platform tracker.
 
+namespace {
+
 STARTUP(System.enableFeature(FEATURE_RETAINED_MEMORY));
 static retained uint32_t magick = 0;
 static retained uint32_t phase = 0;
+
+constexpr system_tick_t CLOUD_CONNECT_TIMEOUT = 10 * 60 * 1000;
+
+} // anonymous
 
 test(01_System_Sleep_With_Configuration_Object_Hibernate_Mode_Without_Wakeup) {
     if (magick != 0xdeadbeef) {
@@ -326,7 +332,7 @@ test(11_System_Sleep_With_Configuration_Object_Stop_Mode_Wakeup_By_D0) {
           .gpio(D0, RISING);
     SystemSleepResult result = System.sleep(config);
 
-    while (!Serial.isConnected());
+    waitUntil(Serial.isConnected);
 
     assertEqual(result.error(), SYSTEM_ERROR_NONE);
     assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_GPIO);
@@ -346,7 +352,7 @@ test(12_System_Sleep_With_Configuration_Object_Stop_Mode_Wakeup_By_Rtc) {
           .duration(3s);
     SystemSleepResult result = System.sleep(config);
 
-    while (!Serial.isConnected());
+    waitUntil(Serial.isConnected);
 
     assertEqual(result.error(), SYSTEM_ERROR_NONE);
     assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_RTC);
@@ -368,7 +374,7 @@ test(13_System_Sleep_With_Configuration_Object_Stop_Mode_Wakeup_By_Ble) {
           .ble();
     SystemSleepResult result = System.sleep(config);
 
-    while (!Serial.isConnected());
+    waitUntil(Serial.isConnected);
 
     assertEqual(result.error(), SYSTEM_ERROR_NONE);
     assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_BLE);
@@ -387,7 +393,7 @@ test(14_System_Sleep_Mode_Stop_Wakeup_By_D0) {
 
     SleepResult result = System.sleep(D0, RISING);
 
-    while (!Serial.isConnected());
+    waitUntil(Serial.isConnected);
 
     assertEqual(result.error(), SYSTEM_ERROR_NONE);
     assertEqual((int)result.reason(), (int)WAKEUP_REASON_PIN);
@@ -404,7 +410,7 @@ test(15_System_Sleep_Mode_Stop_Wakeup_By_Rtc) {
 
     SleepResult result = System.sleep(nullptr, 0, nullptr, 0, 3s);
 
-    while (!Serial.isConnected());
+    waitUntil(Serial.isConnected);
 
     assertEqual(result.error(), SYSTEM_ERROR_NONE);
     assertEqual((int)result.reason(), (int)WAKEUP_REASON_RTC);
@@ -423,7 +429,7 @@ test(16_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_D0
           .gpio(D0, RISING);
     SystemSleepResult result = System.sleep(config);
 
-    while (!Serial.isConnected());
+    waitUntil(Serial.isConnected);
 
     assertEqual(result.error(), SYSTEM_ERROR_NONE);
     assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_GPIO);
@@ -443,7 +449,7 @@ test(17_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_Rt
           .duration(3s);
     SystemSleepResult result = System.sleep(config);
 
-    while (!Serial.isConnected());
+    waitUntil(Serial.isConnected);
 
     assertEqual(result.error(), SYSTEM_ERROR_NONE);
     assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_RTC);
@@ -465,7 +471,7 @@ test(18_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_Bl
           .ble();
     SystemSleepResult result = System.sleep(config);
 
-    while (!Serial.isConnected());
+    waitUntil(Serial.isConnected);
 
     assertEqual(result.error(), SYSTEM_ERROR_NONE);
     assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_BLE);
@@ -487,7 +493,7 @@ test(19_System_Sleep_With_Configuration_Object_Stop_Mode_Wakeup_By_Analog_Pin) {
           .analog(A0, 1500, AnalogInterruptMode::CROSS);
     SystemSleepResult result = System.sleep(config);
 
-    while (!Serial.isConnected());
+    waitUntil(Serial.isConnected);
 
     assertEqual(result.error(), SYSTEM_ERROR_NONE);
     assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_LPCOMP);
@@ -507,7 +513,7 @@ test(20_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_An
           .analog(A0, 1500, AnalogInterruptMode::CROSS);
     SystemSleepResult result = System.sleep(config);
 
-    while (!Serial.isConnected());
+    waitUntil(Serial.isConnected);
 
     assertEqual(result.error(), SYSTEM_ERROR_NONE);
     assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_LPCOMP);
@@ -531,7 +537,7 @@ test(21_System_Sleep_With_Configuration_Object_Stop_Mode_Wakeup_By_Usart) {
 
     Serial1.end();
 
-    while (!Serial.isConnected());
+    waitUntil(Serial.isConnected);
 
     assertEqual(result.error(), SYSTEM_ERROR_NONE);
     assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_USART);
@@ -555,7 +561,7 @@ test(22_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_Us
 
     Serial1.end();
 
-    while (!Serial.isConnected());
+    waitUntil(Serial.isConnected);
 
     assertEqual(result.error(), SYSTEM_ERROR_NONE);
     assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_USART);
@@ -574,7 +580,7 @@ test(23_System_Sleep_With_Configuration_Object_Stop_Mode_Wakeup_By_Cellular) {
     Serial.println("    >> Connecting to the cloud");
     Cellular.on();
     Particle.connect();
-    waitUntil(Particle.connected);
+    assertTrue(waitFor(Particle.connected, CLOUD_CONNECT_TIMEOUT));
     Serial.println("    >> Connected to the cloud. You'll see the RGB is turned on after waking up.");
 
     SystemSleepConfiguration config;
@@ -582,7 +588,7 @@ test(23_System_Sleep_With_Configuration_Object_Stop_Mode_Wakeup_By_Cellular) {
           .network(Cellular);
     SystemSleepResult result = System.sleep(config);
 
-    while (!Serial.isConnected());
+    waitUntil(Serial.isConnected);
 
     assertEqual(result.error(), SYSTEM_ERROR_NONE);
     assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_NETWORK);
@@ -600,7 +606,7 @@ test(24_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_Ce
     Serial.println("    >> Connecting to the cloud");
     Cellular.on();
     Particle.connect();
-    waitUntil(Particle.connected);
+    assertTrue(waitFor(Particle.connected, CLOUD_CONNECT_TIMEOUT));
     Serial.println("    >> Connected to the cloud. You'll see the RGB is turned on after waking up.");
 
     SystemSleepConfiguration config;
@@ -608,7 +614,7 @@ test(24_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_Ce
           .network(Cellular);
     SystemSleepResult result = System.sleep(config);
 
-    while (!Serial.isConnected());
+    waitUntil(Serial.isConnected);
 
     assertEqual(result.error(), SYSTEM_ERROR_NONE);
     assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_NETWORK);
@@ -636,7 +642,7 @@ test(25_System_Sleep_With_Configuration_Object_Stop_Mode_Wakeup_By_WiFi) {
           .network(WiFi);
     SystemSleepResult result = System.sleep(config);
 
-    while (!Serial.isConnected());
+    waitUntil(Serial.isConnected);
 
     assertEqual(result.error(), SYSTEM_ERROR_NONE);
     assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_NETWORK);
@@ -662,7 +668,7 @@ test(26_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_Wi
           .network(WiFi);
     SystemSleepResult result = System.sleep(config);
 
-    while (!Serial.isConnected());
+    waitUntil(Serial.isConnected);
 
     assertEqual(result.error(), SYSTEM_ERROR_NONE);
     assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_NETWORK);
@@ -682,7 +688,8 @@ test(27_System_Sleep_With_Configuration_Object_Stop_Mode_Execution_Time) {
     Serial.println("    >> Connecting to the cloud");
     Network.on();
     Particle.connect();
-    waitUntil(Particle.connected);
+    waitFor(Particle.connected, CLOUD_CONNECT_TIMEOUT);
+    assertTrue(Particle.connected());
     Serial.println("    >> Connected to the cloud. You'll see the RGB is turned on after waking up.");
 
     SystemSleepConfiguration config;
@@ -693,7 +700,7 @@ test(27_System_Sleep_With_Configuration_Object_Stop_Mode_Execution_Time) {
     SystemSleepResult result = System.sleep(config);
     time32_t exit = Time.now();
 
-    while (!Serial.isConnected());
+    waitUntil(Serial.isConnected);
     assertMoreOrEqual(exit - enter, SLEEP_DURATION_S);
     // There might be up to 30s delay to turn off the modem for particular platforms.
     assertLessOrEqual(exit - enter, 30 + SLEEP_DURATION_S);
@@ -701,6 +708,9 @@ test(27_System_Sleep_With_Configuration_Object_Stop_Mode_Execution_Time) {
 
     assertEqual(result.error(), SYSTEM_ERROR_NONE);
     assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_RTC);
+
+    // Make sure we reconnect back to the cloud
+    assertTrue(waitFor(Particle.connected, CLOUD_CONNECT_TIMEOUT));
 }
 
 test(28_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_Execution_Time) {
@@ -715,7 +725,8 @@ test(28_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_Execu
     Serial.println("    >> Connecting to the cloud");
     Network.on();
     Particle.connect();
-    waitUntil(Particle.connected);
+    waitFor(Particle.connected, CLOUD_CONNECT_TIMEOUT);
+    assertTrue(Particle.connected());
     Serial.println("    >> Connected to the cloud. You'll see the RGB is turned on after waking up.");
 
     SystemSleepConfiguration config;
@@ -726,7 +737,7 @@ test(28_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_Execu
     SystemSleepResult result = System.sleep(config);
     time32_t exit = Time.now();
 
-    while (!Serial.isConnected());
+    waitUntil(Serial.isConnected);
     assertMoreOrEqual(exit - enter, SLEEP_DURATION_S);
     // There might be up to 30s delay to turn off the modem for particular platforms.
     assertLessOrEqual(exit - enter, 30 + SLEEP_DURATION_S);
@@ -734,4 +745,7 @@ test(28_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_Execu
 
     assertEqual(result.error(), SYSTEM_ERROR_NONE);
     assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_RTC);
+
+    // Make sure we reconnect back to the cloud
+    assertTrue(waitFor(Particle.connected, CLOUD_CONNECT_TIMEOUT));
 }

--- a/user/tests/wiring/sleep20/sleep20.cpp
+++ b/user/tests/wiring/sleep20/sleep20.cpp
@@ -474,7 +474,6 @@ test(18_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_Bl
 }
 #endif // HAL_PLATFORM_BLE
 
-#if HAL_PLATFORM_GEN == 3
 test(19_System_Sleep_With_Configuration_Object_Stop_Mode_Wakeup_By_Analog_Pin) {
     Serial.println("    >> Device enters stop mode. Please reconnect serial after applying voltage crossing 1500mV on A0.");
     Serial.println("    >> Press any key now");
@@ -494,6 +493,7 @@ test(19_System_Sleep_With_Configuration_Object_Stop_Mode_Wakeup_By_Analog_Pin) {
     assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_LPCOMP);
 }
 
+#if HAL_PLATFORM_GEN == 3
 test(20_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_Analog_Pin) {
     Serial.println("    >> Device enters ultra-low power mode. Please reconnect serial after applying voltage crossing 1500mV on A0.");
     Serial.println("    >> Press any key now");
@@ -512,6 +512,7 @@ test(20_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_An
     assertEqual(result.error(), SYSTEM_ERROR_NONE);
     assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_LPCOMP);
 }
+#endif
 
 test(21_System_Sleep_With_Configuration_Object_Stop_Mode_Wakeup_By_Usart) {
     Serial.println("    >> Device enters stop mode. Please reconnect serial after sending characters over Serial1 @115200bps");
@@ -536,6 +537,7 @@ test(21_System_Sleep_With_Configuration_Object_Stop_Mode_Wakeup_By_Usart) {
     assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_USART);
 }
 
+#if HAL_PLATFORM_GEN == 3
 test(22_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_Usart) {
     Serial.println("    >> Device enters ultra-low power mode. Please reconnect serial after sending characters over Serial1 @115200bps");
     Serial.println("    >> Press any key now");
@@ -558,6 +560,7 @@ test(22_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_Us
     assertEqual(result.error(), SYSTEM_ERROR_NONE);
     assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_USART);
 }
+#endif
 
 #if HAL_PLATFORM_CELLULAR
 test(23_System_Sleep_With_Configuration_Object_Stop_Mode_Wakeup_By_Cellular) {
@@ -585,6 +588,7 @@ test(23_System_Sleep_With_Configuration_Object_Stop_Mode_Wakeup_By_Cellular) {
     assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_NETWORK);
 }
 
+#if HAL_PLATFORM_GEN == 3
 test(24_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_Cellular) {
     Serial.println("    >> Device enters ultra-low power mode. Please reconnect serial after waking up by network data");
     Serial.println("    >> Press any key now");
@@ -609,6 +613,7 @@ test(24_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_Ce
     assertEqual(result.error(), SYSTEM_ERROR_NONE);
     assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_NETWORK);
 }
+#endif
 #endif // HAL_PLATFORM_CELLULAR
 
 #if HAL_PLATFORM_WIFI
@@ -637,6 +642,7 @@ test(25_System_Sleep_With_Configuration_Object_Stop_Mode_Wakeup_By_WiFi) {
     assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_NETWORK);
 }
 
+#if HAL_PLATFORM_GEN == 3
 test(26_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_WiFi) {
     Serial.println("    >> Device enters ultra-low power mode. Please reconnect serial after waking up by network data");
     Serial.println("    >> Press any key now");
@@ -661,5 +667,139 @@ test(26_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_Wi
     assertEqual(result.error(), SYSTEM_ERROR_NONE);
     assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_NETWORK);
 }
+#endif
 #endif // HAL_PLATFORM_WIFI
-#endif // HAL_PLATFORM_GEN == 3
+
+#if HAL_PLATFORM_CELLULAR
+test(23_System_Sleep_With_Configuration_Object_Stop_Mode_Execution_Time) {
+    constexpr uint32_t SLEEP_DURATION_MS = 1000;
+    Serial.printf("    >> Device enters stop mode. Please reconnect serial after %ld ms\r\n", SLEEP_DURATION_MS);
+    Serial.println("    >> Press any key now");
+    while(Serial.available() <= 0);
+    while (Serial.available() > 0) {
+        (void)Serial.read();
+    }
+
+    Serial.println("    >> Connecting to the cloud");
+    Cellular.on();
+    Particle.connect();
+    waitUntil(Particle.connected);
+    Serial.println("    >> Connected to the cloud. You'll see the RGB is turned on after waking up.");
+
+    SystemSleepConfiguration config;
+    config.mode(SystemSleepMode::STOP)
+          .duration(SLEEP_DURATION_MS);
+
+    system_tick_t enter = millis();
+    SystemSleepResult result = System.sleep(config);
+    system_tick_t exit = millis();
+
+    while (!Serial.isConnected());
+    // It might wait for up to 120s to turn off the modem
+    assertLessOrEqual(exit - enter - SLEEP_DURATION_MS, 121000);
+    Serial.printf("Sleep execution time: %ld\r\n", (uint32_t)(exit - enter));
+
+    assertEqual(result.error(), SYSTEM_ERROR_NONE);
+    assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_RTC);
+}
+
+#if HAL_PLATFORM_GEN == 3
+test(24_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_Execution_Time) {
+    constexpr uint32_t SLEEP_DURATION_MS = 1000;
+    Serial.printf("    >> Device enters ultra-low power mode. Please reconnect serial after %ld ms\r\n", SLEEP_DURATION_MS);
+    Serial.println("    >> Press any key now");
+    while(Serial.available() <= 0);
+    while (Serial.available() > 0) {
+        (void)Serial.read();
+    }
+
+    Serial.println("    >> Connecting to the cloud");
+    Cellular.on();
+    Particle.connect();
+    waitUntil(Particle.connected);
+    Serial.println("    >> Connected to the cloud. You'll see the RGB is turned on after waking up.");
+
+    SystemSleepConfiguration config;
+    config.mode(SystemSleepMode::ULTRA_LOW_POWER)
+          .duration(SLEEP_DURATION_MS);
+
+    system_tick_t enter = millis();
+    SystemSleepResult result = System.sleep(config);
+    system_tick_t exit = millis();
+
+    while (!Serial.isConnected());
+    // It might wait for up to 120s to turn off the modem
+    assertLessOrEqual(exit - enter - SLEEP_DURATION_MS, 121000);
+    Serial.printf("Sleep execution time: %ld\r\n", (uint32_t)(exit - enter));
+
+    assertEqual(result.error(), SYSTEM_ERROR_NONE);
+    assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_RTC);
+}
+#endif
+#endif // HAL_PLATFORM_CELLULAR
+
+#if HAL_PLATFORM_WIFI
+test(25_System_Sleep_With_Configuration_Object_Stop_Mode_Execution_Time) {
+    constexpr uint32_t SLEEP_DURATION_MS = 1000;
+    Serial.printf("    >> Device enters stop mode. Please reconnect serial after %ld ms\r\n", SLEEP_DURATION_MS);
+    Serial.println("    >> Press any key now");
+    while(Serial.available() <= 0);
+    while (Serial.available() > 0) {
+        (void)Serial.read();
+    }
+
+    Serial.println("    >> Connecting to the cloud");
+    WiFi.on();
+    Particle.connect();
+    waitUntil(Particle.connected);
+    Serial.println("    >> Connected to the cloud. You'll see the RGB is turned on after waking up.");
+
+    SystemSleepConfiguration config;
+    config.mode(SystemSleepMode::STOP)
+          .duration(SLEEP_DURATION_MS);
+    
+    system_tick_t enter = millis();
+    SystemSleepResult result = System.sleep(config);
+    system_tick_t exit = millis();
+
+    while (!Serial.isConnected());
+    // It might wait for up to 120s to turn off the modem
+    assertLessOrEqual(exit - enter - SLEEP_DURATION_MS, 121000);
+    Serial.printf("Sleep execution time: %ld\r\n", (uint32_t)(exit - enter));
+
+    assertEqual(result.error(), SYSTEM_ERROR_NONE);
+    assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_RTC);
+}
+
+test(26_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_WiFi) {
+    constexpr uint32_t SLEEP_DURATION_MS = 1000;
+    Serial.printf("    >> Device enters stop mode. Please reconnect serial after %ld ms\r\n", SLEEP_DURATION_MS);
+    Serial.println("    >> Press any key now");
+    while(Serial.available() <= 0);
+    while (Serial.available() > 0) {
+        (void)Serial.read();
+    }
+
+    Serial.println("    >> Connecting to the cloud");
+    WiFi.on();
+    Particle.connect();
+    waitUntil(Particle.connected);
+    Serial.println("    >> Connected to the cloud. You'll see the RGB is turned on after waking up.");
+
+    SystemSleepConfiguration config;
+    config.mode(SystemSleepMode::ULTRA_LOW_POWER)
+          .duration(SLEEP_DURATION_MS);
+    
+    system_tick_t enter = millis();
+    SystemSleepResult result = System.sleep(config);
+    system_tick_t exit = millis();
+
+    while (!Serial.isConnected());
+    // It might wait for up to 120s to turn off the modem
+    assertLessOrEqual(exit - enter - SLEEP_DURATION_MS, 121000);
+    Serial.printf("Sleep execution time: %ld\r\n", (uint32_t)(exit - enter));
+
+    assertEqual(result.error(), SYSTEM_ERROR_NONE);
+    assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_RTC);
+}
+#endif // HAL_PLATFORM_WIFI

--- a/user/tests/wiring/sleep20/sleep20.cpp
+++ b/user/tests/wiring/sleep20/sleep20.cpp
@@ -694,8 +694,9 @@ test(27_System_Sleep_With_Configuration_Object_Stop_Mode_Execution_Time) {
     time32_t exit = Time.now();
 
     while (!Serial.isConnected());
-    // It might wait for up to 120s to turn off the modem
-    assertLessOrEqual(exit - enter, 120 + SLEEP_DURATION_S);
+    assertMoreOrEqual(exit - enter, SLEEP_DURATION_S);
+    // There might be up to 30s delay to turn off the modem for particular platforms.
+    assertLessOrEqual(exit - enter, 30 + SLEEP_DURATION_S);
     Serial.printf("Sleep execution time: %ld s\r\n", exit - enter);
 
     assertEqual(result.error(), SYSTEM_ERROR_NONE);
@@ -721,13 +722,14 @@ test(28_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_Execu
     config.mode(SystemSleepMode::ULTRA_LOW_POWER)
           .duration(SLEEP_DURATION_S * 1000);
 
-    time32_t enter = millis();
+    time32_t enter = Time.now();
     SystemSleepResult result = System.sleep(config);
-    time32_t exit = millis();
+    time32_t exit = Time.now();
 
     while (!Serial.isConnected());
-    // It might wait for up to 120s to turn off the modem
-    assertLessOrEqual(exit - enter, 120 + SLEEP_DURATION_S);
+    assertMoreOrEqual(exit - enter, SLEEP_DURATION_S);
+    // There might be up to 30s delay to turn off the modem for particular platforms.
+    assertLessOrEqual(exit - enter, 30 + SLEEP_DURATION_S);
     Serial.printf("Sleep execution time: %ld s\r\n", exit - enter);
 
     assertEqual(result.error(), SYSTEM_ERROR_NONE);


### PR DESCRIPTION
### Problem
As the title describes.
### Solution
Set a flag if cellular/wifi connection need to be restored after waking up and let the background system task to handle the connection establishment, instead of calling the network connect api to before exiting the sleep function.
### Steps to Test
`user/tests/wiring/sleep20`
### References
N/A
---
### Completeness
- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
