### PR TITLE
[Gen 3] Fix micros/millis/unixtime becoming non-monotonic / Make I2C bus reset less destructive if performed in the middle of the transaction

### DIFF
--- a/hal/inc/pinmap_hal.h
+++ b/hal/inc/pinmap_hal.h
@@ -31,15 +31,16 @@ typedef struct Hal_Pin_Info Hal_Pin_Info;
 typedef uint16_t pin_t;
 
 typedef enum PinMode {
-    INPUT,
-    OUTPUT,
-    INPUT_PULLUP,
-    INPUT_PULLDOWN,
-    AF_OUTPUT_PUSHPULL, // Used internally for Alternate Function Output PushPull(TIM, UART, SPI etc)
-    AF_OUTPUT_DRAIN,    // Used internally for Alternate Function Output Drain(I2C etc). External pullup resistors required.
-    AN_INPUT,           // Used internally for ADC Input
-    AN_OUTPUT,          // Used internally for DAC Output,
+    INPUT = 0,
+    OUTPUT = 1,
+    INPUT_PULLUP = 2,
+    INPUT_PULLDOWN = 3,
+    AF_OUTPUT_PUSHPULL = 4, // Used internally for Alternate Function Output PushPull(TIM, UART, SPI etc)
+    AF_OUTPUT_DRAIN = 5,    // Used internally for Alternate Function Output Drain(I2C etc). External pullup resistors required.
+    AN_INPUT = 6,           // Used internally for ADC Input
+    AN_OUTPUT = 7,          // Used internally for DAC Output,
     OUTPUT_OPEN_DRAIN = AF_OUTPUT_DRAIN,
+    OUTPUT_OPEN_DRAIN_PULLUP = 8,
     PIN_MODE_NONE = 0xFF
 } PinMode;
 

--- a/hal/src/nRF52840/gpio_hal.cpp
+++ b/hal/src/nRF52840/gpio_hal.cpp
@@ -81,7 +81,7 @@ int HAL_Pin_Configure(pin_t pin, const hal_gpio_config_t* conf, void* reserved) 
         }
 
         // Pre-set the output value if requested to avoid a glitch
