### PR TITLE
Gen2: fixes the issue that the cellular modem is reset unexpectedly.

### DIFF
--- a/system/src/system_network_cellular.h
+++ b/system/src/system_network_cellular.h
@@ -165,6 +165,7 @@ public:
     void connect_cancel(bool cancel) override {
         // only cancel if presently connecting
         bool require_cancel = false;
+        CLR_WLAN_WD();
         ATOMIC_BLOCK() {
             if (connecting || !SPARK_WLAN_STARTED)
             {


### PR DESCRIPTION
### Problem
If the WLAN_WD expires during device is connecting to the cellular tower followed by user requests to cancel the on-going cellular operation, the modem might be reset still.
### Solution
Clear the WLAN_WD on user request to cancel the on-going cellular operation.
### Steps to Test
N/A
### Example App

```c
SYSTEM_THREAD(ENABLED);
SYSTEM_MODE(SEMI_AUTOMATIC);

SerialLogHandler logHandler(115200, LOG_LEVEL_ALL);

bool shutoff = false;
system_tick_t last_sync = 0;

// handler for mode button being clicked to trigger
// connect/disconnect
void mode_clicked(system_event_t event, int param)
{
    shutoff = !shutoff;
    Log.info("mode button clicked");
}

// background thread to call blocking API
// this appears to allow the idle task in during the `Cellular.off` sequence
// and trigger the WLAN watchdog
void background_thread_func()
{
    while(true)
    {
        last_sync = Particle.timeSyncedLast();
        delay(1);
    }
}

void setup()
{
    auto background_thread = new Thread("sysapp_background", background_thread_func);
    (void) background_thread;

    System.on(button_click, mode_clicked);

    Particle.connect();
}

void loop()
{
    static bool last_shutoff = shutoff;

    if(last_shutoff != shutoff)
    {
        last_shutoff = shutoff;

        if(shutoff)
        {
            Log.info("disconnect");
            Cellular.off();
            Log.info("post disconnect");
        }
        else
        {
            Log.info("connecting again");
            Particle.connect();
        }
    }
}
```

### References
N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
