### PR TITLE
Use unique Particle prefix for LED defines

### DIFF
--- a/bootloader/src/main.c
+++ b/bootloader/src/main.c
@@ -92,7 +92,7 @@ void flashModulesCallback(bool isUpdating)
     {
         OTA_FLASH_AVAILABLE = 0;
         if (!LedOverridden) {
-            LED_Off(LED_RGB);
+            LED_Off(PARTICLE_LED_RGB);
         }
     }
 }
@@ -525,12 +525,12 @@ void Timing_Decrement(void)
         }
         else if(FACTORY_RESET_MODE || REFLASH_FROM_BACKUP || OTA_FLASH_AVAILABLE || RESET_SETTINGS)
         {
-            LED_Toggle(LED_RGB);
+            LED_Toggle(PARTICLE_LED_RGB);
             TimingLED = 50;
         }
         else if(SAFE_MODE || USB_DFU_MODE)
         {
-            LED_Toggle(LED_RGB);
+            LED_Toggle(PARTICLE_LED_RGB);
             TimingLED = 100;
         }
     }

--- a/hal/network/ncp/wifi/platform_ncp_update.cpp
+++ b/hal/network/ncp/wifi/platform_ncp_update.cpp
@@ -54,7 +54,7 @@ public:
         size = std::min(size, remaining);
         buffer += size;
         remaining -= size;
-        LED_Toggle(LED_RGB);
+        LED_Toggle(PARTICLE_LED_RGB);
         return size;
     }
 
@@ -100,7 +100,7 @@ __attribute__((optimize("O0"))) int platform_ncp_update_module(const hal_module_
         LOG(INFO, "Updating ESP32 firmware from version %d to version %d", version, module->info->module_version);
     }
     r = ncpClient->updateFirmware(&moduleStream, length);
