### PR TITLE
Fixes the issue that the Particle.disconnect() doesn't clear the auto…

### DIFF
--- a/system/src/system_cloud.cpp
+++ b/system/src/system_cloud.cpp
@@ -234,13 +234,15 @@ int spark_cloud_disconnect(const spark_cloud_disconnect_options* options, void* 
     if (spark_cloud_flag_connected()) {
         CloudConnectionSettings::instance()->setPendingDisconnectOptions(std::move(opts));
         spark_cloud_flag_disconnect();
-    } else if (opts.isClearSessionSet() && opts.clearSession()) {
+    } else {
         spark_cloud_flag_disconnect();
-        SYSTEM_THREAD_CONTEXT_SYNC_CALL([]() {
-            clearSessionData();
-            return 0;
-        }());
-        // Note: The above SYSTEM_THREAD_CONTEXT_SYNC_CALL() causes this function to return
+        if (opts.isClearSessionSet() && opts.clearSession()) {
+            SYSTEM_THREAD_CONTEXT_SYNC_CALL([]() {
+                clearSessionData();
+                return 0;
+            }());
+            // Note: The above SYSTEM_THREAD_CONTEXT_SYNC_CALL() causes this function to return
+        }
     }
     return 0;
 }


### PR DESCRIPTION
### Problem
`Particle.disconnect()` doesn't clear the auto-connect flag if it is called before the cloud connection is established. Running the simple example app below the device will always try connecting to the cloud.
### Solution
Always clear the auto-connect flag on Particle.disconnect() is called.
### Steps to Test
1. Detach the cellular antenna to simulate bad cellular environment.
2. Flash the example app.
3. Device should stop connecting to the tower after 10s.
### Example App
```c
#include "Particle.h"

SYSTEM_MODE(SEMI_AUTOMATIC);
SYSTEM_THREAD(ENABLED);

SerialLogHandler l(LOG_LEVEL_ALL);
time32_t start = 0;

void setup() {
    while (!Serial.isConnected());
    Particle.connect();
    start = Time.now();
}

void loop() {
    if (Time.now() - start > 10) {
        Particle.disconnect();
        Cellular.disconnect();
        while (1);
    }
}
```
### References
N/A

---
### Completeness
- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
