### PR TITLE
Added i2c buffer size to Wire interface

### DIFF
--- a/hal/inc/hal_dynalib_i2c.h
+++ b/hal/inc/hal_dynalib_i2c.h
@@ -87,6 +87,8 @@ DYNALIB_FN(BASE_IDX + 18, hal_i2c, hal_i2c_lock, int32_t(hal_i2c_interface_t, vo
 DYNALIB_FN(BASE_IDX + 19, hal_i2c, hal_i2c_unlock, int32_t(hal_i2c_interface_t, void*))
 DYNALIB_FN(BASE_IDX + 20, hal_i2c, hal_i2c_request_ex, int32_t(hal_i2c_interface_t, const hal_i2c_transmission_config_t*, void*))
 DYNALIB_FN(BASE_IDX + 21, hal_i2c, hal_i2c_sleep, int(hal_i2c_interface_t i2c, bool sleep, void* reserved))
+DYNALIB_FN(BASE_IDX + 22, hal_i2c, hal_i2c_rx_buffer_size, uint32_t(hal_i2c_interface_t, void*))
+DYNALIB_FN(BASE_IDX + 23, hal_i2c, hal_i2c_tx_buffer_size, uint32_t(hal_i2c_interface_t, void*))
 
 DYNALIB_END(hal_i2c)
 

--- a/hal/inc/i2c_hal.h
+++ b/hal/inc/i2c_hal.h
@@ -100,6 +100,8 @@ int32_t hal_i2c_available(hal_i2c_interface_t i2c, void* reserved);
 int32_t hal_i2c_read(hal_i2c_interface_t i2c, void* reserved);
 int32_t hal_i2c_peek(hal_i2c_interface_t i2c, void* reserved);
 void hal_i2c_flush(hal_i2c_interface_t i2c, void* reserved);
+uint32_t hal_i2c_rx_buffer_size(hal_i2c_interface_t i2c, void* reserved);
+uint32_t hal_i2c_tx_buffer_size(hal_i2c_interface_t i2c, void* reserved);
 bool hal_i2c_is_enabled(hal_i2c_interface_t i2c, void* reserved);
 void hal_i2c_set_callback_on_received(hal_i2c_interface_t i2c, void (*function)(int), void* reserved);
 void hal_i2c_set_callback_on_requested(hal_i2c_interface_t i2c, void (*function)(void), void* reserved);

--- a/hal/src/nRF52840/i2c_hal.cpp
+++ b/hal/src/nRF52840/i2c_hal.cpp
@@ -604,6 +604,22 @@ void hal_i2c_flush(hal_i2c_interface_t i2c, void* reserved) {
     i2cMap[i2c].tx_index_tail = 0;
 }
 
+uint32_t hal_i2c_rx_buffer_size(hal_i2c_interface_t i2c, void* reserved) {
+    if (i2c >= HAL_PLATFORM_I2C_NUM) {
+        return 0;
+    }
+    I2cLock lk(i2c);
+    return i2cMap[i2c].rx_buf_size;
+}
+
+uint32_t hal_i2c_tx_buffer_size(hal_i2c_interface_t i2c, void* reserved) {
+    if (i2c >= HAL_PLATFORM_I2C_NUM) {
+        return 0;
+    }
+    I2cLock lk(i2c);
+    return i2cMap[i2c].tx_buf_size;
+}
+
 bool hal_i2c_is_enabled(hal_i2c_interface_t i2c,void* reserved) {
     return i2cMap[i2c].state == HAL_I2C_STATE_ENABLED;
 }

--- a/hal/src/stm32f2xx/i2c_hal.c
+++ b/hal/src/stm32f2xx/i2c_hal.c
@@ -826,6 +826,19 @@ void hal_i2c_flush(hal_i2c_interface_t i2c, void* reserved) {
     // XXX: to be implemented.
 }
 
+uint32_t hal_i2c_rx_buffer_size(hal_i2c_interface_t i2c, void* reserved) {
+    hal_i2c_lock(i2c, NULL);
+    uint32_t value = i2cMap[i2c]->rxBufferSize;
+    hal_i2c_unlock(i2c, NULL);
+    return value;
+}
+uint32_t hal_i2c_tx_buffer_size(hal_i2c_interface_t i2c, void* reserved) {
+    hal_i2c_lock(i2c, NULL);
+    uint32_t value = i2cMap[i2c]->txBufferSize;
+    hal_i2c_unlock(i2c, NULL);
+    return value;
+}
+
 bool hal_i2c_is_enabled(hal_i2c_interface_t i2c, void* reserved) {
     return i2cMap[i2c]->state == HAL_I2C_STATE_ENABLED;
 }

--- a/hal/src/template/i2c_hal.cpp
+++ b/hal/src/template/i2c_hal.cpp
@@ -93,6 +93,16 @@ void hal_i2c_flush(hal_i2c_interface_t i2c,void* reserved)
   // XXX: to be implemented.
 }
 
+uint32_t hal_i2c_rx_buffer_size(hal_i2c_interface_t i2c, void* reserved)
+{
+  return SYSTEM_ERROR_NONE;
+}
+
+uint32_t hal_i2c_tx_buffer_size(hal_i2c_interface_t i2c, void* reserved)
+{
+  return SYSTEM_ERROR_NONE;
+}
+
 bool hal_i2c_is_enabled(hal_i2c_interface_t i2c,void* reserved)
 {
     return false;

--- a/wiring/inc/spark_wiring_i2c.h
+++ b/wiring/inc/spark_wiring_i2c.h
@@ -114,6 +114,8 @@ public:
   virtual int read(void);
   virtual int peek(void);
   virtual void flush(void);
+  size_t rxBufferSize(void);
+  size_t txBufferSize(void);
   void onReceive(void (*)(int));
   void onRequest(void (*)(void));
 

--- a/wiring/src/spark_wiring_i2c.cpp
+++ b/wiring/src/spark_wiring_i2c.cpp
@@ -182,6 +182,16 @@ void TwoWire::flush(void)
   hal_i2c_flush(_i2c, NULL);
 }
 
+size_t TwoWire::rxBufferSize(void) 
+{
+  return hal_i2c_rx_buffer_size(_i2c, NULL);
+}
+
+size_t TwoWire::txBufferSize(void)
+{
+  return hal_i2c_tx_buffer_size(_i2c, NULL);
+}
+
 // sets function called on slave write
 void TwoWire::onReceive( void (*function)(int) )
 {


### PR DESCRIPTION
### Problem

If a custom buffer for i2c is used these functions will give libraries a better ability to determin the i2c buffer size.

### Solution

Added two functions to return the assigned buffer size.

### Example App

```c

constexpr size_t I2C_BUFFER_SIZE = 128;

hal_i2c_config_t acquireWireBuffer() {
    hal_i2c_config_t config = {
        .size = sizeof(hal_i2c_config_t),
        .version = HAL_I2C_CONFIG_VERSION_1,
        .rx_buffer = new (std::nothrow) uint8_t[I2C_BUFFER_SIZE],
        .rx_buffer_size = I2C_BUFFER_SIZE,
        .tx_buffer = new (std::nothrow) uint8_t[I2C_BUFFER_SIZE],
        .tx_buffer_size = I2C_BUFFER_SIZE
    };
    return config;
}

void setup() {
   Serial.begin();
   Wire.begin();

   waitFor (Serial.isConnected, 10000);
   delay(1000);
   Serial.println(Wire.rxBufferSize());
}

void loop() {

}
```

Tested on B-Som platform.

### References

Adds to #1112 

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
