### PR TITLE
Send modem firmware version to cloud

### DIFF
--- a/hal/inc/cellular_hal_constants.h
+++ b/hal/inc/cellular_hal_constants.h
@@ -62,6 +62,7 @@ struct CellularDevice
     uint16_t size;
     char iccid[21];
     char imei[16];
+    char radiofw[17];
     int dev;
 
     CellularDevice()

--- a/hal/inc/cellular_hal_constants.h
+++ b/hal/inc/cellular_hal_constants.h
@@ -62,8 +62,8 @@ struct CellularDevice
     uint16_t size;
     char iccid[21];
     char imei[16];
-    char radiofw[17];
     int dev;
+    char radiofw[25];
 
     CellularDevice()
     {

--- a/hal/network/ncp/cellular/cellular_hal.cpp
+++ b/hal/network/ncp/cellular/cellular_hal.cpp
@@ -192,7 +192,6 @@ int cellular_device_info(CellularDevice* info, void* reserved) {
     CHECK(client->on());
     CHECK(client->getIccid(info->iccid, sizeof(info->iccid)));
     CHECK(client->getImei(info->imei, sizeof(info->imei)));
-    CHECK(client->getFirmwareVersionString(info->radiofw, sizeof(info->radiofw)));
     if (info->size >= offsetof(CellularDevice, dev) + sizeof(CellularDevice::dev)) {
         switch (client->ncpId()) {
         case PLATFORM_NCP_SARA_U201:
@@ -220,6 +219,9 @@ int cellular_device_info(CellularDevice* info, void* reserved) {
             info->dev = DEV_UNKNOWN;
             break;
         }
+    }
+    if (info->size >= offsetof(CellularDevice, radiofw) + sizeof(CellularDevice::radiofw)) {
+        CHECK(client->getFirmwareVersionString(info->radiofw, sizeof(info->radiofw)));
     }
     return 0;
 }

--- a/hal/network/ncp/cellular/cellular_hal.cpp
+++ b/hal/network/ncp/cellular/cellular_hal.cpp
@@ -192,6 +192,7 @@ int cellular_device_info(CellularDevice* info, void* reserved) {
     CHECK(client->on());
     CHECK(client->getIccid(info->iccid, sizeof(info->iccid)));
     CHECK(client->getImei(info->imei, sizeof(info->imei)));
+    CHECK(client->getFirmwareVersionString(info->radiofw, sizeof(info->radiofw)));
     if (info->size >= offsetof(CellularDevice, dev) + sizeof(CellularDevice::dev)) {
         switch (client->ncpId()) {
         case PLATFORM_NCP_SARA_U201:

--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -438,7 +438,7 @@ NcpConnectionState SaraNcpClient::connectionState() {
 int SaraNcpClient::getFirmwareVersionString(char* buf, size_t size) {
     const NcpClientLock lock(this);
     CHECK(checkParser());
-    auto resp = parser_.sendCommand("AT+CGMR");
+    auto resp = parser_.sendCommand("ATI9");
     CHECK_PARSER(resp.readLine(buf, size));
     const int r = CHECK_PARSER(resp.readResult());
     CHECK_TRUE(r == AtResponse::OK, SYSTEM_ERROR_AT_NOT_OK);

--- a/hal/src/b5som/ota_flash_hal.cpp
+++ b/hal/src/b5som/ota_flash_hal.cpp
@@ -32,7 +32,7 @@ void HAL_OTA_Add_System_Info(hal_system_info_t* info, bool create, void* reserve
         cellular_device_info(&device, NULL);
         set_key_value(info->key_values+count, "imei", device.imei);
         set_key_value(info->key_values+count+1, "iccid", device.iccid);
-        set_key_value(info->key_values+count+2, "radiofw", device.radiofw);
+        set_key_value(info->key_values+count+2, "cellfw", device.radiofw);
     }
     platform_radio_stack_fetch_module_info(info, create);
 }

--- a/hal/src/b5som/ota_flash_hal.cpp
+++ b/hal/src/b5som/ota_flash_hal.cpp
@@ -22,7 +22,7 @@
 
 void HAL_OTA_Add_System_Info(hal_system_info_t* info, bool create, void* reserved)
 {
-    const int additional = 2;
+    const int additional = 3;
     int count = add_system_properties(info, create, additional);
     if (create) {
         info->key_value_count = count + additional;
@@ -32,6 +32,7 @@ void HAL_OTA_Add_System_Info(hal_system_info_t* info, bool create, void* reserve
         cellular_device_info(&device, NULL);
         set_key_value(info->key_values+count, "imei", device.imei);
         set_key_value(info->key_values+count+1, "iccid", device.iccid);
+        set_key_value(info->key_values+count+2, "radiofw", device.radiofw);
     }
     platform_radio_stack_fetch_module_info(info, create);
 }

--- a/hal/src/boron/ota_flash_hal.cpp
+++ b/hal/src/boron/ota_flash_hal.cpp
@@ -40,7 +40,7 @@ void HAL_OTA_Add_System_Info(hal_system_info_t* info, bool create, void* reserve
         cellular_device_info(&device, NULL);
         set_key_value(info->key_values+count, "imei", device.imei);
         set_key_value(info->key_values+count+1, "iccid", device.iccid);
-        set_key_value(info->key_values+count+2, "radiofw", device.radiofw);
+        set_key_value(info->key_values+count+2, "cellfw", device.radiofw);
     }
     platform_radio_stack_fetch_module_info(info, create);
 }

--- a/hal/src/boron/ota_flash_hal.cpp
+++ b/hal/src/boron/ota_flash_hal.cpp
@@ -30,7 +30,7 @@
 
 void HAL_OTA_Add_System_Info(hal_system_info_t* info, bool create, void* reserved)
 {
-    const int additional = 2;
+    const int additional = 3;
     int count = add_system_properties(info, create, additional);
     if (create) {
         info->key_value_count = count + additional;
@@ -40,6 +40,7 @@ void HAL_OTA_Add_System_Info(hal_system_info_t* info, bool create, void* reserve
         cellular_device_info(&device, NULL);
         set_key_value(info->key_values+count, "imei", device.imei);
         set_key_value(info->key_values+count+1, "iccid", device.iccid);
+        set_key_value(info->key_values+count+2, "radiofw", device.radiofw);
     }
     platform_radio_stack_fetch_module_info(info, create);
 }

--- a/hal/src/electron/cellular_hal.cpp
+++ b/hal/src/electron/cellular_hal.cpp
@@ -180,9 +180,13 @@ cellular_result_t cellular_device_info(CellularDevice* device, void* reserved)
     // this would benefit from an unsolicited event to call electronMDM.init() automatically on sim card insert)
     strncpy(device->imei, status->imei, sizeof(device->imei));
     strncpy(device->iccid, status->ccid, sizeof(device->iccid));
-    strncpy(device->radiofw, status->ver, sizeof(device->radiofw));
     if (device->size >= offsetof(CellularDevice, dev) + sizeof(CellularDevice::dev)) {
         device->dev = status->dev;
+    }
+    if (device->size >= offsetof(CellularDevice, radiofw) + sizeof(CellularDevice::radiofw)) {
+        char buf[25];
+        electronMDM.getExtRadioVer(buf, sizeof(buf));
+        strncpy(device->radiofw, buf, sizeof(device->radiofw));
     }
     return 0;
 }

--- a/hal/src/electron/cellular_hal.cpp
+++ b/hal/src/electron/cellular_hal.cpp
@@ -180,6 +180,7 @@ cellular_result_t cellular_device_info(CellularDevice* device, void* reserved)
     // this would benefit from an unsolicited event to call electronMDM.init() automatically on sim card insert)
     strncpy(device->imei, status->imei, sizeof(device->imei));
     strncpy(device->iccid, status->ccid, sizeof(device->iccid));
+    strncpy(device->radiofw, status->ver, sizeof(device->radiofw));
     if (device->size >= offsetof(CellularDevice, dev) + sizeof(CellularDevice::dev)) {
         device->dev = status->dev;
     }

--- a/hal/src/electron/cellular_hal.cpp
+++ b/hal/src/electron/cellular_hal.cpp
@@ -184,9 +184,7 @@ cellular_result_t cellular_device_info(CellularDevice* device, void* reserved)
         device->dev = status->dev;
     }
     if (device->size >= offsetof(CellularDevice, radiofw) + sizeof(CellularDevice::radiofw)) {
-        char buf[25];
-        electronMDM.getExtRadioVer(buf, sizeof(buf));
-        strncpy(device->radiofw, buf, sizeof(device->radiofw));
+        electronMDM.getExtRadioVer(device->radiofw, sizeof(device->radiofw));
     }
     return 0;
 }

--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -89,6 +89,8 @@ public:
 
     const DevStatus* getDevStatus() { return &_dev; }
 
+    void getExtRadioVer(char* verStr, int len) { strncpy(verStr, _verExtended, len); };
+
     /** register to the network
         \param status an optional structure to with network information
         \param timeout_ms -1 blocking, else non blocking timeout in ms

--- a/hal/src/electron/ota_flash_hal.cpp
+++ b/hal/src/electron/ota_flash_hal.cpp
@@ -32,7 +32,7 @@
 
 void HAL_OTA_Add_System_Info(hal_system_info_t* info, bool create, void* reserved)
 {
-    const int additional = 2;
+    const int additional = 3;
     int count = add_system_properties(info, create, additional);
     if (create) {
         info->key_value_count = count + additional;
@@ -43,5 +43,6 @@ void HAL_OTA_Add_System_Info(hal_system_info_t* info, bool create, void* reserve
 
         set_key_value(info->key_values + count, "imei", device.imei);
         set_key_value(info->key_values + count + 1, "iccid", device.iccid);
+        set_key_value(info->key_values + count + 2, "radiofw", device.radiofw);
     }
 }

--- a/hal/src/electron/ota_flash_hal.cpp
+++ b/hal/src/electron/ota_flash_hal.cpp
@@ -43,6 +43,6 @@ void HAL_OTA_Add_System_Info(hal_system_info_t* info, bool create, void* reserve
 
         set_key_value(info->key_values + count, "imei", device.imei);
         set_key_value(info->key_values + count + 1, "iccid", device.iccid);
-        set_key_value(info->key_values + count + 2, "radiofw", device.radiofw);
+        set_key_value(info->key_values + count + 2, "cellfw", device.radiofw);
     }
 }

--- a/hal/src/tracker/ota_flash_hal.cpp
+++ b/hal/src/tracker/ota_flash_hal.cpp
@@ -33,7 +33,7 @@ void HAL_OTA_Add_System_Info(hal_system_info_t* info, bool create, void* reserve
         cellular_device_info(&device, NULL);
         set_key_value(info->key_values+count, "imei", device.imei);
         set_key_value(info->key_values+count+1, "iccid", device.iccid);
-        set_key_value(info->key_values+count+2, "radiofw", device.radiofw);
+        set_key_value(info->key_values+count+2, "cellfw", device.radiofw);
     }
     platform_ncp_fetch_module_info(info, create);
     platform_radio_stack_fetch_module_info(info, create);

--- a/hal/src/tracker/ota_flash_hal.cpp
+++ b/hal/src/tracker/ota_flash_hal.cpp
@@ -23,7 +23,7 @@
 
 void HAL_OTA_Add_System_Info(hal_system_info_t* info, bool create, void* reserved)
 {
-    const int additional = 2;
+    const int additional = 3;
     int count = add_system_properties(info, create, additional);
     if (create) {
         info->key_value_count = count + additional;
@@ -33,6 +33,7 @@ void HAL_OTA_Add_System_Info(hal_system_info_t* info, bool create, void* reserve
         cellular_device_info(&device, NULL);
         set_key_value(info->key_values+count, "imei", device.imei);
         set_key_value(info->key_values+count+1, "iccid", device.iccid);
+        set_key_value(info->key_values+count+2, "radiofw", device.radiofw);
     }
     platform_ncp_fetch_module_info(info, create);
     platform_radio_stack_fetch_module_info(info, create);

--- a/system/src/system_setup.cpp
+++ b/system/src/system_setup.cpp
@@ -278,7 +278,7 @@ bool filter_key(const char* src, char* dest, size_t size) {
 	else if (!strcmp(src, "ms")) {
 		strcpy(dest, "Device Secret");
 	}
-	else if (!strcmp(src, "radiofw")) {
+	else if (!strcmp(src, "cellradiofw")) {
 		strcpy(dest, "Radio Version");
 	}
 	return false;

--- a/system/src/system_setup.cpp
+++ b/system/src/system_setup.cpp
@@ -278,6 +278,9 @@ bool filter_key(const char* src, char* dest, size_t size) {
 	else if (!strcmp(src, "ms")) {
 		strcpy(dest, "Device Secret");
 	}
+	else if (!strcmp(src, "radiofw")) {
+		strcpy(dest, "Radio Version");
+	}
 	return false;
 }
 

--- a/system/src/system_setup.cpp
+++ b/system/src/system_setup.cpp
@@ -278,8 +278,8 @@ bool filter_key(const char* src, char* dest, size_t size) {
 	else if (!strcmp(src, "ms")) {
 		strcpy(dest, "Device Secret");
 	}
-	else if (!strcmp(src, "cellradiofw")) {
-		strcpy(dest, "Radio Version");
+	else if (!strcmp(src, "cellfw")) {
+		strcpy(dest, "Cell Radio Version");
 	}
 	return false;
 }


### PR DESCRIPTION
### Problem

Send modem firmware version string to cloud.

### Solution

Report this as a part of System describe message.

### Steps to Test
### Example App
```c
void setup() {
}

void loop() {
}
```
Modem firmware version is reported to cloud, and is seen on the device-service logs as follows:
1. Boron LTE
```
"{\"p\":13,\"imei\":\"352753090224310\",\"iccid\":\"89010303300014910245\",\"radiofw\":\"L0.0.00.00.05.08,A.02.04\",\"m\":
```
2. Electron LTE
```
"{\"p\":10,\"imei\":\"352753091571107\",\"iccid\":\"89014103271229647548\",\"radiofw\":\"L0.0.00.00.05.08,A.02.04\",\"m\":
```
3. Tracker EVB
```
"{\"p\":26,\"imei\":\"860112043255142\",\"iccid\":\"89014103271549980686\",\"radiofw\":\"BG96MAR04A04M1G\",\"m\"......
```
4. Boron 2G/3G
```
"{\"p\":13,\"imei\":\"357520078500895\",\"iccid\":\"89014103271549980678\",\"radiofw\":\"23.60,A01.01\",\"m\":
```

### References

- [ch37230](https://app.clubhouse.io/particle/story/37230/report-the-cellular-modem-version-to-the-cloud)
- [ch68214](https://app.clubhouse.io/particle/story/68214/receive-modem-firmware-version-from-device-os)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
