### PR TITLE
[gen2] usart: fix D0 AF unconditionally being changed in hal_usart_end()

### DIFF
--- a/hal/src/stm32f2xx/usart_hal.c
+++ b/hal/src/stm32f2xx/usart_hal.c
@@ -562,6 +562,10 @@ void hal_usart_begin_config(hal_usart_interface_t serial, uint32_t baud, uint32_
 }
 
 void hal_usart_end(hal_usart_interface_t serial) {
+    if (usartMap[serial]->state == HAL_USART_STATE_DISABLED) {
+        // Invalid state
+        return;
+    }
     usartEndImpl(serial, true);
 
     // clear any received data
@@ -573,6 +577,8 @@ void hal_usart_end(hal_usart_interface_t serial) {
 
     usartMap[serial]->state = HAL_USART_STATE_DISABLED;
     usartMap[serial]->transmitting = false;
+    usartMap[serial]->conf.baud_rate = 0;
+    usartMap[serial]->conf.config = 0;
 }
 
 uint32_t hal_usart_write(hal_usart_interface_t serial, uint8_t data) {

--- a/user/tests/wiring/no_fixture/uart.cpp
+++ b/user/tests/wiring/no_fixture/uart.cpp
@@ -84,3 +84,23 @@ test(UART_01_D0ConfigurationIsIntactWhenSerial1IsDeinitialized) {
 }
 
 #endif // HAL_PLATFORM_GEN == 2
+
+test(UART_02_PinConfigurationNotAffectedWhenEndCalledMultipleTimes) {
+    Serial1.begin(115200, SERIAL_8N1);
+    assertTrue(Serial1.isEnabled());
+    Serial1.end();
+    assertFalse(Serial1.isEnabled());
+
+    pinMode(TX, INPUT_PULLDOWN);
+    pinMode(RX, INPUT_PULLDOWN);
+
+    assertEqual(getPinMode(TX), INPUT_PULLDOWN);
+    assertEqual(getPinMode(RX), INPUT_PULLDOWN);
+
+    Serial1.end();
+    assertEqual(getPinMode(TX), INPUT_PULLDOWN);
+    assertEqual(getPinMode(RX), INPUT_PULLDOWN);
+
+    pinMode(TX, INPUT);
+    pinMode(RX, INPUT);
+}

--- a/user/tests/wiring/no_fixture/uart.cpp
+++ b/user/tests/wiring/no_fixture/uart.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2020 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "application.h"
+#include "unit-test/unit-test.h"
+#include "Serial2/Serial2.h"
+#include "Serial3/Serial3.h"
+#include "Serial4/Serial4.h"
+#include "Serial5/Serial5.h"
+
+#if HAL_PLATFORM_GEN == 2
+
+namespace {
+
+uint32_t getPinAf(pin_t pin) {
+    auto pinmap = HAL_Pin_Map();
+    auto gpiox = pinmap[pin].gpio_peripheral;
+    auto pinSource = pinmap[pin].gpio_pin_source;
+    auto afr = gpiox->AFR[pinSource >> 0x03];
+    return (afr >> ((pinSource & 0x07) * 4)) & 0xF;
+}
+
+} // anomymous
+
+test(UART_00_HardwareFlowControlCannotBeEnabledOnUnsupportedPeripheral) {
+    // On Gen 2 not supported on Serial1 and Serial4/5
+    Serial1.end();
+    Serial1.begin(115200, SERIAL_8N1 | SERIAL_FLOW_CONTROL_RTS_CTS);
+    assertFalse(Serial1.isEnabled());
+
+    Serial1.begin(115200, SERIAL_8N1);
+    assertTrue(Serial1.isEnabled());
+    Serial1.end();
+
+#if Wiring_Serial4
+    Serial4.end();
+    Serial4.begin(115200, SERIAL_8N1 | SERIAL_FLOW_CONTROL_RTS_CTS);
+    assertFalse(Serial4.isEnabled());
+
+    Serial4.begin(115200, SERIAL_8N1);
+    assertTrue(Serial4.isEnabled());
+    Serial4.end();
+#endif // Wiring_Serial4
+
+#if Wiring_Serial5
+    Serial5.end();
+    Serial5.begin(115200, SERIAL_8N1 | SERIAL_FLOW_CONTROL_RTS_CTS);
+    assertFalse(Serial5.isEnabled());
+
+    Serial5.begin(115200, SERIAL_8N1);
+    assertTrue(Serial5.isEnabled());
+    Serial5.end();
+#endif // Wiring_Serial5
+}
+
+test(UART_01_D0ConfigurationIsIntactWhenSerial1IsDeinitialized) {
+    Serial1.end();
+
+    Serial1.begin(115200, SERIAL_8N1);
+    assertTrue(Serial1.isEnabled());
+
+    Wire.end();
+    Wire.begin();
+    assertTrue(Wire.isEnabled());
+    assertEqual(getPinAf(D0), (uint32_t)GPIO_AF_I2C1);
+
+    Serial1.end();
+    assertEqual(getPinAf(D0), (uint32_t)GPIO_AF_I2C1);
+    Wire.end();
+}
+
+#endif // HAL_PLATFORM_GEN == 2


### PR DESCRIPTION
### Problem

```c++
Wire.begin();
Serial1.begin(115200);
Serial1.end();
```

The following code will leave I2C peripheral in a non-functioning state on Gen 2 platforms, because `D0` Alternate-Function will be reset to default value unconditionally by a call to `Serial1.end()`.

### Steps to Test

- `wiring/no_fixture` `UART*` tests

### Example App

N/A

### References

- [CH70258]
- [CH70277]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
