### PR TITLE
[electron] modem: fix C*REG URC parsing

### DIFF
--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -583,10 +583,16 @@ int MDMParser::waitFinalResp(_CALLBACKPTR cb /* = NULL*/,
                     // +CREG|CGREG: <stat>[,<lac>,<ci>[,AcT[,<rac>]]]     // URC (1,3,4,5 results)
                     b = (int)0xFFFF; c = (int)0xFFFFFFFF; d = -1; mode = -1; // default mode to -1 for safety
                     r = sscanf(cmd, "%31s %d,%d,\"%x\",\"%x\",%d",s,&mode,&a,&b,&c,&d);
-                    if (r <= 1)
+                    if (r <= 2) {
+                        // Not a direct command response, re-parse as URC
                         r = sscanf(cmd, "%31s %d,\"%x\",\"%x\",%d",s,&a,&b,&c,&d);
+                        // Fix mode that potentially has invalid value due to first parse attempt as a command response
+                        mode = -1;
+                    } else {
+                        // The code below doesn't consider mode to be one of the parsed values
+                        r--;
+                    }
                     if (r >= 2) {
-                        if (r == 2) mode = 2; // Single URC <stat>, so fix mode that got overwritten in the first sscanf
                         Reg *reg = !strcmp(s, "CREG:")  ? &_net.csd :
                                    !strcmp(s, "CGREG:") ? &_net.psd :
                                    !strcmp(s, "CEREG:") ? &_net.eps : NULL;


### PR DESCRIPTION
### Problem

A regression got introduced in https://github.com/particle-iot/device-os/pull/2219 and C*REG URCs are not correctly being parsed.

### Steps to Test

Don't have a good way to test other than using the app below and watching the logs. There shouldn't be any significant delays (over 10 seconds) after receiving registered URC before connection process continues like in the log below:

```
   185.293 AT read  +   14 "\r\n+CIEV: 2,3\r\n"
   187.105 AT read  +   31 "\r\n+CREG: 5,\"XXXX\",\"XXXXXXXX\",6\r\n"
   187.109 AT read  +   37 "\r\n+CGREG: 5,\"XXXX\",\"XXXXXXXX\",6,\"00\"\r\n"
   187.113 AT read  +   14 "\r\n+CIEV: 3,1\r\n"
   187.117 AT read  +   14 "\r\n+CIEV: 7,1\r\n"
   187.121 AT read  +   14 "\r\n+CIEV: 9,2\r\n"
CIEV matched: 9,2
   // Note over 10s gap here
   198.556 AT send       8 "AT+CSQ\r\n"
   199.622 AT read  +   14 "\r\n+CSQ: 18,1\r\n"
   199.623 AT read OK    6 "\r\nOK\r\n"
   199.624 AT send      10 "AT+CREG?\r\n"
   199.634 AT read  +   33 "\r\n+CREG: 2,5,\"XXXX\",\"XXXXXXXX\",6\r\n"
   199.635 AT read OK    6 "\r\nOK\r\n"
   199.638 AT send      11 "AT+CGREG?\r\n"
   199.649 AT read  +   39 "\r\n+CGREG: 2,5,\"XXXX\",\"XXXXXXXXXX\",6,\"00\"\r\n"
   199.651 AT read OK    6 "\r\nOK\r\n"
   199.654 AT send       4 "AT\r\n"
   199.660 AT read OK    6 "\r\nOK\r\n"
   199.660 AT send       9 "AT+CIMI\r\n"
   199.670 AT read UNK  19 "\r\nXXXXXXX\r\n"
   199.671 AT read OK    6 "\r\nOK\r\n"
   199.672 AT send      13 "AT+COPS=3,2\r\n"
   199.681 AT read OK    6 "\r\nOK\r\n"
   199.681 AT send      10 "AT+COPS?\r\n"
   199.689 AT read  +   24 "\r\n+COPS: 0,2,\"XXXXX\",2\r\n"
   199.690 AT read OK    6 "\r\nOK\r\n"
   199.692 AT send       8 "AT+CSQ\r\n"
   199.701 AT read  +   14 "\r\n+CSQ: 18,1\r\n"
   199.702 AT read OK    6 "\r\nOK\r\n"
```

### Example App

```c++

SerialLogHandler dbg(LOG_LEVEL_ALL);

void setup() {
    waitUntil(Serial.isConnected);
    Particle.disconnect();
    Cellular.off();
    delay(10000);
    Particle.connect();    
}

void loop() {

}
```

### References

- #2219 

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