-        if (conf->set_value && (mode == OUTPUT || mode == OUTPUT_OPEN_DRAIN)) {
+        if (conf->set_value && (mode == OUTPUT || mode == OUTPUT_OPEN_DRAIN || mode == OUTPUT_OPEN_DRAIN_PULLUP)) {
             if (conf->value) {
                 nrf_gpio_pin_set(nrfPin);
             } else {
@@ -89,15 +89,14 @@ int HAL_Pin_Configure(pin_t pin, const hal_gpio_config_t* conf, void* reserved) 
             }
         }
 
-        auto driveStrength = NRF_GPIO_PIN_S0S1;
-        if (conf->version >= HAL_GPIO_VERSION_1) {
-            if (conf->drive_strength == HAL_GPIO_DRIVE_HIGH) {
-                driveStrength = NRF_GPIO_PIN_H0H1;
-            }
-        }
-
         switch (mode) {
             case OUTPUT: {
+                auto driveStrength = NRF_GPIO_PIN_S0S1;
+                if (conf->version >= HAL_GPIO_VERSION_1) {
+                    if (conf->drive_strength == HAL_GPIO_DRIVE_HIGH) {
+                        driveStrength = NRF_GPIO_PIN_H0H1;
+                    }
+                }
                 nrf_gpio_cfg(nrfPin,
                     NRF_GPIO_PIN_DIR_OUTPUT,
                     NRF_GPIO_PIN_INPUT_DISCONNECT,
@@ -119,10 +118,31 @@ int HAL_Pin_Configure(pin_t pin, const hal_gpio_config_t* conf, void* reserved) 
                 break;
             }
             case OUTPUT_OPEN_DRAIN: {
+                auto driveStrength = NRF_GPIO_PIN_S0D1;
+                if (conf->version >= HAL_GPIO_VERSION_1) {
+                    if (conf->drive_strength == HAL_GPIO_DRIVE_HIGH) {
+                        driveStrength = NRF_GPIO_PIN_H0D1;
+                    }
+                }
                 nrf_gpio_cfg(nrfPin,
-                    NRF_GPIO_PIN_DIR_OUTPUT,
-                    NRF_GPIO_PIN_INPUT_DISCONNECT,
+                    NRF_GPIO_PIN_DIR_INPUT,
+                    NRF_GPIO_PIN_INPUT_CONNECT,
                     NRF_GPIO_PIN_NOPULL,
+                    driveStrength,
+                    NRF_GPIO_PIN_NOSENSE);
+                break;
+            }
+            case OUTPUT_OPEN_DRAIN_PULLUP: {
+                auto driveStrength = NRF_GPIO_PIN_S0D1;
+                if (conf->version >= HAL_GPIO_VERSION_1) {
+                    if (conf->drive_strength == HAL_GPIO_DRIVE_HIGH) {
+                        driveStrength = NRF_GPIO_PIN_H0D1;
+                    }
+                }
+                nrf_gpio_cfg(nrfPin,
+                    NRF_GPIO_PIN_DIR_INPUT,
+                    NRF_GPIO_PIN_INPUT_CONNECT,
+                    NRF_GPIO_PIN_PULLUP,
                     driveStrength,
                     NRF_GPIO_PIN_NOSENSE);
                 break;
@@ -261,10 +281,12 @@ int32_t HAL_GPIO_Read(uint16_t pin) {
 
         if ((PIN_MAP[pin].pin_mode == INPUT) ||
             (PIN_MAP[pin].pin_mode == INPUT_PULLUP) ||
-            (PIN_MAP[pin].pin_mode == INPUT_PULLDOWN))
+            (PIN_MAP[pin].pin_mode == INPUT_PULLDOWN) ||
+            (PIN_MAP[pin].pin_mode == OUTPUT_OPEN_DRAIN) ||
+            (PIN_MAP[pin].pin_mode == OUTPUT_OPEN_DRAIN_PULLUP))
         {
             return nrf_gpio_pin_read(nrf_pin);
-        } else if (PIN_MAP[pin].pin_mode == OUTPUT || PIN_MAP[pin].pin_mode == OUTPUT_OPEN_DRAIN) {
+        } else if (PIN_MAP[pin].pin_mode == OUTPUT) {
             return nrf_gpio_pin_out_read(nrf_pin);
         } else {
             return 0;

--- a/hal/src/nRF52840/gpio_hal.cpp
+++ b/hal/src/nRF52840/gpio_hal.cpp
@@ -125,7 +125,7 @@ int HAL_Pin_Configure(pin_t pin, const hal_gpio_config_t* conf, void* reserved) 
                     }
                 }
                 nrf_gpio_cfg(nrfPin,
-                    NRF_GPIO_PIN_DIR_INPUT,
+                    NRF_GPIO_PIN_DIR_OUTPUT,
                     NRF_GPIO_PIN_INPUT_CONNECT,
                     NRF_GPIO_PIN_NOPULL,
                     driveStrength,
@@ -140,7 +140,7 @@ int HAL_Pin_Configure(pin_t pin, const hal_gpio_config_t* conf, void* reserved) 
                     }
                 }
                 nrf_gpio_cfg(nrfPin,
-                    NRF_GPIO_PIN_DIR_INPUT,
+                    NRF_GPIO_PIN_DIR_OUTPUT,
                     NRF_GPIO_PIN_INPUT_CONNECT,
                     NRF_GPIO_PIN_PULLUP,
                     driveStrength,

--- a/hal/src/nRF52840/i2c_hal.cpp
+++ b/hal/src/nRF52840/i2c_hal.cpp
@@ -53,6 +53,9 @@
     res;                                                                        \
 })
 
+// [219] TWIM: I2C timing spec is violated at 400 kHz
+const nrf_twim_frequency_t NRF_TWIM_FREQ_390K = (nrf_twim_frequency_t)(0x06200000UL);
+
 class I2cLock {
 public:
     I2cLock() = delete;
@@ -237,7 +240,13 @@ static int twiUninit(hal_i2c_interface_t i2c) {
 
 static int twiInit(hal_i2c_interface_t i2c) {
     ret_code_t ret;
-    nrf_twim_frequency_t nrfFrequency = (i2cMap[i2c].speed == CLOCK_SPEED_400KHZ) ? NRF_TWIM_FREQ_400K : NRF_TWIM_FREQ_100K;
+    // NOTE:
+    // [219] TWIM: I2C timing spec is violated at 400 kHz
+    // If communication does not work at 400 kHz with an I2C compatible device
+    // that requires the SCL clock to have a minimum low period of 1.3 µs,
+    // use 390 kHz instead of 400kHz by writing 0x06200000 to the FREQUENCY register.
+    // With this setting, the SCL low period is greater than 1.3 µs.
+    nrf_twim_frequency_t nrfFrequency = (i2cMap[i2c].speed == CLOCK_SPEED_400KHZ) ? NRF_TWIM_FREQ_390K : NRF_TWIM_FREQ_100K;
 
     Hal_Pin_Info* PIN_MAP = HAL_Pin_Map();
 

--- a/hal/src/nRF52840/timer_hal.cpp
+++ b/hal/src/nRF52840/timer_hal.cpp
@@ -210,9 +210,12 @@ uint64_t getCurrentTimeWithTicks(uint32_t* ticks, uint64_t* micros) {
 
     if (offset1 != offset2) {
         // Overflow occured between the calls
+        int pri = __get_PRIMASK();
+        __disable_irq();
         rtcValue = getRtcCounter();
         *ticks = sTickCountAtLastOverflow;
         *micros = sTimerMicrosAtLastOverflow;
+        __set_PRIMASK(pri);
     }
 
     return rtcCounterAndTicksToUs(offset2, rtcValue);

--- a/hal/src/stm32f2xx/gpio_hal.c
+++ b/hal/src/stm32f2xx/gpio_hal.c
@@ -282,7 +282,7 @@ int HAL_Pin_Configure(pin_t pin, const hal_gpio_config_t* conf, void* reserved) 
     GPIO_InitStructure.GPIO_Pin = gpio_pin;
 
     // Pre-set the output value if requested to avoid a glitch
-    if (conf->set_value && (conf->mode == OUTPUT || conf->mode == OUTPUT_OPEN_DRAIN)) {
+    if (conf->set_value && (conf->mode == OUTPUT || conf->mode == OUTPUT_OPEN_DRAIN || conf->mode == OUTPUT_OPEN_DRAIN_PULLUP)) {
         if (conf->value) {
             // Modify BSy (bit set)
             gpio_port->BSRRL = gpio_pin;
@@ -347,6 +347,15 @@ int HAL_Pin_Configure(pin_t pin, const hal_gpio_config_t* conf, void* reserved) 
             GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL ;
             PIN_MAP[pin].pin_mode = AN_OUTPUT;
             break;
+
+        case OUTPUT_OPEN_DRAIN_PULLUP:
+            GPIO_InitStructure.GPIO_Mode = GPIO_Mode_OUT;
+            GPIO_InitStructure.GPIO_OType = GPIO_OType_OD;
+            GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
+            GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_UP;
+            PIN_MAP[pin].pin_mode = OUTPUT_OPEN_DRAIN_PULLUP;
+            break;
+
 
         default:
             break;

--- a/hal/src/tracker/am18x5.cpp
+++ b/hal/src/tracker/am18x5.cpp
@@ -78,7 +78,6 @@ int Am18x5::begin() {
     
     if (!hal_i2c_is_enabled(wire_, nullptr)) {
         CHECK(hal_i2c_init(wire_, nullptr));
-        hal_i2c_set_speed(wire_, CLOCK_SPEED_400KHZ, nullptr);
         hal_i2c_begin(wire_, I2C_MODE_MASTER, 0x00, nullptr);
     }
 

--- a/system/src/system_power_manager.cpp
+++ b/system/src/system_power_manager.cpp
@@ -351,17 +351,19 @@ void PowerManager::loop(void* arg) {
     // Load configuration
     self->loadConfig();
 
+    if (self->config_.flags & HAL_POWER_MANAGEMENT_DISABLE) {
+      LOG(WARN, "Disabled by configuration");
+      goto exit;
+    }
+
     LOG_DEBUG(INFO, "Power Management Initializing.");
 #if HAL_PLATFORM_POWER_MANAGEMENT_OPTIONAL
     if (!self->detect()) {
       goto exit;
     }
+#else
+    self->resetBus();
 #endif // HAL_PLATFORM_POWER_MANAGEMENT_OPTIONAL
-
-    if (self->config_.flags & HAL_POWER_MANAGEMENT_DISABLE) {
-      LOG(WARN, "Disabled by configuration");
-      goto exit;
-    }
 
     // IMPORTANT: attach the interrupt handler first
 #if HAL_PLATFORM_PMIC_INT_PIN_PRESENT
@@ -793,6 +795,8 @@ bool PowerManager::detect() {
     return false;
   }
 
+  resetBus();
+
   // Check that PMIC is present by reading its version
   PMIC power(true);
   power.begin();
@@ -822,6 +826,16 @@ bool PowerManager::detect() {
   return true;
 }
 #endif // HAL_PLATFORM_POWER_MANAGEMENT_OPTIONAL
+
+void PowerManager::resetBus() {
+  if (!hal_i2c_is_enabled(HAL_PLATFORM_PMIC_BQ24195_I2C, nullptr)) {
+    hal_i2c_init(HAL_PLATFORM_PMIC_BQ24195_I2C, nullptr);
+    hal_i2c_begin(HAL_PLATFORM_PMIC_BQ24195_I2C, I2C_MODE_MASTER, 0x00, nullptr);
+    // Make sure to reset the I2C bus to avoid potentially corrupting the BQ24195 configuration if
+    // we start communication with it during an ongoing write transaction (which may happen e.g. after a hard reset)
+    hal_i2c_reset(HAL_PLATFORM_PMIC_BQ24195_I2C, 0, nullptr);
+  }
+}
 
 void PowerManager::deinit() {
   LOG(WARN, "Disabling system power manager");

--- a/system/src/system_power_manager.h
+++ b/system/src/system_power_manager.h
@@ -58,6 +58,7 @@ private:
   void applyDefaultConfig(bool dpdm = false);
   void logCurrentConfig();
   bool isRunning() const;
+  void resetBus();
 
   void deduceBatteryStateLoop();
   void deduceBatteryStateChargeDisabled();

--- a/user/tests/wiring/no_fixture/i2c.cpp
+++ b/user/tests/wiring/no_fixture/i2c.cpp
@@ -2,6 +2,222 @@
 #include "application.h"
 #include "unit-test/unit-test.h"
 #include "scope_guard.h"
+#include "check.h"
+#include <utility>
+
+namespace {
+
+#if HAL_PLATFORM_FUELGAUGE_MAX17043
+std::pair<pin_t, pin_t> i2cToSdaSclPins(hal_i2c_interface_t i2c) {
+#if HAL_PLATFORM_GEN == 3
+    switch (i2c) {
+        case HAL_I2C_INTERFACE1: {
+            return {SDA, SCL};
+        }
+        case HAL_I2C_INTERFACE2: {
+#if PLATFORM_ID == PLATFORM_BORON || PLATFORM_ID == PLATFORM_TRACKER
+            return {PMIC_SDA, PMIC_SCL};
+#else
+            return {D2, D3};
+#endif
+        }
+        case HAL_I2C_INTERFACE3: {
+            return {D9, D8};
+        }
+    }
+#else
+    switch (i2c) {
+        case HAL_I2C_INTERFACE1: {
+            return {D0, D1};
+        }
+#if PLATFORM_ID == PLATFORM_ELECTRON
+        case HAL_I2C_INTERFACE2: {
+            return {C4, C5};
+        }
+        case HAL_I2C_INTERFACE3: {
+            return {PM_SDA_UC, PM_SCL_UC};
+        }
+#endif // PLATFORM_ID == PLATFORM_ELECTRON
+    }
+#endif // HAL_PLATFORM_GEN == 3
+    return {PIN_INVALID, PIN_INVALID};
+}
+#endif // HAL_PLATFORM_FUELGAUGE_MAX17043
+
+class SoftWire {
+public:
+    SoftWire(hal_i2c_interface_t i2c, pin_t sda, pin_t scl)
+            : i2c_(i2c),
+              sda_(sda),
+              scl_(scl) {
+        hal_i2c_lock(i2c_, nullptr);
+    }
+
+    ~SoftWire() {
+        hal_i2c_unlock(i2c_, nullptr);
+    }
+
+    void init() {
+        hal_i2c_end(i2c_, nullptr);
+        hal_gpio_config_t conf = {
+            .size = sizeof(conf),
+            .version = HAL_GPIO_VERSION,
+            .mode = OUTPUT_OPEN_DRAIN_PULLUP,
+            .set_value = true,
+            .value = 1
+        };
+        HAL_Pin_Configure(sda_, &conf, nullptr);
+        HAL_Pin_Configure(scl_, &conf, nullptr);
+    }
+
+    int transmit(const uint8_t* data, const WireTransmission& transmission, bool abort = false, size_t abortBitAfterAddress = 0, bool abortAck = false) {
+        auto conf = transmission.halConfig();
+        Log.info("transmit to %02x %lu bytes (abort %d %d)", conf.address, conf.quantity, abort, abortBitAfterAddress);
+
+        startCondition();
+        clockByteOut(conf.address << 1);
+        CHECK(readAck());
+
+        size_t i;
+        const auto bitMargin = 8 + abortAck;
+        for (i = 0; i < conf.quantity && (!abort || i < (abortBitAfterAddress + (bitMargin - 1)) / bitMargin); i++) {
+            if (!abort || ((i + 1) * (bitMargin)) <= abortBitAfterAddress) {
+                clockByteOut(data[i]);
+                CHECK(readAck());
+            } else {
+                clockByteOut(data[i], abortBitAfterAddress % (bitMargin));
+            }
+        }
+
+        if (!abort && !(conf.flags & HAL_I2C_TRANSMISSION_FLAG_STOP)) {
+            stopCondition();
+        }
+
+        return i;
+    }
+
+    int receive(uint8_t* data, const WireTransmission& transmission, bool abort = false, size_t abortBitAfterAddress = 0, bool abortAck = false) {
+        auto conf = transmission.halConfig();
+        Log.info("receive from %02x %lu bytes (abort %d %d)", conf.address, conf.quantity, abort, abortBitAfterAddress);
+
+        startCondition();
+        clockByteOut(conf.address << 1 | 0x01);
+        CHECK(readAck());
+
+        size_t i;
+        for (i = 0; i < conf.quantity && (!abort || i < (abortBitAfterAddress + 7) / 8); i++) {
+            if (!abort || ((i + 1) * 8) <= abortBitAfterAddress) {
+                data[i] = clockByteIn();
+                if (i != conf.quantity - 1) {
+                    ackOut(true);
+                } else {
+                    ackOut(false);
+                }
+            } else {
+                data[i] = clockByteIn(abortBitAfterAddress % 8);
+            }
+        }
+        if (!abort) {
+            stopCondition();
+        }
+
+        return i;
+    }
+
+    int readRegister(uint8_t addr, uint8_t reg, uint8_t* buf, size_t len) {
+        CHECK(transmit(&reg, WireTransmission(addr).quantity(1).stop(false)));
+        return receive(buf, WireTransmission(addr).quantity(len));
+    }
+
+    int writeRegister(uint8_t addr, uint8_t reg, const uint8_t* buf, size_t len) {
+        auto tmpBuf = std::make_unique<uint8_t[]>(len + 1);
+        CHECK_TRUE(tmpBuf, SYSTEM_ERROR_NO_MEMORY);
+        tmpBuf[0] = reg;
+        memcpy(&tmpBuf[1], buf, len);
+        return transmit(tmpBuf.get(), WireTransmission(addr).quantity(len));
+    }
+
+private:
+    void startCondition() {
+        Log.info("start");
+        HAL_GPIO_Write(sda_, 0);
+        HAL_Delay_Microseconds(50);
+        HAL_GPIO_Write(scl_, 0);
+        HAL_Delay_Microseconds(50);
+    }
+
+    void stopCondition() {
+        Log.info("stop");
+        HAL_GPIO_Write(sda_, 0);
+        HAL_Delay_Microseconds(50);
+        HAL_GPIO_Write(scl_, 1);
+        HAL_Delay_Microseconds(50);
+        HAL_GPIO_Write(sda_, 1);
+        HAL_Delay_Microseconds(50);
+    }
+
+    void clockByteOut(uint8_t data, size_t bits = 8) {
+        Log.info("clock out %d bits (%02x)", bits, data);
+        uint8_t res = 0x00;
+        for (size_t i = 0; i < bits; i++) {
+            HAL_GPIO_Write(sda_, data & 0x80);
+            res |= HAL_GPIO_Read(sda_) << (8 - i - 1);
+            HAL_GPIO_Write(scl_, 1);
+            HAL_Delay_Microseconds(50);
+            HAL_GPIO_Write(scl_, 0);
+            HAL_Delay_Microseconds(50);
+            data <<= 1;
+        }
+        Log.info("clocked out (%02x)", res);
+    }
+
+    uint8_t clockByteIn(size_t bits = 8) {
+        Log.info("clocking in %d bits", bits);
+        uint8_t data = 0x00;
+        while (bits-- > 0) {
+            HAL_GPIO_Write(sda_, 1);
+            HAL_GPIO_Write(scl_, 1);
+            HAL_Delay_Microseconds(50);
+            data |= (HAL_GPIO_Read(sda_) & 0x01) << bits;
+            HAL_GPIO_Write(scl_, 0);
+            HAL_Delay_Microseconds(50);
+        }
+        Log.info("clocked in (%02x)", data);
+        return data;
+    }
+
+    int readAck() {
+        HAL_GPIO_Write(sda_, 1);
+        HAL_GPIO_Write(scl_, 1);
+        HAL_Delay_Microseconds(50);
+        bool ack = !HAL_GPIO_Read(sda_);
+        HAL_GPIO_Write(scl_, 0);
+        HAL_Delay_Microseconds(50);
+        Log.info("read ack %d", ack);
+        HAL_GPIO_Write(sda_, 0);
+        if (!ack) {
+            return SYSTEM_ERROR_PROTOCOL;
+        }
+        return 0;
+    }
+
+    int ackOut(bool ack) {
+        Log.info("out ack %d", ack);
+        HAL_GPIO_Write(sda_, !ack);
+        HAL_GPIO_Write(scl_, 1);
+        HAL_Delay_Microseconds(50);
+        HAL_GPIO_Write(scl_, 0);
+        HAL_Delay_Microseconds(50);
+        return 0;
+    }
+
+private:
+    hal_i2c_interface_t i2c_;
+    pin_t sda_;
+    pin_t scl_;
+};
+
+}
 
 #if PLATFORM_ID == PLATFORM_TRACKER
 
@@ -115,4 +331,60 @@ test(I2C_06_I2c_Sleep_FuelGauge) {
     auto ver2 = fuel.getVersion();
     assertEqual(ver, ver2);
 }
+
+test(I2C_07_bus_reset_is_not_destructive) {
+    constexpr uint16_t MAX17043_DEFAULT_CONFIG = 0x971c;
+
+    FuelGauge fuel;
+    fuel.begin();
+    fuel.wakeup();
+    auto ver = fuel.getVersion();
+#if HAL_PLATFORM_POWER_MANAGEMENT_OPTIONAL
+    if (ver < 0) {
+        skip();
+        return;
+    }
+#endif // HAL_PLATFORM_POWER_MANAGEMENT_OPTIONAL
+    assertMoreOrEqual(ver, 0);
+    assertNotEqual(ver, 0x0000);
+    assertNotEqual(ver, 0xffff);
+
+    SCOPE_GUARD({
+        fuel.begin();
+        hal_i2c_reset(HAL_PLATFORM_FUELGAUGE_MAX17043_I2C, 0, nullptr);
+        fuel.reset();
+    });
+
+    auto pins = i2cToSdaSclPins(HAL_PLATFORM_FUELGAUGE_MAX17043_I2C);
+    SoftWire wire(HAL_PLATFORM_FUELGAUGE_MAX17043_I2C, pins.first, pins.second);
+
+    hal_i2c_reset(HAL_PLATFORM_FUELGAUGE_MAX17043_I2C, 0, nullptr);
+    fuel.reset();
+
+    // Validate that fuel gauge has default configuration
+    uint8_t buf[2] = {0xff, 0xff};
+    assertEqual(0, fuel.readConfigRegister(buf[0], buf[1]));
+    uint16_t config = buf[0] << 8 | buf[1];
+    assertEqual(config, MAX17043_DEFAULT_CONFIG);
+
+    // Validate that we can read exactly the same configuration with soft i2c implementation
+    wire.init();
+    memset(buf, 0xff, sizeof(buf));
+    assertMoreOrEqual(wire.readRegister(MAX17043_ADDRESS, CONFIG_REGISTER, buf, sizeof(buf)), 0);
+    config = buf[0] << 8 | buf[1];
+    assertEqual(config, MAX17043_DEFAULT_CONFIG);
+
+    const uint8_t txBuf[4] = {CONFIG_REGISTER, 0x55, 0xaa, 0x00};
+    for (int i = 0; i <= 3 * 9 - 2 /* ignore full write without ack bit and full write with ack bit */; i++) {
+        wire.init();
+        assertMoreOrEqual(wire.transmit(txBuf, WireTransmission(MAX17043_ADDRESS).quantity(3), true /* abort */, i, true), 0);
+        fuel.begin();
+        hal_i2c_reset(HAL_PLATFORM_FUELGAUGE_MAX17043_I2C, 0, nullptr);
+        memset(buf, 0xff, sizeof(buf));
+        assertEqual(0, fuel.readConfigRegister(buf[0], buf[1]));
+        config = buf[0] << 8 | buf[1];
+        assertEqual(config, MAX17043_DEFAULT_CONFIG);
+    }
+}
+
 #endif // HAL_PLATFORM_FUELGAUGE_MAX17043

--- a/user/tests/wiring/timer_stress/README.md
+++ b/user/tests/wiring/timer_stress/README.md
@@ -1,0 +1,3 @@
+## Fixture requirements
+
+This test requires the device under test to be heated above 50°C or below -15°C.

--- a/user/tests/wiring/timer_stress/application.cpp
+++ b/user/tests/wiring/timer_stress/application.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef PARTICLE_TEST_RUNNER
+
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+SYSTEM_MODE(AUTOMATIC);
+
+// make clean all TEST=wiring/no_fixture_long_running PLATFORM=electron -s COMPILE_LTO=n program-dfu DEBUG_BUILD=y
+// make clean all TEST=wiring/no_fixture_long_running PLATFORM=electron -s COMPILE_LTO=n program-dfu DEBUG_BUILD=y USE_THREADING=y
+//
+// Serial1LogHandler logHandler(115200, LOG_LEVEL_ALL, {
+//     { "comm", LOG_LEVEL_NONE }, // filter out comm messages
+//     { "system", LOG_LEVEL_INFO } // only info level for system messages
+// });
+
+UNIT_TEST_APP();
+
+// Enable threading if compiled with "USE_THREADING=y"
+#if PLATFORM_THREADING == 1 && USE_THREADING == 1
+SYSTEM_THREAD(ENABLED);
+#endif
+
+#endif // PARTICLE_TEST_RUNNER

--- a/user/tests/wiring/timer_stress/simple_ntp_client.cpp
+++ b/user/tests/wiring/timer_stress/simple_ntp_client.cpp
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2021 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+// FIXME
+#include "util/simple_ntp_client.cpp"

--- a/user/tests/wiring/timer_stress/test.mk
+++ b/user/tests/wiring/timer_stress/test.mk
@@ -1,0 +1,18 @@
+INCLUDE_DIRS += $(SOURCE_PATH)/$(USRSRC)  # add user sources to include path
+# add C and CPP files - if USRSRC is not empty, then add a slash
+CPPSRC += $(call target_files,$(USRSRC_SLASH),*.cpp)
+CSRC += $(call target_files,$(USRSRC_SLASH),*.c)
+
+APPSOURCES=$(call target_files,$(USRSRC_SLASH),*.cpp)
+APPSOURCES+=$(call target_files,$(USRSRC_SLASH),*.c)
+ifeq ($(strip $(APPSOURCES)),)
+$(error "No sources found in $(SOURCE_PATH)/$(USRSRC)")
+endif
+
+ifeq ("${USE_THREADING}","y")
+USE_THREADING_VALUE=1
+else
+USE_THREADING_VALUE=0
+endif
+
+CFLAGS += -DUSE_THREADING=${USE_THREADING_VALUE}

--- a/user/tests/wiring/timer_stress/ticks.cpp
+++ b/user/tests/wiring/timer_stress/ticks.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "application.h"
+#include "unit-test/unit-test.h"
+#include "simple_ntp_client.h"
+#include <chrono>
+
+test(TICKS_01_micros_busy_loop_monotonically_increases)
+{
+    // Using NTP time as a separate independent timing source
+    auto client = std::make_unique<SimpleNtpClient>();
+    assertTrue((bool)client);
+
+    Particle.connect();
+    waitFor(Particle.connected, 10 * 60 * 10000);
+    assertTrue(Particle.connected());
+
+    const auto getNtpTime = [&client](uint64_t& ntpTime) -> int {
+        int r = SYSTEM_ERROR_UNKNOWN;
+        for (int i = 0; i < 10; i++) {
+            r = client->ntpDate(&ntpTime);
+            if (!r) {
+                break;
+            }
+        }
+        return r;
+    };
+
+    uint64_t ntpTime = 0;
+    assertEqual(0, getNtpTime(ntpTime));
+
+    const auto start = hal_timer_micros(nullptr);
+    const auto startNtpTime = ntpTime;
+    uint64_t prev = start;
+
+    const auto duration = std::chrono::microseconds(30min).count();
+
+    while (prev - start < duration) {
+        uint64_t now = hal_timer_micros(nullptr);
+        assertMoreOrEqual(now, prev);
+        assertMoreOrEqual(now, start);
+        prev = now;
+    }
+
+    assertEqual(0, getNtpTime(ntpTime));
+    assertMoreOrEqual(ntpTime - startNtpTime, duration * 9 / 10);
+}

--- a/wiring/inc/spark_wiring_fuel.h
+++ b/wiring/inc/spark_wiring_fuel.h
@@ -70,6 +70,7 @@ public:
     int quickStart();
     int sleep();
     int wakeup();
+    int readConfigRegister(byte &MSB, byte &LSB);
 
     bool lock();
     bool unlock();
@@ -77,7 +78,6 @@ public:
 private:
     static constexpr system_tick_t FUELGAUGE_DEFAULT_TIMEOUT = 10; // In millisecond
 
-    int readConfigRegister(byte &MSB, byte &LSB);
     int readRegister(byte startAddress, byte &MSB, byte &LSB);
     int writeRegister(byte address, byte MSB, byte LSB);
 


### PR DESCRIPTION
### Problem

1. [Gen 3] Micros/millis/unixtime may become non-monotonic (especially with hot/cold ambient temperature) due to unaccounted clock drift between 32KHz RTC and `DWT->CYCCNT`
2. [Gen 3] Non-monotonic micros may cause internal I2C HAL timeouts to expire early and cause I2C HAL to perform bus reset in the middle of the transaction.
3. [Gen 2 / Gen 3] Current I2C bus reset procedure is destructive if happens in the middle of the unfinished transaction and may cause erroneous data to be written into the I2C slave. Devices populated with BQ24195 PMIC (cellular) or AM1805 RTC (tracker) may very well end up in a broken state (e.g. powered off)

See also https://github.com/particle-iot/device-os/issues/2291

### Solution

1. [Gen 3] Properly account for positive and negative clock drift between RTC and `DWT->CYCCNT`, so that the micros/millis/etc counters stay monotonic.
2. [Gen 3] Every 512 seconds (RTC overflow) clocks are properly synchronized keeping the accumulated drift/bias between them intact, so there is no sudden jump in any direction after RTC overflow.
3. [Gen 2 / Gen 3] I2C reset checks the state of the I2C bus to ensure the reset sequence is only sent when the bus is held busy by one of the slaves and attempts to finalize a potentially interrupted I2C transaction as soon as possible.
4. [HAL] Add new `OUTPUT_OPEN_DRAIN_PULLUP` pin mode.
5. [Gen 3] Add workaround for anomaly [219] TWIM: I2C timing spec is violated at 400 kHz
6. [Cellular / Tracker] Perform PMIC/RTC bus reset on boot to make to avoid clocking erroneous data if booting after e.g. a hard reset

### Steps to Test

- `wiring/no_fixture`: `I2C_07_bus_reset_is_not_destructive`
- `wiring/timer_stress` (requires temperature controlled environment, see README.md)

### Example App

N/A

### References

- Closes https://github.com/particle-iot/device-os/issues/2291

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
