### PR TITLE
Change the condition to disable hwfc on b5som

### DIFF
--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -149,7 +149,7 @@ int QuectelNcpClient::init(const NcpClientConfig& conf) {
 #if PLATFORM_ID == PLATFORM_B5SOM
     uint32_t hwVersion = HW_VERSION_UNDEFINED;
     auto ret = hal_get_device_hw_version(&hwVersion, nullptr);
-    if (ret == SYSTEM_ERROR_NONE && hwVersion == HAL_VERSION_B5SOM_V003) {
+    if (ret == SYSTEM_ERROR_NONE && hwVersion == HAL_VERSION_B5SOM_V003 && ncpId() == PLATFORM_NCP_QUECTEL_EG91_E) {
         sconf = SERIAL_8N1;
         LOG(TRACE, "Disable Hardware Flow control!");
     }
@@ -982,7 +982,7 @@ int QuectelNcpClient::initReady(ModemState state) {
 #if PLATFORM_ID == PLATFORM_B5SOM
         uint32_t hwVersion = HW_VERSION_UNDEFINED;
         auto ret = hal_get_device_hw_version(&hwVersion, nullptr);
-        if (ret == SYSTEM_ERROR_NONE && hwVersion == HAL_VERSION_B5SOM_V003) {
+        if (ret == SYSTEM_ERROR_NONE && hwVersion == HAL_VERSION_B5SOM_V003 && ncpId() == PLATFORM_NCP_QUECTEL_EG91_E) {
             CHECK_PARSER_OK(parser_.execCommand("AT+IFC=0,0"));
         } else
 #endif // PLATFORM_ID == PLATFORM_B5SOM


### PR DESCRIPTION
### Problem
During the B523 SoM development, the engineering samples have issues with RTS and CTS hardware flow control, we use the `hwVersion` 0x00 to filter out the PCBA version by disabling HWFC.

Now, we have another new B5SoM variant that has a new modem and the H/W version in OTP is 0x00, to distinguish the B523 and this new B5XX SoM, we have to combine `hwVersion` and `platform` in this case.

### Solution
Changing the condition to filter out the hardware flow control issue for B523 specifically.

### Steps to Test
N/A

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
