### PR TITLE
[Boron LTE] Fix external SIM getting stuck in init

### DIFF
--- a/hal/network/ncp_client/sara/sara_ncp_client.h
+++ b/hal/network/ncp_client/sara/sara_ncp_client.h
@@ -142,6 +142,7 @@ private:
     int checkRunningImsi();
     int processEventsImpl();
     int getIccidImpl(char* buf, size_t size);
+    int checkNetConfForImsi();
 
     int modemInit() const;
     bool waitModemPowerState(bool onOff, system_tick_t timeout);


### PR DESCRIPTION
### Problem

Boron LTEs get stuck in initialization with third party SIMs, due to AT+CIMI (IMSI lookup) error in certain cases.

### Solution

In an attempt to set credentials during init, for any SIMs whose ICCIDs are not recognized, their IMSI is checked. Checking IMSI after setting UMNOPROF (mobile network operator profile) gives a `CME ERROR: SIM failure` or `CME ERROR: SIM wrong` if not added a delay. Currently when this happens, we already have a retry logic that should have worked but the impl exits with an error instead of retrying. 
1. Added delay so that we don't expect these failures
2. Fixed retry logic
```

Callbox SIM
=========
0000060048 [ncp.at] TRACE: > AT+CIMI
0000060050 [ncp.at] TRACE: < +CME ERROR: SIM wrong
0000060152 [ncp.at] TRACE: > AT+CIMI
0000060157 [ncp.at] TRACE: < 001010123456789
0000060158 [ncp.at] TRACE: < OK


0000099347 [ncp.at] TRACE: > AT+CIMI
0000099350 [ncp.at] TRACE: < +CME ERROR: SIM failure
0000099457 [ncp.at] TRACE: > AT+CIMI
0000099459 [ncp.at] TRACE: < +CME ERROR: SIM wrong
0000099659 [ncp.at] TRACE: > AT+CIMI
0000099661 [ncp.at] TRACE: < 001010123456789
0000099662 [ncp.at] TRACE: < OK

ATT EXTERNAL SIM with unrecongnised iccid
====================================
0000115689 [ncp.at] TRACE: > AT+CIMI
0000115693 [ncp.at] TRACE: < +CME ERROR: SIM wrong
0000115799 [ncp.at] TRACE: > AT+CIMI
0000115801 [ncp.at] TRACE: < +CME ERROR: SIM wrong
0000116001 [ncp.at] TRACE: > AT+CIMI
0000119879 [ncp.at] TRACE: < 310030001491024
0000119879 [ncp.at] TRACE: < OK



```

### Steps to Test

Please make sure to use an external third-party SIM that is not recognized by [network config db](https://github.com/particle-iot/device-os/blob/v2.0.1/hal/network/ncp/cellular/network_config_db.cpp#L39-L45) so that it's IMSI is checked to set credentials. We should no longer get stuck.
1. Run this app
2. Two button presses - resets the umnoprof setting
3. Three button presses - attempts particle connect and should work
### Example App

```c
#include "Particle.h"
SerialLogHandler logHandler(LOG_LEVEL_ALL);
Serial1LogHandler logHandler1(115200, LOG_LEVEL_ALL);
SYSTEM_MODE(SEMI_AUTOMATIC);
bool reset_umnoprof = false;
bool particle_connect = false;
void button_handler(system_event_t event, int clicks)
{
    if (event == button_final_click) {
        if (clicks == 2) {
            reset_umnoprof = true;
        } else if (clicks == 3) {
            particle_connect = true;
        }
    }
}
void setup() {
    System.on(button_final_click, button_handler);
    // Cellular.setActiveSim(EXTERNAL_SIM); // you might need this
    // Cellular.setActiveSim(INTERNAL_SIM);
    Cellular.on();
    delay(5s);
    Log.info("\r\n\r\nCellular On\r\n\r\n");
}
void loop() {
    if (reset_umnoprof) {
        Log.info("Reset UMNOPROF");
        reset_umnoprof = false;
        Cellular.command(60000, "AT+CFUN=0\r\n");
        Cellular.command(1000, "AT+UMNOPROF=0\r\n");
        Cellular.command(1000, "AT+UMNOPROF?\r\n");
        Cellular.command(1000, "AT+CFUN=15\r\n");
        Log.info("\r\n\r\nCold boot for a Factory Boot Experience!\r\n\r\n");
    }
    if (particle_connect) {
        Log.info("Calling Particle.connect");
        particle_connect = false;
        Particle.connect();
    }
}
```

### References

[ch70471](https://app.clubhouse.io/particle/story/70471/external-sim-boron-lte-sim-fails-to-initialize-when-reset-gets-stuck-in-the-loop)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] N/A Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
