### PR TITLE
[u-blox][gen2] COPS_TIMEOUT increased to 5 minutes

### DIFF
--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -87,7 +87,7 @@ std::recursive_mutex mdm_mutex;
 #define CGDCONT_TIMEOUT   ( 10 * 1000)
 #define CIMI_TIMEOUT      ( 10 * 1000) /* Should be immediate, but have observed 3 seconds occassionally on u-blox and rarely longer times */
 #define CMGS_TIMEOUT      (150 * 1000) /* 180s for R4 (set to 150s to match previous implementation) */
-#define COPS_TIMEOUT      (180 * 1000)
+#define COPS_TIMEOUT      (300 * 1000) /* Should be 180s, but there seems to be a bug where this timeout of 3 minutes is not being respected by u-blox modems. Setting to 5 for now. */
 #define CPWROFF_TIMEOUT   ( 40 * 1000)
 #define CSQ_TIMEOUT       ( 10 * 1000)
 #define CREG_TIMEOUT      ( 60 * 1000)


### PR DESCRIPTION
### Problem

On u-blox modems, the COPS timeout of 3 minutes has been found to not be respected by the modem, sometimes taking up to 4 minutes or slightly more.

### Solution

Increase the COPS timeout to 5 minutes.

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] N/A Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
