### PR TITLE
Support for DTLS connection IDs

### DIFF
--- a/communication/inc/dtls_session_persist.h
+++ b/communication/inc/dtls_session_persist.h
@@ -50,6 +50,11 @@ typedef struct __attribute__((packed)) SessionPersistDataOpaque
 namespace particle { namespace protocol {
 
 /**
+ * Size of a DTLS connection ID.
+ */
+const size_t DTLS_CID_SIZE = 8;
+
+/**
  * A simple POD for the persisted session data.
  */
 struct __attribute__((packed)) SessionPersistData
@@ -123,7 +128,7 @@ struct __attribute__((packed)) SessionPersistData
 	/**
 	 * Connection ID.
 	 */
-	uint8_t cid[8];
+	uint8_t cid[DTLS_CID_SIZE];
 };
 
 class __attribute__((packed)) SessionPersistOpaque : public SessionPersistData
@@ -224,7 +229,7 @@ public:
 	/**
 	 * Prepare to transiently save information about this context.
 	 */
-	void prepare_save(const uint8_t* random, uint32_t keys_checksum, mbedtls_ssl_context* context, message_id_t next_id);
+	bool prepare_save(const uint8_t* random, uint32_t keys_checksum, mbedtls_ssl_context* context, message_id_t next_id);
 
 	/**
 	 * Flags this context as being persistent. Subsequent calls
@@ -283,6 +288,8 @@ public:
 
 static_assert(sizeof(SessionPersist)==SessionPersistBaseSize+sizeof(mbedtls_ssl_session::ciphersuite)+sizeof(mbedtls_ssl_session::id_len)+sizeof(mbedtls_ssl_session::compression), "SessionPersist size");
 static_assert(sizeof(SessionPersist)==sizeof(SessionPersistDataOpaque), "SessionPersistDataOpaque size == sizeof(SessionPersist)");
+
+static_assert(DTLS_CID_SIZE == MBEDTLS_SSL_CID_OUT_LEN_MAX, "Invalid DTLS_CID_SIZE");
 
 #endif // defined(MBEDTLS_SSL_H)
 

--- a/communication/inc/dtls_session_persist.h
+++ b/communication/inc/dtls_session_persist.h
@@ -21,7 +21,7 @@
 #include "stddef.h"
 
 // The size of the persisted data
-#define SessionPersistBaseSize 234
+#define SessionPersistBaseSize 250
 
 // variable size due to int/size_t members
 #define SessionPersistVariableSize (sizeof(int)+sizeof(int)+sizeof(size_t))
@@ -125,6 +125,14 @@ struct __attribute__((packed)) SessionPersistData
 	 * Size of an OTA update chunk.
 	 */
 	uint16_t ota_chunk_size;
+	/**
+	 * Last validated sequence number of an incoming record.
+	 */
+	uint64_t in_window_top;
+	/**
+	 * Bitmap of last N incoming records.
+	 */
+	uint64_t in_window;
 	/**
 	 * Connection ID.
 	 */
@@ -289,7 +297,7 @@ public:
 static_assert(sizeof(SessionPersist)==SessionPersistBaseSize+sizeof(mbedtls_ssl_session::ciphersuite)+sizeof(mbedtls_ssl_session::id_len)+sizeof(mbedtls_ssl_session::compression), "SessionPersist size");
 static_assert(sizeof(SessionPersist)==sizeof(SessionPersistDataOpaque), "SessionPersistDataOpaque size == sizeof(SessionPersist)");
 
-static_assert(DTLS_CID_SIZE == MBEDTLS_SSL_CID_OUT_LEN_MAX, "Invalid DTLS_CID_SIZE");
+static_assert(DTLS_CID_SIZE <= MBEDTLS_SSL_CID_OUT_LEN_MAX, "DTLS_CID_SIZE is too large");
 
 #endif // defined(MBEDTLS_SSL_H)
 

--- a/communication/inc/dtls_session_persist.h
+++ b/communication/inc/dtls_session_persist.h
@@ -21,7 +21,7 @@
 #include "stddef.h"
 
 // The size of the persisted data
-#define SessionPersistBaseSize 226
+#define SessionPersistBaseSize 234
 
 // variable size due to int/size_t members
 #define SessionPersistVariableSize (sizeof(int)+sizeof(int)+sizeof(size_t))
@@ -120,6 +120,10 @@ struct __attribute__((packed)) SessionPersistData
 	 * Size of an OTA update chunk.
 	 */
 	uint16_t ota_chunk_size;
+	/**
+	 * Connection ID.
+	 */
+	uint8_t cid[8];
 };
 
 class __attribute__((packed)) SessionPersistOpaque : public SessionPersistData

