### PR TITLE
Add new Kore SIMs to static APN map

### DIFF
--- a/hal/network/ncp/cellular/network_config_db.cpp
+++ b/hal/network/ncp/cellular/network_config_db.cpp
@@ -40,6 +40,7 @@ const NetworkConfig NETWORK_CONFIG[] = {
     { CellularNetworkProvider::TELEFONICA, "214", "07", "", "spark.telefonica.com", "", "" }, // Telefonica
     { CellularNetworkProvider::KORE_VODAFONE, "204", "04", "", "vfd1.korem2m.com", "kore", "kore" }, // Kore/Vodafone
     { CellularNetworkProvider::KORE_ATT, "310", "410", "", "10569.mcs", "", "" }, // Kore/AT&T
+    { CellularNetworkProvider::KORE_ATT, "310", "030", "", "10569.mcs", "", "" }, // Kore/AT&T SIMs with a prefix of 89010 with MCC + MNC: 310 030
     { CellularNetworkProvider::TWILIO, "", "", "8988323", "super", "", "" }, // Twilio Super SIM
     { CellularNetworkProvider::TWILIO, "", "", "8988307", "super", "", "" }, // Twilio Super SIM
 };

--- a/hal/src/electron/cellular_hal_utilities.cpp
+++ b/hal/src/electron/cellular_hal_utilities.cpp
@@ -13,6 +13,7 @@ const char TWILIO_ICCID_1[] = "8988323";
 const char TWILIO_ICCID_2[] = "8988307";
 const char TELEFONICA_MCC_MNC[] = "21407";
 const char KORE_ATT_MCC_MNC[] = "310410";
+const char KORE_ATT2_MCC_MNC[] = "310030";
 const char KORE_VODAFONE_MCC_MNC[] = "20404";
 
 const int MCC_MNC_MIN_SIZE = 5;
@@ -30,6 +31,9 @@ CellularNetProv cellular_sim_to_network_provider_impl(const char* imsi, const ch
             // LOG(INFO, "CELLULAR_NETPROV_TELEFONICA");
             return CELLULAR_NETPROV_TELEFONICA;
         } else if (strncmp(imsi, KORE_ATT_MCC_MNC, strlen(KORE_ATT_MCC_MNC)) == 0) {
+            // LOG(INFO, "CELLULAR_NETPROV_KORE_ATT");
+            return CELLULAR_NETPROV_KORE_ATT;
+        } else if (strncmp(imsi, KORE_ATT2_MCC_MNC, strlen(KORE_ATT2_MCC_MNC)) == 0) {
             // LOG(INFO, "CELLULAR_NETPROV_KORE_ATT");
             return CELLULAR_NETPROV_KORE_ATT;
         } else if (strncmp(imsi, KORE_VODAFONE_MCC_MNC, strlen(KORE_VODAFONE_MCC_MNC)) == 0) {

--- a/test/unit_tests/cellular/cellular.cpp
+++ b/test/unit_tests/cellular/cellular.cpp
@@ -81,6 +81,12 @@ TEST_CASE("Gen 2 cellular credentials") {
         REQUIRE(cellular_sim_to_network_provider_impl("310410999999999", nullptr) == CELLULAR_NETPROV_KORE_ATT);
     }
 
+    SECTION("IMSI range2 should set Kore AT&T as Network Provider", "[cellular]") {
+        REQUIRE(cellular_sim_to_network_provider_impl("310030000000000", nullptr) == CELLULAR_NETPROV_KORE_ATT);
+        REQUIRE(cellular_sim_to_network_provider_impl("310030555555555", nullptr) == CELLULAR_NETPROV_KORE_ATT);
+        REQUIRE(cellular_sim_to_network_provider_impl("310030999999999", nullptr) == CELLULAR_NETPROV_KORE_ATT);
+    }
+
     SECTION("IMSI range should set Telefonica as Network Provider", "[cellular]") {
         REQUIRE(cellular_sim_to_network_provider_impl("214070000000000", nullptr) == CELLULAR_NETPROV_TELEFONICA);
         REQUIRE(cellular_sim_to_network_provider_impl("214075555555555", nullptr) == CELLULAR_NETPROV_TELEFONICA);
@@ -97,6 +103,7 @@ TEST_CASE("Gen 2 cellular credentials") {
         REQUIRE(cellular_sim_to_network_provider_impl("732123200003364", "89883234500011906351") == CELLULAR_NETPROV_TWILIO);   // Twilio IMSI and Twilio ICCID
         REQUIRE(cellular_sim_to_network_provider_impl("214070000000000", "89883235555555555555") == CELLULAR_NETPROV_TWILIO);   // Kore IMSI and Twilio ICCID just in case
         REQUIRE(cellular_sim_to_network_provider_impl("310410999999999", "89883071234567891011") == CELLULAR_NETPROV_TWILIO);   // Kore IMSI and Twilio ICCID just in case
+        REQUIRE(cellular_sim_to_network_provider_impl("310030999999999", "89883071234567891011") == CELLULAR_NETPROV_TWILIO);   // Kore IMSI and Twilio ICCID just in case
     }
 }
 
@@ -141,6 +148,12 @@ TEST_CASE("Gen 3 cellular credentials") {
         auto creds = networkConfigForImsi(imsi, sizeof(imsi) - 1);
         REQUIRE(creds.netProv() == CellularNetworkProvider::KORE_ATT);
     }
+    SECTION("Kore ATT2") {
+        const char imsi[] = "310030900000000";
+        auto creds = networkConfigForImsi(imsi, sizeof(imsi) - 1);
+        REQUIRE(creds.netProv() == CellularNetworkProvider::KORE_ATT);
+    }
+
 }
 
 TEST_CASE("cellular_signal()") {

--- a/test/unit_tests/services/simple_file_storage.cpp
+++ b/test/unit_tests/services/simple_file_storage.cpp
@@ -95,7 +95,7 @@ TEST_CASE("SimpleFileStorage") {
             CHECK(buf[2] == 0);
         }
         SECTION("can read a record larger than the filesystem block") {
-            size_t n = FILESYSTEM_BLOCK_SIZE * 2;
+            const size_t n = FILESYSTEM_BLOCK_SIZE * 2;
             auto d = test::randString(n);
             std::string h(4, '\0');
             h[0] = n & 0xff;


### PR DESCRIPTION
Story details: https://app.clubhouse.io/particle/story/70820

As far as I know I have no way to test this currently, as I don't have an affected SIM (Kore/AT&T SIM with a prefix of 89010)