### PR TITLE
Allow clearing session data and running custom setup code in integration tests

### DIFF
--- a/system/inc/system_cloud.h
+++ b/system/inc/system_cloud.h
@@ -308,8 +308,9 @@ bool spark_cloud_flag_auto_connect(void);
  * Option flags for `spark_cloud_disconnect_options`.
  */
 typedef enum spark_cloud_disconnect_option_flag {
-    SPARK_CLOUD_DISCONNECT_OPTION_GRACEFUL = 0x01, ///< The graceful disconnection option is set.
-    SPARK_CLOUD_DISCONNECT_OPTION_TIMEOUT = 0x02 ///< The timeout option is set.
+    SPARK_CLOUD_DISCONNECT_OPTION_GRACEFUL = 0x01, ///< The `graceful` option is set.
+    SPARK_CLOUD_DISCONNECT_OPTION_TIMEOUT = 0x02, ///< The `timeout` option is set.
+    SPARK_CLOUD_DISCONNECT_OPTION_CLEAR_SESSION = 0x04, ///< The `clear_session` option is set.
 } spark_cloud_disconnect_option_flag;
 
 /**
@@ -318,8 +319,9 @@ typedef enum spark_cloud_disconnect_option_flag {
 typedef struct spark_cloud_disconnect_options {
     uint16_t size; ///< Size of this structure.
     uint8_t flags; ///< Option flags (see `spark_cloud_disconnect_option_flag`).
-    uint8_t graceful; ///< Set to a non-zero value if graceful disconnection is enabled.
+    uint8_t graceful; ///< Enables graceful disconnection if set to a non-zero value.
     uint32_t timeout; ///< Maximum time in milliseconds to wait for message acknowledgements.
+    uint8_t clear_session; ///< Clears the session after disconnecting if set to a non-zero value.
 } spark_cloud_disconnect_options;
 
 /**

--- a/system/inc/system_cloud.h
+++ b/system/inc/system_cloud.h
@@ -310,7 +310,7 @@ bool spark_cloud_flag_auto_connect(void);
 typedef enum spark_cloud_disconnect_option_flag {
     SPARK_CLOUD_DISCONNECT_OPTION_GRACEFUL = 0x01, ///< The `graceful` option is set.
     SPARK_CLOUD_DISCONNECT_OPTION_TIMEOUT = 0x02, ///< The `timeout` option is set.
-    SPARK_CLOUD_DISCONNECT_OPTION_CLEAR_SESSION = 0x04, ///< The `clear_session` option is set.
+    SPARK_CLOUD_DISCONNECT_OPTION_CLEAR_SESSION = 0x04 ///< The `clear_session` option is set.
 } spark_cloud_disconnect_option_flag;
 
 /**

--- a/system/src/active_object.cpp
+++ b/system/src/active_object.cpp
@@ -18,9 +18,11 @@
  */
 
 #include "active_object.h"
-
+#include "system_threading.h"
 #include "spark_wiring_interrupts.h"
 #include "debug.h"
+
+using namespace particle;
 
 #if PLATFORM_THREADING
 
@@ -28,9 +30,6 @@
 #include "concurrent_hal.h"
 #include "timer_hal.h"
 #include "rng_hal.h"
-
-// FIXME:
-extern ActiveObjectThreadQueue SystemThread;
 
 void ActiveObjectBase::start_thread()
 {

--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -537,6 +537,8 @@ void app_thread_idle()
     app_loop(true);
 }
 
+namespace particle {
+
 // don't wait to get items from the queue, so the application loop is processed as often as possible
 // timeout after attempting to put calls into the application queue, so the system thread does not deadlock  (since the application may also
 // be trying to put events in the system queue.)
@@ -544,6 +546,8 @@ ActiveObjectCurrentThreadQueue ApplicationThread(ActiveObjectConfiguration(app_t
 		0, /* take time */
 		5000, /* put time */
 		20 /* queue size */));
+
+} // namespace particle
 
 #endif
 

--- a/system/src/system_cloud.cpp
+++ b/system/src/system_cloud.cpp
@@ -60,13 +60,13 @@ using namespace particle::system;
 #if PLATFORM_THREADING
 VitalsPublisher<Timer> _vitals;
 #else  // not PLATFORM_THREADING
-VitalsPublisher<particle::NullTimer> _vitals;
+VitalsPublisher<NullTimer> _vitals;
 #endif // PLATFORM_THREADING
 
 // These properties are forwarded to the protocol instance as is
