### PR TITLE
Always inline fastPinGetPinmap to speed pin sets

### DIFF
--- a/user/tests/wiring/no_fixture/fastpin.cpp
+++ b/user/tests/wiring/no_fixture/fastpin.cpp
@@ -1,0 +1,68 @@
+
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+
+
+test(FASTPIN_01_MaxDuration_PinSet) {
+    // Attempt pinSetFast and pinResetFast numerous times and check speed.
+    // Duration went from about 62 -> 24 ticks per set on Gen2 with this change list
+
+#if HAL_PLATFORM_GEN == 3
+    // expected max ticks of pinSetFast / pinResetFast on Gen3
+    const uint32_t MAX_DURATION_PINSET_TICKS = 61;
+#elif HAL_PLATFORM_GEN == 2
+    // expected max ticks of pinSetFast / pinResetFast on Gen2
+    const uint32_t MAX_DURATION_PINSET_TICKS = 24;
+#else
+#error "No gpio fastpin timing benchmark yet measured for this platform"
+#endif
+
+    const uint32_t NUM_ITERATIONS = 100;
+    uint32_t start, finish;
+
+    ATOMIC_BLOCK()  {
+        start = System.ticks();
+        for (uint32_t i = 0; i < NUM_ITERATIONS; i++) {
+            pinSetFast(D7);
+            //pinResetFast(D7);
+        }
+        finish = System.ticks();
+    }
+    uint32_t duration = finish - start;
+//    Serial.print("Set duration:");
+//    Serial.println(duration);
+    assertLessOrEqual(duration, NUM_ITERATIONS*MAX_DURATION_PINSET_TICKS);
+}
+
+test(FASTPIN_02_MaxDuration_PinReset) {
+    // Attempt pinResetFast numerous times and check speed.
+
+#if HAL_PLATFORM_GEN == 3
+    // expected max ticks of pinResetFast on Gen3
+    const uint32_t MAX_DURATION_PINRESET_TICKS = 60;
+#elif HAL_PLATFORM_GEN == 2
+    // expected max ticks of pinResetFast on Gen2
+    const uint32_t MAX_DURATION_PINRESET_TICKS = 25;
+#else
+#error "No gpio fastpin timing benchmark yet measured for this platform"
+#endif
+
+    const uint32_t NUM_ITERATIONS = 100;
+    uint32_t start, finish;
+
+    ATOMIC_BLOCK()  {
+        start = System.ticks();
+        for (uint32_t i = 0; i < NUM_ITERATIONS; i++) {
+            pinResetFast(D7);
+        }
+        finish = System.ticks();
+    }
+    uint32_t duration = finish - start;
+//    Serial.print("Reset duration:");
+//    Serial.println(duration);
+    assertLessOrEqual(duration, NUM_ITERATIONS*MAX_DURATION_PINRESET_TICKS);
+}
+
+
+

--- a/wiring/inc/fast_pin.h
+++ b/wiring/inc/fast_pin.h
@@ -32,8 +32,8 @@ extern "C" {
  * by @pkourany on PR: https://github.com/spark/firmware/pull/556 */
 #define USE_BIT_BAND 0
 
-inline const Hal_Pin_Info* fastPinGetPinmap() {
-    static Hal_Pin_Info* pinMap = HAL_Pin_Map();
+__attribute__((always_inline)) inline const Hal_Pin_Info* fastPinGetPinmap() {
+    static const Hal_Pin_Info* pinMap = HAL_Pin_Map();
     return pinMap;
 }
 


### PR DESCRIPTION
<details>
  <summary><i>Always inline fastPinGetPinmap in order to speed pin set</i></summary>

Also add test to catch unintentional slowing of pin set in the future.  
</details>

### Problem

For some users, calling `pinSetFast` or `pinResetFast` was noticeably slower on 2.0.0-rc.4 or later than on earlier releases. 
 
### Solution

The 2.0.0 development line worked around an issue with initialization order by changing the way the HAL pin map was initialized and subsequently accessed.  This introduced some overhead in each call to fastPinGetPinmap.  We reduce that overhead here by always inlining` fastPinGetPinmap()`.

### References

- Closes #2244 

### Steps to Test

Added a test to `/user/tests/wiring/no_fixture/fastpin.cpp` to set a limit to the allowable ticks.  Tested on Electron 2g. 



### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
