### PR TITLE
Restores the modem state after device is woken up.

### DIFF
--- a/system/src/system_network_manager_api.cpp
+++ b/system/src/system_network_manager_api.cpp
@@ -281,6 +281,9 @@ bool network_is_off(network_handle_t network, void* reserved) {
         if_t iface;
         if (!if_get_by_index(network, &iface)) {
             return NetworkManager::instance()->isInterfaceOff(iface);
+        } else {
+            // The interface is not present, so it should be off.
+            return true;
         }
     }
 

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -105,7 +105,7 @@ int system_sleep_network_resume(network_interface_index index, network_status_t&
 } // anonymous namespacee
 
 int system_sleep_ext_impl(const hal_sleep_config_t* config, hal_wakeup_source_base_t** reason, void* reserved) {
-    SYSTEM_THREAD_CONTEXT_SYNC(system_sleep_ext(config, reason, reserved));
+    SYSTEM_THREAD_CONTEXT_SYNC(system_sleep_ext_impl(config, reason, reserved));
 
     // Validates the sleep configuration previous to disconnecting network,
     // so that the network status remains if the configuration is invalid.

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -45,30 +45,46 @@ using namespace particle;
 #undef LOG_COMPILE_TIME_LEVEL
 #define LOG_COMPILE_TIME_LEVEL LOG_LEVEL_ALL
 
-static bool system_sleep_network_suspend(network_interface_index index) {
-    bool resume = false;
+namespace {
+
+typedef struct {
+    bool suspended;
+    bool on;
+    bool connected;
+} network_status_t;
+
+network_status_t system_sleep_network_suspend(network_interface_index index) {
+    network_status_t status = {};
+    status.suspended = true;
+
     // Disconnect from network
     if (network_connecting(index, 0, NULL) || network_ready(index, 0, NULL)) {
         if (network_connecting(index, 0, NULL)) {
             network_connect_cancel(index, 1, 0, 0);
         }
         network_disconnect(index, NETWORK_DISCONNECT_REASON_SLEEP, NULL);
-        resume = true;
+        status.connected = true;
     }
 #if PLATFORM_GEN == 2
     if (!SPARK_WLAN_SLEEP) {
-        resume = true;
+        status.connected = true;
     }
 #endif
     // Turn off the modem
-    network_off(index, 0, 0, NULL);
-    LOG(TRACE, "Waiting interface %d to be off...", (int)index);
-    // There might be up to 30s delay to turn off the modem for particular platforms.
-    network_wait_off(index, 120000/*ms*/, nullptr);
-    return resume;
+    if (!network_is_off(index, nullptr)) {
+        status.on = true;
+        network_off(index, 0, 0, NULL);
+        LOG(TRACE, "Waiting interface %d to be off...", (int)index);
+        // There might be up to 30s delay to turn off the modem for particular platforms.
+        network_wait_off(index, 120000/*ms*/, nullptr);
+    } else {
+        LOG(TRACE, "Interface %d is off already", (int)index);
+    }
+    
+    return status;
 }
 
-static int system_sleep_network_resume(network_interface_index index) {
+int system_sleep_network_resume(network_interface_index index, network_status_t& status) {
 #if PLATFORM_GEN == 2
     /* On Gen2, calling network_on() and network_connect() will block until the connection is established
      * if single threaded, or this function is invoked synchronously by the system thread if system threading
@@ -76,11 +92,17 @@ static int system_sleep_network_resume(network_interface_index index) {
      * application and restore the connection later. */
     SPARK_WLAN_SLEEP = 0;
 #else
-    network_on(index, 0, 0, nullptr);
-    network_connect(index, 0, 0, nullptr);
+    if (status.on) {
+        network_on(index, 0, 0, nullptr);
+    }
+    if (status.connected) {
+        network_connect(index, 0, 0, nullptr);
+    }
 #endif
     return SYSTEM_ERROR_NONE;
 }
+
+} // anonymous namespacee
 
 int system_sleep_ext_impl(const hal_sleep_config_t* config, hal_wakeup_source_base_t** reason, void* reserved) {
     SYSTEM_THREAD_CONTEXT_SYNC(system_sleep_ext(config, reason, reserved));
@@ -132,37 +154,31 @@ int system_sleep_ext_impl(const hal_sleep_config_t* config, hal_wakeup_source_ba
     // Network disconnect.
     // FIXME: if_get_list() can be potentially used, instead of using pre-processor.
 #if HAL_PLATFORM_CELLULAR
-    bool cellularResume = false;
+    network_status_t cellularStatus = {};
     if (!configHelper.wakeupByNetworkInterface(NETWORK_INTERFACE_CELLULAR)) {
         if (configHelper.networkFlags(NETWORK_INTERFACE_CELLULAR).isSet(SystemSleepNetworkFlag::INACTIVE_STANDBY)) {
             // Pause the modem Serial, while leaving the modem keeps running.
             cellular_pause(nullptr);
         } else {
-            if (system_sleep_network_suspend(NETWORK_INTERFACE_CELLULAR)) {
-                cellularResume = true;
-            }
+            cellularStatus = system_sleep_network_suspend(NETWORK_INTERFACE_CELLULAR);
         }
     }
 #endif // HAL_PLATFORM_CELLULAR
 
 #if HAL_PLATFORM_WIFI
-    bool wifiResume = false;
+    network_status_t wifiStatus = {};
     if (!configHelper.wakeupByNetworkInterface(NETWORK_INTERFACE_WIFI_STA) &&
           !configHelper.networkFlags(NETWORK_INTERFACE_CELLULAR).isSet(SystemSleepNetworkFlag::INACTIVE_STANDBY)) {
-        if (system_sleep_network_suspend(NETWORK_INTERFACE_WIFI_STA)) {
-            wifiResume = true;
-        }
+        wifiStatus = system_sleep_network_suspend(NETWORK_INTERFACE_WIFI_STA);
     }
 #endif // HAL_PLATFORM_WIFI
 
 #if HAL_PLATFORM_ETHERNET
     // NOTE: wake-up by Ethernet interfaces is not implemented.
     // For now we are always powering it off
-    bool ethernetResume = false;
+    network_status_t ethernetStatus = {};
     // if (!configHelper.wakeupByNetworkInterface(NETWORK_INTERFACE_ETHERNET)) {
-        if (system_sleep_network_suspend(NETWORK_INTERFACE_ETHERNET)) {
-            ethernetResume = true;
-        }
+        ethernetStatus = system_sleep_network_suspend(NETWORK_INTERFACE_ETHERNET);
     // }
 #endif // HAL_PLATFORM_ETHERNET
 
@@ -185,22 +201,22 @@ int system_sleep_ext_impl(const hal_sleep_config_t* config, hal_wakeup_source_ba
     // Network resume
     // FIXME: if_get_list() can be potentially used, instead of using pre-processor.
 #if HAL_PLATFORM_CELLULAR
-    if (cellularResume) {
-        system_sleep_network_resume(NETWORK_INTERFACE_CELLULAR);
+    if (cellularStatus.suspended) {
+        system_sleep_network_resume(NETWORK_INTERFACE_CELLULAR, cellularStatus);
     } else {
         cellular_resume(nullptr);
     }
 #endif // HAL_PLATFORM_CELLULAR
 
 #if HAL_PLATFORM_WIFI
-    if (wifiResume) {
-        system_sleep_network_resume(NETWORK_INTERFACE_WIFI_STA);
+    if (wifiStatus.suspended) {
+        system_sleep_network_resume(NETWORK_INTERFACE_WIFI_STA, wifiStatus);
     }
 #endif // HAL_PLATFORM_WIFI
 
 #if HAL_PLATFORM_ETHERNET
-    if (ethernetResume) {
-        system_sleep_network_resume(NETWORK_INTERFACE_ETHERNET);
+    if (ethernetStatus.suspended) {
+        system_sleep_network_resume(NETWORK_INTERFACE_ETHERNET, ethernetStatus);
     }
 #endif // HAL_PLATFORM_ETHERNET
 


### PR DESCRIPTION
### Problem
For sleep 2.0 API, if the modem is powered on, but not establishing connection, it won't restore the modem power state after device is woken up.
### Solution
Tracks the modem power state and connection state respectively in system sleep.
### Steps to Test
Running the example below building against develop branch you won't see the modem is on after device is woken up, but you will if you build it against the current branch.
### Example App
```c
#include "Particle.h"

SYSTEM_MODE(SEMI_AUTOMATIC);
SYSTEM_THREAD(ENABLED);

Serial1LogHandler l(115200, LOG_LEVEL_INFO);

void setup() {
    Log.info("Turning on the modem...");
    Cellular.on();

    waitUntil(Cellular.isOn);
    Log.info("Done");
    delay(2s);

    Log.info("Entering sleep...");
    SystemSleepResult r = System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::STOP).duration(5s));

    if (r.error() == SYSTEM_ERROR_NONE) {
        Log.info("Exited sleep.");
    } else {
        Log.error("Failed to enter sleep.");
    }

    Log.info("Waiting for the modem to be turned on...");
    waitFor(Cellular.isOn, 60000);
    Log.info("Modem is %s", Cellular.isOn() ? "on" : "off");
}

void loop() {
}
```
### References
N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
