### PR TITLE
[wiring] BLE: return false if expected characteristic is not found.

### DIFF
--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -1757,7 +1757,7 @@ bool BlePeerDevice::getCharacteristicByDescription(BleCharacteristic& characteri
             return true;
         }
     }
-    return true;
+    return false;
 }
 
 bool BlePeerDevice::getCharacteristicByDescription(BleCharacteristic& characteristic, const String& desc) const {
@@ -1806,7 +1806,7 @@ bool BlePeerDevice::getCharacteristicByDescription(const BleService& service, Bl
             return true;
         }
     }
-    return true;
+    return false;
 }
 
 bool BlePeerDevice::getCharacteristicByDescription(const BleService& service, BleCharacteristic& characteristic, const String& desc) const {


### PR DESCRIPTION
### Problem
`getCharacteristicByDescription()` return `true` even if there is no characteristic is matched.
### Solution
return `false` if there is no characteristic matches the given description.
### Example App
N/A
### References
N/A
### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
