### PR TITLE
System power management inprovements

### DIFF
--- a/system/src/system_power_manager.cpp
+++ b/system/src/system_power_manager.cpp
@@ -46,7 +46,7 @@ namespace {
 
 constexpr uint8_t BQ24195_VERSION = 0x23;
 
-// For deducing battery satte
+// For deducing battery state
 constexpr system_tick_t BATTERY_STATE_NORMAL_CHECK_PERIOD = 10000;
 constexpr system_tick_t BATTERY_STATE_CHANGE_CHECK_PERIOD = 1000;
 constexpr system_tick_t BATTERY_CHARGED_MUTE_WINDOW = 1000;
@@ -698,9 +698,8 @@ connected:
   PMIC power(true);
   const uint8_t status = power.getSystemStatus();
   const uint8_t pwrGood = (status >> 2) & 0b01;
-  if ((status & 0x08) || !pwrGood) {
-    DBG_PWR("In DPM mode or power is not good");
-    // It's in DPM mode, the battery is discharging
+  if (!pwrGood) {
+    DBG_PWR("Power is not good");
     confirmBatteryState(g_batteryState, BATTERY_STATE_DISCHARGING);
   } else if (vCell < BATTERY_CONNECTED_VCELL_THRESHOLD) {
     DBG_PWR("vCell < BATTERY_CONNECTED_VCELL_THRESHOLD");
@@ -743,9 +742,8 @@ void PowerManager::deduceBatteryStateChargeEnabled() {
     batteryStateTransitioningTo(BATTERY_STATE_CHARGING);
   } else if (chargeState == 0b00) {
     const uint8_t pwrGood = (status >> 2) & 0b01;
-    if ((status & 0x08) || !pwrGood) {
-      DBG_PWR("In DPM mode or power is not good");
-      // It's in DPM mode, the battery is discharging
+    if (!pwrGood) {
+      DBG_PWR("Power is not good");
       confirmBatteryState(g_batteryState, BATTERY_STATE_DISCHARGING);
     } else {
       batteryStateTransitioningTo(BATTERY_STATE_NOT_CHARGING);

--- a/system/src/system_power_manager.h
+++ b/system/src/system_power_manager.h
@@ -46,9 +46,7 @@ private:
   void handleCharging();
   void handleUpdate();
   void initDefault(bool dpdm = true);
-  void handleStateChange(battery_state_t from, battery_state_t to, bool low);
-  battery_state_t handlePossibleFault(battery_state_t from, battery_state_t to);
-  void handlePossibleFaultLoop();
+  void handleStateChange(battery_state_t from, battery_state_t to);
   void logStat(uint8_t stat, uint8_t fault);
   void checkWatchdog();
 #if HAL_PLATFORM_POWER_MANAGEMENT_OPTIONAL
@@ -60,6 +58,8 @@ private:
   void applyDefaultConfig(bool dpdm = false);
   void logCurrentConfig();
   bool isRunning() const;
+
+  void deduceBatteryStateLoop();
 
   static power_source_t powerSourceFromStatus(uint8_t status);
 
@@ -73,10 +73,6 @@ private:
   static volatile bool update_;
   os_thread_t thread_ = nullptr;
   os_queue_t queue_ = nullptr;
-  system_tick_t faultSuppressed_ = 0;
-  uint32_t faultSecondaryCounter_ = 0;
-  uint32_t possibleFaultCounter_ = 0;
-  system_tick_t possibleFaultTimestamp_ = 0;
   bool lowBatEnabled_ = true;
   system_tick_t chargingDisabledTimestamp_ = 0;
   bool fuelGaugeAwake_ = true;
@@ -86,6 +82,12 @@ private:
 #if HAL_PLATFORM_POWER_MANAGEMENT_PMIC_WATCHDOG
   system_tick_t pmicWatchdogTimer_ = 0;
 #endif // HAL_PLATFORM_POWER_MANAGEMENT_PMIC_WATCHDOG
+
+  system_tick_t batMonitorTimeStamp_ = 0;
+  system_tick_t chargedTimeStamp_ = 0;
+  system_tick_t disconnectedTimeStamp_ = 0;
+  uint8_t chargingDebounceCount_ = 0;
+  uint8_t vcellDebounceCount_ = 0;
 
   hal_power_config config_ = {};
 };

--- a/system/src/system_power_manager.h
+++ b/system/src/system_power_manager.h
@@ -43,10 +43,10 @@ private:
   static void isrHandler();
   static void usbStateChangeHandler(HAL_USB_State state, void* context);
   void update();
-  void handleCharging();
+  void handleCharging(bool forceDisable = false);
   void handleUpdate();
   void initDefault(bool dpdm = true);
-  void handleStateChange(battery_state_t from, battery_state_t to);
+  void confirmBatteryState(battery_state_t from, battery_state_t to);
   void logStat(uint8_t stat, uint8_t fault);
   void checkWatchdog();
 #if HAL_PLATFORM_POWER_MANAGEMENT_OPTIONAL
@@ -60,6 +60,10 @@ private:
   bool isRunning() const;
 
   void deduceBatteryStateLoop();
+  void deduceBatteryStateChargeDisabled();
+  void deduceBatteryStateChargeEnabled();
+  void batteryStateForwardingTo(battery_state_t targetState, bool count = true);
+  void clearIntermadiateBatteryState();
 
   static power_source_t powerSourceFromStatus(uint8_t status);
 
@@ -84,10 +88,14 @@ private:
 #endif // HAL_PLATFORM_POWER_MANAGEMENT_PMIC_WATCHDOG
 
   system_tick_t batMonitorTimeStamp_ = 0;
-  system_tick_t chargedTimeStamp_ = 0;
-  system_tick_t disconnectedTimeStamp_ = 0;
+  system_tick_t battMonitorPeriod_ = 0;
+  system_tick_t lastChargedTimeStamp_ = 0;
+  system_tick_t disableChargingTimeStamp_ = 0;
+  uint8_t notChargingDebounceCount_ = 0;
   uint8_t chargingDebounceCount_ = 0;
   uint8_t vcellDebounceCount_ = 0;
+  uint8_t chargedFaultCount_ = 0;
+  bool chargingEnabled_ = false;
 
   hal_power_config config_ = {};
 };

--- a/system/src/system_power_manager.h
+++ b/system/src/system_power_manager.h
@@ -43,7 +43,7 @@ private:
   static void isrHandler();
   static void usbStateChangeHandler(HAL_USB_State state, void* context);
   void update();
-  void handleCharging(bool forceDisable = false);
+  void handleCharging(bool batteryDisconnected = false);
   void handleUpdate();
   void initDefault(bool dpdm = true);
   void confirmBatteryState(battery_state_t from, battery_state_t to);
@@ -62,7 +62,7 @@ private:
   void deduceBatteryStateLoop();
   void deduceBatteryStateChargeDisabled();
   void deduceBatteryStateChargeEnabled();
-  void batteryStateForwardingTo(battery_state_t targetState, bool count = true);
+  void batteryStateTransitioningTo(battery_state_t targetState, bool count = true);
   void clearIntermadiateBatteryState();
 
   static power_source_t powerSourceFromStatus(uint8_t status);
@@ -95,7 +95,7 @@ private:
   uint8_t chargingDebounceCount_ = 0;
   uint8_t vcellDebounceCount_ = 0;
   uint8_t chargedFaultCount_ = 0;
-  bool chargingEnabled_ = false;
+  bool poosibleChargedFault_ = false;
 
   hal_power_config config_ = {};
 };

--- a/wiring/inc/spark_wiring_power.h
+++ b/wiring/inc/spark_wiring_power.h
@@ -73,6 +73,7 @@ public:
     // Power ON configuration register
     bool enableCharging(void);
     bool disableCharging(void);
+    bool isChargingEnabled(void);
     bool enableOTG(void);
     bool disableOTG(void);
     bool resetWatchdog(void);
@@ -149,7 +150,7 @@ public:
 
 
 
-private:
+// private:
     static constexpr system_tick_t PMIC_DEFAULT_TIMEOUT = 10; // In millisecond
 
     byte readRegister(byte startAddress);

--- a/wiring/inc/spark_wiring_power.h
+++ b/wiring/inc/spark_wiring_power.h
@@ -150,7 +150,7 @@ public:
 
 
 
-// private:
+private:
     static constexpr system_tick_t PMIC_DEFAULT_TIMEOUT = 10; // In millisecond
 
     byte readRegister(byte startAddress);

--- a/wiring/inc/spark_wiring_system_power.h
+++ b/wiring/inc/spark_wiring_system_power.h
@@ -87,6 +87,11 @@ public:
         return *this;
     }
 
+    SystemPowerConfiguration& clearFeature(EnumFlags<SystemPowerFeature> f) {
+        conf_.flags &= ~(f.value());
+        return *this;
+    }
+
     bool isFeatureSet(EnumFlags<SystemPowerFeature> f) const {
         return (conf_.flags & f.value()) ? true : false;
     }

--- a/wiring/src/spark_wiring_power.cpp
+++ b/wiring/src/spark_wiring_power.cpp
@@ -451,6 +451,12 @@ bool PMIC::disableCharging() {
     return 1;
 }
 
+bool PMIC::isChargingEnabled(void) {
+    std::lock_guard<PMIC> l(*this);
+    byte DATA = readRegister(POWERON_CONFIG_REGISTER);
+    return (DATA & 0b00110000) == 0b00010000;
+}
+
 /*******************************************************************************
  * Function Name  : disableOTG
  * Description    :


### PR DESCRIPTION
### Problem
The battery state is not reported consistently.
### Solution
1. When charging is enabled (through the `HAL_POWER_CHARGE_STATE_DISABLE` flag), we debounce the CHARGING/CHARGED/CHARGING/CHARGED events.
2. When charging is disabled, we use the `VCELL` of the fuel gauge to detect the battery state.
### Steps to Test
1. Flashing the attached application to the platforms with PMIC and fuel gauge installed
2. Attach/detach batteries with different capacity and observe the reported battery state.
3. Plug/unplug the power source and observe the reported battery state, as well as the reported power source
### Example App

```c
#include "Particle.h"

SYSTEM_THREAD(ENABLED);
SYSTEM_MODE(SEMI_AUTOMATIC);

Serial1LogHandler logHandler(115200, LOG_LEVEL_ALL);

static system_tick_t loopTick = 0;

constexpr char const* batteryStates[] = {
  "unknown", "not charging", "charging",
  "charged", "discharging", "fault", "disconnected"
};
constexpr char const* powerSources[] = {
  "unknown", "vin", "usb host", "usb adapter",
  "usb otg", "battery"
};

void setup() {
  Serial1.begin(115200);
  Serial1.printlnf("Application started.");

  System.on(battery_state, [](system_event_t event, int data) -> void {
    Serial1.printlnf("battery_state: %s", batteryStates[std::max(0, data)]);
  });

  System.on(power_source, [](system_event_t event, int data) -> void {
    Serial1.printlnf("power_source: %s", powerSources[std::max(0, data)]);
  });

  System.on(low_battery, [](system_event_t event, int data) -> void {
    Serial1.printlnf("low_battery: %0.2f", System.batteryCharge());
  });

  Particle.connect();
}

void loop() {
  if (Serial1.available()) {
    char c = (char)Serial1.read();
    // Commands are case sensitive
    switch (c) {
      case 'g': {
        auto cfg = System.getPowerConfiguration();
        Serial1.printlnf("cmd, getconfig, %d, %d, %d, %d, %u, %u, %u, %u",
          cfg.isFeatureSet(SystemPowerFeature::PMIC_DETECTION) ? 1 : 0,
          cfg.isFeatureSet(SystemPowerFeature::USE_VIN_SETTINGS_WITH_USB_HOST) ? 1 : 0,
          cfg.isFeatureSet(SystemPowerFeature::DISABLE) ? 1 : 0,
          cfg.isFeatureSet(SystemPowerFeature::DISABLE_CHARGING) ? 1 : 0,
          cfg.powerSourceMinVoltage(),
          cfg.powerSourceMaxCurrent(),
          cfg.batteryChargeVoltage(),
          cfg.batteryChargeCurrent()
        );
        break;
      }
      case '0': { // Disable charging
        int ret = System.setPowerConfiguration(System.getPowerConfiguration().feature(SystemPowerFeature::DISABLE_CHARGING));
        Serial1.printlnf("Disable charging, %d", ret);
        break;
      }
      case '1': { // Enable charging
        int ret = System.setPowerConfiguration(System.getPowerConfiguration().clearFeature(SystemPowerFeature::DISABLE_CHARGING));
        Serial1.printlnf("Enable charging, %d", ret);
        break;
      }
      default: {
        break;
      }
    }
  }

  auto now = millis();
  if ((now - loopTick) >= 2000) {
    loopTick = now;

    FuelGauge fuel;
    int powerSource = System.powerSource();
    int batteryState = System.batteryState();
    float batterySoc = System.batteryCharge();
    Serial1.printlnf("power: %s, batt: %s, SoC: %0.2f, Vol: %0.2f",
      powerSources[std::max(0, powerSource)], batteryStates[std::max(0, batteryState)],
      batterySoc, fuel.getVCell());
  }
}
```
### Completeness
- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
