### PR TITLE
Add system watchdog API for user applications

### DIFF
--- a/hal/inc/exrtc_hal.h
+++ b/hal/inc/exrtc_hal.h
@@ -49,6 +49,8 @@ int hal_exrtc_sleep_timer(system_tick_t ms, void* reserved);
 
 int hal_exrtc_calibrate_xt(int adjValue, void* reserved);
 
+void hal_exrtc_get_watchdog_limits(system_tick_t* low, system_tick_t* high, void* reserved);
+
 #ifdef __cplusplus
 }
 #endif

--- a/hal/inc/hal_dynalib.h
+++ b/hal/inc/hal_dynalib.h
@@ -24,6 +24,8 @@
 
 #include "dynalib.h"
 
+#include "hal_platform.h"
+
 #include "time_compat.h"
 
 #ifdef DYNALIB_EXPORT
@@ -33,6 +35,11 @@
 #include "timer_hal.h"
 #include "rtc_hal.h"
 #include "interrupts_hal.h"
+
+#if PLATFORM_ID == PLATFORM_TRACKER
+#include "exrtc_hal.h"
+#endif // PLATFORM_ID
+
 #endif
 
 /**
@@ -92,7 +99,17 @@ DYNALIB_FN(BASE_IDX + 22, hal, hal_timer_micros, uint64_t(void*))
 DYNALIB_FN(BASE_IDX + 23, hal, hal_rtc_get_time, int(struct timeval*, void*))
 DYNALIB_FN(BASE_IDX + 24, hal, hal_rtc_set_time, int(const struct timeval*, void*))
 
+#if PLATFORM_ID == PLATFORM_TRACKER
+DYNALIB_FN(BASE_IDX + 25, hal, hal_exrtc_enable_watchdog, int(system_tick_t, void*))
+DYNALIB_FN(BASE_IDX + 26, hal, hal_exrtc_feed_watchdog, int(void*))
+DYNALIB_FN(BASE_IDX + 27, hal, hal_exrtc_disable_watchdog, int(void*))
+DYNALIB_FN(BASE_IDX + 28, hal, hal_exrtc_get_watchdog_limits, void(system_tick_t*, system_tick_t*, void*))
+#define BASE_IDX2 (BASE_IDX + 29)
+#else
+#define BASE_IDX2 (BASE_IDX + 25)
+#endif
 
 DYNALIB_END(hal)
 
 #undef BASE_IDX
+#undef BASE_IDX2

--- a/hal/src/nRF52840/exrtc_hal.cpp
+++ b/hal/src/nRF52840/exrtc_hal.cpp
@@ -133,4 +133,13 @@ int hal_exrtc_calibrate_xt(int adjValue, void* reserved) {
     return Am18x5::getInstance().xtOscillatorDigitalCalibration(adjValue);
 }
 
+void hal_exrtc_get_watchdog_limits(system_tick_t* low, system_tick_t* high, void* reserved) {
+    if (low) {
+        *low = 63; // round(Am18x5WatchdogFrequency::HZ_16 * 1)
+    }
+    if (high) {
+        *high = 124000; // // round(Am18x5WatchdogFrequency::HZ_1_4 * 31)
+    }
+}
+
 #endif // HAL_PLATFORM_EXTERNAL_RTC


### PR DESCRIPTION
### Problem

Applications (tracker) must instantiate their own version of RTC drivers to manage the watchdog.  While the device OS handles synchronization of time and general RTC functions, it does not expose the RTC watchdog features, if any.  Application code size may be reduced by not having the additional/redundant driver for things that device OS may already handle.

### Solution

Expose the watchdog portions of the HAL RTC driver to the application so that the device OS can offer it without a separate application driver.  Four functions would be essential to support the watchdog:
1. Enable/configure
2. Disable
3. Reset/kick
4. Check limits of watchdog timeouts

### Steps to Test

1. Setup the watchdog per the user app below, observe that the device does not reset.
2. Comment out the inner `loop()` portion of code and observe the device resetting after 60 seconds.

### Example App

```c
#include "exrtc_hal.h"

constexpr system_tick_t WatchdogTimeout = 60 * 1000;  // Watchdog will expire after 60 seconds
constexpr unsigned int WatchdogKickTime = 10;  // Watchdog will be kicked every 10 seconds
static unsigned int kickTime = 0;

void setup() {
  hal_exrtc_enable_watchdog(WatchdogTimeout, nullptr);
  hal_exrtc_feed_watchdog(nullptr);
}

void loop() {
  if ((System.uptime() - kickTime) >= WatchdogKickTime) {
    kickTime = System.uptime();
    hal_exrtc_feed_watchdog(nullptr);
  }
}
```

### References

- [ch79352]