### PR TITLE
[Gen2] Support for SARA R410 05.12 firmware

### DIFF
--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1154,8 +1154,10 @@ bool MDMParser::init(DevStatus* status)
             // KORE AT&T or 3rd Party SIM
             else {
                 // Hard code ATT for 05.12 firmware versions
-                if (strstr(_verExtended, "L0.0.00.00.05.12")) {
-                    newProf = UBLOX_SARA_UMNOPROF_ATT;
+                if (netProv == CELLULAR_NETPROV_KORE_ATT) {
+                    if (strstr(_verExtended, "L0.0.00.00.05.12")) {
+                        newProf = UBLOX_SARA_UMNOPROF_ATT;
+                    }
                 }
                 // continue on with init if we are trying to set SIM_SELECT or hard-coding ATT a third time
                 if (_resetFailureAttempts >= 2) {

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1137,17 +1137,6 @@ bool MDMParser::init(DevStatus* status)
         {
             bool continueInit = false;
             int newProf = UBLOX_SARA_UMNOPROF_SIM_SELECT;
-            // Hard code ATT for 05.12 firmware versions
-            if (strstr(_verExtended, "L0.0.00.00.05.12")) {
-                if (netProv == CELLULAR_NETPROV_KORE_ATT) {
-                    newProf = UBLOX_SARA_UMNOPROF_ATT;
-                    // continue on with init if we are trying to set SIM_SELECT a third time
-                    if (_resetFailureAttempts >= 2) {
-                        LOG(WARN, "Hard coding to UMNOPROF=2 did not work, please check if UMNOPROF=100 is required!");
-                        continueInit = true;
-                    }
-                }
-            }
             // TWILIO Super SIM
             if (netProv == CELLULAR_NETPROV_TWILIO) {
                 // _oldFirmwarePresent: u-blox firmware 05.06* and 05.07* does not have
@@ -1164,7 +1153,11 @@ bool MDMParser::init(DevStatus* status)
             }
             // KORE AT&T or 3rd Party SIM
             else {
-                // continue on with init if we are trying to set SIM_SELECT a third time
+                // Hard code ATT for 05.12 firmware versions
+                if (strstr(_verExtended, "L0.0.00.00.05.12")) {
+                    newProf = UBLOX_SARA_UMNOPROF_ATT;
+                }
+                // continue on with init if we are trying to set SIM_SELECT or hard-coding ATT a third time
                 if (_resetFailureAttempts >= 2) {
                     LOG(WARN, "UMNOPROF=1 did not resolve a built-in profile, please check if UMNOPROF=100 is required!");
                     continueInit = true;
@@ -1181,7 +1174,7 @@ bool MDMParser::init(DevStatus* status)
                     if (RESP_OK != waitFinalResp(nullptr, nullptr, CFUN_TIMEOUT)) {
                         goto failure;
                     }
-                    waitFinalResp(nullptr, nullptr, 1000); // delay and pump URCs a bit to wait for disconnect
+                    waitFinalResp(nullptr, nullptr, 1200); // delay and pump URCs a bit to wait for disconnect
                 }
                 sendFormated("AT+UMNOPROF=%d\r\n", newProf);
                 waitFinalResp(nullptr, nullptr, UMNOPROF_TIMEOUT);

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1137,6 +1137,17 @@ bool MDMParser::init(DevStatus* status)
         {
             bool continueInit = false;
             int newProf = UBLOX_SARA_UMNOPROF_SIM_SELECT;
+            // Hard code ATT for 05.12 firmware versions
+            if (strstr(_verExtended, "L0.0.00.00.05.12")) {
+                if (netProv == CELLULAR_NETPROV_KORE_ATT) {
+                    newProf = UBLOX_SARA_UMNOPROF_ATT;
+                    // continue on with init if we are trying to set SIM_SELECT a third time
+                    if (_resetFailureAttempts >= 2) {
+                        LOG(WARN, "Hard coding to UMNOPROF=2 did not work, please check if UMNOPROF=100 is required!");
+                        continueInit = true;
+                    }
+                }
+            }
             // TWILIO Super SIM
             if (netProv == CELLULAR_NETPROV_TWILIO) {
                 // _oldFirmwarePresent: u-blox firmware 05.06* and 05.07* does not have


### PR DESCRIPTION
### Problem

The SIM select functionality for Kore ATT defaults the MNO profile to 198 (which does not support ATT band 5) which for older radio firmware defaults to UMNOPROF:2 (which supports Band 5 along with other ATT bands) [ch78344](https://app.clubhouse.io/particle/story/78344/r410-05-12-umnoprof-s-kore-att-equivalent-now-defaults-to-198-instead-of-2)

### Solution

Hard code UMNOPROF to 2 (ATT) if Kore ATT is detected on this radio firmware

### Steps to Test

Test any tinker-like app with Kore ATT SIM and ensure UMNOPROF: 2 is selected

### References

Links to the Community, Docs, Other Issues, etc..

- [ch78344](https://app.clubhouse.io/particle/story/78344/r410-05-12-umnoprof-s-kore-att-equivalent-now-defaults-to-198-instead-of-2)

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
