### PR TITLE
feature/ch72988/workbench-buildscripts-v1.10.0

### DIFF
--- a/.workbench/manifest.json
+++ b/.workbench/manifest.json
@@ -180,7 +180,7 @@
                 {
                     "name": "openocd",
                     "version": "0.11.2-adhoc6ea4372.0",
-                    "main": ".",
+                    "main": "./bin",
                     "url": "https://binaries.particle.io/openocd/windows/x64/openocd-v0.11.2-adhoc6ea4372.0.tar.gz",
                     "sha256": "790954533100e5bd6c2e22085c6c7b099176c51d798fde9895779e12562ee134"
                 }
@@ -192,7 +192,7 @@
                 {
                     "name": "openocd",
                     "version": "0.11.2-adhoc6ea4372.0",
-                    "main": ".",
+                    "main": "./bin",
                     "url": "https://binaries.particle.io/openocd/darwin/x64/openocd-v0.11.2-adhoc6ea4372.0.tar.gz",
                     "sha256": "c2b30c3e933d69c7b9608c7814dbc998e775a6c104c144c567f2835e3f0d862c"
                 }
@@ -204,7 +204,7 @@
                 {
                     "name": "openocd",
                     "version": "0.11.2-adhoc6ea4372.0",
-                    "main": ".",
+                    "main": "./bin",
                     "url": "https://binaries.particle.io/openocd/linux/x64/openocd-v0.11.2-adhoc6ea4372.0.tar.gz",
                     "sha256": "42272bd1f012af43bb2fd80656e9f08a04e97bc8ffdc2d1e3e5062ea46ce657e"
                 }

--- a/.workbench/manifest.json
+++ b/.workbench/manifest.json
@@ -6,7 +6,7 @@
             "compilers": "gcc-arm@9.2.1",
             "debuggers": "openocd@0.11.2-adhoc6ea4372.0",
             "platforms": [6, 8, 10, 12, 13, 22, 23, 25, 26],
-            "scripts": "buildscripts@1.9.2",
+            "scripts": "buildscripts@1.10.0",
             "tools": "buildtools@1.1.1"
         }
     ],
@@ -138,37 +138,40 @@
             "x64": [
                 {
                     "name": "buildscripts",
-                    "version": "1.9.2",
+                    "version": "1.10.0",
                     "main": ".",
-                    "url": "https://binaries.particle.io/buildscripts/windows/x64/buildscripts-v1.9.2.tar.gz",
-                    "sha256": "dab1cd9cac10ab8bf5c572c3c0e4777714e97522b190af5f99c180740fb9a038"
+                    "url": "https://binaries.particle.io/buildscripts/windows/x64/buildscripts-v1.10.0.tar.gz",
+                    "sha256": "66a78bcd13e7cf08e9a8cab09a7ad3a1b179183b9391adbf0b39424c939f433b"
                 }
             ],
