### PR TITLE
Disconnect from the server on OTA update errors

### DIFF
--- a/communication/inc/protocol_defs.h
+++ b/communication/inc/protocol_defs.h
@@ -24,42 +24,40 @@ namespace particle { namespace protocol {
 
 enum ProtocolError
 {
-    /* 00 */ NO_ERROR,
-    /* 01 */ PING_TIMEOUT,
-    /* 02 */ IO_ERROR,  // too generic, discontinue using this.  Perfer/add a specific one below
-    /* 03 */ INVALID_STATE,
-    /* 04 */ INSUFFICIENT_STORAGE,
-    /* 05 */ MALFORMED_MESSAGE,
-    /* 06 */ DECRYPTION_ERROR,
-    /* 07 */ ENCRYPTION_ERROR,
-    /* 08 */ AUTHENTICATION_ERROR,
-    /* 09 */ BANDWIDTH_EXCEEDED,
-    /* 10 */ MESSAGE_TIMEOUT,
-    /* 11 */ MISSING_MESSAGE_ID,
-    /* 12 */ MESSAGE_RESET,
-    /* 13 */ SESSION_RESUMED,
-    /* 14 */ IO_ERROR_FORWARD_MESSAGE_CHANNEL,
-    /* 15 */ IO_ERROR_SET_DATA_MAX_EXCEEDED,
-    /* 16 */ IO_ERROR_PARSING_SERVER_PUBLIC_KEY,
-    /* 17 */ IO_ERROR_GENERIC_ESTABLISH,
-    /* 18 */ IO_ERROR_GENERIC_RECEIVE,
-    /* 19 */ IO_ERROR_GENERIC_SEND,
-    /* 20 */ IO_ERROR_GENERIC_MBEDTLS_SSL_WRITE,
-    /* 21 */ IO_ERROR_DISCARD_SESSION,
-    /* 21 */ IO_ERROR_LIGHTSSL_BLOCKING_SEND,
-    /* 22 */ IO_ERROR_LIGHTSSL_BLOCKING_RECEIVE,
-    /* 23 */ IO_ERROR_LIGHTSSL_RECEIVE,
-    /* 24 */ IO_ERROR_LIGHTSSL_HANDSHAKE_NONCE,
-    /* 25 */ IO_ERROR_LIGHTSSL_HANDSHAKE_RECV_KEY,
-    /* 26 */ NOT_IMPLEMENTED,
-    /* 27 */ MISSING_REQUEST_TOKEN,
-    /* 28 */ NOT_FOUND,
-    /* 29 */ NO_MEMORY,
-    /* 30 */ INTERNAL,
-
-    /*
-     * NOTE: when adding more ProtocolError codes, be sure to update toSystemError() in protocol_defs.cpp
-     */
+    NO_ERROR = 0,
+    PING_TIMEOUT = 1,
+    IO_ERROR = 2, // too generic, discontinue using this. Perfer/add a specific one below
+    INVALID_STATE = 3,
+    INSUFFICIENT_STORAGE = 4,
+    MALFORMED_MESSAGE = 5,
+    DECRYPTION_ERROR = 6,
+    ENCRYPTION_ERROR = 7,
+    AUTHENTICATION_ERROR = 8,
+    BANDWIDTH_EXCEEDED = 9,
+    MESSAGE_TIMEOUT = 10,
+    MISSING_MESSAGE_ID = 11,
+    MESSAGE_RESET = 12,
+    SESSION_RESUMED = 13,
+    IO_ERROR_FORWARD_MESSAGE_CHANNEL = 14,
+    IO_ERROR_SET_DATA_MAX_EXCEEDED = 15,
+    IO_ERROR_PARSING_SERVER_PUBLIC_KEY = 16,
+    IO_ERROR_GENERIC_ESTABLISH = 17,
+    IO_ERROR_GENERIC_RECEIVE = 18,
+    IO_ERROR_GENERIC_SEND = 19,
+    IO_ERROR_GENERIC_MBEDTLS_SSL_WRITE = 20,
+    IO_ERROR_DISCARD_SESSION = 21,
+    IO_ERROR_LIGHTSSL_BLOCKING_SEND = 22,
+    IO_ERROR_LIGHTSSL_BLOCKING_RECEIVE = 23,
+    IO_ERROR_LIGHTSSL_RECEIVE = 24,
+    IO_ERROR_LIGHTSSL_HANDSHAKE_NONCE = 25,
+    IO_ERROR_LIGHTSSL_HANDSHAKE_RECV_KEY = 26,
+    NOT_IMPLEMENTED = 27,
+    MISSING_REQUEST_TOKEN = 28,
+    NOT_FOUND = 29,
+    NO_MEMORY = 30,
+    INTERNAL = 31,
+    OTA_UPDATE_ERROR = 32, // Generic OTA update error
+    // NOTE: when adding more ProtocolError codes, be sure to update toSystemError() in protocol_defs.cpp
     UNKNOWN = 0x7FFFF
 };
 

--- a/communication/src/firmware_update.cpp
+++ b/communication/src/firmware_update.cpp
@@ -121,6 +121,7 @@ ProtocolError FirmwareUpdate::responseAck(Message* msg) {
             updating_ = false;
         }
     } else if (d.id() == errorRespId_) {
+        LOG(ERROR, "Firmware update failed");
         cancelUpdate();
         return ProtocolError::OTA_UPDATE_ERROR;
     }
@@ -271,6 +272,7 @@ ProtocolError FirmwareUpdate::handleRequest(Message* msg, RequestHandlerFn handl
         // TODO: Errors during OTA shouldn't be fatal to the connection unless we weren't able to
         // send an error response to the server
         if (d.type() != CoapType::CON) {
+            LOG(ERROR, "Firmware update failed");
             cancelUpdate();
             return ProtocolError::OTA_UPDATE_ERROR;
         } else if (errorRespId_ < 0) {
@@ -411,6 +413,7 @@ int FirmwareUpdate::handleChunkRequest(const CoapMessageDecoder& d, CoapMessageE
         Message msg;
         const int r = channel_->create(msg);
         if (r != ProtocolError::NO_ERROR) {
+            LOG(ERROR, "Failed to create message: %d", (int)r);
             return SYSTEM_ERROR_NO_MEMORY;
         }
         CHECK(sendEmptyAck(&msg, CoapType::RST, d.id()));

--- a/communication/src/firmware_update.h
+++ b/communication/src/firmware_update.h
@@ -163,6 +163,7 @@ private:
     unsigned unackChunks_; // Number or chunks received since the last acknowledgement
     unsigned stateLogChunks_; // Number of cumulatively acknowledged chunks at the time when the transfer state was last logged
     int finishRespId_; // Message ID of the UpdateFinish response
+    int errorRespId_; // Message ID of the last confirmable error response sent to the server
     bool hasGaps_; // Whether the sequence of received chunks has gaps
     bool updating_; // Whether an update is in progress
 

--- a/communication/src/protocol_defs.cpp
+++ b/communication/src/protocol_defs.cpp
@@ -55,6 +55,8 @@ system_error_t particle::protocol::toSystemError(ProtocolError error) {
         return SYSTEM_ERROR_NO_MEMORY;
     case INTERNAL:
         return SYSTEM_ERROR_INTERNAL;
+    case OTA_UPDATE_ERROR:
+        return SYSTEM_ERROR_OTA;
     default:
         return SYSTEM_ERROR_PROTOCOL; // Generic protocol error
     }

--- a/services/inc/system_error.h
+++ b/services/inc/system_error.h
@@ -66,6 +66,7 @@
         (OTA_INVALID_PLATFORM, "Invalid module platform", -1360), \
         (OTA_INVALID_FORMAT, "Invalid module format", -1370), \
         (OTA_UPDATES_DISABLED, "Firmware updates are disabled", -1380), \
+        (OTA, "Firmware update error", -1390), \
         (CRYPTO, "Crypto error", -1400) /* -1599 ... -1400: Crypto errors */ \
 
 // Expands to enum values for all errors

--- a/test/unit_tests/communication/firmware_update.cpp
+++ b/test/unit_tests/communication/firmware_update.cpp
@@ -615,7 +615,8 @@ TEST_CASE("FirmwareUpdate") {
     }
     SECTION("replies to the server with an error response if an UpdateChunk request cannot be processed") {
         SECTION("no update is in progress") {
-            w.sendChunk(1 /* index */, genString(512) /* data */);
+            int r = w.sendChunk(1 /* index */, genString(512) /* data */);
+            CHECK(r == ProtocolError::NO_ERROR);
             auto resp = w.receiveMessage();
             CHECK(resp.type() == CoapType::RST);
             CHECK(resp.id() == w.lastMessageId());
@@ -786,7 +787,8 @@ TEST_CASE("FirmwareUpdate") {
             CHECK(m.token() == w.lastMessageToken());
             CHECK(hasDiagnosticPayload(m));
             // Acknowledge the response
-            w.sendMessage(CoapMessage().type(CoapType::ACK).code(CoapCode::EMPTY).id(m.id()));
+            int r = w.sendMessage(CoapMessage().type(CoapType::ACK).code(CoapCode::EMPTY).id(m.id()));
+            CHECK(r != ProtocolError::NO_ERROR);
             Verify(Method(cb, finishFirmwareUpdate).Matching([=](unsigned flags) {
                 return FirmwareUpdateFlags::fromUnderlying(flags) == FirmwareUpdateFlag::CANCEL;
             })).Once();
@@ -810,7 +812,8 @@ TEST_CASE("FirmwareUpdate") {
             CHECK(m.payload().find("YOU SHALL NOT PASS!") != std::string::npos);
             CHECK(m.payload().find(std::to_string(SYSTEM_ERROR_NOT_ALLOWED)) != std::string::npos);
             // Acknowledge the response
-            w.sendMessage(CoapMessage().type(CoapType::ACK).code(CoapCode::EMPTY).id(m.id()));
+            int r = w.sendMessage(CoapMessage().type(CoapType::ACK).code(CoapCode::EMPTY).id(m.id()));
+            CHECK(r != ProtocolError::NO_ERROR);
             CHECK(!w.isRunning());
         }
         SECTION("cancelling an update") {

--- a/test/unit_tests/communication/firmware_update.cpp
+++ b/test/unit_tests/communication/firmware_update.cpp
@@ -60,7 +60,7 @@ public:
     }
 
     // Sends an UpdateStart message to the device
-    FirmwareUpdateWrapper& sendStart(size_t fileSize, const std::string& fileHash, size_t chunkSize, bool discardData) {
+    int sendStart(size_t fileSize, const std::string& fileHash, size_t chunkSize, bool discardData) {
         CoapMessage m;
         m.type(CoapType::CON);
         m.code(CoapCode::POST);
@@ -77,7 +77,7 @@ public:
     }
 
     // Sends an UpdateFinish message to the device
-    FirmwareUpdateWrapper& sendFinish(bool cancelUpdate, bool discardData) {
+    int sendFinish(bool cancelUpdate, bool discardData) {
         CoapMessage m;
         m.type(CoapType::CON);
         m.code(CoapCode::POST);
@@ -92,7 +92,7 @@ public:
     }
 
     // Sends an UpdateChunk message to the device
-    FirmwareUpdateWrapper& sendChunk(unsigned index, const std::string& data) {
+    int sendChunk(unsigned index, const std::string& data) {
         CoapMessage m;
         m.type(CoapType::NON);
         m.code(CoapCode::POST);
@@ -104,7 +104,7 @@ public:
     }
 
     // Sends a CoAP message to the device
-    FirmwareUpdateWrapper& sendMessage(CoapMessage msg) {
+    int sendMessage(CoapMessage msg) {
         if (!msg.hasId()) {
             msg.id(++lastMsgId_);
         }
@@ -138,10 +138,7 @@ public:
                 break;
             }
         }
-        if (r != ProtocolError::NO_ERROR) {
-            throw std::runtime_error("Error while receiving message");
-        }
-        return *this;
+        return r;
     }
 
     // Receives a CoAP message from the device
@@ -150,9 +147,8 @@ public:
     }
 
     // Skips N messages received from the device
-    FirmwareUpdateWrapper& skipMessages(unsigned count) {
+    void skipMessages(unsigned count) {
         channel_.skipMessages(count);
-        return *this;
     }
 
     // Returns true if there's a message received from the device
@@ -170,14 +166,12 @@ public:
         return std::string(1, lastMsgToken_);
     }
 
-    FirmwareUpdateWrapper& addMillis(system_tick_t ms) {
+    void addMillis(system_tick_t ms) {
         callbacks_.addMillis(ms);
-        return *this;
     }
 
-    FirmwareUpdateWrapper& processTimeouts() {
+    void processTimeouts() {
         CHECK(FirmwareUpdate::process() == ProtocolError::NO_ERROR);
-        return *this;
     }
 
     Mock<CoapMessageChannel> channelMock() {
@@ -779,11 +773,7 @@ TEST_CASE("FirmwareUpdate") {
         }
         SECTION("finishing an incomplete update") {
             w.sendFinish(false /* cancelUpdate */, false /* discardData */);
-            Verify(Method(cb, finishFirmwareUpdate).Matching([=](unsigned flags) {
-                return FirmwareUpdateFlags::fromUnderlying(flags) == FirmwareUpdateFlag::CANCEL;
-            })).Once();
-            VerifyNoOtherInvocations(Method(cb, finishFirmwareUpdate));
-            CHECK(!w.isRunning());
+            Verify(Method(cb, finishFirmwareUpdate)).Never();
             // Empty ACK
             auto m = w.receiveMessage();
             CHECK(m.type() == CoapType::ACK);
@@ -795,6 +785,13 @@ TEST_CASE("FirmwareUpdate") {
             CHECK((isCoapResponseCode(m.code()) && !isCoapSuccessCode(m.code())));
             CHECK(m.token() == w.lastMessageToken());
             CHECK(hasDiagnosticPayload(m));
+            // Acknowledge the response
+            w.sendMessage(CoapMessage().type(CoapType::ACK).code(CoapCode::EMPTY).id(m.id()));
+            Verify(Method(cb, finishFirmwareUpdate).Matching([=](unsigned flags) {
+                return FirmwareUpdateFlags::fromUnderlying(flags) == FirmwareUpdateFlag::CANCEL;
+            })).Once();
+            VerifyNoOtherInvocations(Method(cb, finishFirmwareUpdate));
+            CHECK(!w.isRunning());
         }
         SECTION("failed validation") {
             When(Method(cb, finishFirmwareUpdate)).AlwaysDo([=](unsigned flags) {
@@ -812,6 +809,8 @@ TEST_CASE("FirmwareUpdate") {
             CHECK(hasDiagnosticPayload(m));
             CHECK(m.payload().find("YOU SHALL NOT PASS!") != std::string::npos);
             CHECK(m.payload().find(std::to_string(SYSTEM_ERROR_NOT_ALLOWED)) != std::string::npos);
+            // Acknowledge the response
+            w.sendMessage(CoapMessage().type(CoapType::ACK).code(CoapCode::EMPTY).id(m.id()));
             CHECK(!w.isRunning());
         }
         SECTION("cancelling an update") {


### PR DESCRIPTION
### Problem

Before https://github.com/particle-iot/device-os/pull/2199, a failure to apply an OTA update was causing the device to be reset. This PR restores that behavior on Gen 2 platforms and updates the v3 protocol implementation on Gen 3 platforms so that it breaks the comms loop on OTA errors causing a reconnection to the cloud.

### Steps to Test

Reproducing the issue caused by the new logic introduced in https://github.com/particle-iot/device-os/pull/2199 with an unmodified firmware is tricky. The easiest way would be to modify `HAL_FLASH_End()` so that it fails early. With that change in place:

1. Flash a user app that requires a newer system firmware to a Gen 2 or Gen 3 device. The device should reconnect to the cloud in safe mode.
2. When the device will receive the new system firmware and fail to apply it, verify that it either resets (Gen 2) or just reconnects to the cloud (Gen 3) so that the server can retry the attempt to fix the device's firmware dependencies.
