### PR TITLE
AT parser and gsm0710 muxer custom log category support

### DIFF
--- a/hal/network/ncp/at_parser/at_parser.h
+++ b/hal/network/ncp/at_parser/at_parser.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <memory>
+#include "c_string.h"
 
 namespace particle {
 
@@ -77,6 +78,12 @@ public:
      * @see `logEnabled()`
      */
     static const auto DEFAULT_LOG_ENABLED = true;
+    /**
+     * Default logging category
+     *
+     * @see `logCategory()`
+     */
+    static constexpr auto DEFAULT_LOG_CATEGORY = "ncp.at";
 
     /**
      * Constructs a settings object with all parameters set to their default values.
@@ -176,6 +183,22 @@ public:
      * @see `DEFAULT_LOG_ENABLED`
      */
     bool logEnabled() const;
+    /**
+     * Sets the logging category.
+     *
+     * @return This settings object.
+     *
+     * @see `DEFAULT_LOG_CATEGORY`
+     */
+    AtParserConfig& logCategory(const char* category);
+    /**
+     * Returns the logging category.
+     *
+     * @return Logging category.
+     *
+     * @see `DEFAULT_LOG_CATEGORY`
+     */
+    const char* logCategory() const;
 
 private:
     Stream* strm_;
@@ -184,6 +207,7 @@ private:
     unsigned strmTimeout_;
     bool echoEnabled_;
     bool logEnabled_;
+    CString logCategory_;
 };
 
 /**
@@ -444,6 +468,15 @@ inline AtParserConfig& AtParserConfig::logEnabled(bool enabled) {
 
 inline bool AtParserConfig::logEnabled() const {
     return logEnabled_;
+}
+
+inline AtParserConfig& AtParserConfig::logCategory(const char* category) {
+    logCategory_ = category;
+    return *this;
+}
+
+inline const char* AtParserConfig::logCategory() const {
+    return logCategory_ ? static_cast<const char*>(logCategory_) : DEFAULT_LOG_CATEGORY;
 }
 
 } // particle

--- a/hal/network/ncp/at_parser/at_parser_impl.cpp
+++ b/hal/network/ncp/at_parser/at_parser_impl.cpp
@@ -32,7 +32,6 @@
 
 #undef LOG_COMPILE_TIME_LEVEL
 #define LOG_COMPILE_TIME_LEVEL LOG_LEVEL_ALL
-LOG_SOURCE_CATEGORY("ncp.at");
 
 namespace particle {
 
@@ -64,18 +63,6 @@ size_t appendToBuf(char* dest, size_t destSize, const char* src, size_t srcSize)
     const size_t n = std::min(srcSize, destSize);
     memcpy(dest, src, n);
     return n;
-}
-
-void logCmdLine(const char* data, size_t size) {
-    if (size > 0) {
-        LOG(TRACE, "> %.*s", size, data);
-    }
-}
-
-void logRespLine(const char* data, size_t size) {
-    if (size > 0) {
-        LOG(TRACE, "< %.*s", size, data);
-    }
 }
 
 const char* cmdTermStr(AtCommandTerminator term) {
@@ -404,7 +391,7 @@ int AtParserImpl::parseLine(unsigned flags, unsigned* timeout) {
                 const int r = h->callback(&reader, h->prefix, h->data);
                 clearStatus(StatusFlag::URC_HANDLER);
                 if (r < 0) {
-                    LOG(ERROR, "URC handler error: %d", r);
+                    LOG_C(ERROR, conf_.logCategory(), "URC handler error: %d", r);
                 }
             }
         }
@@ -686,6 +673,18 @@ int AtParserImpl::error(int ret) {
         resetCommand();
     }
     return ret;
+}
+
+void AtParserImpl::logCmdLine(const char* data, size_t size) const {
+    if (size > 0) {
+        LOG_C(TRACE, conf_.logCategory(), "> %.*s", size, data);
+    }
+}
+
+void AtParserImpl::logRespLine(const char* data, size_t size) const {
+    if (size > 0) {
+        LOG_C(TRACE, conf_.logCategory(), "< %.*s", size, data);
+    }
 }
 
 } // particle::detail

--- a/hal/network/ncp/at_parser/at_parser_impl.h
+++ b/hal/network/ncp/at_parser/at_parser_impl.h
@@ -152,6 +152,9 @@ private:
     unsigned checkStatus(unsigned flags) const;
 
     int error(int ret);
+
+    void logCmdLine(const char* data, size_t size) const;
+    void logRespLine(const char* data, size_t size) const;
 };
 
 inline void AtParserImpl::commandTimeout(unsigned timeout) {

--- a/hal/network/ncp_client/esp32/esp32_ncp_client.cpp
+++ b/hal/network/ncp_client/esp32/esp32_ncp_client.cpp
@@ -16,6 +16,9 @@
  */
 
 #define NO_STATIC_ASSERT
