### PR TITLE
[network] quectel: ignore CGEREP errors, send data mode break sequence multiple times

### DIFF
--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -1343,6 +1343,7 @@ int QuectelNcpClient::enterDataMode() {
     // NOTE: we are ignoring step 1 and are acting more optimistic on the first attempt
     // Subsequent attempts to exit data mode follow this step.
     const int attempts = 5;
+    bool responsive = false;
     for (int i = 0; i < attempts; i++) {
         // Send data mode break
         const char breakCmd[] = "+++";
@@ -1356,8 +1357,12 @@ int QuectelNcpClient::enterDataMode() {
         dataParser_.destroy();
         CHECK(dataParser_.init(std::move(parserConf)));
 
-        CHECK(waitAtResponse(dataParser_, 1000));
+        responsive = waitAtResponse(dataParser_, 1000) == 0;
+        if (responsive) {
+            break;
+        }
     }
+    CHECK_TRUE(responsive, SYSTEM_ERROR_TIMEOUT);
 
     const char connectResponse[] = "CONNECT";
 

--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -1066,7 +1066,8 @@ int QuectelNcpClient::initReady(ModemState state) {
     CHECK_PARSER(parser_.execCommand("AT+QCFG=\"cmux/urcport\",1"));
 
     // Enable packet domain error reporting
-    CHECK_PARSER_OK(parser_.execCommand("AT+CGEREP=1,0"));
+    // Ignore error responses, this command is known to fail sometimes
+    CHECK_PARSER(parser_.execCommand("AT+CGEREP=1,0"));
 
     return SYSTEM_ERROR_NONE;
 }
@@ -1333,19 +1334,30 @@ int QuectelNcpClient::enterDataMode() {
     muxerDataStream_->enabled(true);
 
     CHECK_TRUE(muxer_.setChannelDataHandler(QUECTEL_NCP_PPP_CHANNEL, muxerDataStream_->channelDataCb, muxerDataStream_.get()) == 0, SYSTEM_ERROR_INTERNAL);
-    // Send data mode break
-    const char breakCmd[] = "+++";
-    muxerDataStream_->write(breakCmd, sizeof(breakCmd) - 1);
-    skipAll(muxerDataStream_.get(), 1000);
+    // From Quectel AT commands manual:
+    // To prevent the +++ escape sequence from being misinterpreted as data, the following sequence should be followed:
+    // 1) Do not input any character within 1s before inputting +++.
+    // 2) Input +++ within 1s, and no other characters can be inputted during the time.
+    // 3) Do not input any character within 1s after +++ has been inputted.
+    // 4) Switch to command mode; otherwise return to step 1)
+    // NOTE: we are ignoring step 1 and are acting more optimistic on the first attempt
+    // Subsequent attempts to exit data mode follow this step.
+    const int attempts = 5;
+    for (int i = 0; i < attempts; i++) {
+        // Send data mode break
+        const char breakCmd[] = "+++";
+        muxerDataStream_->write(breakCmd, sizeof(breakCmd) - 1);
+        skipAll(muxerDataStream_.get(), 1000);
 
-    // Initialize AT parser
-    auto parserConf = AtParserConfig()
-            .stream(muxerDataStream_.get())
-            .commandTerminator(AtCommandTerminator::CRLF);
-    dataParser_.destroy();
-    CHECK(dataParser_.init(std::move(parserConf)));
+        // Initialize AT parser
+        auto parserConf = AtParserConfig()
+                .stream(muxerDataStream_.get())
+                .commandTerminator(AtCommandTerminator::CRLF);
+        dataParser_.destroy();
+        CHECK(dataParser_.init(std::move(parserConf)));
 
-    CHECK(waitAtResponse(dataParser_, 5000));
+        CHECK(waitAtResponse(dataParser_, 1000));
+    }
 
     const char connectResponse[] = "CONNECT";
 

--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -1076,6 +1076,16 @@ int QuectelNcpClient::checkRuntimeState(ModemState& state) {
     // Assume we are running at the runtime baudrate
     CHECK(serial_->setBaudRate(QUECTEL_NCP_RUNTIME_SERIAL_BAUDRATE));
 
+    // Essentially we are generating empty 07.10 frames here
+    // This is done so that we can complete an ongoing frame transfer that was aborted e.g.
+    // due to a reset.
+    const char basicFlag = static_cast<char>(gsm0710::proto::BASIC_FLAG);
+    for (int i = 0; i < QUECTEL_NCP_MAX_MUXER_FRAME_SIZE; i++) {
+        CHECK(serial_->waitEvent(Stream::WRITABLE, 1000));
+        CHECK(serial_->write(&basicFlag, sizeof(basicFlag)));
+        skipAll(serial_.get());
+    }
+
     // Feeling optimistic, try to see if the muxer is already available
     if (!muxer_.isRunning()) {
         LOG_DEBUG(TRACE, "Muxer is not currently running");

--- a/hal/network/ncp_client/quectel/quectel_ncp_client.h
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.h
@@ -146,6 +146,7 @@ private:
     int modemHardReset(bool powerOff = false);
     bool modemPowerState() const;
     int modemSetUartState(bool state) const;
+    uint32_t getDefaultSerialConfig() const;
 };
 
 inline AtParser* QuectelNcpClient::atParser() {

--- a/hal/src/nRF52840/serial_stream.cpp
+++ b/hal/src/nRF52840/serial_stream.cpp
@@ -154,6 +154,22 @@ int SerialStream::setBaudRate(unsigned int baudrate) {
     hal_usart_end(serial_);
     phyOn_ = false;
     hal_usart_begin_config(serial_, baudrate, config_, 0);
+    baudrate_ = baudrate;
+    phyOn_ = true;
+    return 0;
+}
+
+int SerialStream::setConfig(uint32_t config, unsigned int baudrate /* optional */) {
+    if (!phyOn_ || !enabled_) {
+        return SYSTEM_ERROR_INVALID_STATE;
+    }
+    hal_usart_end(serial_);
+    phyOn_ = false;
+    if (baudrate != 0) {
+        baudrate_ = baudrate;
+    }
+    config_ = config;
+    hal_usart_begin_config(serial_, baudrate_, config_, 0);
     phyOn_ = true;
     return 0;
 }

--- a/hal/src/nRF52840/serial_stream.h
+++ b/hal/src/nRF52840/serial_stream.h
@@ -41,6 +41,7 @@ public:
     int waitEvent(unsigned flags, unsigned timeout) override;
 
     int setBaudRate(unsigned int baudrate);
+    int setConfig(uint32_t config, unsigned int baudrate = 0);
 
     void enabled(bool enabled);
     bool enabled() const;


### PR DESCRIPTION
### Problem

Restoring network connection from warm bootup on Trackers does not work reliably and fails sometimes.

Two problems have been identified:
1. `AT+CGEREP` returning ERROR response
2. Failure to exit data mode in the data channel

### Solution

1. Ignore `AT+CGEREP` errors, there are no negative consequences to that, this command is simply for informative purposes
2. Modify the sequence to exit data mode to perform several attempts

### Steps to Test

Perform OTA updates of Cat M1 Trackers while watching Serial1 logs. The devices should not be resetting the modem on boot and should be successfully restoring the connection.

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
