### PR TITLE
[photon/p1] wlan: make sure to close all sockets when deinitializing WICED connectivity subsystem

### DIFF
--- a/hal/src/photon/wlan_hal.cpp
+++ b/hal/src/photon/wlan_hal.cpp
@@ -556,6 +556,9 @@ int wlan_supplicant_stop()
 }
 
 int wlan_restart(void* reserved) {
+    // XXX: make sure to close all sockets, as wiced_wlan_connectivity_deinit() will deinitialize LwIP
+    // which in turn invalidates LwIP netconns in use by WICED sockets and our socket layer.
+    socket_close_all();
     wiced_wlan_connectivity_deinit();
     wiced_wlan_connectivity_init();
 

--- a/user/tests/wiring/no_fixture/wifi.cpp
+++ b/user/tests/wiring/no_fixture/wifi.cpp
@@ -300,6 +300,49 @@ test(WIFI_14_wifi_class_methods_work_correctly_when_wifi_interface_is_off) {
     assertTrue(!memcmp(bssidRef, bssid, sizeof(bssidRef)) || !memcmp(bssidRefFf, bssid, sizeof(bssidRefFf)));
 }
 
+#if HAL_PLATFORM_GEN == 2 // Photon and P1
+
+test(WIFI_15_entering_listening_mode_and_enabling_softap_closes_active_sockets_cleanly) {
+    const char testHost[] = "google.com";
+    const uint16_t testPort = 80;
+    const int resolveAttempts = 5;
+    const auto listenTime = 2s;
+
+    Serial.printlnf("on/connect");
+    WiFi.on();
+    WiFi.connect();
+    Particle.connect();
+    assertTrue(waitFor(Particle.connected, 30000));
+
+    IPAddress address;
+    for (int i = 0; i < resolveAttempts; i++) {
+        address = WiFi.resolve(testHost);
+        if (address) {
+            break;
+        }
+    }
+    assertNotEqual(address, 0);
+
+    TCPClient client;
+    assertEqual(1, client.connect(address, testPort));
+    assertTrue(client.connected());
+
+    WiFi.setListenTimeout(listenTime);
+    WiFi.listen(true);
+    if (system_thread_get_state(nullptr) == spark::feature::ENABLED) {
+        delay(listenTime);
+    }
+    WiFi.listen(false);
+
+    waitFor(Particle.connected, 30000);
+    assertFalse(client.connected());
+    client.stop();
+}
+
+#endif // HAL_PLATFORM_GEN == 2
+
 #endif // !HAL_PLATFORM_WIFI_SCAN_ONLY
+
+
 
 #endif


### PR DESCRIPTION
### Problem

Entering listening mode on Photon and P1 does not invalidate current sockets, while at the same time `wlan_restart()` will call into WICED to deinitialize LwIP stack, which invalidates netconns that are in use by WICED sockets and our socket layer.

Performing socket actions on a handle that has a reference to invalidated WICED socket/LwIP netconn may cause a crash.

### Solution

Make sure to call `socket_close_all()` in `wlan_restart()` to avoid getting into this state.

### Steps to Test

- `wiring/no_fixture`: `WIFI_15_entering_listening_mode_and_enabling_softap_closes_active_sockets_cleanly`

### Example App

N/A

### References

- [CH78867]

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
