### PR TITLE
Wiznetif: report module power state.

### DIFF
--- a/hal/network/lwip/wiznet/wiznetif.cpp
+++ b/hal/network/lwip/wiznet/wiznetif.cpp
@@ -109,6 +109,7 @@ WizNetif::WizNetif(hal_spi_interface_t spi, pin_t cs, pin_t reset, pin_t interru
           cs_(cs),
           reset_(reset),
           interrupt_(interrupt),
+          pwrState_(IF_POWER_STATE_NONE),
           spiLock_(spi, WIZNET_DEFAULT_CONFIG) {
 
     LOG(INFO, "Creating Wiznet LwIP interface");
@@ -265,8 +266,10 @@ err_t WizNetif::initInterface() {
 
     hwReset();
     if (!isPresent()) {
+        pwrState_ = IF_POWER_STATE_DOWN;
         return ERR_IF;
     }
+    pwrState_ = IF_POWER_STATE_UP;
 
     return ERR_OK;
 }
@@ -345,6 +348,12 @@ int WizNetif::up() {
         down_ = false;
     }
 
+    // Just in case. We might call up() directly after powerDown().
+    if (pwrState_ != IF_POWER_STATE_UP) {
+        pwrState_ = IF_POWER_STATE_UP;
+        notifyPowerState();
+    }
+
     return r;
 }
 
@@ -358,16 +367,40 @@ int WizNetif::down() {
 }
 
 int WizNetif::powerUp() {
-    return 0;
+    // FIXME: As long as the interface is initialized,
+    // it must have been powered up as of right now.
+    if (pwrState_ != IF_POWER_STATE_UP) {
+        pwrState_ = IF_POWER_STATE_UP;
+        notifyPowerState();
+    }
+    return SYSTEM_ERROR_NONE;
 }
 
 int WizNetif::powerDown() {
-    return down();
+    int ret = down();
+    // FIXME: This don't really power off the module.
+    // Notify the system network manager that the module is powered down
+    // to bypass waitInterfaceOff() as required by system sleep.
+    if (pwrState_ != IF_POWER_STATE_DOWN) {
+        pwrState_ = IF_POWER_STATE_DOWN;
+        notifyPowerState();
+    }
+    return ret;
+}
+
+void WizNetif::notifyPowerState() {
+    if_event evt = {};
+    struct if_event_power_state ev_if_power_state = {};
+    evt.ev_len = sizeof(if_event);
+    evt.ev_type = IF_EVENT_POWER_STATE;
+    evt.ev_power_state = &ev_if_power_state;
+    evt.ev_power_state->state = pwrState_;
+    if_notify_event(interface(), &evt, nullptr);
 }
 
 int WizNetif::getPowerState(if_power_state_t* state) const {
-    // TODO: implement it
-    return SYSTEM_ERROR_NOT_SUPPORTED;
+    *state = pwrState_;
+    return SYSTEM_ERROR_NONE;
 }
 
 int WizNetif::getNcpState(unsigned int* state) const {

--- a/hal/network/lwip/wiznet/wiznetif.cpp
+++ b/hal/network/lwip/wiznet/wiznetif.cpp
@@ -368,9 +368,9 @@ int WizNetif::down() {
 int WizNetif::powerUp() {
     // FIXME: As long as the interface is initialized,
     // it must have been powered up as of right now.
-    if (pwrState_ != IF_POWER_STATE_UP) {
-        notifyPowerState(IF_POWER_STATE_UP);
-    }
+    // The system network manager transit the interface to powering up,
+    // we should always notify the event to transit the interface to powered up.
+    notifyPowerState(IF_POWER_STATE_UP);
     return SYSTEM_ERROR_NONE;
 }
 
@@ -379,9 +379,9 @@ int WizNetif::powerDown() {
     // FIXME: This don't really power off the module.
     // Notify the system network manager that the module is powered down
     // to bypass waitInterfaceOff() as required by system sleep.
-    if (pwrState_ != IF_POWER_STATE_DOWN) {
-        notifyPowerState(IF_POWER_STATE_DOWN);
-    }
+    // The system network manager transit the interface to powering down,
+    // we should always notify the event to transit the interface to powered down.
+    notifyPowerState(IF_POWER_STATE_DOWN);
     return ret;
 }
 

--- a/hal/network/lwip/wiznet/wiznetif.cpp
+++ b/hal/network/lwip/wiznet/wiznetif.cpp
@@ -350,8 +350,7 @@ int WizNetif::up() {
 
     // Just in case. We might call up() directly after powerDown().
     if (pwrState_ != IF_POWER_STATE_UP) {
-        pwrState_ = IF_POWER_STATE_UP;
-        notifyPowerState();
+        notifyPowerState(IF_POWER_STATE_UP);
     }
 
     return r;
@@ -370,8 +369,7 @@ int WizNetif::powerUp() {
     // FIXME: As long as the interface is initialized,
     // it must have been powered up as of right now.
     if (pwrState_ != IF_POWER_STATE_UP) {
-        pwrState_ = IF_POWER_STATE_UP;
-        notifyPowerState();
+        notifyPowerState(IF_POWER_STATE_UP);
     }
     return SYSTEM_ERROR_NONE;
 }
@@ -382,13 +380,13 @@ int WizNetif::powerDown() {
     // Notify the system network manager that the module is powered down
     // to bypass waitInterfaceOff() as required by system sleep.
     if (pwrState_ != IF_POWER_STATE_DOWN) {
-        pwrState_ = IF_POWER_STATE_DOWN;
-        notifyPowerState();
+        notifyPowerState(IF_POWER_STATE_DOWN);
     }
     return ret;
 }
 
-void WizNetif::notifyPowerState() {
+void WizNetif::notifyPowerState(if_power_state_t state) {
+    pwrState_ = state;
     if_event evt = {};
     struct if_event_power_state ev_if_power_state = {};
     evt.ev_len = sizeof(if_event);

--- a/hal/network/lwip/wiznet/wiznetif.h
+++ b/hal/network/lwip/wiznet/wiznetif.h
@@ -76,11 +76,15 @@ private:
     static err_t linkOutputCb(netif* netif, pbuf* p);
     err_t linkOutput(pbuf* p);
 
+    void notifyPowerState();
+
 private:
     hal_spi_interface_t spi_;
     pin_t cs_;
     pin_t reset_;
     pin_t interrupt_;
+
+    std::atomic<if_power_state_t> pwrState_;
 
     os_thread_t thread_ = nullptr;
     os_queue_t queue_ = nullptr;

--- a/hal/network/lwip/wiznet/wiznetif.h
+++ b/hal/network/lwip/wiznet/wiznetif.h
@@ -76,7 +76,7 @@ private:
     static err_t linkOutputCb(netif* netif, pbuf* p);
     err_t linkOutput(pbuf* p);
 
-    void notifyPowerState();
+    void notifyPowerState(if_power_state_t state);
 
 private:
     hal_spi_interface_t spi_;

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -62,7 +62,7 @@ static bool system_sleep_network_suspend(network_interface_index index) {
 #endif
     // Turn off the modem
     network_off(index, 0, 0, NULL);
-    LOG(TRACE, "Waiting interface to be off...");
+    LOG(TRACE, "Waiting interface %d to be off...", (int)index);
     // There might be up to 30s delay to turn off the modem for particular platforms.
     network_wait_off(index, 120000/*ms*/, nullptr);
     return resume;


### PR DESCRIPTION

### Problem
The device may timeout waiting the ethernet interface to be off() when sleep is requested and the ethernet interface is present.
### Solution
Report the Wiznetif power state to system network manager.

Note that the W5500 module is actually on still even if we've called the corresponding API to turn it off. Because there is no hardware pins to control the power to the W5500 module, nor we implement the low power mode for W5500.
### Example App
```c
#include "application.h"

STARTUP(System.enableFeature(FEATURE_ETHERNET_DETECTION));

SerialLogHandler l(LOG_LEVEL_ALL);

SYSTEM_MODE(MANUAL);

void setup() {
    while (!Serial.isConnected());
    Log.info("Application started.");

    System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::ULTRA_LOW_POWER).duration(5s));
}

void loop() {
}
```
---
### Completeness
- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
