### PR TITLE
Fix default assignment for SPI chip select

### DIFF
--- a/hal/network/lwip/wiznet/wiznetif.cpp
+++ b/hal/network/lwip/wiznet/wiznetif.cpp
@@ -128,14 +128,6 @@ WizNetif::WizNetif(hal_spi_interface_t spi, pin_t cs, pin_t reset, pin_t interru
     /* There is an external 10k pull-up */
     HAL_Pin_Mode(interrupt_, INPUT);
 
-    if (!hal_spi_is_enabled(spi_)) {
-        hal_spi_init(spi_);
-        // Make sure the SPI peripheral is initialized with default settings
-        hal_spi_acquire(spi_, nullptr);
-        hal_spi_begin_ext(spi_, SPI_MODE_MASTER, SPI_DEFAULT_SS, nullptr);
-        hal_spi_release(spi_, nullptr);
-    }
-
     SPARK_ASSERT(os_semaphore_create(&spiSem_, 1, 0) == 0);
 
     reg_wizchip_cris_cbfunc(

--- a/hal/shared/spi_lock.h
+++ b/hal/shared/spi_lock.h
@@ -50,7 +50,7 @@ public:
             hal_spi_init(spi_);
             // Make sure the SPI peripheral is initialized with default settings
             hal_spi_acquire(spi_, nullptr);
-            hal_spi_begin_ext(spi_, SPI_MODE_MASTER, SPI_DEFAULT_SS, nullptr);
+            hal_spi_begin_ext(spi_, SPI_MODE_MASTER, PIN_INVALID, nullptr);
         } else {
             hal_spi_acquire(spi_, nullptr);
         }


### PR DESCRIPTION
### Problem

The SPI interface default chip select state is set to `SPI_DEFAULT_SS` which may override user defined pin map controls over GPIO pins.  Normally the user will assign and manage their own chip select and not use the native SS pin from the MCU peripheral.

### Solution

Replace references to the default MCU peripheral chip select pin, SS, with an invalid pin map entry, `PIN_INVALID` so that the user can specify GPIO.

### Steps to Test

N/A

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