-            "x86": []
+            "x86": [
+            ]
         },
         "darwin": {
             "x64": [
                 {
                     "name": "buildscripts",
-                    "version": "1.9.2",
+                    "version": "1.10.0",
                     "main": ".",
-                    "url": "https://binaries.particle.io/buildscripts/darwin/x64/buildscripts-v1.9.2.tar.gz",
-                    "sha256": "dab1cd9cac10ab8bf5c572c3c0e4777714e97522b190af5f99c180740fb9a038"
+                    "url": "https://binaries.particle.io/buildscripts/darwin/x64/buildscripts-v1.10.0.tar.gz",
+                    "sha256": "66a78bcd13e7cf08e9a8cab09a7ad3a1b179183b9391adbf0b39424c939f433b"
                 }
             ],
-            "x86": []
+            "x86": [
+            ]
         },
         "linux": {
             "x64": [
                 {
                     "name": "buildscripts",
-                    "version": "1.9.2",
+                    "version": "1.10.0",
                     "main": ".",
-                    "url": "https://binaries.particle.io/buildscripts/linux/x64/buildscripts-v1.9.2.tar.gz",
-                    "sha256": "dab1cd9cac10ab8bf5c572c3c0e4777714e97522b190af5f99c180740fb9a038"
+                    "url": "https://binaries.particle.io/buildscripts/linux/x64/buildscripts-v1.10.0.tar.gz",
+                    "sha256": "66a78bcd13e7cf08e9a8cab09a7ad3a1b179183b9391adbf0b39424c939f433b"
                 }
             ],
-            "x86": []
+            "x86": [
+            ]
         }
     },
     "tools": {

--- a/.workbench/manifest.json
+++ b/.workbench/manifest.json
@@ -2,90 +2,14 @@
     "version": "1.0.0",
     "toolchains": [
         {
+            "platforms": [6, 8, 10, 12, 13, 22, 23, 25, 26],
             "firmware": "deviceOS@source",
             "compilers": "gcc-arm@9.2.1",
-            "debuggers": "openocd@0.11.2-adhoc6ea4372.0",
-            "platforms": [6, 8, 10, 12, 13, 22, 23, 25, 26],
+            "tools": "buildtools@1.1.1",
             "scripts": "buildscripts@1.10.0",
-            "tools": "buildtools@1.1.1"
+            "debuggers": "openocd@0.11.2-adhoc6ea4372.0"
         }
     ],
-    "compilers": {
-        "windows": {
-            "x64": [
-                {
-                    "name": "gcc-arm",
-                    "version": "9.2.1",
-                    "main": "./bin",
-                    "url": "https://binaries.particle.io/gcc-arm/windows/x64/gcc-arm-v9.2.1.tar.gz",
-                    "sha256": "4cd5e43a2ab144b2beb589b0b0d9f9632ad918154f3749fcff0c36da93468a96"
-                }
-            ],
-            "x86": []
-        },
-        "darwin": {
-            "x64": [
-                {
-                    "name": "gcc-arm",
-                    "version": "9.2.1",
-                    "main": "./bin",
-                    "url": "https://binaries.particle.io/gcc-arm/darwin/x64/gcc-arm-v9.2.1.tar.gz",
-                    "sha256": "c98939900d147182f3e603a7ec4fd13e4e67292f3c7f1f3bc09308c7f97e9974"
-                }
-            ],
-            "x86": []
-        },
-        "linux": {
-            "x64": [
-                {
-                    "name": "gcc-arm",
-                    "version": "9.2.1",
-                    "main": "./bin",
-                    "url": "https://binaries.particle.io/gcc-arm/linux/x64/gcc-arm-v9.2.1.tar.gz",
-                    "sha256": "d7c24c8a3464b1806c8d2e93e2d616acb1ac934199756316cf746fdfddaaefe4"
-                }
-            ],
-            "x86": []
-        }
-    },
-    "debuggers": {
-        "windows": {
-            "x64": [
-                {
-                    "name": "openocd",
-                    "version": "0.11.2-adhoc6ea4372.0",
-                    "main": ".",
-                    "url": "https://binaries.particle.io/openocd/windows/x64/openocd-v0.11.2-adhoc6ea4372.0.tar.gz",
-                    "sha256": "790954533100e5bd6c2e22085c6c7b099176c51d798fde9895779e12562ee134"
-                }
-            ],
-            "x86": []
-        },
-        "darwin": {
-            "x64": [
-                {
-                    "name": "openocd",
-                    "version": "0.11.2-adhoc6ea4372.0",
-                    "main": ".",
-                    "url": "https://binaries.particle.io/openocd/darwin/x64/openocd-v0.11.2-adhoc6ea4372.0.tar.gz",
-                    "sha256": "c2b30c3e933d69c7b9608c7814dbc998e775a6c104c144c567f2835e3f0d862c"
-                }
-            ],
-            "x86": []
-        },
-        "linux": {
-            "x64": [
-                {
-                    "name": "openocd",
-                    "version": "0.11.2-adhoc6ea4372.0",
-                    "main": ".",
-                    "url": "https://binaries.particle.io/openocd/linux/x64/openocd-v0.11.2-adhoc6ea4372.0.tar.gz",
-                    "sha256": "42272bd1f012af43bb2fd80656e9f08a04e97bc8ffdc2d1e3e5062ea46ce657e"
-                }
-            ],
-            "x86": []
-        }
-    },
     "platforms": [
         {
             "id": 6,
@@ -133,6 +57,82 @@
             "generation": 3
         }
     ],
+    "compilers": {
+        "windows": {
+            "x64": [
+                {
+                    "name": "gcc-arm",
+                    "version": "9.2.1",
+                    "main": "./bin",
+                    "url": "https://binaries.particle.io/gcc-arm/windows/x64/gcc-arm-v9.2.1.tar.gz",
+                    "sha256": "4cd5e43a2ab144b2beb589b0b0d9f9632ad918154f3749fcff0c36da93468a96"
+                }
+            ],
+            "x86": []
+        },
+        "darwin": {
+            "x64": [
+                {
+                    "name": "gcc-arm",
+                    "version": "9.2.1",
+                    "main": "./bin",
+                    "url": "https://binaries.particle.io/gcc-arm/darwin/x64/gcc-arm-v9.2.1.tar.gz",
+                    "sha256": "c98939900d147182f3e603a7ec4fd13e4e67292f3c7f1f3bc09308c7f97e9974"
+                }
+            ],
+            "x86": []
+        },
+        "linux": {
+            "x64": [
+                {
+                    "name": "gcc-arm",
+                    "version": "9.2.1",
+                    "main": "./bin",
+                    "url": "https://binaries.particle.io/gcc-arm/linux/x64/gcc-arm-v9.2.1.tar.gz",
+                    "sha256": "d7c24c8a3464b1806c8d2e93e2d616acb1ac934199756316cf746fdfddaaefe4"
+                }
+            ],
+            "x86": []
+        }
+    },
+    "tools": {
+        "windows": {
+            "x64": [
+                {
+                    "name":  "buildtools",
+                    "version":  "1.1.1",
+                    "main":  "./bin",
+                    "url":  "https://binaries.particle.io/buildtools/windows/x64/buildtools-v1.1.1.tar.gz",
+                    "sha256":  "674c9c0bca32f8f6345199e7f97834476182210c9e15a79eb4942df8988c28fe"
+                }
+            ],
+            "x86": []
+        },
+        "darwin": {
+            "x64": [
+                {
+                    "name": "buildtools",
+                    "version":  "1.1.1",
+                    "main": ".",
+                    "url": "https://binaries.particle.io/buildtools/darwin/x64/buildtools-v1.1.1.tar.gz",
+                    "sha256": "789f7b5bdd4213b5bb5e57f3aad4f99ff775fff721bef40c65b8abf59c57c630"
+                }
+            ],
+            "x86": []
+        },
+        "linux": {
+            "x64": [
+                {
+                    "name": "buildtools",
+                    "version":  "1.1.1",
+                    "main": ".",
+                    "url": "https://binaries.particle.io/buildtools/linux/x64/buildtools-v1.1.1.tar.gz",
+                    "sha256": "a7c15b28966ed4d77d010001eee19de4385732e765c199051bc3bcdfb1e55846"
+                }
+            ],
+            "x86": []
+        }
+    },
     "scripts": {
         "windows": {
             "x64": [
@@ -174,15 +174,15 @@
             ]
         }
     },
-    "tools": {
+    "debuggers": {
         "windows": {
             "x64": [
                 {
-                    "name":  "buildtools",
-                    "version":  "1.1.1",
-                    "main":  "./bin",
-                    "url":  "https://binaries.particle.io/buildtools/windows/x64/buildtools-v1.1.1.tar.gz",
-                    "sha256":  "674c9c0bca32f8f6345199e7f97834476182210c9e15a79eb4942df8988c28fe"
+                    "name": "openocd",
+                    "version": "0.11.2-adhoc6ea4372.0",
+                    "main": ".",
+                    "url": "https://binaries.particle.io/openocd/windows/x64/openocd-v0.11.2-adhoc6ea4372.0.tar.gz",
+                    "sha256": "790954533100e5bd6c2e22085c6c7b099176c51d798fde9895779e12562ee134"
                 }
             ],
             "x86": []
@@ -190,11 +190,11 @@
         "darwin": {
             "x64": [
                 {
-                    "name": "buildtools",
-                    "version":  "1.1.1",
+                    "name": "openocd",
+                    "version": "0.11.2-adhoc6ea4372.0",
                     "main": ".",
-                    "url": "https://binaries.particle.io/buildtools/darwin/x64/buildtools-v1.1.1.tar.gz",
-                    "sha256": "789f7b5bdd4213b5bb5e57f3aad4f99ff775fff721bef40c65b8abf59c57c630"
+                    "url": "https://binaries.particle.io/openocd/darwin/x64/openocd-v0.11.2-adhoc6ea4372.0.tar.gz",
+                    "sha256": "c2b30c3e933d69c7b9608c7814dbc998e775a6c104c144c567f2835e3f0d862c"
                 }
             ],
             "x86": []
@@ -202,11 +202,11 @@
         "linux": {
             "x64": [
                 {
-                    "name": "buildtools",
-                    "version":  "1.1.1",
+                    "name": "openocd",
+                    "version": "0.11.2-adhoc6ea4372.0",
                     "main": ".",
-                    "url": "https://binaries.particle.io/buildtools/linux/x64/buildtools-v1.1.1.tar.gz",
-                    "sha256": "a7c15b28966ed4d77d010001eee19de4385732e765c199051bc3bcdfb1e55846"
+                    "url": "https://binaries.particle.io/openocd/linux/x64/openocd-v0.11.2-adhoc6ea4372.0.tar.gz",
+                    "sha256": "42272bd1f012af43bb2fd80656e9f08a04e97bc8ffdc2d1e3e5062ea46ce657e"
                 }
             ],
             "x86": []


### PR DESCRIPTION
### Problem

`.workbench/manifest.json` uses an older version of the `buildscripts` dependency

### Solution

Update to `buildscripts@1.10.0`

### Steps to Test

Follow the steps to enable the `deviceOS@source` toolchain within Particle Workbench ([docs](https://docs.particle.io/support/particle-tools-faq/workbench/#working-with-a-custom-device-os-build)) - you should be able to compile and flash all platforms successfully

### References

https://github.com/particle-iot/workbench/pull/149
https://github.com/particle-iot/device-os/pull/2020

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
