### PR TITLE
Inhibit Cellular URCs before going into sleep

### DIFF
--- a/hal/inc/cellular_hal.h
+++ b/hal/inc/cellular_hal.h
@@ -61,6 +61,8 @@ cellular_result_t  cellular_off(void* reserved);
  */
 bool cellular_powered(void* reserved);
 
+cellular_result_t cellular_urcs(bool enable, void* reserved);
+
 /**
  * Wait for the cellular module to register on the GSM network.
  */

--- a/hal/inc/hal_dynalib_cellular.h
+++ b/hal/inc/hal_dynalib_cellular.h
@@ -94,6 +94,8 @@ DYNALIB_FN(BASE_CELL_IDX + 3, hal_cellular, cellular_powered, bool(void*))
 #define BASE_CELL_IDX1 (BASE_CELL_IDX + 2)
 #endif // !HAL_PLATFORM_NCP
 
+DYNALIB_FN(BASE_CELL_IDX1 + 0, hal_cellular, cellular_urcs, cellular_result_t(bool, void*))
+
 DYNALIB_END(hal_cellular)
 
 #endif  // PLATFORM_ID == 10 || HAL_PLATFORM_CELLULAR

--- a/hal/network/lwip/cellular/pppncpnetif.h
+++ b/hal/network/lwip/cellular/pppncpnetif.h
@@ -43,6 +43,9 @@ public:
     virtual if_t interface() override;
 
     void setCellularManager(CellularNetworkManager* celMan);
+    CellularNetworkManager* getCellularManager() {
+        return celMan_;
+    }
 
     virtual int powerUp() override;
     virtual int powerDown() override;

--- a/hal/network/lwip/cellular/pppncpnetif.h
+++ b/hal/network/lwip/cellular/pppncpnetif.h
@@ -43,9 +43,6 @@ public:
     virtual if_t interface() override;
 
     void setCellularManager(CellularNetworkManager* celMan);
-    CellularNetworkManager* getCellularManager() {
-        return celMan_;
-    }
 
     virtual int powerUp() override;
     virtual int powerDown() override;

--- a/hal/network/ncp/cellular/cellular_hal.cpp
+++ b/hal/network/ncp/cellular/cellular_hal.cpp
@@ -553,6 +553,15 @@ int cellular_resume(void* reserved) {
     return SYSTEM_ERROR_NOT_SUPPORTED;
 }
 
+int cellular_urcs(bool enable, void* reserved) {
+    const auto mgr = cellularNetworkManager();
+    CHECK_TRUE(mgr, SYSTEM_ERROR_UNKNOWN);
+    const auto client = mgr->ncpClient();
+    CHECK_TRUE(client, SYSTEM_ERROR_UNKNOWN);
+    CHECK(client->urcs(enable));
+    return SYSTEM_ERROR_NONE;
+}
+
 int cellular_sim_to_network_provider(void* reserved) {
     return SYSTEM_ERROR_NOT_SUPPORTED;
 }

--- a/hal/network/ncp/cellular/cellular_ncp_client.h
+++ b/hal/network/ncp/cellular/cellular_ncp_client.h
@@ -131,8 +131,7 @@ public:
     virtual int getTxDelayInDataChannel() = 0;
     virtual int enterDataMode() = 0;
     virtual int getMtu() = 0;
-    virtual int enterSleepyState() = 0;
-    virtual int exitSleepyState() = 0;
+    virtual int urcs(bool enable) = 0;
 };
 
 inline CellularNcpClientConfig::CellularNcpClientConfig() :

--- a/hal/network/ncp/cellular/cellular_ncp_client.h
+++ b/hal/network/ncp/cellular/cellular_ncp_client.h
@@ -131,6 +131,8 @@ public:
     virtual int getTxDelayInDataChannel() = 0;
     virtual int enterDataMode() = 0;
     virtual int getMtu() = 0;
