### PR TITLE
Modify mapping for LTE signal values to percentages

### DIFF
--- a/hal/shared/cellular_sig_perc_mapping.cpp
+++ b/hal/shared/cellular_sig_perc_mapping.cpp
@@ -35,41 +35,43 @@ enum SignalMappingRegions {
     MAX_REGION_THRESHOLDS
 };
 
-/* RF Characterization internal testing. Please see https://docs.google.com/spreadsheets/d/11qpipAc7JWzr8rAk-SOClfhflT-gXabDPGOMQU4be8I/edit?usp=sharing */
+/* RF Characterization internal testing plus data from live network.
+Please see https://docs.google.com/spreadsheets/d/11qpipAc7JWzr8rAk-SOClfhflT-gXabDPGOMQU4be8I/edit?usp=sharing */
 const int CATM1_STRN_MAP[] = {
     -141,   /* SIG_REGION_POOR */
-    -122,   /* SIG_REGION_BAD */
-    -116,   /* SIG_REGION_FAIR */
-    -107,   /* SIG_REGION_GOOD */
-    -95,    /* SIG_REGION_GREAT */
+    -105,   /* SIG_REGION_BAD */
+    -95,   /* SIG_REGION_FAIR */
+    -85,   /* SIG_REGION_GOOD */
+    -70,    /* SIG_REGION_GREAT */
     //-44     /* MAX */
 };
 
 const int CATM1_QUAL_MAP[] = {
     -20,   /* SIG_REGION_POOR */
-    -19,   /* SIG_REGION_BAD */
-    -17,   /* SIG_REGION_FAIR */
-    -14,   /* SIG_REGION_GOOD */
-    -12,   /* SIG_REGION_GREAT */
+    -15,   /* SIG_REGION_BAD */
+    -10,   /* SIG_REGION_FAIR */
+    -8,   /* SIG_REGION_GOOD */
+    -6,   /* SIG_REGION_GREAT */
     //-3     /* MAX */
 };
 
-/* Source: https://github.com/aosp-mirror/platform_frameworks_base/blob/master/telephony/java/android/telephony/CellSignalStrengthLte.java */
+/* Source: https://github.com/aosp-mirror/platform_frameworks_base/blob/master/telephony/java/android/telephony/CellSignalStrengthLte.java
+plus data from live networks */
 const int CAT1_STRN_MAP[] = {
     -141,   /* SIG_REGION_POOR */
-    -115,   /* SIG_REGION_BAD */
-    -105,   /* SIG_REGION_FAIR */
-    -95,    /* SIG_REGION_GOOD */
-    -85,    /* SIG_REGION_GREAT */
+    -105,   /* SIG_REGION_BAD */
+    -95,   /* SIG_REGION_FAIR */
+    -85,    /* SIG_REGION_GOOD */
+    -70,    /* SIG_REGION_GREAT */
     //-44     /* MAX */
 };
 
 const int CAT1_QUAL_MAP[] = {
     -20,   /* SIG_REGION_POOR */
-    -19,   /* SIG_REGION_BAD */
-    -17,   /* SIG_REGION_FAIR */
-    -14,   /* SIG_REGION_GOOD */
-    -12,   /* SIG_REGION_GREAT */
+    -16,   /* SIG_REGION_BAD */
+    -10,   /* SIG_REGION_FAIR */
+    -8,   /* SIG_REGION_GOOD */
+    -6,   /* SIG_REGION_GREAT */
     //-3     /* MAX */
 };
 

