### PR TITLE
Allow power manager to disable charging

### DIFF
--- a/hal/inc/power_hal.h
+++ b/hal/inc/power_hal.h
@@ -45,6 +45,9 @@ typedef enum hal_power_config_flags {
     HAL_POWER_MANAGEMENT_DISABLE = 0x100,
     HAL_POWER_USE_VIN_SETTINGS_WITH_USB_HOST = 0x200,
 
+    // Disables power management control over enabling charging on PMIC
+    HAL_POWER_CHARGE_STATE_DISABLE = 0x400,
+
     HAL_POWER_FLAG_MAX = 0x7fffffff
 } hal_power_config_flags;
 

--- a/system/inc/system_dynalib.h
+++ b/system/inc/system_dynalib.h
@@ -110,9 +110,17 @@ DYNALIB_FN(BASE_IDX + 17, system, system_power_management_set_config, int(const 
 DYNALIB_FN(BASE_IDX1 + 0, system, system_sleep_ext, int(const hal_sleep_config_t*, hal_wakeup_source_base_t**, void*))
 DYNALIB_FN(BASE_IDX1 + 1, system, system_reset, int(unsigned, unsigned, unsigned, unsigned, void*))
 
+#if HAL_PLATFORM_POWER_MANAGEMENT
+DYNALIB_FN(BASE_IDX1 + 2, system, system_power_management_get_config, int(hal_power_config*, void*))
+#define BASE_IDX2 (BASE_IDX1 + 3)
+#else
+#define BASE_IDX2 (BASE_IDX1 + 2)
+#endif  // HAL_PLATFORM_POWER_MANAGEMENT
+
 DYNALIB_END(system)
 
 #undef BASE_IDX
 #undef BASE_IDX1
+#undef BASE_IDX2
 
 #endif	/* SYSTEM_DYNALIB_H */

--- a/system/inc/system_power.h
+++ b/system/inc/system_power.h
@@ -49,6 +49,7 @@ void system_power_management_init();
 void system_power_management_sleep(bool fuelGaugeSleep);
 void system_power_management_wakeup();
 int system_power_management_set_config(const hal_power_config* conf, void* reserved);
+int system_power_management_get_config(hal_power_config* conf, void* reserved);
 
 #ifdef __cplusplus
 }

--- a/system/src/system_power.cpp
+++ b/system/src/system_power.cpp
@@ -54,6 +54,10 @@ int system_power_management_set_config(const hal_power_config* conf, void* reser
     return PowerManager::instance()->setConfig(conf);
 }
 
+int system_power_management_get_config(hal_power_config* conf, void* reserved) {
+    return PowerManager::instance()->getConfig(conf);
+}
+
 #else /* !HAL_PLATFORM_POWER_MANAGEMENT */
 
 void system_power_management_init() {
@@ -66,6 +70,10 @@ void system_power_management_wakeup() {
 }
 
 int system_power_management_set_config(const hal_power_config* conf, void* reserved) {
+    return SYSTEM_ERROR_NOT_SUPPORTED;
+}
+
+int system_power_management_get_config(hal_power_config* conf, void* reserved) {
     return SYSTEM_ERROR_NOT_SUPPORTED;
 }
 

--- a/system/src/system_power_manager.h
+++ b/system/src/system_power_manager.h
@@ -33,6 +33,7 @@ public:
   void sleep(bool fuelGaugeSleep = true);
   void wakeup();
   int setConfig(const hal_power_config* conf);
+  int getConfig(hal_power_config* conf);
 
 protected:
   PowerManager();
@@ -42,6 +43,7 @@ private:
   static void isrHandler();
   static void usbStateChangeHandler(HAL_USB_State state, void* context);
   void update();
+  void handleCharging();
   void handleUpdate();
   void initDefault(bool dpdm = true);
   void handleStateChange(battery_state_t from, battery_state_t to, bool low);

--- a/user/tests/wiring/power_management/power.cpp
+++ b/user/tests/wiring/power_management/power.cpp
@@ -184,6 +184,16 @@ test(POWER_01_PoweredByUsbHostAndBatteryStateIsValid) {
         return;
     }
 
+    auto cfg = System.getPowerConfiguration();
+    assertEqual(cfg.isFeatureSet(SystemPowerFeature::PMIC_DETECTION), true);
+    assertEqual(cfg.isFeatureSet(SystemPowerFeature::USE_VIN_SETTINGS_WITH_USB_HOST), false);
+    assertEqual(cfg.isFeatureSet(SystemPowerFeature::DISABLE), false);
+    assertEqual(cfg.isFeatureSet(SystemPowerFeature::DISABLE_CHARGING), false);
+    assertEqual(cfg.powerSourceMaxCurrent(), particle::power::DEFAULT_INPUT_CURRENT_LIMIT);
+    assertEqual(cfg.powerSourceMinVoltage(), particle::power::DEFAULT_INPUT_VOLTAGE_LIMIT);
+    assertEqual(cfg.batteryChargeCurrent(), particle::power::DEFAULT_CHARGE_CURRENT);
+    assertEqual(cfg.batteryChargeVoltage(), particle::power::DEFAULT_TERMINATION_VOLTAGE);
+
     // Allow some time for the power management subsystem to settle
     waitFor(powerManagementSettled, 10000);
 
@@ -314,6 +324,16 @@ test(POWER_06_PoweredByVinAndBatteryStateIsValid) {
         return;
     }
 
+    auto cfg = System.getPowerConfiguration();
+    assertEqual(cfg.isFeatureSet(SystemPowerFeature::PMIC_DETECTION), true);
+    assertEqual(cfg.isFeatureSet(SystemPowerFeature::USE_VIN_SETTINGS_WITH_USB_HOST), true);
+    assertEqual(cfg.isFeatureSet(SystemPowerFeature::DISABLE), false);
+    assertEqual(cfg.isFeatureSet(SystemPowerFeature::DISABLE_CHARGING), false);
+    assertEqual(cfg.powerSourceMaxCurrent(), particle::power::DEFAULT_INPUT_CURRENT_LIMIT);
+    assertEqual(cfg.powerSourceMinVoltage(), particle::power::DEFAULT_INPUT_VOLTAGE_LIMIT);
+    assertEqual(cfg.batteryChargeCurrent(), particle::power::DEFAULT_CHARGE_CURRENT);
+    assertEqual(cfg.batteryChargeVoltage(), particle::power::DEFAULT_TERMINATION_VOLTAGE);
+
     // Allow some time for the power management subsystem to settle
     waitFor(powerManagementSettled, 10000);
     assertEqual(System.powerSource(), (int)POWER_SOURCE_VIN);
@@ -435,6 +455,16 @@ test(POWER_11_ApplyingDefaultPowerManagementConfigurationInRuntimeWorksAsIntende
     assertEqual(System.setPowerConfiguration(conf), (int)SYSTEM_ERROR_NONE);
     delay(1000);
 
+    auto cfg = System.getPowerConfiguration();
+    assertEqual(cfg.isFeatureSet(SystemPowerFeature::PMIC_DETECTION), false);
+    assertEqual(cfg.isFeatureSet(SystemPowerFeature::USE_VIN_SETTINGS_WITH_USB_HOST), true);
+    assertEqual(cfg.isFeatureSet(SystemPowerFeature::DISABLE), false);
+    assertEqual(cfg.isFeatureSet(SystemPowerFeature::DISABLE_CHARGING), false);
+    assertEqual(cfg.powerSourceMaxCurrent(), particle::power::DEFAULT_INPUT_CURRENT_LIMIT);
+    assertEqual(cfg.powerSourceMinVoltage(), particle::power::DEFAULT_INPUT_VOLTAGE_LIMIT);
+    assertEqual(cfg.batteryChargeCurrent(), particle::power::DEFAULT_CHARGE_CURRENT);
+    assertEqual(cfg.batteryChargeVoltage(), particle::power::DEFAULT_TERMINATION_VOLTAGE);
+
     PMIC power(true);
     assertEqual(power.getInputCurrentLimit(), particle::power::DEFAULT_INPUT_CURRENT_LIMIT);
     assertEqual(power.getInputVoltageLimit(), particle::power::DEFAULT_INPUT_VOLTAGE_LIMIT);
@@ -462,6 +492,16 @@ test(POWER_12_ApplyingCustomPowerManagementConfigurationInRuntimeWorksAsIntended
     assertEqual(System.setPowerConfiguration(conf), (int)SYSTEM_ERROR_NONE);
     delay(1000);
 
+    auto cfg = System.getPowerConfiguration();
+    assertEqual(cfg.isFeatureSet(SystemPowerFeature::PMIC_DETECTION), true);
+    assertEqual(cfg.isFeatureSet(SystemPowerFeature::USE_VIN_SETTINGS_WITH_USB_HOST), true);
+    assertEqual(cfg.isFeatureSet(SystemPowerFeature::DISABLE), false);
+    assertEqual(cfg.isFeatureSet(SystemPowerFeature::DISABLE_CHARGING), false);
+    assertEqual(cfg.powerSourceMaxCurrent(), 550);
+    assertEqual(cfg.powerSourceMinVoltage(), 4300);
+    assertEqual(cfg.batteryChargeCurrent(), 850);
+    assertEqual(cfg.batteryChargeVoltage(), 4210);
+
     PMIC power(true);
     assertEqual(power.getInputCurrentLimit(), 500);
     assertEqual(power.getInputVoltageLimit(), 4280);
@@ -478,6 +518,16 @@ test(POWER_13_AppliedConfigurationIsPersisted) {
         skip();
         return;
     }
+
+    auto cfg = System.getPowerConfiguration();
+    assertEqual(cfg.isFeatureSet(SystemPowerFeature::PMIC_DETECTION), true);
+    assertEqual(cfg.isFeatureSet(SystemPowerFeature::USE_VIN_SETTINGS_WITH_USB_HOST), true);
+    assertEqual(cfg.isFeatureSet(SystemPowerFeature::DISABLE), false);
+    assertEqual(cfg.isFeatureSet(SystemPowerFeature::DISABLE_CHARGING), false);
+    assertEqual(cfg.powerSourceMaxCurrent(), 550);
+    assertEqual(cfg.powerSourceMinVoltage(), 4300);
+    assertEqual(cfg.batteryChargeCurrent(), 850);
+    assertEqual(cfg.batteryChargeVoltage(), 4210);
 
     PMIC power(true);
     assertEqual(power.getInputCurrentLimit(), 500);
@@ -500,6 +550,20 @@ test(POWER_14_PmicDetectionFlagIsCompatibleWithOldDeviceOsVersions) {
 #endif // HAL_PLATFORM_POWER_WORKAROUND_USB_HOST_VIN_SOURCE
     assertEqual(System.setPowerConfiguration(conf), (int)SYSTEM_ERROR_NONE);
     delay(1000);
+
+    auto cfg = System.getPowerConfiguration();
+    assertEqual(cfg.isFeatureSet(SystemPowerFeature::PMIC_DETECTION), true);
+#if HAL_PLATFORM_POWER_WORKAROUND_USB_HOST_VIN_SOURCE
+    assertEqual(cfg.isFeatureSet(SystemPowerFeature::USE_VIN_SETTINGS_WITH_USB_HOST), true);
+#else
+    assertEqual(cfg.isFeatureSet(SystemPowerFeature::USE_VIN_SETTINGS_WITH_USB_HOST), false);
+#endif // HAL_PLATFORM_POWER_WORKAROUND_USB_HOST_VIN_SOURCE
+    assertEqual(cfg.isFeatureSet(SystemPowerFeature::DISABLE), false);
+    assertEqual(cfg.isFeatureSet(SystemPowerFeature::DISABLE_CHARGING), false);
+    assertEqual(cfg.powerSourceMaxCurrent(), particle::power::DEFAULT_INPUT_CURRENT_LIMIT);
+    assertEqual(cfg.powerSourceMinVoltage(), particle::power::DEFAULT_INPUT_VOLTAGE_LIMIT);
+    assertEqual(cfg.batteryChargeCurrent(), particle::power::DEFAULT_CHARGE_CURRENT);
+    assertEqual(cfg.batteryChargeVoltage(), particle::power::DEFAULT_TERMINATION_VOLTAGE);
 
     // Feature enabled
     uint8_t v;
@@ -530,6 +594,20 @@ test(POWER_15_DisableFeatureFlag) {
         delay(5000);
         notifyAndReset();
     } else if (g_state == STATE11_MAGICK) {
+        auto cfg = System.getPowerConfiguration();
+        assertEqual(cfg.isFeatureSet(SystemPowerFeature::PMIC_DETECTION), false);
+#if HAL_PLATFORM_POWER_WORKAROUND_USB_HOST_VIN_SOURCE
+        assertEqual(cfg.isFeatureSet(SystemPowerFeature::USE_VIN_SETTINGS_WITH_USB_HOST), true);
+#else
+        assertEqual(cfg.isFeatureSet(SystemPowerFeature::USE_VIN_SETTINGS_WITH_USB_HOST), false);
+#endif // HAL_PLATFORM_POWER_WORKAROUND_USB_HOST_VIN_SOURCE
+        assertEqual(cfg.isFeatureSet(SystemPowerFeature::DISABLE), true);
+        assertEqual(cfg.isFeatureSet(SystemPowerFeature::DISABLE_CHARGING), false);
+        assertEqual(cfg.powerSourceMaxCurrent(), particle::power::DEFAULT_INPUT_CURRENT_LIMIT);
+        assertEqual(cfg.powerSourceMinVoltage(), particle::power::DEFAULT_INPUT_VOLTAGE_LIMIT);
+        assertEqual(cfg.batteryChargeCurrent(), particle::power::DEFAULT_CHARGE_CURRENT);
+        assertEqual(cfg.batteryChargeVoltage(), particle::power::DEFAULT_TERMINATION_VOLTAGE);
+
         assertEqual(System.batteryState(), (int)BATTERY_STATE_UNKNOWN);
         assertEqual(System.powerSource(), (int)POWER_SOURCE_UNKNOWN);
         // Restore default power management configuration

--- a/wiring/inc/spark_wiring_power.h
+++ b/wiring/inc/spark_wiring_power.h
@@ -102,7 +102,8 @@ public:
     byte readChargeTermRegister();
     bool disableWatchdog(void);
     bool setWatchdog(byte time);
-
+    bool enableSafetyTimer();
+    bool disableSafetyTimer();
 
 
     //Thermal Regulation Control Register

--- a/wiring/inc/spark_wiring_system.h
+++ b/wiring/inc/spark_wiring_system.h
@@ -721,6 +721,13 @@ public:
         return system_power_management_set_config(conf.config(), nullptr);
     }
 
+    particle::SystemPowerConfiguration getPowerConfiguration() const {
+        hal_power_config config = {};
+        config.size = sizeof(config);
+        system_power_management_get_config(&config, nullptr);
+        return particle::SystemPowerConfiguration(config);
+    }
+
     int powerSource() const {
         particle::AbstractIntegerDiagnosticData::IntType val;
         const auto r = particle::AbstractIntegerDiagnosticData::get(DIAG_ID_SYSTEM_POWER_SOURCE, val);

--- a/wiring/inc/spark_wiring_system_power.h
+++ b/wiring/inc/spark_wiring_system_power.h
@@ -30,7 +30,8 @@ enum class SystemPowerFeature {
     NONE = 0,
     PMIC_DETECTION = HAL_POWER_PMIC_DETECTION,
     USE_VIN_SETTINGS_WITH_USB_HOST = HAL_POWER_USE_VIN_SETTINGS_WITH_USB_HOST,
-    DISABLE = HAL_POWER_MANAGEMENT_DISABLE
+    DISABLE = HAL_POWER_MANAGEMENT_DISABLE,
+    DISABLE_CHARGING = HAL_POWER_CHARGE_STATE_DISABLE
 };
 
 class SystemPowerConfiguration {
@@ -42,6 +43,7 @@ public:
     }
 
     SystemPowerConfiguration(SystemPowerConfiguration&&) = default;
+    SystemPowerConfiguration(const hal_power_config& conf) : conf_(conf) {}
     SystemPowerConfiguration& operator=(SystemPowerConfiguration&&) = default;
 
     SystemPowerConfiguration& powerSourceMinVoltage(uint16_t voltage) {
@@ -49,9 +51,17 @@ public:
         return *this;
     }
 
+    uint16_t powerSourceMinVoltage() const {
+        return conf_.vin_min_voltage;
+    }
+
     SystemPowerConfiguration& powerSourceMaxCurrent(uint16_t current) {
         conf_.vin_max_current = current;
         return *this;
+    }
+
+    uint16_t powerSourceMaxCurrent() const {
+        return conf_.vin_max_current;
     }
 
     SystemPowerConfiguration& batteryChargeVoltage(uint16_t voltage) {
@@ -59,14 +69,26 @@ public:
         return *this;
     }
 
+    uint16_t batteryChargeVoltage() const {
+        return conf_.termination_voltage;
+    }
+
     SystemPowerConfiguration& batteryChargeCurrent(uint16_t current) {
         conf_.charge_current = current;
         return *this;
     }
 
+    uint16_t batteryChargeCurrent() const {
+        return conf_.charge_current;
+    }
+
     SystemPowerConfiguration& feature(EnumFlags<SystemPowerFeature> f) {
         conf_.flags |= f.value();
         return *this;
+    }
+
+    bool isFeatureSet(EnumFlags<SystemPowerFeature> f) const {
+        return (conf_.flags & f.value()) ? true : false;
     }
 
     const hal_power_config* config() const {


### PR DESCRIPTION
### Problem

The power manager may override user requests to disable battery charging.  While the user may set the charge state on the PMIC, the power manager may enable charge state silently.

### Solution

Add a flag for non-volatile power management configuration that ensures that the power manager honor user requests to disable charging.  Additionally create get methods for the configuration so that the user can query the current configuration.

### Steps to Test

Which unit/integration/application tests are applicable to this code change? (At minimum a test of some kind should be provided)

### Example App

```c
SerialLogHandler logHandler;

void setup() {
    // Apply a custom power configuration
    SystemPowerConfiguration conf;

    conf.feature(SystemPowerFeature::DISABLE_CHARGING);

    int res = System.setPowerConfiguration(conf);
    Log.info("setPowerConfiguration=%d", res);
    // returns SYSTEM_ERROR_NONE (0) in case of success

    // Settings are persisted, you normally wouldn't do this on every startup.
}

void loop() {
    auto config = System.getPowerConfiguration();
    Log.info("Current PMIC settings:");
    Log.info("PMIC detection: %s", cfg.isFeatureSet(SystemPowerFeature::PMIC_DETECTION) ? "true" : "false");
    Log.info("Use VIN with USB: %s", cfg.isFeatureSet(SystemPowerFeature::USE_VIN_SETTINGS_WITH_USB_HOST) ? "true" : "false");
    Log.info("Power manager disabled: %s", cfg.isFeatureSet(SystemPowerFeature::DISABLE) ? "true" : "false");
    Log.info("Charging disabled: %s", cfg.isFeatureSet(SystemPowerFeature::DISABLE_CHARGING) ? "true" : "false");
    Log.info("Input voltage: %u mV", cfg.powerSourceMinVoltage())
    Log.info("Input current: %u mA", cfg.powerSourceMaxCurrent());
    Log.info("Charge voltage: %u mV", cfg.batteryChargeVoltage());
    Log.info("Charge current: %u mA", cfg.batteryChargeCurrent());
}
```

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
