### PR TITLE
[Gen3] Support for SARA R410 - 05.12 firmware

### DIFF
--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -967,6 +967,126 @@ int SaraNcpClient::checkNetConfForImsi() {
     return SYSTEM_ERROR_TIMEOUT;
 }
 
+int SaraNcpClient::selectNetworkProf(ModemState& state) {
+    bool reset = false;
+    int resetCount = 0;
+    bool disableLowPowerModes = false;
+    // Note: Not failing on AT error on ICCID/IMSI lookup since SIMs have shown strange edge cases
+    // where they error for no reason, and hard resetting the modem or power cycling would not clear it.
+    //
+    // Check if we are using a Twilio Super SIM based on ICCID
+    char buf[32] = {};
+    int ccidCount = 0;
+    do {
+        memset(buf, 0, sizeof(buf));
+        auto lenCcid = getIccidImpl(buf, sizeof(buf));
+        if (lenCcid > 5) {
+            netConf_ = networkConfigForIccid(buf, lenCcid);
+            break;
+        }
+    } while (++ccidCount < CCID_MAX_RETRY_CNT);
+    // If failed above i.e., netConf_ is still not valid, look for network settings based on IMSI
+    if (!netConf_.isValid()) {
+        CHECK(checkNetConfForImsi());
+    }
+
+    do {
+        // Set UMNOPROF and UBANDMASK as appropriate based on SIM
+        auto respUmnoprof = parser_.sendCommand("AT+UMNOPROF?");
+        reset = false;
+        int curProf = static_cast<int>(UbloxSaraUmnoprof::NONE);
+        auto r = CHECK_PARSER(respUmnoprof.scanf("+UMNOPROF: %d", &curProf));
+        CHECK_PARSER_OK(respUmnoprof.readResult());
+        // First time setup, or switching between official SIM on wrong profile?
+        if (r == 1 && (static_cast<UbloxSaraUmnoprof>(curProf) == UbloxSaraUmnoprof::SW_DEFAULT ||
+                (netConf_.netProv() == CellularNetworkProvider::TWILIO &&
+                static_cast<UbloxSaraUmnoprof>(curProf) != UbloxSaraUmnoprof::STANDARD_EUROPE) ||
+                (netConf_.netProv() == CellularNetworkProvider::KORE_ATT &&
+                static_cast<UbloxSaraUmnoprof>(curProf) != UbloxSaraUmnoprof::ATT)) ) {
+            int newProf = static_cast<int>(UbloxSaraUmnoprof::SIM_SELECT);
+
+            // Hard code ATT for 05.12 firmware versions
+            if (netConf_.netProv() == CellularNetworkProvider::KORE_ATT) {
+                if (getAppFirmwareVersion() == UBLOX_NCP_R4_APP_FW_VERSION_0512) {
+                    newProf = static_cast<int>(UbloxSaraUmnoprof::ATT);
+                }
+            }
+            // TWILIO Super SIM
+            if (netConf_.netProv() == CellularNetworkProvider::TWILIO) {
+                // _oldFirmwarePresent: u-blox firmware 05.06* and 05.07* does not have
+                // UMNOPROF=100 available. Default to UMNOPROF=0 in that case.
+                if (oldFirmwarePresent_) {
+                    if (static_cast<UbloxSaraUmnoprof>(curProf) == UbloxSaraUmnoprof::SW_DEFAULT) {
+                        break;
+                    } else {
+                        newProf = static_cast<int>(UbloxSaraUmnoprof::SW_DEFAULT);
+                    }
+                } else {
+                    newProf = static_cast<int>(UbloxSaraUmnoprof::STANDARD_EUROPE);
+                }
+            }
+            // KORE AT&T or 3rd Party SIM
+            else {
+                // break out of do-while if we're trying to set SIM_SELECT a third time
+                if (resetCount >= 2) {
+                    LOG(WARN, "UMNOPROF=1 did not resolve a built-in profile, please check if UMNOPROF=100 is required!");
+                    break;
+                }
+            }
+
+            // Disconnect before making changes to the UMNOPROF
+            auto respCfun = parser_.sendCommand(UBLOX_CFUN_TIMEOUT, "AT+CFUN?");
+            int cfunVal = -1;
+            auto retCfun = CHECK_PARSER(respCfun.scanf("+CFUN: %d", &cfunVal));
+            CHECK_PARSER_OK(respCfun.readResult());
+            if (retCfun == 1 && cfunVal != 0) {
+                CHECK_PARSER_OK(parser_.execCommand(UBLOX_CFUN_TIMEOUT, "AT+CFUN=0,0"));
+            }
+            // This is a persistent setting
+            parser_.execCommand(1000, "AT+UMNOPROF=%d", newProf);
+            // Not checking for error since we will reset either way
+            reset = true;
+            disableLowPowerModes = true;
+        } else if (r == 1 && static_cast<UbloxSaraUmnoprof>(curProf) == UbloxSaraUmnoprof::STANDARD_EUROPE) {
+            auto respBand = parser_.sendCommand(UBLOX_UBANDMASK_TIMEOUT, "AT+UBANDMASK?");
+            uint64_t ubandUint64 = 0;
+            char ubandStr[24] = {};
+            auto retBand = CHECK_PARSER(respBand.scanf("+UBANDMASK: 0,%23[^,]", ubandStr));
+            CHECK_PARSER_OK(respBand.readResult());
+            if (netConf_.netProv() == CellularNetworkProvider::TWILIO && retBand == 1) {
+                char* pEnd = &ubandStr[0];
+                ubandUint64 = strtoull(ubandStr, &pEnd, 10);
+                // Only update if Twilio Super SIM and not set to correct bands
+                if (pEnd - ubandStr > 0 && ubandUint64 != 6170) {
+                    // Enable Cat-M1 bands 2,4,5,12 (AT&T), 13 (VZW) = 6170
+                    parser_.execCommand(UBLOX_UBANDMASK_TIMEOUT, "AT+UBANDMASK=0,6170");
+                    // Not checking for error since we will reset either way
+                    reset = true;
+                    disableLowPowerModes = false;
+                }
+            }
+        }
+        if (reset) {
+            CHECK_PARSER_OK(parser_.execCommand("AT+CFUN=15,0"));
+            HAL_Delay_Milliseconds(2000);
+
+            CHECK(waitAtResponseFromPowerOn(state));
+
+            // Checking for SIM readiness ensures that other related commands
+            // like IFC or PSM/eDRX won't error out
+            CHECK(checkSimReadiness());
+			// Prevent modem from immediately dropping into PSM/eDRX modes
+			// which (on 05.12) may be enabled as soon as the UMNOPROF has taken effect
+            if (disableLowPowerModes) {
+                // Not checking the error
+                disablePsmEdrx();
+            }
+        }
+    } while (reset && ++resetCount < 4); // Note: Twilio SIMs could take more than 2 tries in some error cases, others <= 2
+
+    return SYSTEM_ERROR_NONE;
+}
+
 int SaraNcpClient::selectSimCard(ModemState& state) {
     // Read current GPIO configuration
     int mode = -1;
@@ -1055,163 +1175,19 @@ int SaraNcpClient::selectSimCard(ModemState& state) {
         CHECK(waitAtResponseFromPowerOn(state));
     }
 
-    // Using numeric CME ERROR codes
-    // int r = CHECK_PARSER(parser_.execCommand("AT+CMEE=2"));
-    // CHECK_TRUE(r == AtResponse::OK, SYSTEM_ERROR_AT_NOT_OK);
-
-    int simState = 0;
-    unsigned attempts = 0;
-    for (attempts = 0; attempts < 10; attempts++) {
-        simState = checkSimCard();
-        if (!simState) {
-            break;
-        }
-        HAL_Delay_Milliseconds(1000);
-    }
-
-    if (simState != SYSTEM_ERROR_NONE) {
-        return simState;
-    }
-
-    if (attempts != 0 && ncpId() == PLATFORM_NCP_SARA_R410) {
-        // There was an error initializing the SIM
-        // This often leads to inability to talk over the data (PPP) muxed channel
-        // for some reason. Attempt to cycle the modem through minimal/full functional state.
-        // We only do this for R4-based devices, as U2-based modems seem to fail
-        // to change baudrate later on for some reason
-        CHECK_PARSER_OK(parser_.execCommand(UBLOX_CFUN_TIMEOUT, "AT+CFUN=0,0"));
-        CHECK_PARSER_OK(parser_.execCommand(UBLOX_CFUN_TIMEOUT, "AT+CFUN=1,0"));
-    }
-
-    if (ncpId() == PLATFORM_NCP_SARA_R410) {
-        int resetCount = 0;
-        bool disableLowPowerModes = false;
-        // Note: Not failing on AT error on ICCID/IMSI lookup since SIMs have shown strange edge cases
-        // where they error for no reason, and hard resetting the modem or power cycling would not clear it.
-        //
-        // Check if we are using a Twilio Super SIM based on ICCID
-        char buf[32] = {};
-        int ccidCount = 0;
-        do {
-            memset(buf, 0, sizeof(buf));
-            auto lenCcid = getIccidImpl(buf, sizeof(buf));
-            if (lenCcid > 5) {
-                netConf_ = networkConfigForIccid(buf, lenCcid);
-                break;
-            }
-        } while (++ccidCount < CCID_MAX_RETRY_CNT);
-        // If failed above i.e., netConf_ is still not valid, look for network settings based on IMSI
-        if (!netConf_.isValid()) {
-            CHECK(checkNetConfForImsi());
-        }
-
-        do {
-            // Set UMNOPROF and UBANDMASK as appropriate based on SIM
-            auto respUmnoprof = parser_.sendCommand("AT+UMNOPROF?");
-            reset = false;
-            int curProf = static_cast<int>(UbloxSaraUmnoprof::NONE);
-            auto r = CHECK_PARSER(respUmnoprof.scanf("+UMNOPROF: %d", &curProf));
-            CHECK_PARSER_OK(respUmnoprof.readResult());
-            // First time setup, or switching between official SIM on wrong profile?
-            if (r == 1 && (static_cast<UbloxSaraUmnoprof>(curProf) == UbloxSaraUmnoprof::SW_DEFAULT ||
-                    (netConf_.netProv() == CellularNetworkProvider::TWILIO &&
-                    static_cast<UbloxSaraUmnoprof>(curProf) != UbloxSaraUmnoprof::STANDARD_EUROPE) ||
-                    (netConf_.netProv() == CellularNetworkProvider::KORE_ATT &&
-                    static_cast<UbloxSaraUmnoprof>(curProf) != UbloxSaraUmnoprof::ATT)) ) {
-                int newProf = static_cast<int>(UbloxSaraUmnoprof::SIM_SELECT);
-                // Hard code ATT for 05.12 firmware versions
-                if (netConf_.netProv() == CellularNetworkProvider::KORE_ATT) {
-                    if (getAppFirmwareVersion() == UBLOX_NCP_R4_APP_FW_VERSION_0512) {
-                        newProf = static_cast<int>(UbloxSaraUmnoprof::ATT);
-                    }
-                }
-                // TWILIO Super SIM
-                if (netConf_.netProv() == CellularNetworkProvider::TWILIO) {
-                    // _oldFirmwarePresent: u-blox firmware 05.06* and 05.07* does not have
-                    // UMNOPROF=100 available. Default to UMNOPROF=0 in that case.
-                    if (oldFirmwarePresent_) {
-                        if (static_cast<UbloxSaraUmnoprof>(curProf) == UbloxSaraUmnoprof::SW_DEFAULT) {
-                            break;
-                        } else {
-                            newProf = static_cast<int>(UbloxSaraUmnoprof::SW_DEFAULT);
-                        }
-                    } else {
-                        newProf = static_cast<int>(UbloxSaraUmnoprof::STANDARD_EUROPE);
-                    }
-                }
-                // KORE AT&T or 3rd Party SIM
-                else {
-                    // break out of do-while if we're trying to set SIM_SELECT a third time
-                    if (resetCount >= 2) {
-                        LOG(WARN, "UMNOPROF=1 did not resolve a built-in profile, please check if UMNOPROF=100 is required!");
-                        break;
-                    }
-                }
-                // Disconnect before making changes to the UMNOPROF
-                auto respCfun = parser_.sendCommand(UBLOX_CFUN_TIMEOUT, "AT+CFUN?");
-                int cfunVal = -1;
-                auto retCfun = CHECK_PARSER(respCfun.scanf("+CFUN: %d", &cfunVal));
-                CHECK_PARSER_OK(respCfun.readResult());
-                if (retCfun == 1 && cfunVal != 0) {
-                    CHECK_PARSER_OK(parser_.execCommand(UBLOX_CFUN_TIMEOUT, "AT+CFUN=0,0"));
-                }
-
-                // This is a persistent setting
-                parser_.execCommand(1000, "AT+UMNOPROF=%d", newProf);
-                // Not checking for error since we will reset either way
-                reset = true;
-                disableLowPowerModes = true;
-            } else if (r == 1 && static_cast<UbloxSaraUmnoprof>(curProf) == UbloxSaraUmnoprof::STANDARD_EUROPE) {
-                auto respBand = parser_.sendCommand(UBLOX_UBANDMASK_TIMEOUT, "AT+UBANDMASK?");
-                uint64_t ubandUint64 = 0;
-                char ubandStr[24] = {};
-                auto retBand = CHECK_PARSER(respBand.scanf("+UBANDMASK: 0,%23[^,]", ubandStr));
-                CHECK_PARSER_OK(respBand.readResult());
-                if (netConf_.netProv() == CellularNetworkProvider::TWILIO && retBand == 1) {
-                    char* pEnd = &ubandStr[0];
-                    ubandUint64 = strtoull(ubandStr, &pEnd, 10);
-                    // Only update if Twilio Super SIM and not set to correct bands
-                    if (pEnd - ubandStr > 0 && ubandUint64 != 6170) {
-                        // Enable Cat-M1 bands 2,4,5,12 (AT&T), 13 (VZW) = 6170
-                        parser_.execCommand(UBLOX_UBANDMASK_TIMEOUT, "AT+UBANDMASK=0,6170");
-                        // Not checking for error since we will reset either way
-                        reset = true;
-                    }
-                }
-            }
-            if (reset) {
-                CHECK_PARSER_OK(parser_.execCommand("AT+CFUN=15,0"));
-                HAL_Delay_Milliseconds(2000);
-				// Radio sometimes takes a while to resetfrom CFUN=15
-                CHECK(waitAtResponseFromPowerOn(state, 6000));
-				// Prevent modem from immediately dropping into PSM/eDRX modes
-				// which (on 05.12) may be enabled as soon as the UMNOPROF has taken effect
-                if (disableLowPowerModes) {
-                    // Not checking the error
-                    disablePsmEdrx();
-                }
-            }
-        } while (reset && ++resetCount < 4); // Note: Twilio SIMs could take more than 2 tries in some error cases, others <= 2
-
-    }
+    // Checking for SIM readiness ensures that other related commands
+    // like IFC or PSM/eDRX won't error out
+    CHECK(checkSimReadiness(true));
 
     return SYSTEM_ERROR_NONE;
 }
 
 int SaraNcpClient::disablePsmEdrx() {
 
-    // Check SIM state as PSM command's readiness could depend on it
-    int simState = 0;
-    for (unsigned attempts = 0; attempts < 10; attempts++) {
-        simState = checkSimCard();
-        if (!simState) {
-            break;
-        }
-        HAL_Delay_Milliseconds(1000);
-    }
-    if (simState != SYSTEM_ERROR_NONE) {
-        return simState;
-    }
+    // XXX: In theory, it's good to check for SIM readiness as PSM/eDRX commands seem
+    // to depend on it's readiness. However, if we have reached this point, it means
+    // that sim readiness is already checked
+    // CHECK(checkSimReadiness());
 
     // Force Power Saving mode to be disabled
     //
@@ -1252,7 +1228,7 @@ int SaraNcpClient::disablePsmEdrx() {
     return SYSTEM_ERROR_NONE;
 }
 
-int SaraNcpClient::waitAtResponseFromPowerOn(ModemState& modemState, unsigned int timeout) {
+int SaraNcpClient::waitAtResponseFromPowerOn(ModemState& modemState) {
     // Make sure we reset back to using hardware serial port @ default baudrate
     muxer_.stop();
 
@@ -1273,31 +1249,17 @@ int SaraNcpClient::waitAtResponseFromPowerOn(ModemState& modemState, unsigned in
             modemState = ModemState::DefaultBaudrate;
         }
     } else {
-        r = waitAtResponse(timeout);
+        LOG_DEBUG(TRACE, "Trying at %d baud rate", attemptedBaudRate);
+        r = waitAtResponse(10000);
         if (r) {
-            LOG_DEBUG(INFO, "Trying UBLOX_NCP_DEFAULT_SERIAL_BAUDRATE");
             CHECK(serial_->setBaudRate(UBLOX_NCP_DEFAULT_SERIAL_BAUDRATE));
             CHECK(initParser(serial_.get()));
             skipAll(serial_.get());
             parser_.reset();
-            r = waitAtResponse(timeout);
+            LOG_DEBUG(TRACE, "Trying at %d baud rate", UBLOX_NCP_DEFAULT_SERIAL_BAUDRATE);
+            r = waitAtResponse(5000);
             if (!r) {
-                if (!(fwVersion_ >= UBLOX_NCP_R4_APP_FW_VERSION_NO_HW_FLOW_CONTROL_MIN &&
-                fwVersion_ <= UBLOX_NCP_R4_APP_FW_VERSION_NO_HW_FLOW_CONTROL_MAX)) {
-                    LOG_DEBUG(INFO, "Restoring UBLOX_NCP_RUNTIME_SERIAL_BAUDRATE_R4");
-                    r = changeBaudRate(UBLOX_NCP_RUNTIME_SERIAL_BAUDRATE_R4);
-                    if (r != SYSTEM_ERROR_NONE && r != SYSTEM_ERROR_AT_NOT_OK) {
-                        return r;
-                    }
-                    // Check that the modem is responsive at the new baudrate
-                    skipAll(serial_.get());
-                    r = waitAtResponse(timeout);
-                    if (!r) {
-                        modemState = ModemState::RuntimeBaudrate;
-                    }
-                }
-            } else {
-                 modemState = ModemState::DefaultBaudrate;
+                modemState = ModemState::DefaultBaudrate;
             }
         } else {
             modemState = ModemState::RuntimeBaudrate;
@@ -1342,18 +1304,10 @@ int SaraNcpClient::initReady(ModemState state) {
     oldFirmwarePresent_ = (fwVersion_ < UBLOX_NCP_R4_APP_FW_VERSION_LATEST_02B_01);
     // Select either internal or external SIM card slot depending on the configuration
     CHECK(selectSimCard(state));
-
     // Make sure flow control is enabled as well
     // NOTE: this should work fine on SARA R4 firmware revisions that don't support it as well
     CHECK_PARSER_OK(parser_.execCommand("AT+IFC=2,2"));
     CHECK(waitAtResponse(10000));
-
-    // Reformat the operator string to be numeric
-    // (allows the capture of `mcc` and `mnc`)
-    int r = CHECK_PARSER(parser_.execCommand("AT+COPS=3,2"));
-
-    // Enable packet domain error reporting
-    CHECK_PARSER_OK(parser_.execCommand("AT+CGEREP=1,0"));
 
     if (state != ModemState::MuxerAtChannel) {
         if (conf_.ncpIdentifier() != PLATFORM_NCP_SARA_R410) {
@@ -1374,11 +1328,22 @@ int SaraNcpClient::initReady(ModemState state) {
                 }
             }
         }
-
         // Check that the modem is responsive at the new baudrate
         skipAll(serial_.get(), 1000);
         CHECK(waitAtResponse(10000));
     }
+
+    // Select MNO and band profiles depending on the configuration
+    if (conf_.ncpIdentifier() == PLATFORM_NCP_SARA_R410) {
+        CHECK(selectNetworkProf(state));
+    }
+
+    // Reformat the operator string to be numeric
+    // (allows the capture of `mcc` and `mnc`)
+    int r = CHECK_PARSER(parser_.execCommand("AT+COPS=3,2"));
+
+    // Enable packet domain error reporting
+    CHECK_PARSER_OK(parser_.execCommand("AT+CGEREP=1,0"));
 
     if (ncpId() == PLATFORM_NCP_SARA_R410) {
         // Force Cat M1-only mode
@@ -1602,6 +1567,34 @@ int SaraNcpClient::checkSimCard() {
         return SYSTEM_ERROR_NONE;
     }
     return SYSTEM_ERROR_UNKNOWN;
+}
+
+int SaraNcpClient::checkSimReadiness(bool checkForRfReset) {
+    // Using numeric CME ERROR codes
+    // int r = CHECK_PARSER(parser_.execCommand("AT+CMEE=2"));
+    // CHECK_TRUE(r == AtResponse::OK, SYSTEM_ERROR_AT_NOT_OK);
+
+    int simState = 0;
+    unsigned attempts = 0;
+    for (attempts = 0; attempts < 10; attempts++) {
+        simState = checkSimCard();
+        if (!simState) {
+            break;
+        }
+        HAL_Delay_Milliseconds(1000);
+    }
+
+    if (checkForRfReset && attempts != 0 && ncpId() == PLATFORM_NCP_SARA_R410) {
+        // There was an error initializing the SIM
+        // This often leads to inability to talk over the data (PPP) muxed channel
+        // for some reason. Attempt to cycle the modem through minimal/full functional state.
+        // We only do this for R4-based devices, as U2-based modems seem to fail
+        // to change baudrate later on for some reason
+        CHECK_PARSER_OK(parser_.execCommand(UBLOX_CFUN_TIMEOUT, "AT+CFUN=0,0"));
+        CHECK_PARSER_OK(parser_.execCommand(UBLOX_CFUN_TIMEOUT, "AT+CFUN=1,0"));
+    }
+
+    return (simState == 0 ? SYSTEM_ERROR_NONE : simState);
 }
 
 int SaraNcpClient::configureApn(const CellularNetworkConfig& conf) {

--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -1075,8 +1075,8 @@ int SaraNcpClient::selectNetworkProf(ModemState& state) {
             // Checking for SIM readiness ensures that other related commands
             // like IFC or PSM/eDRX won't error out
             CHECK(checkSimReadiness());
-			// Prevent modem from immediately dropping into PSM/eDRX modes
-			// which (on 05.12) may be enabled as soon as the UMNOPROF has taken effect
+            // Prevent modem from immediately dropping into PSM/eDRX modes
+            // which (on 05.12) may be enabled as soon as the UMNOPROF has taken effect
             if (disableLowPowerModes) {
                 // Not checking the error
                 disablePsmEdrx();

--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -1268,7 +1268,7 @@ int SaraNcpClient::waitAtResponseFromPowerOn(ModemState& modemState, unsigned in
     int r = SYSTEM_ERROR_TIMEOUT;
 
     if (ncpId() != PLATFORM_NCP_SARA_R410) {
-        r = waitAtResponse(10000);
+        r = waitAtResponse(20000);
         if (!r) {
             modemState = ModemState::DefaultBaudrate;
         }

--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -1187,6 +1187,7 @@ int SaraNcpClient::selectSimCard(ModemState& state) {
 				// Prevent modem from immediately dropping into PSM/eDRX modes
 				// which (on 05.12) may be enabled as soon as the UMNOPROF has taken effect
                 if (disableLowPowerModes) {
+                    // Not checking the error
                     disablePsmEdrx();
                 }
             }
@@ -1274,7 +1275,7 @@ int SaraNcpClient::waitAtResponseFromPowerOn(ModemState& modemState, unsigned in
     } else {
         r = waitAtResponse(timeout);
         if (r) {
-            LOG(INFO, "Trying UBLOX_NCP_DEFAULT_SERIAL_BAUDRATE");
+            LOG_DEBUG(INFO, "Trying UBLOX_NCP_DEFAULT_SERIAL_BAUDRATE");
             CHECK(serial_->setBaudRate(UBLOX_NCP_DEFAULT_SERIAL_BAUDRATE));
             CHECK(initParser(serial_.get()));
             skipAll(serial_.get());
@@ -1283,7 +1284,7 @@ int SaraNcpClient::waitAtResponseFromPowerOn(ModemState& modemState, unsigned in
             if (!r) {
                 if (!(fwVersion_ >= UBLOX_NCP_R4_APP_FW_VERSION_NO_HW_FLOW_CONTROL_MIN &&
                 fwVersion_ <= UBLOX_NCP_R4_APP_FW_VERSION_NO_HW_FLOW_CONTROL_MAX)) {
-                    LOG(INFO, "Restoring UBLOX_NCP_RUNTIME_SERIAL_BAUDRATE_R4");
+                    LOG_DEBUG(INFO, "Restoring UBLOX_NCP_RUNTIME_SERIAL_BAUDRATE_R4");
                     r = changeBaudRate(UBLOX_NCP_RUNTIME_SERIAL_BAUDRATE_R4);
                     if (r != SYSTEM_ERROR_NONE && r != SYSTEM_ERROR_AT_NOT_OK) {
                         return r;
@@ -1399,7 +1400,7 @@ int SaraNcpClient::initReady(ModemState state) {
         }
 
         // Disable Cat-M1 low power modes
-        disablePsmEdrx();
+        CHECK(disablePsmEdrx());
 
     } else {
         // Force Power Saving mode to be disabled

--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -1740,6 +1740,12 @@ int SaraNcpClient::enterDataMode() {
     skipAll(muxerDataStream_.get());
     muxerDataStream_->enabled(true);
 
+    // There is some kind of a bug in 02.19 R410 modem firmware in where it does not accept
+    // any AT commands over the second muxed channel, unless we send something over channel 1 first.
+    if (ncpId() == PLATFORM_NCP_SARA_R410) {
+        CHECK(waitAtResponse(parser_, 5000));
+    }
+
     CHECK_TRUE(muxer_.setChannelDataHandler(UBLOX_NCP_PPP_CHANNEL, muxerDataStream_->channelDataCb, muxerDataStream_.get()) == 0, SYSTEM_ERROR_INTERNAL);
     // Send data mode break
     if (ncpId() != PLATFORM_NCP_SARA_R410) {

--- a/hal/network/ncp_client/sara/sara_ncp_client.h
+++ b/hal/network/ncp_client/sara/sara_ncp_client.h
@@ -157,7 +157,8 @@ private:
     int modemSetUartState(bool state) const;
     void waitForPowerOff();
     int getAppFirmwareVersion();
-    int waitAtResponseFromPowerOn(ModemState& modemState);
+    int waitAtResponseFromPowerOn(ModemState& modemState, unsigned int timeout = 10000);
+    int disablePsmEdrx();
 };
 
 inline AtParser* SaraNcpClient::atParser() {

--- a/hal/network/ncp_client/sara/sara_ncp_client.h
+++ b/hal/network/ncp_client/sara/sara_ncp_client.h
@@ -129,6 +129,7 @@ private:
     int waitAtResponse(unsigned int timeout, unsigned int period = 1000);
     int waitAtResponse(AtParser& parser, unsigned int timeout, unsigned int period = 1000);
     int selectSimCard(ModemState& state);
+    int selectNetworkProf(ModemState& state);
     int checkSimCard();
     int configureApn(const CellularNetworkConfig& conf);
     int registerNet();
@@ -157,8 +158,9 @@ private:
     int modemSetUartState(bool state) const;
     void waitForPowerOff();
     int getAppFirmwareVersion();
-    int waitAtResponseFromPowerOn(ModemState& modemState, unsigned int timeout = 10000);
+    int waitAtResponseFromPowerOn(ModemState& modemState);
     int disablePsmEdrx();
+    int checkSimReadiness(bool checkForRfReset = false);
 };
 
 inline AtParser* SaraNcpClient::atParser() {


### PR DESCRIPTION
### Differences between 05.12 and older versions

1. The SIM select functionality for Kore ATT defaults the MNO profile to 198 (which does not support ATT band 5) which for older radio firmware defaults to UMNOPROF:2 (which supports Band 5 along with other ATT bands) [ch78344](https://app.clubhouse.io/particle/story/78344/r410-05-12-umnoprof-s-kore-att-equivalent-now-defaults-to-198-instead-of-2)
2. Radio does not respond over data channel after some cold boot runs [ch78322](https://app.clubhouse.io/particle/story/78322/r410-05-12-radio-does-not-respond-over-data-channel-after-some-cold-boot-runs)
3. PSM/eDRX are enabled by default with UMNOPROF=100. Disable it before (it's idle timer expires when) AT becomes unresponsive [ch78529](https://app.clubhouse.io/particle/story/78529/r410-05-12-psm-enabled-by-default-with-umnoprof-100-disable-it-before-it-s-idle-timer-expires-when-at-becomes-unresponsive)

### Changes / Features

1. Hard code UMNOPROF to 2 (ATT) if Kore ATT is detected on this radio firmware
2. There is some kind of a bug in 02.19 R410 modem firmware in where it does not accept any AT commands over the second muxed channel, unless we send something over channel 1 first. Separately, [fixed resumeChannel in gsm0710muxer](https://github.com/particle-iot/gsm0710muxer/pull/9/files) which is potentially related.
3. Refactor sim selection and umnoprof code such that we are setting the hardware flow control (using IFC=2,2) and the run time baud rate as soon as possible (after sim is ready), which prevents longer wait times when the radio recovers from a reset, potentially prevents PSM taking over (and AT becoming unresponsive)

### Steps to Test

Which unit/integration/application tests are applicable to this code change? (At minimum a test of some kind should be provided)

### Example App
#### 1. Kore ATT SIMs
Test with Kore ATT SIM and ensure UMNOPROF: 2 is selected

#### 2. Cold boot data channel responsiveness
Use any tinker-like app, cold boot the device, check if the modem is responding to AT interface over data channel every single run. May need to test multiple times as it's not reproducible every run.

#### 3. Verify PSM does not take over after EFS backup/restore
1. Use Twilio SIM which sets the UMNOPROF=100 (which enables PSM by default)
2. Use three clicks (backup) followed by four clicks (restore), and ensure the modem recovers without getting stuck in AT unresponsive state.

```c
#include "Particle.h"

Serial1LogHandler log1Handler(115200, LOG_LEVEL_ALL);
SerialLogHandler logHandler(LOG_LEVEL_ALL);

SYSTEM_MODE(SEMI_AUTOMATIC);

bool clicks_3 = false;
bool clicks_4 = false;
bool clicks_5 = false;

void button_handler(system_event_t event, int clicks) {
    if (event == button_final_click) {
        if (clicks == 3) {
            clicks_3 = true;
        } else if (clicks == 4) {
            clicks_4 = true;
        } else if (clicks == 5) {
            clicks_5 = true;
        }
    }
}

void setup() {
    System.on(button_final_click, button_handler);
    waitUntil(Serial.isConnected);
    // Cellular.setActiveSim(EXTERNAL_SIM);
    // Cellular.setActiveSim(INTERNAL_SIM);
    Particle.connect();
}

void loop() {
    if (clicks_3 || clicks_4 || clicks_5) {
        if (clicks_3) {
            Log.info("\r\n\r\nAT+UBKUPDATA?");
            Cellular.command(1000, "AT+UBKUPDATA?\r\n");
        } else if (clicks_4) {
            Log.info("\r\n\r\nAT+UBKUPDATA=r");
            Cellular.command(1000, "AT+UBKUPDATA=r\r\n");
        } else if (clicks_5) {
            Log.info("\r\n\r\nAT+UBKUPDATA");
            Cellular.command(1000, "AT+UBKUPDATA\r\n");
        }
        clicks_3 = false;
        clicks_4 = false;
        clicks_5 = false;

        uint32_t start = millis();
        while (millis() - start < 20000UL) {
            if (RESP_OK == Cellular.command(1000, "AT\r\n")) {
                break;
            }
        }
    }
}
```

### References

- [ch78529](https://app.clubhouse.io/particle/story/78529/r410-05-12-psm-enabled-by-default-with-umnoprof-100-disable-it-before-it-s-idle-timer-expires-when-at-becomes-unresponsive)
- [ch78322](https://app.clubhouse.io/particle/story/78322/r410-05-12-radio-does-not-respond-over-data-channel-after-some-cold-boot-runs)
- [ch78344](https://app.clubhouse.io/particle/story/78344/r410-05-12-umnoprof-s-kore-att-equivalent-now-defaults-to-198-instead-of-2)

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
