### PR TITLE
docs: fix simple typo, tecnhology -> technology

### DIFF
--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -2255,7 +2255,7 @@ int MDMParser::_cbCSQ(int type, const char* buf, int len, NetStatus* status)
                 status->rsrq = (b != 99) ? (b * 34)/7 : 255;  // [0, 7] -> [0,34]
                 break;
             default:
-                // Unknown access tecnhology
+                // Unknown access technology
                 status->asu = std::numeric_limits<int32_t>::min();
                 status->aqual = std::numeric_limits<int32_t>::min();
                 break;


### PR DESCRIPTION
There is a small typo in hal/src/electron/modem/mdm_hal.cpp.

Should read `technology` rather than `tecnhology`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md