### PR TITLE
Ble5 long range wiring API

### DIFF
--- a/hal/inc/ble_hal.h
+++ b/hal/inc/ble_hal.h
@@ -190,7 +190,6 @@ typedef struct hal_ble_adv_params_t {
     hal_ble_adv_fp_t filter_policy;
     uint8_t inc_tx_power;
     uint8_t primary_phy;                /**< Supports BLE_PHYS_1MBPS (standard) or BLE_PHYS_CODED (long range) */
-    uint8_t reserved;
 } hal_ble_adv_params_t;
 
 /* BLE scanning parameters */
@@ -203,6 +202,7 @@ typedef struct hal_ble_scan_params_t {
     uint8_t active;
     hal_ble_scan_fp_t filter_policy;
     uint8_t scan_phys;                  /**< Supports BLE_PHYS_1MBPS, BLE_PHYS_CODED, or (BLE_PHYS_1MBPS | BLE_PHYS_CODED) */
+    uint8_t reserved[3];
 } hal_ble_scan_params_t;
 
 /* BLE connection parameters */

--- a/hal/inc/ble_hal.h
+++ b/hal/inc/ble_hal.h
@@ -42,7 +42,7 @@ extern "C" {
  * @{
  */
 
-#define BLE_API_VERSION 2
+#define BLE_API_VERSION 3
 
 // Particle's company ID
 #define PARTICLE_COMPANY_ID     0x0662

--- a/hal/src/nRF52840/ble_hal.cpp
+++ b/hal/src/nRF52840/ble_hal.cpp
@@ -74,6 +74,7 @@ using namespace particle::ble;
 
 #define BLE_API_VERSION_1   1
 #define BLE_API_VERSION_2   2
+#define BLE_API_VERSION_3   3
 
 //anonymous namespace
 namespace {

--- a/hal/src/nRF52840/ble_hal.cpp
+++ b/hal/src/nRF52840/ble_hal.cpp
@@ -1033,6 +1033,7 @@ int BleObject::Broadcaster::setAdvertisingParams(const hal_ble_adv_params_t* par
         tempParams.interval = BLE_DEFAULT_ADVERTISING_INTERVAL;
         tempParams.timeout = BLE_DEFAULT_ADVERTISING_TIMEOUT;
         tempParams.inc_tx_power = false;
+        tempParams.primary_phy = BLE_PHYS_AUTO;
     } else {
         memcpy(&tempParams, params, std::min(tempParams.size, params->size));
         if (tempParams.primary_phy != BLE_PHYS_AUTO && tempParams.primary_phy != BLE_PHYS_1MBPS && tempParams.primary_phy != BLE_PHYS_CODED) {
@@ -1219,8 +1220,12 @@ int BleObject::Broadcaster::resume() {
 ble_gap_adv_params_t BleObject::Broadcaster::toPlatformAdvParams(const hal_ble_adv_params_t* halParams) {
     ble_gap_adv_params_t params = {};
     if (halParams->primary_phy == BLE_PHYS_CODED) {
-        // For Coded Phy advertising, type must be extended, nonscannable
-        params.properties.type = BLE_GAP_ADV_TYPE_EXTENDED_CONNECTABLE_NONSCANNABLE_UNDIRECTED;
+        if (halParams->type == BLE_ADV_SCANABLE_UNDIRECTED_EVT) {
+            params.properties.type = BLE_GAP_ADV_TYPE_EXTENDED_NONCONNECTABLE_NONSCANNABLE_UNDIRECTED;
+        } else {
+            // For Coded Phy advertising, type must be extended, nonscannable
+            params.properties.type = BLE_GAP_ADV_TYPE_EXTENDED_CONNECTABLE_NONSCANNABLE_UNDIRECTED;
+        }
         params.primary_phy = BLE_GAP_PHY_CODED;
     } else {
         // For 1 MBPS advertising, use whatever type is specified

--- a/hal/src/nRF52840/ble_hal.cpp
+++ b/hal/src/nRF52840/ble_hal.cpp
@@ -1034,7 +1034,7 @@ int BleObject::Broadcaster::setAdvertisingParams(const hal_ble_adv_params_t* par
         tempParams.inc_tx_power = false;
     } else {
         memcpy(&tempParams, params, std::min(tempParams.size, params->size));
-        if (tempParams.primary_phy != BLE_PHYS_1MBPS && tempParams.primary_phy != BLE_PHYS_CODED) {
+        if (tempParams.primary_phy != BLE_PHYS_AUTO && tempParams.primary_phy != BLE_PHYS_1MBPS && tempParams.primary_phy != BLE_PHYS_CODED) {
             LOG(ERROR, "primary_phy value not supported");
             return SYSTEM_ERROR_NOT_SUPPORTED;
         }

--- a/hal/src/nRF52840/ble_hal.cpp
+++ b/hal/src/nRF52840/ble_hal.cpp
@@ -1034,6 +1034,10 @@ int BleObject::Broadcaster::setAdvertisingParams(const hal_ble_adv_params_t* par
         tempParams.inc_tx_power = false;
     } else {
         memcpy(&tempParams, params, std::min(tempParams.size, params->size));
+        if (tempParams.primary_phy != BLE_PHYS_1MBPS && tempParams.primary_phy != BLE_PHYS_CODED) {
+            LOG(ERROR, "primary_phy value not supported");
+            return SYSTEM_ERROR_NOT_SUPPORTED;
+        }
     }
     CHECK(suspend());
     if (connHandle_ != BLE_INVALID_CONN_HANDLE) {
@@ -1458,7 +1462,7 @@ int BleObject::Observer::stopScanning() {
 
 ble_gap_scan_params_t BleObject::Observer::toPlatformScanParams() const {
     ble_gap_scan_params_t params = {};
-    params.extended = (scanParams_.scan_phys == BLE_PHYS_1MBPS) ? 0x00 : 0x01; /**< Extended required if other than PHYS_1MBPS */
+    params.extended = ( (scanParams_.scan_phys & BLE_PHYS_CODED) != 0) ? 0x01 : 0x00; /**< Extended must be 1 if using Coded PHY */
     params.active = scanParams_.active;
     params.interval = scanParams_.interval;
     params.window = scanParams_.window;

--- a/user/tests/wiring/api/ble.cpp
+++ b/user/tests/wiring/api/ble.cpp
@@ -198,6 +198,14 @@ test(ble_pairing_event_type) {
     (void)type;
 }
 
+test(ble_phys_type) {
+    BlePhy phy;
+    API_COMPILE({ phy = BlePhy::BLE_PHYS_AUTO; });
+    API_COMPILE({ phy = BlePhy::BLE_PHYS_1MBPS; });
+    API_COMPILE({ phy = BlePhy::BLE_PHYS_CODED; });
+    (void)phy;
+}
+
 test(ble_address_class) {
     hal_ble_addr_t halAddr;
     uint8_t addrArray[BLE_SIG_ADDR_LEN];
@@ -690,6 +698,7 @@ test(ble_local_device_class) {
     API_COMPILE({ int ret = BLE.setAdvertisingInterval(0); (void)ret; });
     API_COMPILE({ int ret = BLE.setAdvertisingTimeout(0); (void)ret; });
     API_COMPILE({ int ret = BLE.setAdvertisingType(BleAdvertisingEventType::CONNECTABLE_SCANNABLE_UNDIRECRED); (void)ret; });
+    API_COMPILE({ int ret = BLE.setAdvertisingPhy(BlePhy::BLE_PHYS_AUTO); (void)ret; });
     API_COMPILE({ int ret = BLE.setAdvertisingParameters(&params); (void)ret; });
     API_COMPILE({ int ret = BLE.setAdvertisingParameters(params); (void)ret; });
     API_COMPILE({ int ret = BLE.setAdvertisingParameters(0, 0, BleAdvertisingEventType::CONNECTABLE_SCANNABLE_UNDIRECRED); (void)ret; });
@@ -715,6 +724,7 @@ test(ble_local_device_class) {
     API_COMPILE({ bool ret = BLE.advertising(); (void)ret; });
 
     API_COMPILE({ int ret = BLE.setScanTimeout(0); (void)ret; });
+    API_COMPILE({ int ret = BLE.setScanPhy(BlePhy::BLE_PHYS_AUTO | BlePhy::BLE_PHYS_CODED); (void)ret; });
     API_COMPILE({ int ret = BLE.setScanParameters(&scanParams); (void)ret; });
     API_COMPILE({ int ret = BLE.setScanParameters(scanParams); (void)ret; });
     API_COMPILE({ int ret = BLE.getScanParameters(&scanParams); (void)ret; });

--- a/user/tests/wiring/ble_scanner_broadcaster/ble_broadcaster/broadcaster.cpp
+++ b/user/tests/wiring/ble_scanner_broadcaster/ble_broadcaster/broadcaster.cpp
@@ -16,7 +16,8 @@ typedef enum {
     CMD_RESTART_ADV,
     CMD_ADV_DEVICE_NAME,
     CMD_ADV_APPEARANCE,
-    CMD_ADV_CUSTOM_DATA
+    CMD_ADV_CUSTOM_DATA,
+    CMD_ADV_CODED_PHY
 } TestCommand;
 TestCommand cmd = CMD_UNKNOWN;
 
@@ -84,6 +85,20 @@ test(BLE_Broadcaster_05_Advertise_Custom_Data) {
     data.appendCustomData(buf, sizeof(buf));
     data.customData(read, sizeof(read));
     assertEqual(memcmp(buf, read, sizeof(buf)), 0);
+    int ret = BLE.advertise(&data);
+    assertEqual(ret, 0);
+    assertTrue(BLE.advertising());
+}
+
+test(BLE_Broadcaster_06_Advertise_On_Coded_Phy) {
+    assertTrue(BLE.connected());
+    assertTrue(waitFor([&]{ return cmd == CMD_ADV_CODED_PHY; }, 60000));
+
+    assertEqual(BLE.setAdvertisingPhy(BlePhy::BLE_PHYS_CODED), 0);
+
+    BleAdvertisingData data;
+    data.appendLocalName("CODED_PHY");
+    assertEqual(data.deviceName(), String("CODED_PHY"));
     int ret = BLE.advertise(&data);
     assertEqual(ret, 0);
     assertTrue(BLE.advertising());

--- a/user/tests/wiring/ble_scanner_broadcaster/ble_scanner/scanner.cpp
+++ b/user/tests/wiring/ble_scanner_broadcaster/ble_scanner/scanner.cpp
@@ -16,7 +16,8 @@ typedef enum {
     CMD_RESTART_ADV,
     CMD_ADV_DEVICE_NAME,
     CMD_ADV_APPEARANCE,
-    CMD_ADV_CUSTOM_DATA
+    CMD_ADV_CUSTOM_DATA,
+    CMD_ADV_CODED_PHY
 } TestCommand;
 
 const char* peerServiceUuid = "6E400000-B5A3-F393-E0A9-E50E24DCCA9E";
@@ -214,6 +215,26 @@ test(BLE_Scanner_09_Scan_With_Custom_Data) {
     // We assume that there is no device nearby advertising this custom data
     constexpr uint8_t magic[] = {0x12, 0x34, 0x56, 0x78};
     results = BLE.scanWithFilter(BleScanFilter().customData(magic, sizeof(magic)));
+    assertEqual(results.size(), 0);
+}
+
+test(BLE_Scanner_10_Scan_On_Coded_Phy) {
+    assertTrue(BLE.connected());
+
+    int ret;
+    TestCommand cmd = CMD_ADV_CODED_PHY;
+    ret = peerCharWriteWoRsp.setValue((const uint8_t*)&cmd, 1);
+    assertEqual(ret, 1);
+
+    delay(1s);
+
+    assertEqual(BLE.setScanPhy(BlePhy::BLE_PHYS_CODED), 0);
+    Vector<BleScanResult> results = BLE.scanWithFilter(BleScanFilter().deviceName("CODED_PHY"));
+    assertEqual(results.size(), 1);
+    
+    // Scan on 1MBPS PHY
+    assertEqual(BLE.setScanPhy(BlePhy::BLE_PHYS_1MBPS), 0);
+    results = BLE.scanWithFilter(BleScanFilter().deviceName("CODED_PHY"));
     assertEqual(results.size(), 0);
 }
 

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -128,6 +128,14 @@ enum class BleAdvertisingEventType : uint8_t {
     SCANABLE_DIRECTED                       = BLE_ADV_SCANABLE_DIRECTED_EVT
 };
 
+enum class BlePhy : uint8_t {
+    AUTO        = 0x00,
+    MBPS1       = 0x01,
+    CODED       = 0x04
+};
+
+ENABLE_ENUM_CLASS_BITWISE(BlePhy);
+
 enum class BleAntennaType : uint8_t {
     DEFAULT = BLE_ANT_DEFAULT,
     INTERNAL = BLE_ANT_INTERNAL,
@@ -921,6 +929,7 @@ public:
     int setAdvertisingInterval(uint16_t interval) const;
     int setAdvertisingTimeout(uint16_t timeout) const;
     int setAdvertisingType(BleAdvertisingEventType type) const;
+    int setAdvertisingPhy(EnumFlags<BlePhy> phy) const;
     int setAdvertisingParameters(const BleAdvertisingParams* params) const;
     int setAdvertisingParameters(const BleAdvertisingParams& params) const;
     int setAdvertisingParameters(uint16_t interval, uint16_t timeout, BleAdvertisingEventType type) const;
@@ -948,6 +957,7 @@ public:
 
     // Access scanning parameters
     int setScanTimeout(uint16_t timeout) const;
+    int setScanPhy(EnumFlags<BlePhy> phy) const;
     int setScanParameters(const BleScanParams* params) const;
     int setScanParameters(const BleScanParams& params) const;
     int getScanParameters(BleScanParams* params) const;

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -929,7 +929,7 @@ public:
     int setAdvertisingInterval(uint16_t interval) const;
     int setAdvertisingTimeout(uint16_t timeout) const;
     int setAdvertisingType(BleAdvertisingEventType type) const;
-    int setAdvertisingPhy(EnumFlags<BlePhy> phy) const;
+    int setAdvertisingPhy(BlePhy phy) const; // Only one of the enum values can be specified as the argument.
     int setAdvertisingParameters(const BleAdvertisingParams* params) const;
     int setAdvertisingParameters(const BleAdvertisingParams& params) const;
     int setAdvertisingParameters(uint16_t interval, uint16_t timeout, BleAdvertisingEventType type) const;

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -129,9 +129,9 @@ enum class BleAdvertisingEventType : uint8_t {
 };
 
 enum class BlePhy : uint8_t {
-    BLE_PHYS_AUTO        = 0x00,
-    BLE_PHYS_1MBPS       = 0x01,
-    BLE_PHYS_CODED       = 0x04
+    BLE_PHYS_AUTO        = hal_ble_phys_t::BLE_PHYS_AUTO,
+    BLE_PHYS_1MBPS       = hal_ble_phys_t::BLE_PHYS_1MBPS,
+    BLE_PHYS_CODED       = hal_ble_phys_t::BLE_PHYS_CODED
 };
 
 ENABLE_ENUM_CLASS_BITWISE(BlePhy);

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -129,9 +129,9 @@ enum class BleAdvertisingEventType : uint8_t {
 };
 
 enum class BlePhy : uint8_t {
-    AUTO        = 0x00,
-    MBPS1       = 0x01,
-    CODED       = 0x04
+    BLE_PHYS_AUTO        = 0x00,
+    BLE_PHYS_1MBPS       = 0x01,
+    BLE_PHYS_CODED       = 0x04
 };
 
 ENABLE_ENUM_CLASS_BITWISE(BlePhy);

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -2112,12 +2112,12 @@ int BleLocalDevice::setAdvertisingType(BleAdvertisingEventType type) const {
     return hal_ble_gap_set_advertising_parameters(&advParams, nullptr);
 }
 
-int BleLocalDevice::setAdvertisingPhy(EnumFlags<BlePhy> phy) const {
+int BleLocalDevice::setAdvertisingPhy(BlePhy phy) const {
     hal_ble_adv_params_t advParams = {};
     advParams.size = sizeof(hal_ble_adv_params_t);
     advParams.version = BLE_API_VERSION;
     CHECK(hal_ble_gap_get_advertising_parameters(&advParams, nullptr));
-    advParams.primary_phy = static_cast<uint8_t>(phy.value());
+    advParams.primary_phy = static_cast<uint8_t>(phy);
     return hal_ble_gap_set_advertising_parameters(&advParams, nullptr);
 }
 

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -2487,7 +2487,7 @@ int BleLocalDevice::setScanPhy(EnumFlags<BlePhy> phy) const {
     hal_ble_scan_params_t scanParams = {};
     scanParams.size = sizeof(hal_ble_scan_params_t);
     hal_ble_gap_get_scan_parameters(&scanParams, nullptr);
-    scanParams.scan_phys = static_cast<uint8_t>(phy);
+    scanParams.scan_phys = static_cast<uint8_t>(phy.value());
     return hal_ble_gap_set_scan_parameters(&scanParams, nullptr);
 }
 

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -2089,6 +2089,7 @@ int BleLocalDevice::setAdvertisingInterval(uint16_t interval) const {
     hal_ble_adv_params_t advParams = {};
     advParams.size = sizeof(hal_ble_adv_params_t);
     CHECK(hal_ble_gap_get_advertising_parameters(&advParams, nullptr));
+    advParams.version = BLE_API_VERSION;
     advParams.interval = interval;
     return hal_ble_gap_set_advertising_parameters(&advParams, nullptr);
 }
@@ -2097,6 +2098,7 @@ int BleLocalDevice::setAdvertisingTimeout(uint16_t timeout) const {
     hal_ble_adv_params_t advParams = {};
     advParams.size = sizeof(hal_ble_adv_params_t);
     CHECK(hal_ble_gap_get_advertising_parameters(&advParams, nullptr));
+    advParams.version = BLE_API_VERSION;
     advParams.timeout = timeout;
     return hal_ble_gap_set_advertising_parameters(&advParams, nullptr);
 }
@@ -2105,6 +2107,7 @@ int BleLocalDevice::setAdvertisingType(BleAdvertisingEventType type) const {
     hal_ble_adv_params_t advParams = {};
     advParams.size = sizeof(hal_ble_adv_params_t);
     CHECK(hal_ble_gap_get_advertising_parameters(&advParams, nullptr));
+    advParams.version = BLE_API_VERSION;
     advParams.type = static_cast<hal_ble_adv_evt_type_t>(type);
     return hal_ble_gap_set_advertising_parameters(&advParams, nullptr);
 }
@@ -2113,6 +2116,7 @@ int BleLocalDevice::setAdvertisingPhy(EnumFlags<BlePhy> phy) const {
     hal_ble_adv_params_t advParams = {};
     advParams.size = sizeof(hal_ble_adv_params_t);
     CHECK(hal_ble_gap_get_advertising_parameters(&advParams, nullptr));
+    advParams.version = BLE_API_VERSION;
     advParams.primary_phy = static_cast<uint8_t>(phy.value());
     return hal_ble_gap_set_advertising_parameters(&advParams, nullptr);
 }
@@ -2129,6 +2133,7 @@ int BleLocalDevice::setAdvertisingParameters(uint16_t interval, uint16_t timeout
     hal_ble_adv_params_t advParams = {};
     advParams.size = sizeof(hal_ble_adv_params_t);
     CHECK(hal_ble_gap_get_advertising_parameters(&advParams, nullptr));
+    advParams.version = BLE_API_VERSION;
     advParams.interval = interval;
     advParams.timeout = timeout;
     advParams.type = static_cast<hal_ble_adv_evt_type_t>(type);

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -2109,6 +2109,15 @@ int BleLocalDevice::setAdvertisingType(BleAdvertisingEventType type) const {
     return hal_ble_gap_set_advertising_parameters(&advParams, nullptr);
 }
 
+int BleLocalDevice::setAdvertisingPhy(EnumFlags<BlePhy> phy) const {
+    if(phy != BlePhy::CODED && phy != BlePhy::MBPS1) return SYSTEM_ERROR_NOT_SUPPORTED;
+    hal_ble_adv_params_t advParams = {};
+    advParams.size = sizeof(hal_ble_adv_params_t);
+    CHECK(hal_ble_gap_get_advertising_parameters(&advParams, nullptr));
+    advParams.primary_phy = static_cast<uint8_t>(phy.value());
+    return hal_ble_gap_set_advertising_parameters(&advParams, nullptr);
+}
+
 int BleLocalDevice::setAdvertisingParameters(const BleAdvertisingParams* params) const {
     return hal_ble_gap_set_advertising_parameters(params, nullptr);
 }
@@ -2471,6 +2480,14 @@ int BleLocalDevice::setScanTimeout(uint16_t timeout) const {
     scanParams.size = sizeof(hal_ble_scan_params_t);
     hal_ble_gap_get_scan_parameters(&scanParams, nullptr);
     scanParams.timeout = timeout;
+    return hal_ble_gap_set_scan_parameters(&scanParams, nullptr);
+}
+
+int BleLocalDevice::setScanPhy(EnumFlags<BlePhy> phy) const {
+    hal_ble_scan_params_t scanParams = {};
+    scanParams.size = sizeof(hal_ble_scan_params_t);
+    hal_ble_gap_get_scan_parameters(&scanParams, nullptr);
+    scanParams.scan_phys = static_cast<uint8_t>(phy);
     return hal_ble_gap_set_scan_parameters(&scanParams, nullptr);
 }
 

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -2088,8 +2088,8 @@ int BleLocalDevice::selectAntenna(BleAntennaType antenna) const {
 int BleLocalDevice::setAdvertisingInterval(uint16_t interval) const {
     hal_ble_adv_params_t advParams = {};
     advParams.size = sizeof(hal_ble_adv_params_t);
-    CHECK(hal_ble_gap_get_advertising_parameters(&advParams, nullptr));
     advParams.version = BLE_API_VERSION;
+    CHECK(hal_ble_gap_get_advertising_parameters(&advParams, nullptr));
     advParams.interval = interval;
     return hal_ble_gap_set_advertising_parameters(&advParams, nullptr);
 }
@@ -2097,8 +2097,8 @@ int BleLocalDevice::setAdvertisingInterval(uint16_t interval) const {
 int BleLocalDevice::setAdvertisingTimeout(uint16_t timeout) const {
     hal_ble_adv_params_t advParams = {};
     advParams.size = sizeof(hal_ble_adv_params_t);
-    CHECK(hal_ble_gap_get_advertising_parameters(&advParams, nullptr));
     advParams.version = BLE_API_VERSION;
+    CHECK(hal_ble_gap_get_advertising_parameters(&advParams, nullptr));
     advParams.timeout = timeout;
     return hal_ble_gap_set_advertising_parameters(&advParams, nullptr);
 }
@@ -2106,8 +2106,8 @@ int BleLocalDevice::setAdvertisingTimeout(uint16_t timeout) const {
 int BleLocalDevice::setAdvertisingType(BleAdvertisingEventType type) const {
     hal_ble_adv_params_t advParams = {};
     advParams.size = sizeof(hal_ble_adv_params_t);
-    CHECK(hal_ble_gap_get_advertising_parameters(&advParams, nullptr));
     advParams.version = BLE_API_VERSION;
+    CHECK(hal_ble_gap_get_advertising_parameters(&advParams, nullptr));
     advParams.type = static_cast<hal_ble_adv_evt_type_t>(type);
     return hal_ble_gap_set_advertising_parameters(&advParams, nullptr);
 }
@@ -2115,8 +2115,8 @@ int BleLocalDevice::setAdvertisingType(BleAdvertisingEventType type) const {
 int BleLocalDevice::setAdvertisingPhy(EnumFlags<BlePhy> phy) const {
     hal_ble_adv_params_t advParams = {};
     advParams.size = sizeof(hal_ble_adv_params_t);
-    CHECK(hal_ble_gap_get_advertising_parameters(&advParams, nullptr));
     advParams.version = BLE_API_VERSION;
+    CHECK(hal_ble_gap_get_advertising_parameters(&advParams, nullptr));
     advParams.primary_phy = static_cast<uint8_t>(phy.value());
     return hal_ble_gap_set_advertising_parameters(&advParams, nullptr);
 }
@@ -2132,8 +2132,8 @@ int BleLocalDevice::setAdvertisingParameters(const BleAdvertisingParams& params)
 int BleLocalDevice::setAdvertisingParameters(uint16_t interval, uint16_t timeout, BleAdvertisingEventType type) const {
     hal_ble_adv_params_t advParams = {};
     advParams.size = sizeof(hal_ble_adv_params_t);
-    CHECK(hal_ble_gap_get_advertising_parameters(&advParams, nullptr));
     advParams.version = BLE_API_VERSION;
+    CHECK(hal_ble_gap_get_advertising_parameters(&advParams, nullptr));
     advParams.interval = interval;
     advParams.timeout = timeout;
     advParams.type = static_cast<hal_ble_adv_evt_type_t>(type);
@@ -2482,6 +2482,7 @@ private:
 int BleLocalDevice::setScanTimeout(uint16_t timeout) const {
     hal_ble_scan_params_t scanParams = {};
     scanParams.size = sizeof(hal_ble_scan_params_t);
+    scanParams.version = BLE_API_VERSION;
     hal_ble_gap_get_scan_parameters(&scanParams, nullptr);
     scanParams.timeout = timeout;
     return hal_ble_gap_set_scan_parameters(&scanParams, nullptr);
@@ -2490,6 +2491,7 @@ int BleLocalDevice::setScanTimeout(uint16_t timeout) const {
 int BleLocalDevice::setScanPhy(EnumFlags<BlePhy> phy) const {
     hal_ble_scan_params_t scanParams = {};
     scanParams.size = sizeof(hal_ble_scan_params_t);
+    scanParams.version = BLE_API_VERSION;
     hal_ble_gap_get_scan_parameters(&scanParams, nullptr);
     scanParams.scan_phys = static_cast<uint8_t>(phy.value());
     return hal_ble_gap_set_scan_parameters(&scanParams, nullptr);

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -2110,7 +2110,6 @@ int BleLocalDevice::setAdvertisingType(BleAdvertisingEventType type) const {
 }
 
 int BleLocalDevice::setAdvertisingPhy(EnumFlags<BlePhy> phy) const {
-    if(phy != BlePhy::CODED && phy != BlePhy::MBPS1) return SYSTEM_ERROR_NOT_SUPPORTED;
     hal_ble_adv_params_t advParams = {};
     advParams.size = sizeof(hal_ble_adv_params_t);
     CHECK(hal_ble_gap_get_advertising_parameters(&advParams, nullptr));


### PR DESCRIPTION
This builds on the community-submitted PR(https://github.com/particle-iot/device-os/pull/2287) to add BLE5 long range and does the following:

HAL:
- Add check when setting Advertising parameters, that the PHY is properly selected (for advertising, only one PHY can be chosen).
- When setting the extended scan parameter, check if Coded PHY is selected either by itself or bitwise with another PHY. In either of those cases, extended must be set to 1.

Wiring:
- Add setScanPhy() API
- Add setAdvertisingPhy() API

Integration/Application tests run on 2 Tracker Ones, which can communicate with each other and switch PHYs

Usage example:

Scanner:
BLE.setScanPhy(BlePhy::CODED | BlePhy::MBPS1);

Advertiser:
BLE.setAdvertisingPhy(BlePhy::CODED);

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