-    LED_On(LED_RGB);
+    LED_On(PARTICLE_LED_RGB);
     CHECK(r);
     r = ncpClient->getFirmwareModuleVersion(&version);
     if (r == 0) {

--- a/hal/src/gcc/platform_config.h
+++ b/hal/src/gcc/platform_config.h
@@ -1,0 +1,5 @@
+// Need to define some LED constants that are normally provided by platform_config.h,
+// used by sparking_wiring_rgb.cpp
+#define PARTICLE_LED_RED             PARTICLE_LED2
+#define PARTICLE_LED_GREEN           PARTICLE_LED3
+#define PARTICLE_LED_BLUE            PARTICLE_LED4

--- a/hal/src/gcc/platform_config.h
+++ b/hal/src/gcc/platform_config.h
@@ -1,5 +1,27 @@
+/*
+ * Copyright (c) 2020 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __PLATFORM_CONFIG_H
+#define __PLATFORM_CONFIG_H
+
 // Need to define some LED constants that are normally provided by platform_config.h,
 // used by sparking_wiring_rgb.cpp
 #define PARTICLE_LED_RED             PARTICLE_LED2
 #define PARTICLE_LED_GREEN           PARTICLE_LED3
 #define PARTICLE_LED_BLUE            PARTICLE_LED4
+
+#endif /* __PLATFORM_CONFIG_H */

--- a/hal/src/nRF52840/core_hal.c
+++ b/hal/src/nRF52840/core_hal.c
@@ -317,10 +317,10 @@ void HAL_Core_Config(void) {
     // TODO: Use current LED theme
     if (HAL_Feature_Get(FEATURE_LED_OVERRIDDEN)) {
         // Just in case
-        LED_Off(LED_RGB);
+        LED_Off(PARTICLE_LED_RGB);
     } else {
         LED_SetRGBColor(RGB_COLOR_WHITE);
-        LED_On(LED_RGB);
+        LED_On(PARTICLE_LED_RGB);
     }
 
     FLASH_AddToFactoryResetModuleSlot(

--- a/hal/src/nRF52840/littlefs/filesystem.cpp
+++ b/hal/src/nRF52840/littlefs/filesystem.cpp
@@ -290,7 +290,7 @@ int filesystem_mount(filesystem_t* fs) {
 #if MODULE_FUNCTION == MOD_FUNC_BOOTLOADER
         /* Give some indication that the bootloader is alive */
         LED_SetRGBColor(RGB_COLOR_WHITE);
-        LED_On(LED_RGB);
+        LED_On(PARTICLE_LED_RGB);
 #endif /* MODULE_FUNCTION == MOD_FUNC_BOOTLOADER */
         /* This operation takes about 5-10 seconds. It isn't strictly necessary
          * and was added simlpy as a precaution. We should still be able to recover

--- a/hal/src/nRF52840/rgbled_hal.c
+++ b/hal/src/nRF52840/rgbled_hal.c
@@ -51,13 +51,13 @@ static void set_led_value(Led_TypeDef led, uint16_t value) {
  * @brief  Set RGB LED value
  */
 void Set_RGB_LED_Values(uint16_t r, uint16_t g, uint16_t b) {
-    set_led_value(LED_RED, r);
-    set_led_value(LED_GREEN, g);
-    set_led_value(LED_BLUE, b);
+    set_led_value(PARTICLE_LED_RED, r);
+    set_led_value(PARTICLE_LED_GREEN, g);
+    set_led_value(PARTICLE_LED_BLUE, b);
 
-    set_led_value(LED_RED + LED_MIRROR_OFFSET, r);
-    set_led_value(LED_GREEN + LED_MIRROR_OFFSET, g);
-    set_led_value(LED_BLUE + LED_MIRROR_OFFSET, b);
+    set_led_value((Led_TypeDef)(PARTICLE_LED_RED   + LED_MIRROR_OFFSET), r);
+    set_led_value((Led_TypeDef)(PARTICLE_LED_GREEN + LED_MIRROR_OFFSET), g);
+    set_led_value((Led_TypeDef)(PARTICLE_LED_BLUE  + LED_MIRROR_OFFSET), b);
 }
 
 /**
@@ -66,32 +66,32 @@ void Set_RGB_LED_Values(uint16_t r, uint16_t g, uint16_t b) {
 void Get_RGB_LED_Values(uint16_t* values) {
     uint32_t pwm_max = Get_RGB_LED_Max_Value();
 
-    values[0] = HAL_Leds[LED_RED].is_inverted ?
-                (pwm_max - hal_pwm_get_analog_value(HAL_Leds[LED_RED].pin)) :
-                hal_pwm_get_analog_value(HAL_Leds[LED_RED].pin);
-    values[1] = HAL_Leds[LED_GREEN].is_inverted ?
-                (pwm_max - hal_pwm_get_analog_value(HAL_Leds[LED_GREEN].pin)) :
-                hal_pwm_get_analog_value(HAL_Leds[LED_GREEN].pin);
-    values[2] = HAL_Leds[LED_BLUE].is_inverted ?
-                (pwm_max - hal_pwm_get_analog_value(HAL_Leds[LED_BLUE].pin)) :
-                hal_pwm_get_analog_value(HAL_Leds[LED_BLUE].pin);
+    values[0] = HAL_Leds[PARTICLE_LED_RED].is_inverted ?
+                (pwm_max - hal_pwm_get_analog_value(HAL_Leds[PARTICLE_LED_RED].pin)) :
+                hal_pwm_get_analog_value(HAL_Leds[PARTICLE_LED_RED].pin);
+    values[1] = HAL_Leds[PARTICLE_LED_GREEN].is_inverted ?
+                (pwm_max - hal_pwm_get_analog_value(HAL_Leds[PARTICLE_LED_GREEN].pin)) :
+                hal_pwm_get_analog_value(HAL_Leds[PARTICLE_LED_GREEN].pin);
+    values[2] = HAL_Leds[PARTICLE_LED_BLUE].is_inverted ?
+                (pwm_max - hal_pwm_get_analog_value(HAL_Leds[PARTICLE_LED_BLUE].pin)) :
+                hal_pwm_get_analog_value(HAL_Leds[PARTICLE_LED_BLUE].pin);
 }
 
 /**
  * @brief  Get RGB LED max value
  */
 uint16_t Get_RGB_LED_Max_Value(void) {
-    return (1 << hal_pwm_get_resolution(HAL_Leds[LED_RED].pin)) - 1;
+    return (1 << hal_pwm_get_resolution(HAL_Leds[PARTICLE_LED_RED].pin)) - 1;
 }
 
 /**
  * @brief  Configure user LED
  */
 void Set_User_LED(uint8_t state) {
-    if ((!state && HAL_Leds[LED_USER].is_inverted) || (state && !HAL_Leds[LED_USER].is_inverted)) {
-        HAL_GPIO_Write(HAL_Leds[LED_USER].pin, 1);
+    if ((!state && HAL_Leds[PARTICLE_LED_USER].is_inverted) || (state && !HAL_Leds[PARTICLE_LED_USER].is_inverted)) {
+        HAL_GPIO_Write(HAL_Leds[PARTICLE_LED_USER].pin, 1);
     } else {
-        HAL_GPIO_Write(HAL_Leds[LED_USER].pin, 0);
+        HAL_GPIO_Write(HAL_Leds[PARTICLE_LED_USER].pin, 0);
     }
 }
 
@@ -99,7 +99,7 @@ void Set_User_LED(uint8_t state) {
  * @brief  Toggle user LED
  */
 void Toggle_User_LED(void) {
-    HAL_GPIO_Write(HAL_Leds[LED_USER].pin, !HAL_GPIO_Read(HAL_Leds[LED_USER].pin));
+    HAL_GPIO_Write(HAL_Leds[PARTICLE_LED_USER].pin, !HAL_GPIO_Read(HAL_Leds[PARTICLE_LED_USER].pin));
 }
 
 /**

--- a/hal/src/newhal/platform_config.h
+++ b/hal/src/newhal/platform_config.h
@@ -1,0 +1,5 @@
+// These are defaults defined for existing Particle platforms -- you should define these
+// for any new platform.
+#define PARTICLE_LED_RED             PARTICLE_LED2
+#define PARTICLE_LED_GREEN           PARTICLE_LED3
+#define PARTICLE_LED_BLUE            PARTICLE_LED4

--- a/hal/src/newhal/platform_config.h
+++ b/hal/src/newhal/platform_config.h
@@ -1,5 +1,27 @@
+/*
+ * Copyright (c) 2020 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __PLATFORM_CONFIG_H
+#define __PLATFORM_CONFIG_H
+
 // These are defaults defined for existing Particle platforms -- you should define these
 // for any new platform.
 #define PARTICLE_LED_RED             PARTICLE_LED2
 #define PARTICLE_LED_GREEN           PARTICLE_LED3
 #define PARTICLE_LED_BLUE            PARTICLE_LED4
+
+#endif /* __PLATFORM_CONFIG_H */

--- a/hal/src/stm32f2xx/core_hal_stm32f2xx.c
+++ b/hal/src/stm32f2xx/core_hal_stm32f2xx.c
@@ -375,10 +375,10 @@ void HAL_Core_Config(void)
     // TODO: Use current LED theme
     if (HAL_Feature_Get(FEATURE_LED_OVERRIDDEN)) {
         // Just in case
-        LED_Off(LED_RGB);
+        LED_Off(PARTICLE_LED_RGB);
     } else {
         LED_SetRGBColor(RGB_COLOR_WHITE);
-        LED_On(LED_RGB);
+        LED_On(PARTICLE_LED_RGB);
     }
 
     // override the WICED interrupts, specifically SysTick - there is a bug

--- a/hal/src/stm32f2xx/rgbled_hal.cpp
+++ b/hal/src/stm32f2xx/rgbled_hal.cpp
@@ -75,9 +75,9 @@ void HAL_Led_Rgb_Set_Values(uint16_t r, uint16_t g, uint16_t b, void* reserved)
 {
     Set_RGB_LED_Values(r, g, b);
 
-    Set_LED_Value((Led_TypeDef)(LED_RED   + LED_MIRROR_OFFSET), r);
-    Set_LED_Value((Led_TypeDef)(LED_GREEN + LED_MIRROR_OFFSET), g);
-    Set_LED_Value((Led_TypeDef)(LED_BLUE  + LED_MIRROR_OFFSET), b);
+    Set_LED_Value((Led_TypeDef)(PARTICLE_LED_RED   + LED_MIRROR_OFFSET), r);
+    Set_LED_Value((Led_TypeDef)(PARTICLE_LED_GREEN + LED_MIRROR_OFFSET), g);
+    Set_LED_Value((Led_TypeDef)(PARTICLE_LED_BLUE  + LED_MIRROR_OFFSET), b);
 }
 
 void HAL_Led_Rgb_Get_Values(uint16_t* rgb, void* reserved)
@@ -92,12 +92,12 @@ uint32_t HAL_Led_Rgb_Get_Max_Value(void* reserved)
 
 void HAL_Led_User_Set(uint8_t state, void* reserved)
 {
-    Set_LED_State(LED_USER, state);
+    Set_LED_State(PARTICLE_LED_USER, state);
 }
 
 void HAL_Led_User_Toggle(void* reserved)
 {
-    Toggle_LED_State(LED_USER);
+    Toggle_LED_State(PARTICLE_LED_USER);
 }
 
 led_config_t* HAL_Led_Set_Configuration(uint8_t led, led_config_t* conf, void* reserved)

--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/platform_config.h
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/platform_config.h
@@ -57,21 +57,21 @@
 #define LED1_GPIO_PORT                      GPIOA                   //User Led
 #define LED1_GPIO_CLK                       RCC_AHB1Periph_GPIOA    //User Led
 #define LED1_GPIO_MODE                      GPIO_Mode_OUT           //User Led
-#define LED_BLUE                            LED2
+#define PARTICLE_LED_BLUE                   PARTICLE_LED2
 #define LED2_GPIO_AF_TIM                    GPIO_AF_TIM2            //BLUE Led
 #define LED2_GPIO_PIN                       GPIO_Pin_3              //BLUE Led
 #define LED2_GPIO_PIN_SOURCE                GPIO_PinSource3         //BLUE Led
 #define LED2_GPIO_PORT                      GPIOA                   //BLUE Led
 #define LED2_GPIO_CLK                       RCC_AHB1Periph_GPIOA    //BLUE Led
 #define LED2_GPIO_MODE                      GPIO_Mode_AF            //BLUE Led
-#define LED_RED                             LED3
+#define PARTICLE_LED_RED                   PARTICLE_LED3
 #define LED3_GPIO_AF_TIM                    GPIO_AF_TIM2            //RED Led
 #define LED3_GPIO_PIN                       GPIO_Pin_1              //RED Led
 #define LED3_GPIO_PIN_SOURCE                GPIO_PinSource1         //RED Led
 #define LED3_GPIO_PORT                      GPIOA                   //RED Led
 #define LED3_GPIO_CLK                       RCC_AHB1Periph_GPIOA    //RED Led
 #define LED3_GPIO_MODE                      GPIO_Mode_AF            //RED Led
-#define LED_GREEN                           LED4
+#define PARTICLE_LED_GREEN                   PARTICLE_LED4
 #define LED4_GPIO_AF_TIM                    GPIO_AF_TIM2            //GREEN Led
 #define LED4_GPIO_PIN                       GPIO_Pin_2              //GREEN Led
 #define LED4_GPIO_PIN_SOURCE                GPIO_PinSource2         //GREEN Led

--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/platform_config.h
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/platform_config.h
@@ -64,14 +64,14 @@
 #define LED2_GPIO_PORT                      GPIOA                   //BLUE Led
 #define LED2_GPIO_CLK                       RCC_AHB1Periph_GPIOA    //BLUE Led
 #define LED2_GPIO_MODE                      GPIO_Mode_AF            //BLUE Led
-#define PARTICLE_LED_RED                   PARTICLE_LED3
+#define PARTICLE_LED_RED                    PARTICLE_LED3
 #define LED3_GPIO_AF_TIM                    GPIO_AF_TIM2            //RED Led
 #define LED3_GPIO_PIN                       GPIO_Pin_1              //RED Led
 #define LED3_GPIO_PIN_SOURCE                GPIO_PinSource1         //RED Led
 #define LED3_GPIO_PORT                      GPIOA                   //RED Led
 #define LED3_GPIO_CLK                       RCC_AHB1Periph_GPIOA    //RED Led
 #define LED3_GPIO_MODE                      GPIO_Mode_AF            //RED Led
-#define PARTICLE_LED_GREEN                   PARTICLE_LED4
+#define PARTICLE_LED_GREEN                  PARTICLE_LED4
 #define LED4_GPIO_AF_TIM                    GPIO_AF_TIM2            //GREEN Led
 #define LED4_GPIO_PIN                       GPIO_Pin_2              //GREEN Led
 #define LED4_GPIO_PIN_SOURCE                GPIO_PinSource2         //GREEN Led

--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/src/hw_config.c
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/src/hw_config.c
@@ -545,9 +545,9 @@ void Set_RGB_LED_Values(uint16_t r, uint16_t g, uint16_t b)
 #endif
 
 #if MODULE_FUNCTION == MOD_FUNC_BOOTLOADER
-    Led_Set_Value(LED_RED + LED_MIRROR_OFFSET, r);
-    Led_Set_Value(LED_GREEN + LED_MIRROR_OFFSET, g);
-    Led_Set_Value(LED_BLUE + LED_MIRROR_OFFSET, b);
+    Led_Set_Value(PARTICLE_LED_RED + LED_MIRROR_OFFSET, r);
+    Led_Set_Value(PARTICLE_LED_GREEN + LED_MIRROR_OFFSET, g);
+    Led_Set_Value(PARTICLE_LED_BLUE + LED_MIRROR_OFFSET, b);
 #endif // MODULE_FUNCTION == MOD_FUNC_BOOTLOADER
 }
 
@@ -568,14 +568,14 @@ void Get_RGB_LED_Values(uint16_t* values)
 void Set_User_LED(uint8_t state)
 {
     if (state)
-        HAL_Leds_Default[LED_USER].port->BSRRL = HAL_Leds_Default[LED_USER].pin;
+        HAL_Leds_Default[PARTICLE_LED_USER].port->BSRRL = HAL_Leds_Default[PARTICLE_LED_USER].pin;
     else
-        HAL_Leds_Default[LED_USER].port->BSRRH = HAL_Leds_Default[LED_USER].pin;
+        HAL_Leds_Default[PARTICLE_LED_USER].port->BSRRH = HAL_Leds_Default[PARTICLE_LED_USER].pin;
 }
 
 void Toggle_User_LED()
 {
-    HAL_Leds_Default[LED_USER].port->ODR ^= HAL_Leds_Default[LED_USER].pin;
+    HAL_Leds_Default[PARTICLE_LED_USER].port->ODR ^= HAL_Leds_Default[PARTICLE_LED_USER].pin;
 }
 #endif // MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
 

--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/src/hw_config.c
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/src/hw_config.c
@@ -196,7 +196,7 @@ void Set_System(void)
     for(LEDx = 1; LEDx < LEDn * 2; ++LEDx)
 #endif // MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
     {
-        //LED_USER initialization is skipped during system setup
+        //PARTICLE_LED_USER initialization is skipped during system setup
         //since PA13 pin is also JTMS-SWDIO. Initializing LED_USER
         //here will boycott JTAG programmer hence avoided.
         LED_Init(LEDx);
@@ -477,7 +477,7 @@ static void Led_Set_Value(Led_TypeDef led, uint16_t val)
  * @brief  Configures LED GPIO.
  * @param  Led: Specifies the Led to be configured.
  *   This parameter can be one of following parameters:
- *     @arg LED1, LED2, LED3, LED4
+ *     @arg PARTICLE_LED1, PARTICLE_LED2, PARTICLE_LED3, PARTICLE_LED4
  * @retval None
  */
 void LED_Init(Led_TypeDef Led)

--- a/platform/MCU/nRF52840/inc/platform_config.h
+++ b/platform/MCU/nRF52840/inc/platform_config.h
@@ -101,9 +101,9 @@
 //RGB LEDs
 #define LED_MIRROR_SUPPORTED                        1
 #define LEDn                                        (4 * (LED_MIRROR_SUPPORTED + 1))
-#define LED_RED                                     LED2  // RED Led
-#define LED_GREEN                                   LED3  // GREEN Led
-#define LED_BLUE                                    LED4  // BLUE Led
+#define PARTICLE_LED_RED                            PARTICLE_LED2  // RED Led
+#define PARTICLE_LED_GREEN                          PARTICLE_LED3  // GREEN Led
+#define PARTICLE_LED_BLUE                           PARTICLE_LED4  // BLUE Led
 #define LED_PIN_USER                                D7
 #define LED_PIN_RED                                 RGBR
 #define LED_PIN_GREEN                               RGBG

--- a/platform/MCU/nRF52840/src/hw_config.c
+++ b/platform/MCU/nRF52840/src/hw_config.c
@@ -162,7 +162,7 @@ void Set_System(void)
     int LEDx;
     for(LEDx = 1; LEDx < LEDn; ++LEDx)
     {
-        // LED_USER initialization is skipped during system setup
+        // PARTICLE_LED_USER initialization is skipped during system setup
         LED_Init(LEDx);
     }
 

--- a/services/inc/rgbled.h
+++ b/services/inc/rgbled.h
@@ -6,9 +6,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#ifndef SPARK_NO_PLATFORM
 #include "platform_config.h"
-#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,38 +23,23 @@ typedef struct {
 
 #define DEFAULT_LED_RGB_BRIGHTNESS (96)
 
+typedef uint8_t Led_TypeDef;
+
 #define LED_MIRROR_OFFSET          (4)
 
-typedef enum
-{
-    LED1           = 0,
-    LED2           = 1,
-    LED3           = 2,
-    LED4           = 3,
-    LED3_LED4_LED2 = 231,
-    LED1_MIRROR    = LED1 + LED_MIRROR_OFFSET,
-    LED2_MIRROR    = LED2 + LED_MIRROR_OFFSET,
-    LED3_MIRROR    = LED3 + LED_MIRROR_OFFSET,
-    LED4_MIRROR    = LED4 + LED_MIRROR_OFFSET
-} Led_TypeDef;
-
+#define PARTICLE_LED1               (0)
+#define PARTICLE_LED2               (1)
+#define PARTICLE_LED3               (2)
+#define PARTICLE_LED4               (3)
+#define PARTICLE_LED3_LED4_LED2     (231)
+#define PARTICLE_LED1_MIRROR        (PARTICLE_LED1 + LED_MIRROR_OFFSET)
+#define PARTICLE_LED2_MIRROR        (PARTICLE_LED2 + LED_MIRROR_OFFSET)
+#define PARTICLE_LED3_MIRROR        (PARTICLE_LED3 + LED_MIRROR_OFFSET)
+#define PARTICLE_LED4_MIRROR        (PARTICLE_LED4 + LED_MIRROR_OFFSET)
 
 //Extended LED Types
-#define LED_RGB           LED3_LED4_LED2
-#define LED_USER          LED1
-
-// FIXME: These should be pulled from platform_config.h
-#ifndef LED_RED
-#define LED_RED           LED3
-#endif
-
-#ifndef LED_GREEN
-#define LED_GREEN         LED4
-#endif
-
-#ifndef LED_BLUE
-#define LED_BLUE          LED2
-#endif
+#define PARTICLE_LED_RGB            (PARTICLE_LED3_LED4_LED2)
+#define PARTICLE_LED_USER           (PARTICLE_LED1)
 
 //RGB Basic Colors
 #define RGB_COLOR_RED     0xFF0000

--- a/services/inc/rgbled.h
+++ b/services/inc/rgbled.h
@@ -41,16 +41,6 @@ typedef uint8_t Led_TypeDef;
 #define PARTICLE_LED_RGB            (PARTICLE_LED3_LED4_LED2)
 #define PARTICLE_LED_USER           (PARTICLE_LED1)
 
-#ifndef PARTICLE_LED_RED
-#error "PARTICLE_LED_RED is not defined."
-#endif
-#ifndef PARTICLE_LED_GREEN
-#error "PARTICLE_LED_GREEN is not defined."
-#endif
-#ifndef PARTICLE_LED_BLUE
-#error "PARTICLE_LED_BLUE is not defined."
-#endif
-
 //RGB Basic Colors
 #define RGB_COLOR_RED     0xFF0000
 #define RGB_COLOR_GREEN   0x00FF00

--- a/services/inc/rgbled.h
+++ b/services/inc/rgbled.h
@@ -41,6 +41,16 @@ typedef uint8_t Led_TypeDef;
 #define PARTICLE_LED_RGB            (PARTICLE_LED3_LED4_LED2)
 #define PARTICLE_LED_USER           (PARTICLE_LED1)
 
+#ifndef PARTICLE_LED_RED
+#error "PARTICLE_LED_RED is not defined."
+#endif
+#ifndef PARTICLE_LED_GREEN
+#error "PARTICLE_LED_GREEN is not defined."
+#endif
+#ifndef PARTICLE_LED_BLUE
+#error "PARTICLE_LED_BLUE is not defined."
+#endif
+
 //RGB Basic Colors
 #define RGB_COLOR_RED     0xFF0000
 #define RGB_COLOR_GREEN   0x00FF00

--- a/services/src/panic.c
+++ b/services/src/panic.c
@@ -55,32 +55,32 @@ void panic_(ePanicCode code, void* extraInfo, void (*HAL_Delay_Microseconds)(uin
         uint16_t c;
         int loops = 2;
         LOG_PRINT(TRACE, "!");
-        LED_Off(LED_RGB);
+        LED_Off(PARTICLE_LED_RGB);
         while(loops) {
                 // preamble
             for (c = 3; c; c--) {
                 LED_SetRGBColor(pcd.led);
-                LED_On(LED_RGB);
+                LED_On(PARTICLE_LED_RGB);
                 HAL_Delay_Microseconds(MS2u(150));
-                LED_Off(LED_RGB);
+                LED_Off(PARTICLE_LED_RGB);
                 HAL_Delay_Microseconds(MS2u(100));
             }
 
             HAL_Delay_Microseconds(MS2u(100));
             for (c = 3; c; c--) {
                 LED_SetRGBColor(pcd.led);
-                LED_On(LED_RGB);
+                LED_On(PARTICLE_LED_RGB);
                 HAL_Delay_Microseconds(MS2u(300));
-                LED_Off(LED_RGB);
+                LED_Off(PARTICLE_LED_RGB);
                 HAL_Delay_Microseconds(MS2u(100));
             }
             HAL_Delay_Microseconds(MS2u(100));
 
             for (c = 3; c; c--) {
                 LED_SetRGBColor(pcd.led);
-                LED_On(LED_RGB);
+                LED_On(PARTICLE_LED_RGB);
                 HAL_Delay_Microseconds(MS2u(150));
-                LED_Off(LED_RGB);
+                LED_Off(PARTICLE_LED_RGB);
                 HAL_Delay_Microseconds(MS2u(100));
             }
 
@@ -89,9 +89,9 @@ void panic_(ePanicCode code, void* extraInfo, void (*HAL_Delay_Microseconds)(uin
             // play code
             for (c = code; c; c--) {
                 LED_SetRGBColor(pcd.led);
-                LED_On(LED_RGB);
+                LED_On(PARTICLE_LED_RGB);
                 HAL_Delay_Microseconds(MS2u(300));
-                LED_Off(LED_RGB);
+                LED_Off(PARTICLE_LED_RGB);
                 HAL_Delay_Microseconds(MS2u(300));
             }
             // pause

--- a/services/src/rgbled.c
+++ b/services/src/rgbled.c
@@ -67,7 +67,7 @@ void LED_Signaling_Start(void)
     if (LED_RGB_OVERRIDE == 0) {
         LED_RGB_OVERRIDE = 1;
         led_set_update_enabled(0, NULL); // Disable background LED updates
-        LED_Off(LED_RGB);
+        LED_Off(PARTICLE_LED_RGB);
     }
 }
 
@@ -139,18 +139,18 @@ void Set_RGB_LED_Scale(uint8_t step, uint32_t color) {
   * @brief  Turns selected LED On.
   * @param  Led: Specifies the Led to be set on.
   *   This parameter can be one of following parameters:
-  *     @arg LED1, LED2, LED_USER, LED_RGB
+  *     @arg PARTICLE_LED_USER, PARTICLE_LED_RGB
   * @retval None
   */
 void LED_On(Led_TypeDef Led)
 {
     switch(Led)
     {
-    case LED_USER:
+    case PARTICLE_LED_USER:
         Set_User_LED(1);
         break;
 
-    case LED_RGB:	//LED_SetRGBColor() should be called first for this Case
+    case PARTICLE_LED_RGB:	//LED_SetRGBColor() should be called first for this Case
         Set_RGB_LED_Color(LED_RGB_OVERRIDE ? lastSignalColor : lastRGBColor);
         led_fade_step = NUM_LED_FADE_STEPS - 1;
         led_fade_direction = -1; /* next fade is falling */
@@ -164,18 +164,18 @@ void LED_On(Led_TypeDef Led)
   * @brief  Turns selected LED Off.
   * @param  Led: Specifies the Led to be set off.
   *   This parameter can be one of following parameters:
-  *     @arg LED1, LED2, LED_USER, LED_RGB
+  *     @arg PARTICLE_LED_USER, PARTICLE_LED_RGB
   * @retval None
   */
 void LED_Off(Led_TypeDef Led)
 {
     switch(Led)
     {
-    case LED_USER:
+    case PARTICLE_LED_USER:
         Set_User_LED(0);
         break;
 
-    case LED_RGB:
+    case PARTICLE_LED_RGB:
         Set_RGB_LED_Color(0);
         led_fade_step = 0;
         led_fade_direction = 1; /* next fade is rising. */
@@ -191,7 +191,7 @@ void LED_Off(Led_TypeDef Led)
   * @brief  Toggles the selected LED.
   * @param  Led: Specifies the Led to be toggled.
   *   This parameter can be one of following parameters:
-  *     @arg LED1, LED2, LED_USER, LED_RGB
+  *     @arg PARTICLE_LED_USER, PARTICLE_LED_RGB
   * @retval None
   */
 void LED_Toggle(Led_TypeDef Led)
@@ -200,14 +200,13 @@ void LED_Toggle(Led_TypeDef Led)
     uint16_t rgb[3];
     switch(Led)
     {
-    case LED_USER:
+    case PARTICLE_LED_USER:
         LED_Callbacks.Led_User_Toggle(NULL);
         break;
     default:
         break;
 
-    case LED_RGB://LED_SetRGBColor() and LED_On() should be called first for this Case
-
+    case PARTICLE_LED_RGB://LED_SetRGBColor() and LED_On() should be called first for this Case
         color = LED_RGB_OVERRIDE ? lastSignalColor : lastRGBColor;
         LED_Callbacks.Led_Rgb_Get_Values(rgb, NULL);
         if (rgb[0] | rgb[1] | rgb[2])
@@ -236,7 +235,7 @@ void LED_Fade(Led_TypeDef Led)
 
     led_fade_step += led_fade_direction;
 
-    if(Led == LED_RGB)
+    if(Led == PARTICLE_LED_RGB)
     {
         Set_RGB_LED_Scale(led_fade_step, LED_RGB_OVERRIDE ? lastSignalColor : lastRGBColor);
     }

--- a/services/src/rgbled.c
+++ b/services/src/rgbled.c
@@ -222,7 +222,7 @@ void LED_Toggle(Led_TypeDef Led)
   * @brief  Fades selected LED.
   * @param  Led: Specifies the Led to be set on.
   *   This parameter can be one of following parameters:
-  *     @arg LED1, LED2, LED_RGB
+  *     @arg PARTICLE_LED1, PARTICLE_LED2, PARTICLE_LED_RGB
   * @retval None
   */
 void LED_Fade(Led_TypeDef Led)

--- a/system/src/firmware_update.cpp
+++ b/system/src/firmware_update.cpp
@@ -253,7 +253,7 @@ int FirmwareUpdate::saveChunk(const char* chunkData, size_t chunkSize, size_t ch
     }
 #endif
     if (!ledOverridden_) {
-        LED_Toggle(LED_RGB);
+        LED_Toggle(PARTICLE_LED_RGB);
     }
     // Generate a system event
     fileDesc_.chunk_address = fileDesc_.file_address + chunkOffset;

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -172,7 +172,7 @@ int system_sleep_ext(const hal_sleep_config_t* config, hal_wakeup_source_base_t*
 
     // Stop RGB signaling
     led_set_update_enabled(0, nullptr); // Disable background LED updates
-    LED_Off(LED_RGB);
+    LED_Off(PARTICLE_LED_RGB);
 
     system_power_management_sleep(configHelper.wakeupByFuelGauge() ? false : true);
 
@@ -182,7 +182,7 @@ int system_sleep_ext(const hal_sleep_config_t* config, hal_wakeup_source_base_t*
     system_power_management_wakeup();
 
     led_set_update_enabled(1, nullptr); // Enable background LED updates
-    LED_On(LED_RGB); // Turn RGB on in case that RGB is controlled by user application before entering sleep mode.
+    LED_On(PARTICLE_LED_RGB); // Turn RGB on in case that RGB is controlled by user application before entering sleep mode.
 
     // Network resume
     // FIXME: if_get_list() can be potentially used, instead of using pre-processor.

--- a/system/src/system_sleep_compat.cpp
+++ b/system/src/system_sleep_compat.cpp
@@ -243,12 +243,12 @@ int system_sleep_pin_impl(const uint16_t* pins, size_t pins_count, const Interru
 #endif // HAL_PLATFORM_CELLULAR
 
     led_set_update_enabled(0, nullptr); // Disable background LED updates
-    LED_Off(LED_RGB);
+    LED_Off(PARTICLE_LED_RGB);
 
     int ret = system_sleep_enter_stop_compat(pins, pins_count, modes, modes_count, seconds);
 
     led_set_update_enabled(1, nullptr); // Enable background LED updates
-    LED_On(LED_RGB); // Turn RGB on in case that RGB is controlled by user application before entering sleep mode.
+    LED_On(PARTICLE_LED_RGB); // Turn RGB on in case that RGB is controlled by user application before entering sleep mode.
 
 #if HAL_PLATFORM_CELLULAR
     if (!network_sleep_flag(param)) {

--- a/user/tests/unit/led_service.cpp
+++ b/user/tests/unit/led_service.cpp
@@ -288,7 +288,7 @@ TEST_CASE("LEDStatus") {
 
     SECTION("LED is not affected when no active status is available") {
         LED_SetRGBColor(0x00123456); // Set LED color directly
-        LED_On(LED_RGB);
+        LED_On(PARTICLE_LED_RGB);
         update(); // No active status
         CHECK(led.color() == Color(0x00123456));
         LEDStatus s(Color::WHITE);

--- a/user/tests/unit/rgbled.cpp
+++ b/user/tests/unit/rgbled.cpp
@@ -79,7 +79,7 @@ SCENARIO( "User can set the LED Color", "[led]" ) {
     }
     WHEN("The LED color is set to RGB_COLOR_RED") {
         LED_SetSignalingColor(RGB_COLOR_RED);
-        LED_On(LED_RGB);
+        LED_On(PARTICLE_LED_RGB);
         THEN("The rgb values of the LED should be (255,0,0,)") {
             assertLEDRGB(255,0,0);
         }
@@ -91,7 +91,7 @@ SCENARIO( "User can turn the LED off", "[led]" ) {
     GIVEN("The RGB led is in override mode") {
         LED_Signaling_Start();
         WHEN("The LED is turned off") {
-            LED_Off(LED_RGB);
+            LED_Off(PARTICLE_LED_RGB);
             THEN("The rgb values of the LED should be (0,0,0)") {
                 assertLEDRGB(0,0,0);
             }
@@ -107,13 +107,13 @@ SCENARIO("Led can be toggled off then on again") {
         LED_SetSignalingColor(0xFEDCBA);
 
         WHEN ("The LED turned on and is toggled") {
-            LED_On(LED_RGB);
-            LED_Toggle(LED_RGB);
+            LED_On(PARTICLE_LED_RGB);
+            LED_Toggle(PARTICLE_LED_RGB);
             THEN("The rgb values of the LED should be (0,0,0)") {
                 assertLEDRGB(0,0,0);
             }
             AND_WHEN ("The LED is toggled again") {
-                LED_Toggle(LED_RGB);
+                LED_Toggle(PARTICLE_LED_RGB);
                 THEN("The rgb values match the original") {
                     assertLEDRGB(0xFE,0xDC,0xBA);
                 }
@@ -129,13 +129,13 @@ SCENARIO("Led can be toggled on") {
         LED_Signaling_Start();
         LED_SetSignalingColor(0xFEDCBA);
         WHEN ("The LED is switched on and toggled") {
-            LED_Off(LED_RGB);
-            LED_Toggle(LED_RGB);
+            LED_Off(PARTICLE_LED_RGB);
+            LED_Toggle(PARTICLE_LED_RGB);
             THEN("The rgb values match the original") {
                 assertLEDRGB(0xFE,0xDC,0xBA);
             }
             AND_WHEN ("The LED is toggled again") {
-                LED_Toggle(LED_RGB);
+                LED_Toggle(PARTICLE_LED_RGB);
                 THEN("The rgb values of the LED should be (0,0,0)") {
                     assertLEDRGB(0,0,0);
                 }
@@ -152,7 +152,7 @@ SCENARIO("LED Brightness can be set") {
 
         WHEN("The brightness is set to 48 (50%)") {
             LED_SetBrightness(48);
-            LED_On(LED_RGB);
+            LED_On(PARTICLE_LED_RGB);
             THEN("The RGB values are half of the original") {
                 assertLEDRGB(0xFE,0xDC,0xBA, 48);
             }
@@ -168,10 +168,10 @@ SCENARIO("LED can fade to half brightness in 50 steps", "[led]") {
         LED_SetSignalingColor(0xFEDCBA);
     }
     WHEN ("The led is turned on and faded 50 times") {
-        LED_On(LED_RGB);
+        LED_On(PARTICLE_LED_RGB);
         // fade starts at 99, so 49 takes us to 50.
         for (int i=0; i<50; i++) {
-            LED_Fade(LED_RGB);
+            LED_Fade(PARTICLE_LED_RGB);
         }
         THEN("The LED values are 1/2 of the original") {
             assertLEDRGB(0xFE,0xDC,0xBA,96, 49);
@@ -187,7 +187,7 @@ SCENARIO("LED_RGB_Get can retrieve correct 8-bit values from 16-bit CCR counters
         LED_SetSignalingColor(0xFEDCBA);
     }
     WHEN ("The LED is turned on and values fetched") {
-        LED_On(LED_RGB);
+        LED_On(PARTICLE_LED_RGB);
         uint8_t rgb[3];
         LED_RGB_Get(rgb);
         THEN("The corresponding values match the original") {

--- a/wiring/src/spark_wiring_rgb.cpp
+++ b/wiring/src/spark_wiring_rgb.cpp
@@ -50,14 +50,14 @@ void RGBClass::color(int red, int green, int blue)
         return;
     }
     LED_SetSignalingColor(red << 16 | green << 8 | blue);
-    LED_On(LED_RGB);
+    LED_On(PARTICLE_LED_RGB);
 }
 
 void RGBClass::brightness(uint8_t brightness, bool update)
 {
     LED_SetBrightness(brightness);
     if (controlled() && update) {
-        LED_On(LED_RGB);
+        LED_On(PARTICLE_LED_RGB);
     }
 }
 
@@ -87,16 +87,16 @@ void RGBClass::onChange(raw_rgb_change_handler_t* handler)
 
 void RGBClass::mirrorTo(pin_t rpin, pin_t gpin, pin_t bpin, bool invert, bool bootloader)
 {
-    HAL_Core_Led_Mirror_Pin(LED_RED + LED_MIRROR_OFFSET, rpin, (uint32_t)invert, (uint8_t)bootloader, nullptr);
-    HAL_Core_Led_Mirror_Pin(LED_GREEN + LED_MIRROR_OFFSET, gpin, (uint32_t)invert, (uint8_t)bootloader, nullptr);
-    HAL_Core_Led_Mirror_Pin(LED_BLUE + LED_MIRROR_OFFSET, bpin, (uint32_t)invert, (uint8_t)bootloader, nullptr);
+    HAL_Core_Led_Mirror_Pin(PARTICLE_LED_RED + LED_MIRROR_OFFSET, rpin, (uint32_t)invert, (uint8_t)bootloader, nullptr);
+    HAL_Core_Led_Mirror_Pin(PARTICLE_LED_GREEN + LED_MIRROR_OFFSET, gpin, (uint32_t)invert, (uint8_t)bootloader, nullptr);
+    HAL_Core_Led_Mirror_Pin(PARTICLE_LED_BLUE + LED_MIRROR_OFFSET, bpin, (uint32_t)invert, (uint8_t)bootloader, nullptr);
 }
 
 void RGBClass::mirrorDisable(bool bootloader)
 {
-    HAL_Core_Led_Mirror_Pin_Disable(LED_RED + LED_MIRROR_OFFSET, (uint8_t)bootloader, nullptr);
-    HAL_Core_Led_Mirror_Pin_Disable(LED_GREEN + LED_MIRROR_OFFSET, (uint8_t)bootloader, nullptr);
-    HAL_Core_Led_Mirror_Pin_Disable(LED_BLUE + LED_MIRROR_OFFSET, (uint8_t)bootloader, nullptr);
+    HAL_Core_Led_Mirror_Pin_Disable(PARTICLE_LED_RED + LED_MIRROR_OFFSET, (uint8_t)bootloader, nullptr);
+    HAL_Core_Led_Mirror_Pin_Disable(PARTICLE_LED_GREEN + LED_MIRROR_OFFSET, (uint8_t)bootloader, nullptr);
+    HAL_Core_Led_Mirror_Pin_Disable(PARTICLE_LED_BLUE + LED_MIRROR_OFFSET, (uint8_t)bootloader, nullptr);
 }
 
 void RGBClass::ledChangeHandler(void* data, uint8_t r, uint8_t g, uint8_t b, void* reserved)

--- a/wiring/src/spark_wiring_wifitester.cpp
+++ b/wiring/src/spark_wiring_wifitester.cpp
@@ -539,7 +539,7 @@ void WiFiTester::tester_connect(char *ssid, char *pass) {
     //
     //  RGBColor = 0xFF00FF;        //purple
     //USERLED_SetRGBColor(0xFF00FF);        //purple
-    //USERLED_On(LED_RGB);
+    //USERLED_On(PARTICLE_LED_RGB);
     serialPrintln("  WIFI Connected?    ");
 #endif
 }


### PR DESCRIPTION
<details>
  <summary><i>Rename simple numbered LED defines to have PARTICLE prefix to avoid possible collision with user applications.</i></summary>

</details>

### Problem

What Bug or Missing Feature does this PR address? (A short summary is preferred over links)

Simple define names such as `LED2` have caused some users problems due to namespace collisions.  

### Solution

By adding a `PARTICLE_` prefix to these defines, we avoid possible namespace collisions. 

### Steps to Test

At the moment tests under `/user/tests` are using `LED_RGB` which is derived from these defines. 

### Example App

Replace any reference to eg `LED2` with `PARTICLE_LED2` in your applications.  


---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
