### PR TITLE
[gen2] speed up cellular modem powerOn time

### DIFF
--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -654,8 +654,8 @@ protected:
     bool _powerOn(void);
     void _incModemStateChangeCount(void);
     void _setBandSelectString(MDM_BandSelect &data, char* bands, int index=0); // private helper to create bands strings
-    int _checkAtResponse(void);
-    bool _atOk(void);
+    int _checkAtResponse(bool fastTimeout = false);
+    bool _atOk(bool fastTimeout = false);
     bool _checkModem(bool force = true);
     void _checkVerboseCxreg(void);
     bool _checkEpsReg(void);


### PR DESCRIPTION
### Problem

We recently increased the AT_TIMEOUT from 1 to 3 seconds, which is causing a few extra seconds of power on time.

### Solution

- Set AT_TIMEOUT for _powerOn() function back to 1s, and use 3s for everywhere else when modem is on.
- Also increase number of tries from 10 to 25 to keep the power on delay to roughly 30 seconds before attempting to hard reset the modem.

### Steps to Test

- wiring/no_fixture
- can also simulate modem not responsive by changing baudrate in mdm_hal.cpp to something other than 115200
- monitor cold and hard boot times


---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] N/A - Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
