### PR TITLE
[ci] fix MarkupSafe weirdness

### DIFF
--- a/ci/install_gcovr.sh
+++ b/ci/install_gcovr.sh
@@ -20,7 +20,9 @@ else
 fi
 
 
-pip3 install git+https://github.com/gcovr/gcovr.git
 pip3 install requests
+pip3 install git+https://github.com/gcovr/gcovr.git
+# FIXME: MarkupSafe is broken on python3.5
+ln -s /usr/local/lib/python3.5/dist-packages/MarkupSafe-0.0.0.dist-info /usr/local/lib/python3.5/dist-packages/MarkupSafe-2.0.0.dist-info
 
 gcovr --version


### PR DESCRIPTION
### Problem

CI fails when installing `gcovr` and its dependencies. See e.g. https://g.codefresh.io/build/609bcf2539bf357f8705df27

```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 635, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 943, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 834, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (MarkupSafe 0.0.0 (/usr/local/lib/python3.5/dist-packages), Requirement.parse('MarkupSafe>=2.0.0rc2'), {'jinja2'})

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/gcovr", line 5, in 
    from pkg_resources import load_entry_point
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2927, in 
    @_call_aside
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2913, in _call_aside
    f(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 2940, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 637, in _build_master
    return cls._build_from_requirements(__requires__)
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 650, in _build_from_requirements
    dists = ws.resolve(reqs, Environment())
  File "/usr/lib/python3/dist-packages/pkg_resources/__init__.py", line 829, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'MarkupSafe>=2.0.0rc2' distribution was not found and is required by jinja2 
```

### Solution

Don't ask.

### Steps to Test

CI build should succeed.

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
