### PR TITLE
Enable LTO for Photon system firmware

### DIFF
--- a/.buildpackrc
+++ b/.buildpackrc
@@ -6,7 +6,7 @@
 # build targets in Particle Cloud when pushing a tag.
 
 # GCC buildpack variation to use ( see: https://hub.docker.com/r/particle/buildpack-hal/tags/ )
-export BUILDPACK_VARIATION=gcc-arm-none-eabi-9_2-2019q4
+export BUILDPACK_VARIATION=gcc-arm-none-eabi-10_2-2020q4
 
 # Platforms for which this firmware is considered stable
 export RELEASE_PLATFORMS=( )

--- a/.workbench/manifest.json
+++ b/.workbench/manifest.json
@@ -4,7 +4,7 @@
         {
             "platforms": [6, 8, 10, 12, 13, 22, 23, 25, 26],
             "firmware": "deviceOS@source",
-            "compilers": "gcc-arm@9.2.1",
+            "compilers": "gcc-arm@10.2.1",
             "tools": "buildtools@1.1.1",
             "scripts": "buildscripts@1.10.0",
             "debuggers": "openocd@0.11.2-adhoc6ea4372.0"
@@ -62,10 +62,10 @@
             "x64": [
                 {
                     "name": "gcc-arm",
-                    "version": "9.2.1",
+                    "version": "10.2.1",
                     "main": "./bin",
-                    "url": "https://binaries.particle.io/gcc-arm/windows/x64/gcc-arm-v9.2.1.tar.gz",
-                    "sha256": "4cd5e43a2ab144b2beb589b0b0d9f9632ad918154f3749fcff0c36da93468a96"
+                    "url": "https://binaries.particle.io/gcc-arm/windows/x64/gcc-arm-v10.2.1.tar.gz",
+                    "sha256": "81d51a85dae99dd64012f620306ff14b55b38b66e4af1697b9f71cc08b63e6f8"
                 }
             ],
             "x86": []
@@ -74,10 +74,10 @@
             "x64": [
                 {
                     "name": "gcc-arm",
-                    "version": "9.2.1",
+                    "version": "10.2.1",
                     "main": "./bin",
-                    "url": "https://binaries.particle.io/gcc-arm/darwin/x64/gcc-arm-v9.2.1.tar.gz",
-                    "sha256": "c98939900d147182f3e603a7ec4fd13e4e67292f3c7f1f3bc09308c7f97e9974"
+                    "url": "https://binaries.particle.io/gcc-arm/darwin/x64/gcc-arm-v10.2.1.tar.gz",
+                    "sha256": "c340f722c06f5768320bb02a1e9cb654b6f824649c17554cbff82b337b0b43af"
                 }
             ],
             "x86": []
@@ -86,10 +86,10 @@
             "x64": [
                 {
                     "name": "gcc-arm",
-                    "version": "9.2.1",
+                    "version": "10.2.1",
                     "main": "./bin",
-                    "url": "https://binaries.particle.io/gcc-arm/linux/x64/gcc-arm-v9.2.1.tar.gz",
-                    "sha256": "d7c24c8a3464b1806c8d2e93e2d616acb1ac934199756316cf746fdfddaaefe4"
+                    "url": "https://binaries.particle.io/gcc-arm/linux/x64/gcc-arm-v10.2.1.tar.gz",
+                    "sha256": "b6ce735c36c79caa02a95aaefc6d829e7d265c68eda73ac6e5afcd6cd6ba68a1"
                 }
             ],
             "x86": []

--- a/bootloader/src/nRF52840/nrf_it.c
+++ b/bootloader/src/nRF52840/nrf_it.c
@@ -83,7 +83,7 @@ void HardFault_Handler(void)
         " mrseq r0, msp                                             \n"
         " mrsne r0, psp                                             \n"
         " ldr r1, [r0, #24]                                         \n"
-        " ldr r2, handler2_address_const                            \n"
+        " ldr r2, =handler2_address_const                           \n"
         " bx r2                                                     \n"
         " handler2_address_const: .word prvGetRegistersFromStack    \n"
     );

