### PR TITLE
System: make sure that the power source being USB host is well detected

### DIFF
--- a/system/src/system_power_manager.cpp
+++ b/system/src/system_power_manager.cpp
@@ -70,6 +70,9 @@ constexpr uint16_t PMIC_FAULT_TERM_CHARGE_CURRENT = 128; // mA
 constexpr system_tick_t BATTERY_REPEATED_CHARGED_WINDOW = 5000; // ms
 constexpr uint8_t BATTERY_REPEATED_CHARGED_COUNT = 2;
 
+constexpr system_tick_t DPDM_PERIOD = 1000;
+constexpr uint8_t DPDM_RETRY_COUNT = 3;
+
 constexpr hal_power_config defaultPowerConfig = {
   .flags = 0,
   .version = 0,
@@ -321,10 +324,11 @@ void PowerManager::handleUpdate() {
         break;
     }
   } else {
-    if (g_batteryState == BATTERY_STATE_DISCHARGING) {
-      src = POWER_SOURCE_BATTERY;
-    } else {
-      src = POWER_SOURCE_UNKNOWN;
+    // Do not update power source if power is good and in DPDM
+    if (!pwr_good || !power.isInDPDM()) {
+      if (g_batteryState == BATTERY_STATE_DISCHARGING) {
+        src = POWER_SOURCE_BATTERY;
+      }
     }
   }
 
@@ -424,6 +428,7 @@ void PowerManager::loop(void* arg) {
     }
     self->checkWatchdog();
     self->deduceBatteryStateLoop();
+    self->runDpdm();
   }
 
 exit:
@@ -503,6 +508,27 @@ void PowerManager::initDefault(bool dpdm) {
   }
 
   clearIntermediateBatteryState(STATE_ALL);
+}
+
+void PowerManager::runDpdm() {
+  static system_tick_t lastRun = 0;
+
+  if (millis() - lastRun >= DPDM_PERIOD) {
+    lastRun = millis();
+    if (g_powerSource == POWER_SOURCE_VIN && HAL_USB_Get_State(nullptr) >= HAL_USB_STATE_POWERED) {
+      if (dpdmRetry_ >= DPDM_RETRY_COUNT) {
+        return;
+      }
+      PMIC power(true);
+      if (power.isInDPDM()) {
+        return;
+      }
+      power.enableDPDM();
+      dpdmRetry_++;
+    } else {
+      dpdmRetry_ = 0;
+    }
+  }
 }
 
 void PowerManager::confirmBatteryState(battery_state_t from, battery_state_t to) {

--- a/system/src/system_power_manager.h
+++ b/system/src/system_power_manager.h
@@ -66,6 +66,8 @@ private:
   void batteryStateTransitioningTo(battery_state_t targetState, bool count = true);
   void clearIntermediateBatteryState(uint8_t state);
 
+  void runDpdm();
+
   static power_source_t powerSourceFromStatus(uint8_t status);
 
 private:
@@ -107,6 +109,8 @@ private:
   uint8_t chargedFaultCount_ = 0;
   uint8_t repeatedChargedCount_ = 0;
   bool possibleChargedFault_ = false;
+
+  uint8_t dpdmRetry_ = 0;
 
   hal_power_config config_ = {};
 };


### PR DESCRIPTION
### Problem
This issue can be easily replicated on Tracker. 
1. Attached both battery and connect device to computer via USB cable
2. Unplug the USB cable and plug back again
3. The power source is detected as `VIN`, instead of `USB Host`

If there is a power source attached to the DC jack, pluging back USB cable won't update the power source either.
### Solution
When it detects the power source is `VIN` and the USB peripheral is powered, try to run DPDM in the system power management loop to make sure the USB host is correctly reported by PMIC
### Steps to Test
As steps to replicate the issue.
### Example App
```c
#include "Particle.h"

SYSTEM_THREAD(ENABLED);
SYSTEM_MODE(SEMI_AUTOMATIC);

Serial1LogHandler logHandler(115200, LOG_LEVEL_ALL);

constexpr char const* batteryStates[] = {
  "unknown", "not charging", "charging",
  "charged", "discharging", "fault", "disconnected"
};
constexpr char const* powerSources[] = {
  "unknown", "vin", "usb host", "usb adapter",
  "usb otg", "battery"
};

void setup() {
#if PLATFORM_ID == PLATFORM_TRACKER
  // We need to enable the CAN_5V to connect the Serial1 to M8.
  pinMode(CAN_PWR, OUTPUT);
  digitalWrite(CAN_PWR, HIGH);
#endif

  Serial1.begin(115200);
  Serial1.printlnf("Application started.");

  System.on(battery_state, [](system_event_t event, int data) -> void {
    Serial1.printlnf("battery_state: %s", batteryStates[std::max(0, data)]);
  });

  System.on(power_source, [](system_event_t event, int data) -> void {
    Serial1.printlnf("power_source: %s", powerSources[std::max(0, data)]);
  });
}

void loop() {
}
```

### References
- ch77765

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