+#include "logging.h"
+LOG_SOURCE_CATEGORY("ncp.esp32.client");
+
 #include "esp32_ncp_client.h"
 
 #include "at_command.h"
@@ -148,7 +151,8 @@ int Esp32NcpClient::initParser(Stream* stream) {
     // Initialize AT parser
     auto parserConf = AtParserConfig()
             .stream(stream)
-            .commandTerminator(AtCommandTerminator::CRLF);
+            .commandTerminator(AtCommandTerminator::CRLF)
+            .logCategory("ncp.esp32.at");
     parser_.destroy();
     CHECK(parser_.init(std::move(parserConf)));
     // Register URC handlers
@@ -581,6 +585,7 @@ int Esp32NcpClient::initMuxer() {
     muxer_.setMaxRetransmissions(3);
     muxer_.setAckTimeout(2530);
     muxer_.setControlResponseTimeout(2540);
+    muxer_.setLogCategory("ncp.esp32.mux");
 
     // Set channel state handler
     muxer_.setChannelStateHandler(muxChannelStateCb, this);

--- a/hal/network/ncp_client/esp32/esp32_ncp_client.h
+++ b/hal/network/ncp_client/esp32/esp32_ncp_client.h
@@ -85,7 +85,7 @@ private:
     volatile NcpPowerState pwrState_;
     int parserError_;
     bool ready_;
-    gsm0710::Muxer<decltype(serial_)::element_type, StaticRecursiveMutex> muxer_;
+    gsm0710::Muxer<EventGroupBasedStream, StaticRecursiveMutex> muxer_;
     std::unique_ptr<particle::MuxerChannelStream<decltype(muxer_)> > muxerAtStream_;
     bool muxerNotStarted_;
     volatile bool inFlowControl_ = false;

--- a/hal/network/ncp_client/quectel/quectel_ncp_client.h
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.h
@@ -87,7 +87,7 @@ private:
     volatile NcpPowerState pwrState_ = NcpPowerState::UNKNOWN;
     int parserError_ = 0;
     bool ready_ = false;
-    gsm0710::Muxer<particle::SerialStream, StaticRecursiveMutex> muxer_;
+    gsm0710::Muxer<EventGroupBasedStream, StaticRecursiveMutex> muxer_;
     std::unique_ptr<particle::MuxerChannelStream<decltype(muxer_)> > muxerAtStream_;
     std::unique_ptr<particle::MuxerChannelStream<decltype(muxer_)> > muxerDataStream_;
     CellularNetworkConfig netConf_;

--- a/hal/network/ncp_client/sara/sara_ncp_client.h
+++ b/hal/network/ncp_client/sara/sara_ncp_client.h
@@ -83,7 +83,7 @@ private:
     volatile NcpPowerState pwrState_ = NcpPowerState::UNKNOWN;
     int parserError_ = 0;
     bool ready_ = false;
-    gsm0710::Muxer<particle::SerialStream, StaticRecursiveMutex> muxer_;
+    gsm0710::Muxer<EventGroupBasedStream, StaticRecursiveMutex> muxer_;
     std::unique_ptr<particle::MuxerChannelStream<decltype(muxer_)> > muxerAtStream_;
     std::unique_ptr<particle::MuxerChannelStream<decltype(muxer_)> > muxerDataStream_;
     CellularNetworkConfig netConf_;

--- a/hal/src/nRF52840/event_group_stream.h
+++ b/hal/src/nRF52840/event_group_stream.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2020 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "stream.h"
+#include <FreeRTOS.h>
+#include <event_groups.h>
+
+namespace particle {
+
+class EventGroupBasedStream: public Stream {
+public:
+    virtual EventGroupHandle_t eventGroup() = 0;
+};
+
+} // particle

--- a/hal/src/nRF52840/gsm0710muxer/channel_stream.h
+++ b/hal/src/nRF52840/gsm0710muxer/channel_stream.h
@@ -217,10 +217,11 @@ inline int MuxerChannelStream<MuxerT>::waitEvent(unsigned flags, unsigned timeou
         if (f &= flags) {
             break;
         }
-        if (timeout > 0 && HAL_Timer_Get_Milli_Seconds() - t >= timeout) {
+        const auto elapsed = HAL_Timer_Get_Milli_Seconds() - t;
+        if (timeout == 0 || elapsed >= timeout) {
             return SYSTEM_ERROR_TIMEOUT;
         }
-        os_semaphore_take(sem_, HAL_Timer_Get_Milli_Seconds() - t, false);
+        os_semaphore_take(sem_, timeout - elapsed, false);
         if (!enabled_) {
             return SYSTEM_ERROR_INVALID_STATE;
         }

--- a/hal/src/nRF52840/serial_stream.h
+++ b/hal/src/nRF52840/serial_stream.h
@@ -19,13 +19,13 @@
 
 #include "usart_hal.h"
 #include "usart_hal_private.h"
-#include "stream.h"
+#include "event_group_stream.h"
 #include "check.h"
 #include <memory>
 
 namespace particle {
 
-class SerialStream: public Stream {
+class SerialStream: public EventGroupBasedStream {
 public:
     SerialStream(hal_usart_interface_t serial, uint32_t baudrate, uint32_t config,
             size_t rxBufferSize = 0, size_t txBufferSize = 0);
@@ -48,7 +48,7 @@ public:
     int on(bool on);
     bool on() const;
 
-    EventGroupHandle_t eventGroup();
+    EventGroupHandle_t eventGroup() override;
 
 private:
     hal_usart_interface_t serial_;

--- a/hal/src/tracker/esp32_sdio_stream.h
+++ b/hal/src/tracker/esp32_sdio_stream.h
@@ -17,18 +17,16 @@
 
 #pragma once
 
-#include "stream.h"
+#include "event_group_stream.h"
 #include <memory>
 #include "spi_hal.h"
-#include <FreeRTOS.h>
-#include <event_groups.h>
 #include "ringbuffer.h"
 
 namespace particle {
 
 class Esp32Sdio;
 
-class Esp32SdioStream: public Stream {
+class Esp32SdioStream: public EventGroupBasedStream {
 public:
     Esp32SdioStream(hal_spi_interface_t spi, uint32_t clock, pin_t csPin, pin_t intPin);
     ~Esp32SdioStream();
@@ -49,7 +47,7 @@ public:
     int on(bool on);
     bool on() const;
 
-    EventGroupHandle_t eventGroup();
+    EventGroupHandle_t eventGroup() override;
 
     void txInterruptSupported(bool state);
 


### PR DESCRIPTION
### Problem

Now that we have ESP32 support on Tracker, it's impossible to differentiate between NCP client / gsm0710 muxer logs that come from the cellular modem and ESP32.

### Solution

Add instance-local custom log categories support for AT parser and gsm0710muxer.

This PR also fixes a bug in `ChannelStream` in `waitEvent()` timeout handling and makes sure that we have a single implementation of the gsm0710muxer (by having a common Stream base class that support `eventGroup()` method).

### Steps to Test

Run the test app, watch logs. It should be easy to differentiate NCP/muxer logs that come from the modem and from ESP32.

### Example App

```c++
SerialLogHandler dbg(LOG_LEVEL_ALL);

SYSTEM_MODE(SEMI_AUTOMATIC);

void setup() {
    waitUntil(Serial.isConnected);
    Particle.connect();
}

void loop() {
    WiFiAccessPoint results[5];
    WiFi.scan(results, sizeof(results) / sizeof(results[0]));
    auto sig = Cellular.RSSI();
    (void)sig;
    delay(5000);
}
```

### Logs

```
0000034741 [ncp.at] TRACE: > AT+CCID
0000034743 [ncp.at] TRACE: < +CCID: XXXXXX
0000034743 [ncp.at] TRACE: < OK
0000034745 [ncp.at] TRACE: > AT+CGSN
0000034746 [ncp.at] TRACE: < YYYYYYY
0000034746 [ncp.at] TRACE: < OK
0000034753 [ncp.esp32.at] TRACE: > AT+MVER
0000034763 [ncp.esp32.at] TRACE: < 9
0000034763 [ncp.esp32.at] TRACE: < OK
```

```
0000029981 [mux] INFO: Starting GSM07.10 muxer
0000029981 [mux] INFO: Openning mux channel 0
0000029982 [mux] INFO: GSM07.10 muxer thread started
0000030083 [mux] INFO: Openning mux channel 1
0000022002 [ncp.esp32.mux] INFO: Starting GSM07.10 muxer
0000022004 [ncp.esp32.mux] INFO: Openning mux channel 0
0000022004 [ncp.esp32.mux] INFO: GSM07.10 muxer thread started
0000022010 [ncp.esp32.mux] INFO: Openning mux channel 1
```

### References

- https://github.com/particle-iot/gsm0710muxer/pull/8

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