-static_assert(SPARK_CLOUD_PING_INTERVAL == (int)particle::protocol::Connection::PING,
+static_assert(SPARK_CLOUD_PING_INTERVAL == (int)protocol::Connection::PING,
         "The value of SPARK_CLOUD_PING_INTERVAL has changed");
-static_assert(SPARK_CLOUD_FAST_OTA_ENABLED == (int)particle::protocol::Connection::FAST_OTA,
+static_assert(SPARK_CLOUD_FAST_OTA_ENABLED == (int)protocol::Connection::FAST_OTA,
         "The value of SPARK_CLOUD_FAST_OTA_ENABLED has changed");
 
 } // namespace
@@ -232,7 +232,7 @@ int spark_cloud_disconnect(const spark_cloud_disconnect_options* options, void* 
         if (options) {
             opts = CloudDisconnectOptions::fromSystemOptions(options);
         }
-        particle::CloudConnectionSettings::instance()->setPendingDisconnectOptions(std::move(opts));
+        CloudConnectionSettings::instance()->setPendingDisconnectOptions(std::move(opts));
     }
     spark_cloud_flag_disconnect();
     return 0;
@@ -270,13 +270,13 @@ int spark_set_connection_property(unsigned property, unsigned value, const void*
     case SPARK_CLOUD_DISCONNECT_OPTIONS: {
         const auto d = (const spark_cloud_disconnect_options*)data;
         auto opts = CloudDisconnectOptions::fromSystemOptions(d);
-        particle::CloudConnectionSettings::instance()->setDefaultDisconnectOptions(std::move(opts));
+        CloudConnectionSettings::instance()->setDefaultDisconnectOptions(std::move(opts));
         return 0;
     }
     // These properties are forwarded to the protocol instance as is
     case SPARK_CLOUD_PING_INTERVAL:
     case SPARK_CLOUD_FAST_OTA_ENABLED: {
-        const auto d = (const particle::protocol::connection_properties_t*)data;
+        const auto d = (const protocol::connection_properties_t*)data;
         const auto r = spark_protocol_set_connection_property(sp, property, value, d, reserved);
         return spark_protocol_to_system_error(r);
     }

--- a/system/src/system_cloud_connection.cpp
+++ b/system/src/system_cloud_connection.cpp
@@ -91,7 +91,7 @@ int SessionConnection::load(const ServerAddress& addr)
             return -1;
         }
     } else {
-        LOG(ERROR, "Failed to load session data from persistent storage");
+        LOG(WARN, "Failed to load session data from persistent storage");
         discard();
         return -1;
     }

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -191,6 +191,14 @@ void registerSystemSubscriptions() {
     }
 }
 
