### PR TITLE
[hal] sleep: allows the network to stay standby in HIBERNATE mode.

### DIFF
--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1252,7 +1252,7 @@ int MDMParser::getModemStateChangeCount(void) const {
     return _mdm_state_change_count;
 }
 
-bool MDMParser::powerState(void) const {
+bool MDMParser::powerState(void) {
     auto state = HAL_GPIO_Read(RI_UC);
     if (state) {
         // RI is high, which means that V_INT is high as well
@@ -1273,6 +1273,10 @@ bool MDMParser::powerState(void) const {
     state = HAL_GPIO_Read(RI_UC);
     // If RI is still low - we are off
     // If RI is high - we are on
+    if (getModemStateChangeCount() == 0) {
+        _incModemStateChangeCount();
+        _pwr = state;
+    }
     return state;
 }
 

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1385,7 +1385,6 @@ bool MDMParser::powerOff(void)
     } else {
         MDM_INFO("%s failed", POWER_OFF_MSG);
     }
-    HAL_Delay_Milliseconds(1000); // give peace a chance
     // Increment the state change counter to show that the modem has been powered on -> off
     if (!_pwr) {
         _incModemStateChangeCount();

--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -536,7 +536,7 @@ protected:
 
     /** Detects the modem power state
     */
-    bool powerState(void) const;
+    bool powerState(void);
 
 protected:
     // String helper to prevent buffer overrun

--- a/hal/src/nRF52840/sleep_hal.cpp
+++ b/hal/src/nRF52840/sleep_hal.cpp
@@ -685,6 +685,9 @@ static bool isWokenUpByLpcomp() {
 
 static bool isWokenUpByNetwork(const hal_wakeup_source_network_t* networkWakeup) {
 // TODO: More than one network interface are supported on platform.
+    if (networkWakeup->flags & HAL_SLEEP_NETWORK_FLAG_INACTIVE_STANDBY) {
+        return false;
+    }
 #if HAL_PLATFORM_CELLULAR
     if (networkWakeup->index == NETWORK_INTERFACE_CELLULAR && NVIC_GetPendingIRQ(UARTE1_IRQn)) {
         return true;

--- a/hal/src/nRF52840/sleep_hal.cpp
+++ b/hal/src/nRF52840/sleep_hal.cpp
@@ -742,11 +742,13 @@ static int validateUsartWakeupSource(hal_sleep_mode_t mode, const hal_wakeup_sou
 }
 
 static int validateNetworkWakeupSource(hal_sleep_mode_t mode, const hal_wakeup_source_network_t* network) {
-    if (!(network->flags & HAL_SLEEP_NETWORK_FLAG_INACTIVE_STANDBY) && !hal_usart_is_enabled(HAL_USART_SERIAL2)) {
-        return SYSTEM_ERROR_INVALID_STATE;
-    }
-    if (mode == HAL_SLEEP_MODE_HIBERNATE) {
-        return SYSTEM_ERROR_NOT_SUPPORTED;
+    if (!(network->flags & HAL_SLEEP_NETWORK_FLAG_INACTIVE_STANDBY)) {
+        if (!hal_usart_is_enabled(HAL_USART_SERIAL2)) {
+            return SYSTEM_ERROR_INVALID_STATE;
+        }
+        if (mode == HAL_SLEEP_MODE_HIBERNATE) {
+            return SYSTEM_ERROR_NOT_SUPPORTED;
+        }
     }
     return SYSTEM_ERROR_NONE;
 }

--- a/hal/src/stm32f2xx/sleep_hal.cpp
+++ b/hal/src/stm32f2xx/sleep_hal.cpp
@@ -661,17 +661,17 @@ static int enterStopBasedSleep(const hal_sleep_config_t* config, hal_wakeup_sour
 #endif
                 ) {
                 ret = constructUsartWakeupReason(wakeupReason, usartWakeup->serial);
+                break; // Stop traversing the wakeup sources list.
             }
-            break; // Stop traversing the wakeup sources list.
         }
         else if (wakeupSource->type == HAL_WAKEUP_SOURCE_TYPE_NETWORK) {
 #if HAL_PLATFORM_CELLULAR
             auto networkWakeup = reinterpret_cast<hal_wakeup_source_network_t*>(wakeupSource);
-            if (NVIC_GetPendingIRQ(USART3_IRQn) && networkWakeup->index == NETWORK_INTERFACE_CELLULAR) {
+            if (NVIC_GetPendingIRQ(USART3_IRQn) && networkWakeup->index == NETWORK_INTERFACE_CELLULAR && !(networkWakeup->flags & HAL_SLEEP_NETWORK_FLAG_INACTIVE_STANDBY)) {
                 ret = constructNetworkWakeupReason(wakeupReason, networkWakeup->index);
+                break; // Stop traversing the wakeup sources list.
             }
 #endif
-            break; // Stop traversing the wakeup sources list.
         }
         wakeupSource = wakeupSource->next;
     }

--- a/hal/src/stm32f2xx/sleep_hal.cpp
+++ b/hal/src/stm32f2xx/sleep_hal.cpp
@@ -450,11 +450,7 @@ static int validateRtcWakeupSource(hal_sleep_mode_t mode, const hal_wakeup_sourc
 
 static int validateNetworkWakeupSource(hal_sleep_mode_t mode, const hal_wakeup_source_network_t* network) {
 #if HAL_PLATFORM_CELLULAR
-    if (network->flags & HAL_SLEEP_NETWORK_FLAG_INACTIVE_STANDBY) {
-        if (mode == HAL_SLEEP_MODE_HIBERNATE) {
-            return SYSTEM_ERROR_NOT_SUPPORTED;
-        }
-    } else {
+    if (!(network->flags & HAL_SLEEP_NETWORK_FLAG_INACTIVE_STANDBY)) {
         if (!(USART3->CR1 & USART_CR1_UE)) {
             return SYSTEM_ERROR_INVALID_STATE;
         }
@@ -466,9 +462,6 @@ static int validateNetworkWakeupSource(hal_sleep_mode_t mode, const hal_wakeup_s
 
 #if HAL_PLATFORM_WIFI
     if (!(network->flags & HAL_SLEEP_NETWORK_FLAG_INACTIVE_STANDBY)) {
-        return SYSTEM_ERROR_NOT_SUPPORTED;
-    }
-    if (mode == HAL_SLEEP_MODE_HIBERNATE) {
         return SYSTEM_ERROR_NOT_SUPPORTED;
     }
 #endif


### PR DESCRIPTION
### Problem
`System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::HIBERNATE).network(SystemSleepNetworkFlag::INACTIVE_STANDBY))` doesn't make the device enter sleep.
### Solution
Removes the restriction in sleep HAL to allow network stay standby in hibernate mode. 
### Example App

```c
#include "Particle.h"
#include "system_threading.h"

SerialLogHandler logHandler(Serial, LOG_LEVEL_TRACE);

SYSTEM_THREAD(ENABLED);
SYSTEM_MODE(SEMI_AUTOMATIC);

void setup()
{
    waitFor(Serial.isConnected, 10000);

    Log.info("before sleep");
    SystemSleepConfiguration config;
    config.network(Cellular, SystemSleepNetworkFlag::INACTIVE_STANDBY);
    config.mode(SystemSleepMode::HIBERNATE);
    config.gpio(D0, RISING);
    System.sleep(config);
}

void loop()
{
}
```
---
### Completeness
- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