--- a/crypto/inc/mbedtls_config_default.h
+++ b/crypto/inc/mbedtls_config_default.h
@@ -918,6 +918,36 @@
 #define MBEDTLS_SSL_ALL_ALERT_MESSAGES
 
 /**
+ * \def MBEDTLS_SSL_DTLS_CONNECTION_ID
+ *
+ * Enable support for the DTLS Connection ID extension
+ * (version draft-ietf-tls-dtls-connection-id-05,
+ * https://tools.ietf.org/html/draft-ietf-tls-dtls-connection-id-05)
+ * which allows to identify DTLS connections across changes
+ * in the underlying transport.
+ *
+ * Setting this option enables the SSL APIs `mbedtls_ssl_set_cid()`,
+ * `mbedtls_ssl_get_peer_cid()` and `mbedtls_ssl_conf_cid()`.
+ * See the corresponding documentation for more information.
+ *
+ * \warning The Connection ID extension is still in draft state.
+ *          We make no stability promises for the availability
+ *          or the shape of the API controlled by this option.
+ *
+ * The maximum lengths of outgoing and incoming CIDs can be configured
+ * through the options
+ * - MBEDTLS_SSL_CID_OUT_LEN_MAX
+ * - MBEDTLS_SSL_CID_IN_LEN_MAX.
+ *
+ * Requires: MBEDTLS_SSL_PROTO_DTLS
+ *
+ * Uncomment to enable the Connection ID extension.
+ */
+#define MBEDTLS_SSL_DTLS_CONNECTION_ID
+#define MBEDTLS_SSL_CID_IN_LEN_MAX 0
+#define MBEDTLS_SSL_CID_OUT_LEN_MAX 8
+
+/**
  * \def MBEDTLS_SSL_DEBUG_ALL
  *
  * Enable the debug messages in SSL module for all issues.

--- a/hal/src/nRF52840/mbedtls/mbedtls_config_platform.h
+++ b/hal/src/nRF52840/mbedtls/mbedtls_config_platform.h
@@ -943,7 +943,7 @@
  * Uncomment to enable the Connection ID extension.
  */
 #define MBEDTLS_SSL_DTLS_CONNECTION_ID
-#define MBEDTLS_SSL_CID_IN_LEN_MAX 8
+#define MBEDTLS_SSL_CID_IN_LEN_MAX 0
 #define MBEDTLS_SSL_CID_OUT_LEN_MAX 8
 
 /**

--- a/hal/src/nRF52840/mbedtls/mbedtls_config_platform.h
+++ b/hal/src/nRF52840/mbedtls/mbedtls_config_platform.h
@@ -917,6 +917,36 @@
 #define MBEDTLS_SSL_ALL_ALERT_MESSAGES
 
 /**
+ * \def MBEDTLS_SSL_DTLS_CONNECTION_ID
+ *
+ * Enable support for the DTLS Connection ID extension
+ * (version draft-ietf-tls-dtls-connection-id-05,
+ * https://tools.ietf.org/html/draft-ietf-tls-dtls-connection-id-05)
+ * which allows to identify DTLS connections across changes
+ * in the underlying transport.
+ *
+ * Setting this option enables the SSL APIs `mbedtls_ssl_set_cid()`,
+ * `mbedtls_ssl_get_peer_cid()` and `mbedtls_ssl_conf_cid()`.
+ * See the corresponding documentation for more information.
+ *
+ * \warning The Connection ID extension is still in draft state.
+ *          We make no stability promises for the availability
+ *          or the shape of the API controlled by this option.
+ *
+ * The maximum lengths of outgoing and incoming CIDs can be configured
+ * through the options
+ * - MBEDTLS_SSL_CID_OUT_LEN_MAX
+ * - MBEDTLS_SSL_CID_IN_LEN_MAX.
+ *
+ * Requires: MBEDTLS_SSL_PROTO_DTLS
+ *
+ * Uncomment to enable the Connection ID extension.
+ */
+#define MBEDTLS_SSL_DTLS_CONNECTION_ID
+#define MBEDTLS_SSL_CID_IN_LEN_MAX 8
+#define MBEDTLS_SSL_CID_OUT_LEN_MAX 8
+
+/**
  * \def MBEDTLS_SSL_DEBUG_ALL
  *
  * Enable the debug messages in SSL module for all issues.


### PR DESCRIPTION
### Problem

This PR enables the DTLS Connection ID extension (described in [this](https://tools.ietf.org/html/draft-ietf-tls-dtls-connection-id-09) draft RFC).

### Steps to Test

Verify that session resumption works as expected.

### References

- [ch55112]