+void clearSessionData() {
+    SessionPersistDataOpaque d = {};
+    const int r = Spark_Save(&d, sizeof(d), SparkCallbacks::PERSIST_SESSION, nullptr);
+    if (r < 0) {
+        LOG(ERROR, "Spark_Save() failed: %d", r);
+    }
+}
+
 } // namespace particle
 
 extern uint8_t feature_cloud_udp;

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -90,7 +90,7 @@ inline uint8_t dataToFlag(const char* data) {
  */
 void systemEventHandler(const char* name, const char* data)
 {
-    if (particle::startsWith(name, DEVICE_UPDATES_EVENT)) {
+    if (startsWith(name, DEVICE_UPDATES_EVENT)) {
         const uint8_t flagValue = dataToFlag(data);
         if (isSuffix(name, DEVICE_UPDATES_EVENT, FORCED_EVENT)) {
             system_set_flag(SYSTEM_FLAG_OTA_UPDATE_FORCED, flagValue, nullptr);
@@ -118,7 +118,7 @@ void systemEventHandler(const char* name, const char* data)
                 if (task) {
                     task->func = [](ISRTaskQueue::Task* task) {
                         delete task;
-                        particle::resetNetworkInterfaces();
+                        resetNetworkInterfaces();
                     };
                     SystemISRTaskQueue.enqueue(task);
                 }
@@ -1086,11 +1086,11 @@ void Spark_Protocol_Init(void)
         }
 #endif // HAL_PLATFORM_COMPRESSED_OTA
 
-        spark_protocol_set_connection_property(sp, particle::protocol::Connection::SYSTEM_MODULE_VERSION, MODULE_VERSION,
+        spark_protocol_set_connection_property(sp, protocol::Connection::SYSTEM_MODULE_VERSION, MODULE_VERSION,
                 nullptr, nullptr);
-        spark_protocol_set_connection_property(sp, particle::protocol::Connection::MAX_BINARY_SIZE, HAL_OTA_FlashLength(),
+        spark_protocol_set_connection_property(sp, protocol::Connection::MAX_BINARY_SIZE, HAL_OTA_FlashLength(),
                 nullptr, nullptr);
-        spark_protocol_set_connection_property(sp, particle::protocol::Connection::OTA_CHUNK_SIZE, HAL_OTA_ChunkSize(),
+        spark_protocol_set_connection_property(sp, protocol::Connection::OTA_CHUNK_SIZE, HAL_OTA_ChunkSize(),
                 nullptr, nullptr);
 
         CommunicationsHandlers handlers;

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -192,11 +192,14 @@ void registerSystemSubscriptions() {
 }
 
 void clearSessionData() {
+#if HAL_PLATFORM_CLOUD_UDP
+    LOG(INFO, "Clearing session data");
     SessionPersistDataOpaque d = {};
     const int r = Spark_Save(&d, sizeof(d), SparkCallbacks::PERSIST_SESSION, nullptr);
     if (r < 0) {
         LOG(ERROR, "Spark_Save() failed: %d", r);
     }
+#endif
 }
 
 } // namespace particle

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -63,6 +63,7 @@
 
 using namespace particle;
 using namespace particle::system;
+using particle::protocol::ProtocolError;
 
 namespace particle {
 
@@ -192,12 +193,6 @@ void registerSystemSubscriptions() {
 
 } // namespace particle
 
-using namespace particle::system;
-using particle::CloudDiagnostics;
-using particle::CloudConnectionSettings;
-using particle::publishEvent;
-using particle::protocol::ProtocolError;
-
 extern uint8_t feature_cloud_udp;
 extern volatile bool cloud_socket_aborted;
 
@@ -205,8 +200,6 @@ static volatile uint32_t lastCloudEvent = 0;
 uint32_t particle_key_errors = NO_ERROR;
 
 const int CLAIM_CODE_SIZE = 63;
-
-using particle::LEDStatus;
 
 int userVarType(const char *varKey);
 int userFuncSchedule(const char *funcKey, const char *paramString, SparkDescriptor::FunctionResultCallback callback, void* reserved);
@@ -251,7 +244,7 @@ template<typename T> T* add_if_sufficient_describe(append_list<T>& list, const c
 	if (result) {
 		spark_protocol_describe_data data;
 		data.size = sizeof(data);
-		data.flags = particle::protocol::DESCRIBE_APPLICATION;
+		data.flags = protocol::DESCRIBE_APPLICATION;
 		if (!spark_protocol_get_describe_data(spark_protocol_instance(), &data, nullptr)) {
 			if (data.maximum_size<data.current_size) {
 				list.removeAt(list.size()-1);
@@ -1073,12 +1066,12 @@ void Spark_Protocol_Init(void)
         spark_protocol_init(sp, (const char*) id, keys, callbacks, descriptor);
 
         // Enable device-initiated describe messages
-        spark_protocol_set_connection_property(sp, particle::protocol::Connection::DEVICE_INITIATED_DESCRIBE, 0, nullptr, nullptr);
+        spark_protocol_set_connection_property(sp, protocol::Connection::DEVICE_INITIATED_DESCRIBE, 0, nullptr, nullptr);
 
 #if HAL_PLATFORM_COMPRESSED_OTA
         // Enable compressed/combined OTA updates
         if (bootloader_get_version() >= COMPRESSED_OTA_MIN_BOOTLOADER_VERSION) {
-            spark_protocol_set_connection_property(sp, particle::protocol::Connection::COMPRESSED_OTA, 0, nullptr, nullptr);
+            spark_protocol_set_connection_property(sp, protocol::Connection::COMPRESSED_OTA, 0, nullptr, nullptr);
         }
 #endif // HAL_PLATFORM_COMPRESSED_OTA
 
@@ -1139,13 +1132,13 @@ int Spark_Handshake(bool presence_announce)
     // We have a workaround for this issue in the NCP client, so the modem should no longer crash
     // in any case, but we want to avoid dropping a set of publishes which are generated below,
     // hence a delay here as a workaround.
-    auto timeout = particle::cellularNetworkManager()->ncpClient()->getTxDelayInDataChannel();
+    auto timeout = cellularNetworkManager()->ncpClient()->getTxDelayInDataChannel();
     if (timeout > 0) {
         HAL_Delay_Milliseconds(timeout);
     }
 #endif // HAL_PLATFORM_MUXER_MAY_NEED_DELAY_IN_TX
 
-    if (err == particle::protocol::SESSION_RESUMED) {
+    if (err == protocol::SESSION_RESUMED) {
         session_resumed = true;
     } else if (err != 0) {
         return spark_protocol_to_system_error(err);
@@ -1197,7 +1190,7 @@ int Spark_Handshake(bool presence_announce)
         }
     }
     if (system_mode() != AUTOMATIC || APPLICATION_SETUP_DONE) {
-        err = particle::sendApplicationDescription();
+        err = sendApplicationDescription();
         if (err != 0) {
             return err;
         }

--- a/system/src/system_cloud_internal.h
+++ b/system/src/system_cloud_internal.h
@@ -137,10 +137,12 @@ public:
     // Default disconnection settings
     static const bool DEFAULT_DISCONNECT_GRACEFULLY = false;
     static const unsigned DEFAULT_DISCONNECT_TIMEOUT = 30000;
+    static const bool DEFAULT_DISCONNECT_CLEAR_SESSION = false;
 
     CloudConnectionSettings() :
             defaultDisconnectTimeout_(DEFAULT_DISCONNECT_TIMEOUT),
-            defaultDisconnectGracefully_(DEFAULT_DISCONNECT_GRACEFULLY) {
+            defaultDisconnectGracefully_(DEFAULT_DISCONNECT_GRACEFULLY),
+            defaultDisconnectClearSession_(DEFAULT_DISCONNECT_CLEAR_SESSION) {
     }
 
     void setDefaultDisconnectOptions(const CloudDisconnectOptions& options) {
@@ -149,6 +151,9 @@ public:
         }
         if (options.isTimeoutSet()) {
             defaultDisconnectTimeout_ = options.timeout();
+        }
+        if (options.isClearSessionSet()) {
+            defaultDisconnectClearSession_ = options.clearSession();
         }
     }
 
@@ -179,6 +184,11 @@ public:
         } else {
             result.timeout(defaultDisconnectTimeout_);
         }
+        if (pending.isClearSessionSet()) {
+            result.clearSession(pending.clearSession());
+        } else {
+            result.clearSession(defaultDisconnectClearSession_);
+        }
         return result;
     }
 
@@ -190,6 +200,7 @@ private:
     // defaultDisconnectGracefully_ may also be accessed from an ISR
     unsigned defaultDisconnectTimeout_;
     volatile bool defaultDisconnectGracefully_;
+    bool defaultDisconnectClearSession_;
     // Pending disconnection options are set atomically and guarded by a spinlock
     CloudDisconnectOptions pendingDisconnectOptions_;
 };
@@ -204,6 +215,9 @@ int sendApplicationDescription();
 
 // Subscribes to system cloud events
 void registerSystemSubscriptions();
+
+// Invalidates the cached session data
+void clearSessionData();
 
 } // namespace particle
 

--- a/system/src/system_event.cpp
+++ b/system/src/system_event.cpp
@@ -26,6 +26,8 @@
 
 namespace {
 
+using namespace particle;
+
 struct SystemEventSubscription {
 
     system_event_t events;

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -621,6 +621,9 @@ void cloud_disconnect(unsigned flags, cloud_disconnect_reason cloudReason, netwo
                 spark_protocol_command(spark_protocol_instance(), ProtocolCommands::TERMINATE, 0, nullptr);
             }
         }
+        if (opts.clearSession()) {
+            clearSessionData();
+        }
         if (!(flags & CLOUD_DISCONNECT_DONT_CLOSE)) {
             spark_cloud_socket_disconnect(graceful);
         }

--- a/test/unit_tests/cloud/publish_vitals.cpp
+++ b/test/unit_tests/cloud/publish_vitals.cpp
@@ -33,7 +33,11 @@ int spark_cloud_flag_connected_result;
 bool spark_protocol_post_description_called;
 int spark_protocol_post_description_result;
 
+namespace particle {
+
 ISRTaskQueue SystemISRTaskQueue;
+
+} // namespace particle
 
 void ISRTaskQueue::enqueue(ISRTaskQueue::Task*)
 {

--- a/user/tests/integration/application/include/test.h
+++ b/user/tests/integration/application/include/test.h
@@ -18,3 +18,11 @@
 #pragma once
 
 #include "unit-test/unit-test.h"
+
+namespace particle {
+
+void testAppInit();
+void testAppSetup();
+void testAppLoop();
+
+} // namespace particle

--- a/user/tests/integration/application/src/application.cpp
+++ b/user/tests/integration/application/src/application.cpp
@@ -1,15 +1,38 @@
+#include "test.h"
 #include "test_suite.h"
 
-#include "spark_wiring_system.h"
 #include "spark_wiring_startup.h"
 
 #include "unit-test/unit-test.h"
 
-using namespace particle;
-
+#ifndef NO_TEST_APP_INIT
 STARTUP({
-    System.enableFeature(FEATURE_RETAINED_MEMORY);
-    TestSuite::instance()->init();
+    particle::testAppInit();
 });
+#endif
 
-UNIT_TEST_APP();
+#ifndef NO_TEST_APP_SETUP_AND_LOOP
+void setup() {
+    particle::testAppSetup();
+}
+
+void loop() {
+    particle::testAppLoop();
+}
+#endif
+
+namespace particle {
+
+void testAppInit() {
+    SPARK_ASSERT(TestSuite::instance()->init() == 0);
+}
+
+void testAppSetup() {
+    TestRunner::instance()->setup();
+}
+
+void testAppLoop() {
+    TestRunner::instance()->loop();
+}
+
+} // namespace particle

--- a/user/tests/integration/application/src/test_suite.cpp
+++ b/user/tests/integration/application/src/test_suite.cpp
@@ -20,6 +20,8 @@
 #include "platform_headers.h"
 #include "check.h"
 
+#include "spark_wiring_system.h"
+
 #include "unit-test/unit-test.h"
 
 namespace particle {
@@ -48,6 +50,8 @@ TestSuite::~TestSuite() {
 }
 
 int TestSuite::init() {
+    // Enable backup memory
+    System.enableFeature(FEATURE_RETAINED_MEMORY);
     // Set system mode
     if (g_config.size != sizeof(CurrentConfig) || g_config.magicNumber != MAGIC_NUMBER) {
         g_config.size = sizeof(CurrentConfig);

--- a/user/tests/unit/usb_control_request_channel.cpp
+++ b/user/tests/unit/usb_control_request_channel.cpp
@@ -12,7 +12,11 @@
 #include <set>
 #include <list>
 
+namespace particle {
+
 ISRTaskQueue SystemISRTaskQueue;
+
+} // namespace particle
 
 namespace {
 

--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -77,20 +77,20 @@ public:
     system_tick_t timeout() const;
     bool isTimeoutSet() const;
 
+    CloudDisconnectOptions& clearSession(bool enabled);
+    bool clearSession() const;
+    bool isClearSessionSet() const;
+
     spark_cloud_disconnect_options toSystemOptions() const;
     static CloudDisconnectOptions fromSystemOptions(const spark_cloud_disconnect_options* options);
 
 private:
-    enum OptionFlag {
-        GRACEFUL = SPARK_CLOUD_DISCONNECT_OPTION_GRACEFUL,
-        TIMEOUT = SPARK_CLOUD_DISCONNECT_OPTION_TIMEOUT
-    };
-
     unsigned flags_; // TODO: Use std::optional (C++17)
     system_tick_t timeout_;
     bool graceful_;
+    bool clearSession_;
 
-    CloudDisconnectOptions(unsigned flags, system_tick_t timeout, bool graceful);
+    CloudDisconnectOptions(unsigned flags, system_tick_t timeout, bool graceful, bool clearSession);
 };
 
 class CloudClass {
@@ -513,18 +513,20 @@ extern CloudClass Spark __attribute__((deprecated("Spark is now Particle.")));
 extern CloudClass Particle;
 
 inline CloudDisconnectOptions::CloudDisconnectOptions() :
-        CloudDisconnectOptions(0, 0, false) {
+        CloudDisconnectOptions(0, 0, false, false) {
 }
 
-inline CloudDisconnectOptions::CloudDisconnectOptions(unsigned flags, system_tick_t timeout, bool graceful) :
+inline CloudDisconnectOptions::CloudDisconnectOptions(unsigned flags, system_tick_t timeout, bool graceful,
+        bool clearSession) :
         flags_(flags),
         timeout_(timeout),
-        graceful_(graceful) {
+        graceful_(graceful),
+        clearSession_(clearSession) {
 }
 
 inline CloudDisconnectOptions& CloudDisconnectOptions::graceful(bool enabled) {
     graceful_ = enabled;
-    flags_ |= OptionFlag::GRACEFUL;
+    flags_ |= SPARK_CLOUD_DISCONNECT_OPTION_GRACEFUL;
     return *this;
 }
 
@@ -533,12 +535,12 @@ inline bool CloudDisconnectOptions::graceful() const {
 }
 
 inline bool CloudDisconnectOptions::isGracefulSet() const {
-    return (flags_ & OptionFlag::GRACEFUL);
+    return (flags_ & SPARK_CLOUD_DISCONNECT_OPTION_GRACEFUL);
 }
 
 inline CloudDisconnectOptions& CloudDisconnectOptions::timeout(system_tick_t timeout) {
     timeout_ = timeout;
-    flags_ |= OptionFlag::TIMEOUT;
+    flags_ |= SPARK_CLOUD_DISCONNECT_OPTION_TIMEOUT;
     return *this;
 }
 
@@ -551,7 +553,21 @@ inline system_tick_t CloudDisconnectOptions::timeout() const {
 }
 
 inline bool CloudDisconnectOptions::isTimeoutSet() const {
-    return (flags_ & OptionFlag::TIMEOUT);
+    return (flags_ & SPARK_CLOUD_DISCONNECT_OPTION_TIMEOUT);
+}
+
+inline CloudDisconnectOptions& CloudDisconnectOptions::clearSession(bool enabled) {
+    clearSession_ = enabled;
+    flags_ |= SPARK_CLOUD_DISCONNECT_OPTION_CLEAR_SESSION;
+    return *this;
+}
+
+inline bool CloudDisconnectOptions::clearSession() const {
+    return clearSession_;
+}
+
+inline bool CloudDisconnectOptions::isClearSessionSet() const {
+    return (flags_ & SPARK_CLOUD_DISCONNECT_OPTION_CLEAR_SESSION);
 }
 
 inline particle::Future<bool> CloudClass::publish(const char* name) {

--- a/wiring/src/spark_wiring_cloud.cpp
+++ b/wiring/src/spark_wiring_cloud.cpp
@@ -25,12 +25,18 @@ spark_cloud_disconnect_options CloudDisconnectOptions::toSystemOptions() const
     opts.flags = flags_;
     opts.graceful = graceful_;
     opts.timeout = timeout_;
+    opts.clear_session = clearSession_;
     return opts;
 }
 
 CloudDisconnectOptions CloudDisconnectOptions::fromSystemOptions(const spark_cloud_disconnect_options* options)
 {
-    return CloudDisconnectOptions(options->flags, options->timeout, options->graceful);
+    bool clearSession = false;
+    if (options->size >= offsetof(spark_cloud_disconnect_options, clear_session) +
+            sizeof(spark_cloud_disconnect_options::clear_session)) {
+        clearSession = options->clear_session;
+    }
+    return CloudDisconnectOptions(options->flags, options->timeout, options->graceful, clearSession);
 }
 
 int CloudClass::call_raw_user_function(void* data, const char* param, void* reserved)


### PR DESCRIPTION
### Problem

1. The integration test framework defines the `setup()` and `loop()` functions making it impossible for test applications to run custom code in those functions.
2. The system Device OS API doesn't provide a way to force a new session to be established with the cloud which makes it difficult to write tests around session resumption.

### Solution

1. Introduce a couple macros that can be defined in an integration test's `test.mk`: `NO_TEST_APP_INIT` and `NO_TEST_APP_SETUP_AND_LOOP`. The first macro disables automatic execution of the test framework's global initialization code, and the second one prevents the framework from defining the `setup()` and `loop()` functions. In both cases the test application is responsible for initializing the test framework:
```cpp
#include "test.h"

STARTUP({
    testAppInit();
});

void setup() {
    testAppSetup();
}

void loop() {
    testAppLoop();
}

test(my_test_case) {
    ...
}
```

2. Add an option to `CloudDisconnectOptions` that allows clearing the cached session data when disconnecting from the cloud and thus forcing a new session to be established on the next connection attempt:
```cpp
SYSTEM_MODE(SEMI_AUTOMATIC)

void setup() {
    Particle.disconnect(CloudDisconnectOptions().clearSession(true));
    Particle.connect();
}

void loop() {
}
```

This PR also moves the system threading definitions to the `particle` namespace. It's an artifact from the previous implementation of this PR which I decided too keep since it reduces the usage of the global namespace in our code a tiny bit (I originally wanted to extend the `system_internal()` function instead of introducing a new disconnection option).

### References

- [ch72812]
