### PR TITLE
Gen2: network connection is established unexpectedly.

### DIFF
--- a/system/inc/system_task.h
+++ b/system/inc/system_task.h
@@ -57,6 +57,7 @@ extern volatile uint32_t TimingFlashUpdateTimeout;
 
 extern volatile uint8_t SPARK_WLAN_RESET;
 extern volatile uint8_t SPARK_WLAN_SLEEP;
+extern volatile uint8_t SPARK_WLAN_CONNECT_RESTORE;
 extern volatile uint8_t SPARK_WLAN_STARTED;
 extern volatile uint8_t SPARK_CLOUD_SOCKETED;
 extern volatile uint8_t SPARK_CLOUD_CONNECTED;

--- a/system/src/system_network_internal.h
+++ b/system/src/system_network_internal.h
@@ -43,6 +43,7 @@ enum eWanTimings
 
 extern volatile uint8_t SPARK_WLAN_RESET;
 extern volatile uint8_t SPARK_WLAN_SLEEP;
+extern volatile uint8_t SPARK_WLAN_CONNECT_RESTORE;
 extern volatile uint8_t SPARK_WLAN_STARTED;
 
 extern uint32_t wlan_watchdog_duration;

--- a/system/src/system_network_manager_api.cpp
+++ b/system/src/system_network_manager_api.cpp
@@ -48,6 +48,7 @@ uint32_t wlan_watchdog_duration;
 /* FIXME */
 volatile uint8_t SPARK_WLAN_RESET;
 volatile uint8_t SPARK_WLAN_SLEEP;
