### PR TITLE
Update disable charging feature in power management wiring and API tests

### DIFF
--- a/user/tests/wiring/api/system.cpp
+++ b/user/tests/wiring/api/system.cpp
@@ -415,11 +415,23 @@ test(system_power_management) {
     API_COMPILE(conf.feature(SystemPowerFeature::PMIC_DETECTION));
     API_COMPILE(conf.feature(SystemPowerFeature::USE_VIN_SETTINGS_WITH_USB_HOST));
     API_COMPILE(conf.feature(SystemPowerFeature::DISABLE));
+    API_COMPILE(conf.feature(SystemPowerFeature::DISABLE_CHARGING));
 
     API_COMPILE(System.setPowerConfiguration(conf));
 
     API_COMPILE({ auto source = System.powerSource() == POWER_SOURCE_VIN; (void)source; });
     API_COMPILE({ auto state = System.batteryState() == BATTERY_STATE_CHARGING; (void)state; });
     API_COMPILE({ auto charge = System.batteryCharge(); (void)charge; });
+
+    SystemPowerConfiguration getConf = {};
+    API_COMPILE({ getConf = System.getPowerConfiguration(); });
+    API_COMPILE({ auto featurePmic = getConf.isFeatureSet(SystemPowerFeature::PMIC_DETECTION); (void)featurePmic; });
+    API_COMPILE({ auto featureVin = getConf.isFeatureSet(SystemPowerFeature::USE_VIN_SETTINGS_WITH_USB_HOST); (void)featureVin; });
+    API_COMPILE({ auto featureDisable = getConf.isFeatureSet(SystemPowerFeature::DISABLE); (void)featureDisable; });
+    API_COMPILE({ auto featureCharging = getConf.isFeatureSet(SystemPowerFeature::DISABLE_CHARGING); (void)featureCharging; });
+    API_COMPILE({ auto getSourceA = getConf.powerSourceMaxCurrent(); (void)getSourceA; });
+    API_COMPILE({ auto getSourceV = getConf.powerSourceMinVoltage(); (void)getSourceV; });
+    API_COMPILE({ auto getBatteryA = getConf.batteryChargeCurrent(); (void)getBatteryA; });
+    API_COMPILE({ auto getBatteryV = getConf.batteryChargeVoltage(); (void)getBatteryV; });
 }
 #endif // HAL_PLATFORM_POWER_MANAGEMENT


### PR DESCRIPTION
### Problem

Power management tests were incomplete for a new battery charge disable feature.

### Solution

How does this PR address the problem stated above? (Describing the solutions implemented in code will facilitate a smooth discussion, review and testing of this PR)

### Steps to Test

The `wiring/api` and `wiring/power_management` tests were updated for compile and on-device tests.  Use make commands to compile and program

``` bash
$ make PLATFORM=<your platform> TEST=wiring/api clean all
$ make PLATFORM=<your platform> TEST=wiring/power_management all program-dfu
```
Results will show a clean build for the `wiring/api` compile and something similar to the following for `wiring/power_management`

```
Test POWER_16_PrepareDisableChargingFeatureFlag skipped.
Test POWER_17_DisableChargingFeatureFlag passed.
Device will pause about 40s to check PMIC watchdog reset
Test POWER_18_DisableChargingFeatureFlagWithWatchdog passed.
Device will pause about 40s to check PMIC watchdog reset
Test POWER_19_NotDisableChargingFeatureFlagWithWatchdog passed.
```

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
