### PR TITLE
Make sure that ESP32 NCP power state is correctly initialized on boot

### DIFF
--- a/hal/network/ncp_client/esp32/esp32_ncp_client.cpp
+++ b/hal/network/ncp_client/esp32/esp32_ncp_client.cpp
@@ -160,6 +160,8 @@ int Esp32NcpClient::init(const NcpClientConfig& conf) {
     ready_ = false;
     muxerNotStarted_ = false;
     pwrState_ = NcpPowerState::UNKNOWN;
+    // We know for a fact that ESP32 is off on boot because we've initialized ESPEN pin to output 0
+    ncpPowerState(NcpPowerState::OFF);
     return 0;
 }
 


### PR DESCRIPTION
### Problem

Tracker takes several minutes to enter sleep mode. The root cause is that ESP32 NCP power state is not reflecting the actual state on boot (which should be off).

### Solution

Fix that.

### Steps to Test

N/A

### Example App

N/A

### References

- [CH72616]

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
