### PR TITLE
[Gen 3] Fix warm boot; [Tracker] Cache ESP32 firmware version

### DIFF
--- a/hal/network/ncp/wifi/platform_ncp_update.cpp
+++ b/hal/network/ncp/wifi/platform_ncp_update.cpp
@@ -98,9 +98,9 @@ int invalidateWifiNcpVersionCache() {
 }
 
 int getWifiNcpFirmwareVersion(uint16_t* ncpVersion) {
+    uint16_t version = 0;
 #if HAL_PLATFORM_NCP_COUNT > 1
     using namespace particle::services;
-    uint16_t version = 0;
     int res = SystemCache::instance().get(SystemCacheKey::WIFI_NCP_FIRMWARE_VERSION, &version, sizeof(version));
     if (res == sizeof(version)) {
         LOG(TRACE, "Cached ESP32 NCP firmware version: %d", (int)version);

--- a/hal/network/ncp_client/esp32/esp32_ncp_client.cpp
+++ b/hal/network/ncp_client/esp32/esp32_ncp_client.cpp
@@ -35,6 +35,7 @@ LOG_SOURCE_CATEGORY("ncp.esp32.client");
 #include "check.h"
 
 #include <cstdlib>
+#include "system_cache.h"
 
 #define CHECK_PARSER(_expr) \
         ({ \
@@ -73,6 +74,21 @@ void espReset() {
 
 size_t espEscape(const char* src, char* dest, size_t destSize) {
     return escape(src, ",\"\\", '\\', dest, destSize);
+}
+
+int updateCachedNcpFirmwareVersion(uint16_t version) {
+#if HAL_PLATFORM_NCP_COUNT > 1
+    using namespace particle::services;
+
+    uint16_t cached = 0;
+    int r = SystemCache::instance().get(SystemCacheKey::WIFI_NCP_FIRMWARE_VERSION, &cached, sizeof(cached));
+    if (r == sizeof(cached) && cached == version) {
+        return 0;
+    }
+    return SystemCache::instance().set(SystemCacheKey::WIFI_NCP_FIRMWARE_VERSION, &version, sizeof(version));
+#else
+    return 0;
+#endif // HAL_PLATFORM_NCP_COUNT > 0
 }
 
 const auto ESP32_NCP_MAX_MUXER_FRAME_SIZE = 1536;
@@ -274,7 +290,11 @@ int Esp32NcpClient::getFirmwareVersionString(char* buf, size_t size) {
 int Esp32NcpClient::getFirmwareModuleVersion(uint16_t* ver) {
     const NcpClientLock lock(this);
     CHECK(checkParser());
-    return getFirmwareModuleVersionImpl(ver);
+    const int r = getFirmwareModuleVersionImpl(ver);
+    if (!r) {
+        updateCachedNcpFirmwareVersion(*ver);
+    }
+    return r;
 }
 
 int Esp32NcpClient::getFirmwareModuleVersionImpl(uint16_t* ver) {

--- a/services/inc/system_cache.h
+++ b/services/inc/system_cache.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "tlv_file.h"
+
+namespace particle { namespace services {
+
+enum class SystemCacheKey : uint16_t {
+    WIFI_NCP_FIRMWARE_VERSION = 0x0000
+};
+
+class SystemCache {
+public:
+    static SystemCache& instance();
+
+    // Just straight up proxying to TlvFile
+    // TODO: add support for multiple values for a key?
+    int get(SystemCacheKey key, void* value, size_t length);
+    int set(SystemCacheKey key, const void* value, size_t length);
+    int del(SystemCacheKey key);
+
+    SystemCache(SystemCache const&) = delete;
+    SystemCache(SystemCache&&) = delete;
+    SystemCache& operator=(SystemCache const&) = delete;
+    SystemCache& operator=(SystemCache &&) = delete;
+
+protected:
+    SystemCache();
+
+private:
+    settings::TlvFile tlv_;
+};
+
+} } // particle::service

--- a/services/src/system_cache.cpp
+++ b/services/src/system_cache.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "system_cache.h"
+#include "enumclass.h"
+#include "check.h"
+
+namespace particle { namespace services {
+
+SystemCache::SystemCache()
+        : tlv_("/sys/cache.dat") {
+}
+
+SystemCache& SystemCache::instance() {
+    static SystemCache cache;
+    cache.tlv_.init();
+    return cache;
+}
+
+int SystemCache::get(SystemCacheKey key, void* value, size_t length) {
+    return tlv_.get(to_underlying(key), (uint8_t*)value, length);
+}
+
+int SystemCache::set(SystemCacheKey key, const void* value, size_t length) {
+    CHECK_TRUE(length <= sizeof(uint16_t), SYSTEM_ERROR_TOO_LARGE);
+    return tlv_.set(to_underlying(key), (const uint8_t*)value, length);
+}
+
+int SystemCache::del(SystemCacheKey key) {
+    return tlv_.del(to_underlying(key));
+}
+
+} } // particle::services

--- a/services/src/system_cache.cpp
+++ b/services/src/system_cache.cpp
@@ -15,6 +15,10 @@
  * License along with this library; if not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "hal_platform.h"
+
+#if HAL_PLATFORM_FILESYSTEM
+
 #include "system_cache.h"
 #include "enumclass.h"
 #include "check.h"
@@ -45,3 +49,5 @@ int SystemCache::del(SystemCacheKey key) {
 }
 
 } } // particle::services
+
+#endif // HAL_PLATFORM_FILESYSTEM

--- a/system/src/control/cellular.cpp
+++ b/system/src/control/cellular.cpp
@@ -116,6 +116,7 @@ int getIccid(ctrl_request* req) {
     CHECK_TRUE(cellMgr, SYSTEM_ERROR_UNKNOWN);
     const auto ncpClient = cellMgr->ncpClient();
     CHECK_TRUE(ncpClient, SYSTEM_ERROR_UNKNOWN);
+    const NcpClientLock lock(ncpClient);
     CHECK(ncpClient->on());
     char buf[32] = {};
     CHECK(ncpClient->getIccid(buf, sizeof(buf)));

--- a/system/src/control/config.cpp
+++ b/system/src/control/config.cpp
@@ -108,6 +108,7 @@ int getNcpFirmwareVersion(ctrl_request* req) {
     CHECK_TRUE(wifiMgr, SYSTEM_ERROR_UNKNOWN);
     const auto ncpClient = wifiMgr->ncpClient();
     CHECK_TRUE(ncpClient, SYSTEM_ERROR_UNKNOWN);
+    const NcpClientLock lock(ncpClient);
     CHECK(ncpClient->on());
     char verStr[32] = {};
     CHECK(ncpClient->getFirmwareVersionString(verStr, sizeof(verStr)));

--- a/system/src/control/wifi_new.cpp
+++ b/system/src/control/wifi_new.cpp
@@ -102,6 +102,7 @@ int joinNewNetwork(ctrl_request* req) {
     // Connect to the network
     const auto ncpClient = wifiMgr->ncpClient();
     CHECK_TRUE(ncpClient, SYSTEM_ERROR_UNKNOWN);
+    const NcpClientLock lock(ncpClient);
     CHECK(ncpClient->on());
     CHECK(ncpClient->disconnect());
     CHECK(wifiMgr->connect(dSsid.data));
@@ -117,6 +118,7 @@ int joinKnownNetwork(ctrl_request* req) {
     CHECK_TRUE(wifiMgr, SYSTEM_ERROR_UNKNOWN);
     const auto ncpClient = wifiMgr->ncpClient();
     CHECK_TRUE(ncpClient, SYSTEM_ERROR_UNKNOWN);
+    const NcpClientLock lock(ncpClient);
     CHECK(ncpClient->on());
     CHECK(ncpClient->disconnect());
     CHECK(wifiMgr->connect(dSsid.data));
@@ -195,6 +197,7 @@ int scanNetworks(ctrl_request* req) {
     CHECK_TRUE(wifiMgr, SYSTEM_ERROR_UNKNOWN);
     const auto ncpClient = wifiMgr->ncpClient();
     CHECK_TRUE(ncpClient, SYSTEM_ERROR_UNKNOWN);
+    const NcpClientLock lock(ncpClient);
     CHECK(ncpClient->on());
     // Scan for networks
     Vector<WifiScanResult> networks;


### PR DESCRIPTION
### Problem

1. We've introduced a regression in https://github.com/particle-iot/device-os/pull/2217 and broke warm boot
2. During handshake with the cloud we need to send ESP32 NCP firmware version as it is one of the module, so it's present in the system describe. On Tracker during the cloud connection establishment it's not guaranteed that ESP32 is on, so we have to turn it on in order to query for its version, which prolongs the handshake process. What complicates things even more is that since https://github.com/particle-iot/device-os/pull/2217 we'll also watch the current NCP state closely and power off immediately, so several sequential calls to query ESP32 NCP firmware version may have to power on the ESP32 and initialize it multiple times

### Solution

1. Keep the NCP state as-is unless some command (on, off, up, down) is submitted
2. Cache ESP32 NCP firmware version in non-volatile memory and read it from there

### Steps to Test

1. Use an app with `SEMI_AUTOMATIC` modem and suspend the connection process for some time. Wait until the device connects to the cloud, reset with a button, watch the logs - it should reconnect without powering off the NCP
2. Watch the logs, make sure that ESP32 firmware version is taken out of cache: `Cached ESP32 NCP firmware version`
3. Update ESP32 NCP OTA, watch the logs, make sure that ESP32 firmware version changes and gets taken out of cache.

For step 3, the following 0.0.8 ESP32 NCP firmware can be used: [tracker-esp32-ncp@0.0.8.zip](https://github.com/particle-iot/device-os/files/5839490/tracker-esp32-ncp%400.0.8.zip)

### Example App

N/A

### References

- [CH71350]

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
