### PR TITLE
[gen3] disable some of the elliptic-curves not in use to save flash space

### DIFF
--- a/hal/src/nRF52840/mbedtls/ecp_curves_enable.c
+++ b/hal/src/nRF52840/mbedtls/ecp_curves_enable.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2020 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stddef.h>
+#include <mbedtls_config.h>
+
+#ifndef MBEDTLS_ECP_DP_SECP192R1_ENABLED
+const void* SaSi_ECPKI_GetSecp192r1DomainP(void) {
+    return NULL;
+}
+#endif // MBEDTLS_ECP_DP_SECP192R1_ENABLED
+
+#ifndef MBEDTLS_ECP_DP_SECP224R1_ENABLED
+const void* SaSi_ECPKI_GetSecp224r1DomainP(void) {
+    return NULL;
+}
+#endif // MBEDTLS_ECP_DP_SECP224R1_ENABLED
+
+#ifndef MBEDTLS_ECP_DP_SECP256R1_ENABLED
+const void* SaSi_ECPKI_GetSecp256r1DomainP(void) {
+    return NULL;
+}
+#endif // MBEDTLS_ECP_DP_SECP256R1_ENABLED
+
+#ifndef MBEDTLS_ECP_DP_SECP384R1_ENABLED
+const void* SaSi_ECPKI_GetSecp384r1DomainP(void) {
+    return NULL;
+}
+#endif // MBEDTLS_ECP_DP_SECP384R1_ENABLED
+
+#ifndef MBEDTLS_ECP_DP_SECP521R1_ENABLED
+const void* SaSi_ECPKI_GetSecp521r1DomainP(void) {
+    return NULL;
+}
+#endif // MBEDTLS_ECP_DP_SECP521R1_ENABLED
+
+#ifndef MBEDTLS_ECP_DP_BP512R1_ENABLED
+const void* SaSi_ECPKI_GetSecp512r1DomainP(void) {
+    return NULL;
+}
+#endif // MBEDTLS_ECP_DP_BP512R1_ENABLED
+
+#ifndef MBEDTLS_ECP_DP_SECP192K1_ENABLED
+const void* SaSi_ECPKI_GetSecp192k1DomainP(void) {
+    return NULL;
+}
+#endif // MBEDTLS_ECP_DP_SECP192K1_ENABLED
+
+#ifndef MBEDTLS_ECP_DP_SECP224K1_ENABLED
+const void* SaSi_ECPKI_GetSecp224k1DomainP(void) {
+    return NULL;
+}
+#endif // MBEDTLS_ECP_DP_SECP224K1_ENABLED
+
+#ifndef MBEDTLS_ECP_DP_SECP256K1_ENABLED
+const void* SaSi_ECPKI_GetSecp256k1DomainP(void) {
+    return NULL;
+}
+#endif // MBEDTLS_ECP_DP_SECP256K1_ENABLED
+
+// Not supported by MbedTLS as of right now
+#ifndef MBEDTLS_ECP_DP_SECP160R1_ENABLED
+const void* SaSi_ECPKI_GetSecp160r1DomainP(void) {
+    return NULL;
+}
+#endif // MBEDTLS_ECP_DP_SECP256K1_ENABLED
+
+#ifndef MBEDTLS_ECP_DP_SECP160R2_ENABLED
+const void* SaSi_ECPKI_GetSecp160r2DomainP(void) {
+    return NULL;
+}
+#endif // MBEDTLS_ECP_DP_SECP256K1_ENABLED
+
+
+#ifndef MBEDTLS_ECP_DP_SECP160K1_ENABLED
+const void* SaSi_ECPKI_GetSecp160k1DomainP(void) {
+    return NULL;
+}
+#endif // MBEDTLS_ECP_DP_SECP256K1_ENABLED


### PR DESCRIPTION
### Problem

nRF52840 CC310 hardware crypto support for each particular elliptic curve takes about 700 bytes in closed source Nordic CC310 support library (see `ssi_ecpki_domain_*` symbols in the map file).

### Solution

Stub out ECC curves not supported by mbedTLS!

#### Original sizes

```
   text	   data	    bss	    dec	    hex	filename
 481540	   2588	  60404	 544532	  84f14	../../../build/target/system-part1/platform-12-m/system-part1.elf
   text	   data	    bss	    dec	    hex	filename
 511904	   2660	  61552	 576116	  8ca74	../../../build/target/system-part1/platform-13-m/system-part1.elf
   text	   data	    bss	    dec	    hex	filename
 512224	   2692	  61560	 576476	  8cbdc	../../../build/target/system-part1/platform-23-m/system-part1.elf
   text	   data	    bss	    dec	    hex	filename
 508688	   2692	  61560	 572940	  8be0c	../../../build/target/system-part1/platform-25-m/system-part1.elf
   text	   data	    bss	    dec	    hex	filename
 543608	   3076	  62592	 609276	  94bfc	../../../build/target/system-part1/platform-26-m/system-part1.elf
```

#### After PR
```
   text	   data	    bss	    dec	    hex	filename
 474180	   2588	  60408	 537176	  83258	../../../build/target/system-part1/platform-12-m/system-part1.elf
   text	   data	    bss	    dec	    hex	filename
 504528	   2660	  61556	 568744	  8ada8	../../../build/target/system-part1/platform-13-m/system-part1.elf
   text	   data	    bss	    dec	    hex	filename
 504864	   2692	  61564	 569120	  8af20	../../../build/target/system-part1/platform-23-m/system-part1.elf
   text	   data	    bss	    dec	    hex	filename
 501328	   2692	  61564	 565584	  8a150	../../../build/target/system-part1/platform-25-m/system-part1.elf
   text	   data	    bss	    dec	    hex	filename
 536248	   3068	  62596	 601912	  92f38	../../../build/target/system-part1/platform-26-m/system-part1.elf
```

About 8K savings!

### Steps to Test

N/A

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