+volatile uint8_t SPARK_WLAN_CONNECT_RESTORE;
 volatile uint8_t SPARK_WLAN_STARTED;
 extern int cfod_count;
 

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -60,11 +60,11 @@ network_status_t system_sleep_network_suspend(network_interface_index index) {
     status.suspended = true;
 
     // Disconnect from network
-    if (network_connecting(index, 0, NULL) || network_ready(index, 0, NULL)) {
-        if (network_connecting(index, 0, NULL)) {
+    if (network_connecting(index, 0, nullptr) || network_ready(index, 0, nullptr)) {
+        if (network_connecting(index, 0, nullptr)) {
             network_connect_cancel(index, 1, 0, 0);
         }
-        network_disconnect(index, NETWORK_DISCONNECT_REASON_SLEEP, NULL);
+        network_disconnect(index, NETWORK_DISCONNECT_REASON_SLEEP, nullptr);
         status.connected = true;
     }
 
@@ -101,8 +101,11 @@ int system_sleep_network_resume(network_interface_index index, network_status_t 
      * if single threaded, or this function is invoked synchronously by the system thread if system threading
      * is enabled. In both case, that would block the user application. Setting a flag here to unblock the user
      * application and restore the connection later. */
-    if (status.on || status.connected) {
+    if (status.on) {
         SPARK_WLAN_SLEEP = 0;
+    }
+    if (status.connected) {
+        SPARK_WLAN_CONNECT_RESTORE = 1;
     }
 #else
     if (status.on) {
@@ -254,7 +257,7 @@ int system_sleep_ext(const hal_sleep_config_t* config, hal_wakeup_source_base_t*
 #if HAL_PLATFORM_GEN == 2
     // Cancel current connection attempt to unblock the system thread
     // on Gen 2 platforms
-    if (network_connecting(NETWORK_INTERFACE_ALL, 0, NULL)) {
+    if (network_connecting(NETWORK_INTERFACE_ALL, 0, nullptr)) {
         network_connect_cancel(NETWORK_INTERFACE_ALL, 1, 0, 0);
     }
 #endif // HAL_PLATFORM_GEN == 2

--- a/system/src/system_sleep_compat.cpp
+++ b/system/src/system_sleep_compat.cpp
@@ -64,7 +64,9 @@ static void network_resume() {
     if (wakeupState.wifi) {
         SPARK_WLAN_SLEEP = 0;
     }
-    // Set the system flags that triggers the wifi/cloud reconnection in the background loop
+    // Gen2-only: Set the system flags that triggers the wifi/cloud reconnection in the background loop
+    // FIXME: Gen3 won't automatically restore the modem state and network connection if cloud auto-connect flag is not set.
+    // See manage_network_connection() in system_network_manager_api.cpp.
     if (wakeupState.wifiConnected) {
         SPARK_WLAN_CONNECT_RESTORE = 1;
     }

--- a/system/src/system_sleep_compat.cpp
+++ b/system/src/system_sleep_compat.cpp
@@ -52,20 +52,25 @@ static void network_suspend() {
 
     wakeupState.cloud = spark_cloud_flag_auto_connect();
     wakeupState.wifi = !SPARK_WLAN_SLEEP;
-    wakeupState.wifiConnected = wakeupState.cloud || network_ready(0, 0, NULL) || network_connecting(0, 0, NULL);
+    wakeupState.wifiConnected = wakeupState.cloud || network_ready(0, 0, nullptr) || network_connecting(0, 0, nullptr);
     // Disconnect the cloud and the network
-    network_disconnect(0, NETWORK_DISCONNECT_REASON_SLEEP, NULL);
+    network_disconnect(0, NETWORK_DISCONNECT_REASON_SLEEP, nullptr);
     // Clear the auto connect status
     spark_cloud_flag_disconnect();
-    network_off(0, 0, 0, NULL);
+    network_off(0, 0, 0, nullptr);
 }
 
 static void network_resume() {
-    // Set the system flags that triggers the wifi/cloud reconnection in the background loop
-    if (wakeupState.wifiConnected || wakeupState.wifi)  // at present, no way to get the background loop to only turn on wifi.
+    if (wakeupState.wifi) {
         SPARK_WLAN_SLEEP = 0;
-    if (wakeupState.cloud)
+    }
+    // Set the system flags that triggers the wifi/cloud reconnection in the background loop
+    if (wakeupState.wifiConnected) {
+        SPARK_WLAN_CONNECT_RESTORE = 1;
+    }
+    if (wakeupState.cloud) {
         spark_cloud_flag_connect();
+    }
 }
 
 /*******************************************************************************
@@ -205,8 +210,8 @@ int system_sleep_impl(Spark_Sleep_TypeDef sleepMode, long seconds, uint32_t para
 #if HAL_PLATFORM_SETUP_BUTTON_UX
         case SLEEP_MODE_SOFTPOWEROFF:
             if (!networkTurnedOff) {
-                network_disconnect(0, NETWORK_DISCONNECT_REASON_SLEEP, NULL);
-                network_off(0, 0, 0, NULL);
+                network_disconnect(0, NETWORK_DISCONNECT_REASON_SLEEP, nullptr);
+                network_off(0, 0, 0, nullptr);
             }
             return system_sleep_enter_standby_compat(seconds, param);
 #endif


### PR DESCRIPTION
### Problem
1. If the modem is just turned on by `Network.on()` and there is something wrong processing the modem events to cause a WLAN_WD to fire or somehow the `SPARK_WLAN_RESET` is set to reset the modem, device will try connecting to the network after the modem is reset.
2. If the modem is just turned on by `Network.on()` and system sleep API is called to make device enter sleep mode, after the device wakes up it will try connecting to the network. (Gen2 with all sleep API and Gen3 with sleep 1.0 API)
### Solution
Introduce a new flag to indicate if network connection should be restored after powering cycle the modem. The flag is set 
1. before the modem is reset if networking in connecting or ready:
```diff
--- a/system/src/system_network_compat.cpp
+++ b/system/src/system_network_compat.cpp
@@ -248,6 +249,7 @@ void manage_network_connection()
         {
             WARN("Resetting WLAN due to %s", (WLAN_WD_TO()) ? "WLAN_WD_TO()":((SPARK_WLAN_RESET) ? "SPARK_WLAN_RESET" : "SPARK_WLAN_SLEEP"));
             auto was_sleeping = SPARK_WLAN_SLEEP;
+            SPARK_WLAN_CONNECT_RESTORE = network_ready(0, 0, 0) || network_connecting(0, 0, 0);
             //auto was_disconnected = network.manual_disconnect();
````
2. after device wakes up if network needs to be restored:
```diff
--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -90,7 +90,12 @@ int system_sleep_network_resume(network_interface_index index, network_status_t&
      * if single threaded, or this function is invoked synchronously by the system thread if system threading
      * is enabled. In both case, that would block the user application. Setting a flag here to unblock the user
      * application and restore the connection later. */
-    SPARK_WLAN_SLEEP = 0;
+    if (status.on) {
+        SPARK_WLAN_SLEEP = 0;
+    }
+    if (status.connected) {
+        SPARK_WLAN_CONNECT_RESTORE = 1;
+    }
 #else
     if (status.on) {

--- a/system/src/system_sleep_compat.cpp
+++ b/system/src/system_sleep_compat.cpp
 static void network_resume() {
-    // Set the system flags that triggers the wifi/cloud reconnection in the background loop
-    if (wakeupState.wifiConnected || wakeupState.wifi)  // at present, no way to get the background loop to only turn on wifi.
+    if (wakeupState.wifi) {
         SPARK_WLAN_SLEEP = 0;
-    if (wakeupState.cloud)
+    }
+    // Set the system flags that triggers the wifi/cloud reconnection in the background loop
+    if (wakeupState.wifiConnected) {
+        SPARK_WLAN_CONNECT_RESTORE = 1;
+    }
+    if (wakeupState.cloud) {
         spark_cloud_flag_connect();
+    }
 }
```

Finally the `manage_network_connection()` will handle the connection accordingly:
```diff
--- a/system/src/system_network_compat.cpp
+++ b/system/src/system_network_compat.cpp
     else
     {
-        if (!SPARK_WLAN_STARTED || (spark_cloud_flag_auto_connect() && !network_ready(0, 0, 0)))
-        {
-            // INFO("Network Connect: %s", (!SPARK_WLAN_STARTED) ? "!SPARK_WLAN_STARTED" : "SPARK_CLOUD_CONNECT && !network.ready()");
+        if (!SPARK_WLAN_STARTED) {
+            INFO("Network On: !SPARK_WLAN_STARTED");
+            network_on(0, 0, 0, 0);
+        }
+
+        if ((SPARK_WLAN_CONNECT_RESTORE || spark_cloud_flag_auto_connect()) && !network_ready(0, 0, 0)) {
+            INFO("Network Connect:%s%s", (SPARK_WLAN_CONNECT_RESTORE ? " SPARK_WLAN_CONNECT_RESTORE" : " "),
+                                         (spark_cloud_flag_auto_connect() ? " spark_cloud_flag_auto_connect()" : " "));
+            // XXX: If the auto-connect flag is not set, we used to only call network_connect() once here,
+            // even if it failed to connect to network for whatever reason. So we should clear the flag here.
+            SPARK_WLAN_CONNECT_RESTORE = 0;
             network_connect(0, 0, 0, 0);
         } else {
```
### Steps to Test
1. Use an electron and detach the Cellular antenna. Comment out the sleep function in the example. The device should persist to connect to network after the modem is reset due to WLAN_WD expired.
2. Comment out the `Network.connect()` in the example. The device should not initiate connection after it wakes up.
3. Run the example without commenting out anything. The device should initiate connection to network after it wakes up.
### Example App
```c
#include "Particle.h"

SYSTEM_MODE(SEMI_AUTOMATIC);
SYSTEM_THREAD(ENABLED);

Serial1LogHandler l(115200, LOG_LEVEL_ALL);
time32_t start = 0;

void setup() {
    Log.info("Push async call to system thread");
    Network.on();

    waitUntil(Network.isOn);
    delay(3s);

    Network.connect();
    delay(1s);

    Log.info("System.sleep");
    System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::STOP).duration(5s));
    Log.info("System.sleep done");
}

void loop() {
}
```
### References
N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