--- a/hal/shared/cellular_sig_perc_mapping.cpp
+++ b/hal/shared/cellular_sig_perc_mapping.cpp
@@ -48,7 +48,7 @@ const int CATM1_STRN_MAP[] = {
 
 const int CATM1_QUAL_MAP[] = {
     -20,   /* SIG_REGION_POOR */
-    -15,   /* SIG_REGION_BAD */
+    -16,   /* SIG_REGION_BAD */
     -10,   /* SIG_REGION_FAIR */
     -8,   /* SIG_REGION_GOOD */
     -6,   /* SIG_REGION_GREAT */

--- a/test/unit_tests/cellular/cellular.cpp
+++ b/test/unit_tests/cellular/cellular.cpp
@@ -661,8 +661,8 @@ TEST_CASE("cellular_signal()") {
         }
 
         SECTION("middle RSRP and RSRQ") {
-            status.rsrp = 36;
-            status.rsrq = 6;
+            status.rsrp = 46;
+            status.rsrq = 20;
 
             cellular_signal_t sig = {};
             sig.size = sizeof(sig);
@@ -670,17 +670,17 @@ TEST_CASE("cellular_signal()") {
             REQUIRE(sig.rat == data.expected_act);
             REQUIRE(std::abs(sig.strength - 32767) == 0);
             REQUIRE(std::abs(sig.quality - 32767) == 0);
-            REQUIRE(sig.rsrp == -10500);
-            REQUIRE(sig.rsrq == -1700);
+            REQUIRE(sig.rsrp == -9500);
+            REQUIRE(sig.rsrq == -1000);
 
             SECTION("CellularSignal") {
                 CellularSignal cs;
                 REQUIRE(cs.fromHalCellularSignal(sig) == true);
                 REQUIRE(cs.getAccessTechnology() == data.expected_act);
                 REQUIRE(std::abs(cs.getStrength()) <= 50.0f);
-                REQUIRE(cs.getStrengthValue() == -105.0f);
+                REQUIRE(cs.getStrengthValue() == -95.0f);
                 REQUIRE(std::abs(cs.getQuality()) <= 50.0f);
-                REQUIRE(cs.getQualityValue() == -17.0f);
+                REQUIRE(cs.getQualityValue() == -10.0f);
             }
         }
 
@@ -791,8 +791,8 @@ TEST_CASE("cellular_signal()") {
         }
 
         SECTION("middle RSRP and RSRQ") {
-            status.rsrp = 25;
-            status.rsrq = 6;
+            status.rsrp = 46;
+            status.rsrq = 20;
 
             cellular_signal_t sig = {};
             sig.size = sizeof(sig);
@@ -800,17 +800,17 @@ TEST_CASE("cellular_signal()") {
             REQUIRE(sig.rat == data.expected_act);
             REQUIRE(std::abs(sig.strength - 32767) == 0);
             REQUIRE(std::abs(sig.quality - 32767) == 0);
-            REQUIRE(sig.rsrp == -11600);
-            REQUIRE(sig.rsrq == -1700);
+            REQUIRE(sig.rsrp == -9500);
+            REQUIRE(sig.rsrq == -1000);
 
             SECTION("CellularSignal") {
                 CellularSignal cs;
                 REQUIRE(cs.fromHalCellularSignal(sig) == true);
                 REQUIRE(cs.getAccessTechnology() == data.expected_act);
                 REQUIRE(std::abs(cs.getStrength()) <= 50.0f);
-                REQUIRE(cs.getStrengthValue() == -116.0f);
+                REQUIRE(cs.getStrengthValue() == -95.0f);
                 REQUIRE(std::abs(cs.getQuality()) <= 50.0f);
-                REQUIRE(cs.getQualityValue() == -17.0f);
+                REQUIRE(cs.getQualityValue() == -10.0f);
             }
         }
 


### PR DESCRIPTION
### Problem

Current mapping is not reflective of the data and performance obtained from the field units.

### Solution

Present this mapping correctly close to the performance observed in the field devices.

### References

- [ch66647](https://app.clubhouse.io/particle/story/66477/device-details-page-shows-poor-rf-warnings-when-it-s-actually-fine-and-the-platform-behaves-as-expected)
- [ch66635](https://app.clubhouse.io/particle/story/66635/change-the-how-device-os-signal-quality-percentages-are-calculated-in-device-os)
- [PR2236](https://github.com/particle-iot/device-os/pull/2236)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
