### PR TITLE
Allow for overriding TwoWire class's internal functions

### DIFF
--- a/wiring/inc/spark_wiring_i2c.h
+++ b/wiring/inc/spark_wiring_i2c.h
@@ -96,29 +96,29 @@ public:
   void setSpeed(uint32_t);
   void enableDMAMode(bool);
   void stretchClock(bool);
-  void begin();
-  void begin(uint8_t);
-  void begin(int);
-  void beginTransmission(uint8_t);
-  void beginTransmission(int);
-  void beginTransmission(const WireTransmission& transfer);
-  void end();
-  uint8_t endTransmission(void);
-  uint8_t endTransmission(uint8_t);
-  size_t requestFrom(uint8_t, size_t);
-  size_t requestFrom(uint8_t, size_t, uint8_t);
-  size_t requestFrom(const WireTransmission& transfer);
+  virtual void begin();
+  virtual void begin(uint8_t);
+  virtual void begin(int);
+  virtual void beginTransmission(uint8_t);
+  virtual void beginTransmission(int);
+  virtual void beginTransmission(const WireTransmission& transfer);
+  virtual void end();
+  virtual uint8_t endTransmission(void);
+  virtual uint8_t endTransmission(uint8_t);
+  virtual size_t requestFrom(uint8_t, size_t);
+  virtual size_t requestFrom(uint8_t, size_t, uint8_t);
+  virtual size_t requestFrom(const WireTransmission& transfer);
   virtual size_t write(uint8_t);
   virtual size_t write(const uint8_t *, size_t);
   virtual int available(void);
   virtual int read(void);
   virtual int peek(void);
   virtual void flush(void);
-  void onReceive(void (*)(int));
-  void onRequest(void (*)(void));
+  virtual void onReceive(void (*)(int));
+  virtual void onRequest(void (*)(void));
 
-  bool lock();
-  bool unlock();
+  virtual bool lock();
+  virtual bool unlock();
 
   inline size_t write(unsigned long n) { return write((uint8_t)n); }
   inline size_t write(long n) { return write((uint8_t)n); }


### PR DESCRIPTION
<details>
  <summary><i>submission notes</i></summary>

```
**Important:** Please sanitize/remove any confidential info like usernames, passwords, org names, product names/ids, access tokens, client ids/secrets, or anything else you don't wish to share.

Please Read and Sign the Contributor License Agreement ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md)).

You may also delete this submission notes header if you'd like. Thank you for contributing!
```
</details>

### Problem

The current implementation of the TwoWire class does not define its methods as `virtual`, therefore preventing any classes that inherit from TwoWire from overriding those functions.

### Solution

This PR adds the `virtual` identifier to most internal functions allowing for override when deriving from this class.

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