--- a/build/arm-tools.mk
+++ b/build/arm-tools.mk
@@ -68,7 +68,7 @@ version_to_number=$(shell v=$1; v=($${v//./ }); echo $$((v[0] * 10000 + v[1] * 1
 get_major_version=$(shell v=$1; v=($${v//./ }); echo $${v[0]})
 arm_gcc_version_str:=$(shell $(CC) -dumpversion)
 arm_gcc_version:=$(call version_to_number,$(arm_gcc_version_str))
-expected_version_str:=9.2.1
+expected_version_str:=10.2.1
 ifeq ($(shell test $(arm_gcc_version) -lt $(call version_to_number,$(expected_version_str)); echo $$?),0)
      $(error "ARM gcc version $(expected_version_str) or later required, but found $(arm_gcc_version_str)")
 endif

--- a/build/common-tools.mk
+++ b/build/common-tools.mk
@@ -1,3 +1,4 @@
+SHELL = /bin/bash
 
 RM = rm -f
 RMDIR = rm -f -r

--- a/hal/src/nRF52840/core_hal.c
+++ b/hal/src/nRF52840/core_hal.c
@@ -146,7 +146,7 @@ void HardFault_Handler(void) {
         " mrseq r0, msp                                             \n"
         " mrsne r0, psp                                             \n"
         " ldr r1, [r0, #24]                                         \n"
-        " ldr r2, handler2_address_const                            \n"
+        " ldr r2, =handler2_address_const                           \n"
         " bx r2                                                     \n"
         " handler2_address_const: .word prvGetRegistersFromStack    \n"
     );

--- a/hal/src/nRF52840/posix/syscalls_posix.cpp
+++ b/hal/src/nRF52840/posix/syscalls_posix.cpp
@@ -20,6 +20,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <stdio.h>
 #include <fcntl.h>
 // IMPORANT: this is our own implementation header
 #include <sys/dirent.h>

--- a/hal/src/nRF52840/spi_hal.cpp
+++ b/hal/src/nRF52840/spi_hal.cpp
@@ -15,7 +15,6 @@
  * License along with this library; if not, see <http://www.gnu.org/licenses/>.
  */
 #include "logging.h"
-#include <memory>
 #include "nrf_gpio.h"
 #include "nrfx_spim.h"
 #include "nrfx_spis.h"
@@ -27,6 +26,9 @@
 #include "concurrent_hal.h"
 #include "delay_hal.h"
 #include "check.h"
+
+#include <memory>
+#include <cstdlib>
 
 #define DEFAULT_SPI_MODE        SPI_MODE_MASTER
 #define DEFAULT_DATA_MODE       SPI_MODE3

--- a/hal/src/stm32f2xx/core_hal_stm32f2xx.c
+++ b/hal/src/stm32f2xx/core_hal_stm32f2xx.c
@@ -120,7 +120,7 @@ void HardFault_Handler(void)
         " mrseq r0, msp                                             \n"
         " mrsne r0, psp                                             \n"
         " ldr r1, [r0, #24]                                         \n"
-        " ldr r2, handler2_address_const                            \n"
+        " ldr r2, =handler2_address_const                           \n"
         " bx r2                                                     \n"
         " handler2_address_const: .word prvGetRegistersFromStack    \n"
     );

--- a/modules/photon/system-part1/makefile
+++ b/modules/photon/system-part1/makefile
@@ -21,6 +21,8 @@ TARGET=elf bin lst hex size
 
 include $(PROJECT_ROOT)/build/arm-tlm.mk
 
+LDFLAGS += -flto -Os -fuse-linker-plugin
+
 $(call check_modular)
 
 

--- a/modules/photon/system-part2/makefile
+++ b/modules/photon/system-part2/makefile
@@ -21,6 +21,8 @@ TARGET=elf bin lst hex size
 
 include $(PROJECT_ROOT)/build/arm-tlm.mk
 
+LDFLAGS += -flto -Os -fuse-linker-plugin
+
 $(call check_modular)
 
 

--- a/newlib_nano/src/mallocr.c
+++ b/newlib_nano/src/mallocr.c
@@ -56,6 +56,7 @@
 #if defined(DEBUG) && DEBUG
 #include <assert.h>
 #else
+#undef assert
 #define assert(x) ((void)0)
 #endif
 

--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/src/hw_config.c
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/src/hw_config.c
@@ -46,7 +46,6 @@
 
 /* Private variables ---------------------------------------------------------*/
 uint8_t USE_SYSTEM_FLAGS = 0;	//0, 1
-uint16_t sys_health_cache = 0; // Used by the SYS_HEALTH macros store new heath if higher
 
 button_config_t HAL_Buttons[] = {
     {

--- a/scripts/fetch-buildpack
+++ b/scripts/fetch-buildpack
@@ -1,4 +1,4 @@
-BUILDPACK_FILES=$(mkdir buildpack && wget https://github.com/particle-iot/firmware-buildpack-builder/tarball/0.0.10 -O - | tar -xvz -C buildpack --strip-components 1)
+BUILDPACK_FILES=$(mkdir buildpack && wget https://github.com/particle-iot/firmware-buildpack-builder/tarball/0.0.11 -O - | tar -xvz -C buildpack --strip-components 1)
 SHORT_REF=$(echo "$BUILDPACK_FILES" | head -n1 | cut -d '/' -f 1 | rev | cut -d '-' -f 1 | rev)
 mkdir buildpack/.git
 echo "${SHORT_REF}" > buildpack/.git/short_ref


### PR DESCRIPTION
### Problem

We're out of flash space in system-part2 on Photon.

### Solution

Enable LTO when building Photon system part modules. We have previously [enabled](https://github.com/particle-iot/device-os/pull/2235) it for Electron, but doing the same for Photon causes various compile- and runtime errors with GCC 9.2.1. Building with GCC 10.2.1 seems to resolve those issues.

Enabling LTO frees up ~3 and ~11K of flash memory in Photon's system-part1 and system-part2 respectively.

### References

- [ch73834]