+    virtual int enterSleepyState() = 0;
+    virtual int exitSleepyState() = 0;
 };
 
 inline CellularNcpClientConfig::CellularNcpClientConfig() :

--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -1505,6 +1505,14 @@ int QuectelNcpClient::getMtu() {
     return 0;
 }
 
+int QuectelNcpClient::enterSleepyState() {
+    return muxer_.suspendChannel(QUECTEL_NCP_AT_CHANNEL);
+}
+
+int QuectelNcpClient::exitSleepyState() {
+    return muxer_.resumeChannel(QUECTEL_NCP_AT_CHANNEL);
+}
+
 void QuectelNcpClient::connectionState(NcpConnectionState state) {
     if (ncpState_ == NcpState::DISABLED) {
         return;

--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -1505,12 +1505,12 @@ int QuectelNcpClient::getMtu() {
     return 0;
 }
 
-int QuectelNcpClient::enterSleepyState() {
-    return muxer_.suspendChannel(QUECTEL_NCP_AT_CHANNEL);
-}
-
-int QuectelNcpClient::exitSleepyState() {
-    return muxer_.resumeChannel(QUECTEL_NCP_AT_CHANNEL);
+int QuectelNcpClient::urcs(bool enable) {
+    if (enable) {
+        return muxer_.resumeChannel(QUECTEL_NCP_AT_CHANNEL);
+    } else {
+        return muxer_.suspendChannel(QUECTEL_NCP_AT_CHANNEL);
+    }
 }
 
 void QuectelNcpClient::connectionState(NcpConnectionState state) {

--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -1507,10 +1507,11 @@ int QuectelNcpClient::getMtu() {
 
 int QuectelNcpClient::urcs(bool enable) {
     if (enable) {
-        return muxer_.resumeChannel(QUECTEL_NCP_AT_CHANNEL);
+        CHECK_TRUE(muxer_.resumeChannel(QUECTEL_NCP_AT_CHANNEL) == 0, SYSTEM_ERROR_INTERNAL);
     } else {
-        return muxer_.suspendChannel(QUECTEL_NCP_AT_CHANNEL);
+        CHECK_TRUE(muxer_.suspendChannel(QUECTEL_NCP_AT_CHANNEL) == 0, SYSTEM_ERROR_INTERNAL);
     }
+    return SYSTEM_ERROR_NONE;
 }
 
 void QuectelNcpClient::connectionState(NcpConnectionState state) {

--- a/hal/network/ncp_client/quectel/quectel_ncp_client.h
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.h
@@ -72,8 +72,7 @@ public:
     virtual int getTxDelayInDataChannel() override;
     virtual int enterDataMode() override;
     virtual int getMtu() override;
-    virtual int enterSleepyState() override;
-    virtual int exitSleepyState() override;
+    virtual int urcs(bool enable) override;
 
     auto getMuxer() {
         return &muxer_;

--- a/hal/network/ncp_client/quectel/quectel_ncp_client.h
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.h
@@ -72,6 +72,8 @@ public:
     virtual int getTxDelayInDataChannel() override;
     virtual int enterDataMode() override;
     virtual int getMtu() override;
+    virtual int enterSleepyState() override;
+    virtual int exitSleepyState() override;
 
     auto getMuxer() {
         return &muxer_;

--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -1760,6 +1760,14 @@ int SaraNcpClient::getMtu() {
     return 0;
 }
 
+int SaraNcpClient::enterSleepyState() {
+    return muxer_.suspendChannel(UBLOX_NCP_AT_CHANNEL);
+}
+
+int SaraNcpClient::exitSleepyState() {
+    return muxer_.resumeChannel(UBLOX_NCP_AT_CHANNEL);
+}
+
 void SaraNcpClient::connectionState(NcpConnectionState state) {
     if (ncpState_ == NcpState::DISABLED) {
         return;

--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -1760,12 +1760,12 @@ int SaraNcpClient::getMtu() {
     return 0;
 }
 
-int SaraNcpClient::enterSleepyState() {
-    return muxer_.suspendChannel(UBLOX_NCP_AT_CHANNEL);
-}
-
-int SaraNcpClient::exitSleepyState() {
-    return muxer_.resumeChannel(UBLOX_NCP_AT_CHANNEL);
+int SaraNcpClient::urcs(bool enable) {
+    if (enable) {
+        return muxer_.resumeChannel(UBLOX_NCP_AT_CHANNEL);
+    } else {
+        return muxer_.suspendChannel(UBLOX_NCP_AT_CHANNEL);
+    }
 }
 
 void SaraNcpClient::connectionState(NcpConnectionState state) {

--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -1762,10 +1762,11 @@ int SaraNcpClient::getMtu() {
 
 int SaraNcpClient::urcs(bool enable) {
     if (enable) {
-        return muxer_.resumeChannel(UBLOX_NCP_AT_CHANNEL);
+        CHECK_TRUE(muxer_.resumeChannel(UBLOX_NCP_AT_CHANNEL) == 0, SYSTEM_ERROR_INTERNAL);
     } else {
-        return muxer_.suspendChannel(UBLOX_NCP_AT_CHANNEL);
+        CHECK_TRUE(muxer_.suspendChannel(UBLOX_NCP_AT_CHANNEL) == 0, SYSTEM_ERROR_INTERNAL);
     }
+    return SYSTEM_ERROR_NONE;
 }
 
 void SaraNcpClient::connectionState(NcpConnectionState state) {

--- a/hal/network/ncp_client/sara/sara_ncp_client.h
+++ b/hal/network/ncp_client/sara/sara_ncp_client.h
@@ -72,8 +72,7 @@ public:
     virtual int getTxDelayInDataChannel() override;
     virtual int enterDataMode() override;
     virtual int getMtu() override;
-    virtual int enterSleepyState() override;
-    virtual int exitSleepyState() override;
+    virtual int urcs(bool enable) override;
 
 private:
     AtParser parser_;

--- a/hal/network/ncp_client/sara/sara_ncp_client.h
+++ b/hal/network/ncp_client/sara/sara_ncp_client.h
@@ -72,6 +72,8 @@ public:
     virtual int getTxDelayInDataChannel() override;
     virtual int enterDataMode() override;
     virtual int getMtu() override;
+    virtual int enterSleepyState() override;
+    virtual int exitSleepyState() override;
 
 private:
     AtParser parser_;

--- a/hal/src/electron/cellular_hal.cpp
+++ b/hal/src/electron/cellular_hal.cpp
@@ -116,6 +116,12 @@ bool cellular_powered(void* reserved)
     return electronMDM.powerState();
 }
 
+cellular_result_t cellular_urcs(bool enable, void* reserved)
+{
+    CHECK_SUCCESS(electronMDM.urcs(enable));
+    return 0;
+}
+
 cellular_result_t  cellular_register(void* reserved)
 {
     CHECK_SUCCESS(electronMDM.registerNet());

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1295,6 +1295,29 @@ bool MDMParser::powerState(void) {
     return state;
 }
 
+bool MDMParser::urcs(bool enable) {
+    if (enable) {
+        sendFormated("AT+UCIND=4095\r\n");
+        if (RESP_OK != waitFinalResp()) {
+            return false;
+        }
+        sendFormated("AT+CMER=1,0,0,2,1\r\n");
+        if (RESP_OK != waitFinalResp()) {
+            return false;
+        }
+    } else {
+        sendFormated("AT+UCIND=0\r\n");
+        if (RESP_OK != waitFinalResp()) {
+            return false;
+        }
+        sendFormated("AT+CMER=0,0,0,0,0\r\n");
+        if (RESP_OK != waitFinalResp()) {
+            return false;
+        }
+    }
+    return true;
+}
+
 bool MDMParser::softPowerOff(void) {
     if (!powerState()) {
         return true;

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1305,6 +1305,21 @@ bool MDMParser::urcs(bool enable) {
         if (RESP_OK != waitFinalResp()) {
             return false;
         }
+        sendFormated("AT+CREG=2\r\n");
+        if (RESP_OK != waitFinalResp()) {
+            return false;
+        }
+        if (_dev.dev == DEV_SARA_R410) {
+            sendFormated("AT+CEREG=2\r\n");
+            if (RESP_OK != waitFinalResp()) {
+                return false;
+            }
+        } else {
+            sendFormated("AT+CGREG=2\r\n");
+            if (RESP_OK != waitFinalResp()) {
+                return false;
+            }
+        }
     } else {
         sendFormated("AT+UCIND=0\r\n");
         if (RESP_OK != waitFinalResp()) {
@@ -1313,6 +1328,21 @@ bool MDMParser::urcs(bool enable) {
         sendFormated("AT+CMER=0,0,0,0,0\r\n");
         if (RESP_OK != waitFinalResp()) {
             return false;
+        }
+        sendFormated("AT+CREG=0\r\n");
+        if (RESP_OK != waitFinalResp()) {
+            return false;
+        }
+        if (_dev.dev == DEV_SARA_R410) {
+            sendFormated("AT+CEREG=0\r\n");
+            if (RESP_OK != waitFinalResp()) {
+                return false;
+            }
+        } else {
+            sendFormated("AT+CGREG=0\r\n");
+            if (RESP_OK != waitFinalResp()) {
+                return false;
+            }
         }
     }
     return true;

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1298,51 +1298,31 @@ bool MDMParser::powerState(void) {
 bool MDMParser::urcs(bool enable) {
     if (enable) {
         sendFormated("AT+UCIND=4095\r\n");
-        if (RESP_OK != waitFinalResp()) {
-            return false;
-        }
+        CHECK_TIMEOUT(waitFinalResp());
         sendFormated("AT+CMER=1,0,0,2,1\r\n");
-        if (RESP_OK != waitFinalResp()) {
-            return false;
-        }
+        CHECK_TIMEOUT(waitFinalResp());
         sendFormated("AT+CREG=2\r\n");
-        if (RESP_OK != waitFinalResp()) {
-            return false;
-        }
+        CHECK_TIMEOUT(waitFinalResp());
         if (_dev.dev == DEV_SARA_R410) {
             sendFormated("AT+CEREG=2\r\n");
-            if (RESP_OK != waitFinalResp()) {
-                return false;
-            }
+            CHECK_TIMEOUT(waitFinalResp());
         } else {
             sendFormated("AT+CGREG=2\r\n");
-            if (RESP_OK != waitFinalResp()) {
-                return false;
-            }
+            CHECK_TIMEOUT(waitFinalResp());
         }
     } else {
         sendFormated("AT+UCIND=0\r\n");
-        if (RESP_OK != waitFinalResp()) {
-            return false;
-        }
+        CHECK_TIMEOUT(waitFinalResp());
         sendFormated("AT+CMER=0,0,0,0,0\r\n");
-        if (RESP_OK != waitFinalResp()) {
-            return false;
-        }
+        CHECK_TIMEOUT(waitFinalResp());
         sendFormated("AT+CREG=0\r\n");
-        if (RESP_OK != waitFinalResp()) {
-            return false;
-        }
+        CHECK_TIMEOUT(waitFinalResp());
         if (_dev.dev == DEV_SARA_R410) {
             sendFormated("AT+CEREG=0\r\n");
-            if (RESP_OK != waitFinalResp()) {
-                return false;
-            }
+            CHECK_TIMEOUT(waitFinalResp());
         } else {
             sendFormated("AT+CGREG=0\r\n");
-            if (RESP_OK != waitFinalResp()) {
-                return false;
-            }
+            CHECK_TIMEOUT(waitFinalResp());
         }
     }
     return true;

--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -508,6 +508,8 @@ public:
     */
     bool powerState(void);
 
+    bool urcs(bool enable);
+
 protected:
     /** Write bytes to the physical interface. This function should be
         implemented in a inherited class.

--- a/hal/src/nRF52840/sleep_hal.cpp
+++ b/hal/src/nRF52840/sleep_hal.cpp
@@ -48,6 +48,13 @@
 #endif
 #include "spark_wiring_vector.h"
 
+#if HAL_PLATFORM_GEN == 3 && HAL_PLATFORM_CELLULAR
+#include "ifapi.h"
+#include "network/lwip/cellular/pppncpnetif.h"
+#include "network/ncp/cellular/cellular_ncp_client.h"
+using namespace particle::net;
+#endif
+
 #if HAL_PLATFORM_IO_EXTENSION && MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
 #if HAL_PLATFORM_MCP23S17
 #include "mcp23s17.h"
@@ -595,6 +602,36 @@ static uint32_t configUsartWakeupSource(const hal_wakeup_source_base_t* wakeupSo
     return intFlags;
 }
 
+#if HAL_PLATFORM_GEN == 3 && HAL_PLATFORM_CELLULAR
+static int inhibitCellularModemUrcs(const hal_sleep_config_t* config, bool inhibit) {
+    auto source = config->wakeup_sources;
+    while (source) {
+        if (source->type == HAL_WAKEUP_SOURCE_TYPE_NETWORK) {
+            auto network = reinterpret_cast<const hal_wakeup_source_network_t*>(source);
+            if (!(network->flags & HAL_SLEEP_NETWORK_FLAG_INACTIVE_STANDBY)) {
+                // XXX: Suspend the muxer's AT channel for now to prevent URCs from waking up the device
+                if_t iface;
+                if (if_get_by_index(NETWORK_INTERFACE_CELLULAR, &iface)) {
+                    return SYSTEM_ERROR_INVALID_STATE;
+                }
+                auto idx = BaseNetif::getClientDataId();
+                CHECK_TRUE(idx >= 0, SYSTEM_ERROR_INVALID_STATE);
+                auto cellMgr = ((PppNcpNetif*)netif_get_client_data(iface, idx))->getCellularManager();
+                CHECK_TRUE(cellMgr, SYSTEM_ERROR_INVALID_STATE);
+                if (inhibit) {
+                    cellMgr->ncpClient()->enterSleepyState();
+                } else {
+                    cellMgr->ncpClient()->exitSleepyState();
+                }
+                break;
+            }
+        }
+        source = source->next;
+    }
+    return SYSTEM_ERROR_NONE;
+}
+#endif
+
 static bool configNetworkWakeupSource(const hal_wakeup_source_base_t* wakeupSources) {
     bool ret = false;
     auto source = wakeupSources;
@@ -819,6 +856,11 @@ static void fpu_sleep_prepare(void) {
 
 static int enterStopBasedSleep(const hal_sleep_config_t* config, hal_wakeup_source_base_t** wakeupReason) {
     int ret = SYSTEM_ERROR_NONE;
+
+#if HAL_PLATFORM_GEN == 3 && HAL_PLATFORM_CELLULAR
+    inhibitCellularModemUrcs(config, true);
+#endif
+    
 
     // Detach USB
     HAL_USB_Detach();
@@ -1223,6 +1265,10 @@ static int enterStopBasedSleep(const hal_sleep_config_t* config, hal_wakeup_sour
 
     // Enable thread scheduling
     os_thread_scheduling(true, nullptr);
+
+#if HAL_PLATFORM_GEN == 3 && HAL_PLATFORM_CELLULAR
+    // inhibitCellularModemUrcs(config, false);
+#endif
 
     if (wakeupReason) {
         if (wakeupSourceType == HAL_WAKEUP_SOURCE_TYPE_GPIO) {

--- a/system/src/system_network_manager_api.cpp
+++ b/system/src/system_network_manager_api.cpp
@@ -234,9 +234,12 @@ bool network_connecting(network_handle_t network, uint32_t param, void* reserved
     } else {
         if_t iface;
         if (!if_get_by_index(network, &iface)) {
-            if (NetworkManager::instance()->isConnectivityAvailable() ||
-                    NetworkManager::instance()->isEstablishingConnections()) {
-                return !network_ready(network, param, reserved);
+            unsigned int flags = 0;
+            if (if_get_flags(iface, &flags) < 0) {
+                return false;
+            }
+            if ((flags & IFF_UP) && !(flags & IFF_LOWER_UP)) {
+                return true;
             }
         }
     }

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -178,6 +178,8 @@ int system_sleep_ext_impl(const hal_sleep_config_t* config, hal_wakeup_source_ba
         } else {
             cellularStatus = system_sleep_network_suspend(NETWORK_INTERFACE_CELLULAR);
         }
+    } else {
+        cellular_urcs(false, nullptr);
     }
 #endif // HAL_PLATFORM_CELLULAR
 
@@ -221,6 +223,7 @@ int system_sleep_ext_impl(const hal_sleep_config_t* config, hal_wakeup_source_ba
         system_sleep_network_resume(NETWORK_INTERFACE_CELLULAR, cellularStatus);
     } else {
         cellular_resume(nullptr);
+        cellular_urcs(true, nullptr);
     }
 #endif // HAL_PLATFORM_CELLULAR
 

--- a/user/tests/wiring/no_fixture/cellular.cpp
+++ b/user/tests/wiring/no_fixture/cellular.cpp
@@ -196,6 +196,74 @@ test(CELLULAR_06_on_off_validity_check) {
     connect_to_cloud(6*60*1000);
 }
 
+#if HAL_PLATFORM_GEN == 2
+static int callbackGeneric(int type, const char* buf, int len, char* string) {
+  if ((type == TYPE_PLUS) && string) {
+    sscanf(buf, "\r\n%*s%15s", string);
+  }
+  return WAIT;
+}
+
+static int callbackModemType(int type, const char* buf, int len, char* string) {
+  if ((type == TYPE_UNKNOWN) && string) {
+    sscanf(buf, "\r\n%s", string);
+  }
+  return WAIT;
+}
+#endif
+
+test(CELLULAR_07_urcs) {
+    connect_to_cloud(6*60*1000);
+
+#if HAL_PLATFORM_GEN == 2
+    char string[16];
+    bool saraR410 = true;
+    memset(string, '\0', sizeof(string));
+
+    Cellular.command(callbackModemType, string, 10000, "AT+CGMM\r\n");
+    if (strstr(string, "SARA-R410") == 0) {
+        saraR410 = false;
+    }
+    assertEqual(cellular_urcs(false, nullptr), (int)SYSTEM_ERROR_NONE);
+    assertEqual(Cellular.command(callbackGeneric, string, 10000, "AT+UCIND?\r\n"), (int)RESP_OK);
+    assertEqual(strncmp((const char*)string, "0", 1), 0);
+    assertEqual(Cellular.command(callbackGeneric, string, 10000, "AT+CMER?\r\n"), (int)RESP_OK);
+    assertEqual(strncmp((const char*)string, "0,0,0,0,0", 9), 0);
+    assertEqual(Cellular.command(callbackGeneric, string, 10000, "AT+CREG?\r\n"), (int)RESP_OK);
+    assertEqual(strncmp((const char*)string, "0", 1), 0);
+    if (saraR410) {
+        assertEqual(Cellular.command(callbackGeneric, string, 10000, "AT+CEREG?\r\n"), (int)RESP_OK);
+        assertEqual(strncmp((const char*)string, "0", 1), 0);
+    } else {
+        assertEqual(Cellular.command(callbackGeneric, string, 10000, "AT+CGREG?\r\n"), (int)RESP_OK);
+        assertEqual(strncmp((const char*)string, "0", 1), 0);
+    }
+
+    assertEqual(cellular_urcs(true, nullptr), (int)SYSTEM_ERROR_NONE);
+    assertEqual(Cellular.command(callbackGeneric, string, 10000, "AT+UCIND?\r\n"), (int)RESP_OK);
+    assertEqual(strncmp((const char*)string, "4095", 4), 0);
+    assertEqual(Cellular.command(callbackGeneric, string, 10000, "AT+CMER?\r\n"), (int)RESP_OK);
+    assertEqual(strncmp((const char*)string, "1,0,0,2,1", 9), 0);
+    assertEqual(Cellular.command(callbackGeneric, string, 10000, "AT+CREG?\r\n"), (int)RESP_OK);
+    assertEqual(strncmp((const char*)string, "2", 1), 0);
+    if (saraR410) {
+        assertEqual(Cellular.command(callbackGeneric, string, 10000, "AT+CEREG?\r\n"), (int)RESP_OK);
+        assertEqual(strncmp((const char*)string, "2", 1), 0);
+    } else {
+        assertEqual(Cellular.command(callbackGeneric, string, 10000, "AT+CGREG?\r\n"), (int)RESP_OK);
+        assertEqual(strncmp((const char*)string, "2", 1), 0);
+    }
+#elif HAL_PLATFORM_GEN == 3
+    assertEqual(Cellular.command("AT\r\n"), (int)RESP_OK);
+
+    assertEqual(cellular_urcs(false, nullptr), (int)SYSTEM_ERROR_NONE);
+    assertNotEqual(Cellular.command("AT\r\n"), (int)RESP_OK);
+
+    assertEqual(cellular_urcs(true, nullptr), (int)SYSTEM_ERROR_NONE);
+    assertEqual(Cellular.command("AT\r\n"), (int)RESP_OK);
+#endif
+}
+
 test(MDM_01_socket_writes_with_length_more_than_1023_work_correctly) {
 
 #if HAL_PLATFORM_NCP

--- a/user/tests/wiring/no_fixture/cellular.cpp
+++ b/user/tests/wiring/no_fixture/cellular.cpp
@@ -261,6 +261,8 @@ test(CELLULAR_07_urcs) {
 
     assertEqual(cellular_urcs(true, nullptr), (int)SYSTEM_ERROR_NONE);
     assertEqual(Cellular.command("AT\r\n"), (int)RESP_OK);
+#else
+#error "Unsupported platform"
 #endif
 }
 


### PR DESCRIPTION
### Problem
When we specify `.network(Cellular)` as a wakeup source when calling the system sleep API, we leave the modem running. When there is URC coming from the modem, like when Cellular moving from tower to another, it wakes up the device, which is unwanted. From the user's view, the device may be woken up frequently.

This PR also fixes issues:
1. Tracker specifically, which is when Cellular is specified as wakeup source, on waking up the on-board ESP32 module is turned on unexpectedly.

### Solution
Inhibit URCs before going into sleep.
### Steps to Test
To verify the patch, you need to make the comparison:
1. Checkout and build the branch within this PR and observe the log from `Serial1`. 
2. Comment out `cellular_urcs(false, nullptr);` in `system_sleep.cpp` and build again. Observe the log from `Serial1`.

You'll see some URCs relevant logs on waking up if you  comment out `cellular_urcs(false, nullptr);`, but not if you build the branch as-is.

### Example App

```c
#include "Particle.h"

SYSTEM_MODE(AUTOMATIC);

Serial1LogHandler l(115200, LOG_LEVEL_ALL);

void setup() {
    LOG(INFO, "Application started.");

    waitUntil(Particle.connected);
    LOG(INFO, "Cloud connected.");

    delay(10s);
}

void loop() {
    delay(3s);
    LOG(INFO, "\r\n\r\n%d:%d:%d Device entering sleep mode...\r\n", Time.hour(), Time.minute(), Time.second());
    SystemSleepResult result = System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::STOP).network(Cellular));
    LOG(INFO, "\r\n\r\n%d:%d:%d Device wakes up, error: %d, reason: %d\r\n", Time.hour(), Time.minute(), Time.second(), result.error(), result.wakeupReason());
}
```

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
