### PR TITLE
[Gen3] 05.12 - Refactor logic that hard codes UMNOPROF for Kore ATT

### DIFF
--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -1075,7 +1075,6 @@ int SaraNcpClient::selectNetworkProf(ModemState& state) {
             // Prevent modem from immediately dropping into PSM/eDRX modes
             // which (on 05.12) may be enabled as soon as the UMNOPROF has taken effect
             if (disableLowPowerModes) {
-                // Not checking the error
                 CHECK(disablePsmEdrx());
             }
         }

--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -1004,19 +1004,6 @@ int SaraNcpClient::selectNetworkProf(ModemState& state) {
                 (netConf_.netProv() == CellularNetworkProvider::KORE_ATT &&
                 static_cast<UbloxSaraUmnoprof>(curProf) != UbloxSaraUmnoprof::ATT)) ) {
             int newProf = static_cast<int>(UbloxSaraUmnoprof::SIM_SELECT);
-
-            // Hard code ATT for 05.12 firmware versions
-            if (fwVersion_ == UBLOX_NCP_R4_APP_FW_VERSION_0512) {
-                if (netConf_.netProv() == CellularNetworkProvider::KORE_ATT) {
-                    newProf = static_cast<int>(UbloxSaraUmnoprof::ATT);
-                    // break out of do-while if we're trying to set ATT a third time
-                    if (resetCount >= 2) {
-                        LOG(WARN, "Hard coding to UMNOPROF=2 did not work, please check if UMNOPROF=100 is required!");
-                        break;
-                    }
-                }
-            }
-
             // TWILIO Super SIM
             if (netConf_.netProv() == CellularNetworkProvider::TWILIO) {
                 // _oldFirmwarePresent: u-blox firmware 05.06* and 05.07* does not have
@@ -1033,6 +1020,10 @@ int SaraNcpClient::selectNetworkProf(ModemState& state) {
             }
             // KORE AT&T or 3rd Party SIM
             else {
+                // Hard code ATT for 05.12 firmware versions
+                if (fwVersion_ == UBLOX_NCP_R4_APP_FW_VERSION_0512) {
+                    newProf = static_cast<int>(UbloxSaraUmnoprof::ATT);
+                }
                 // break out of do-while if we're trying to set SIM_SELECT a third time
                 if (resetCount >= 2) {
                     LOG(WARN, "UMNOPROF=1 did not resolve a built-in profile, please check if UMNOPROF=100 is required!");

--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -1022,7 +1022,9 @@ int SaraNcpClient::selectNetworkProf(ModemState& state) {
             else {
                 // Hard code ATT for 05.12 firmware versions
                 if (fwVersion_ == UBLOX_NCP_R4_APP_FW_VERSION_0512) {
-                    newProf = static_cast<int>(UbloxSaraUmnoprof::ATT);
+                    if (netConf_.netProv() == CellularNetworkProvider::KORE_ATT) {
+                        newProf = static_cast<int>(UbloxSaraUmnoprof::ATT);
+                    }
                 }
                 // break out of do-while if we're trying to set SIM_SELECT a third time
                 if (resetCount >= 2) {


### PR DESCRIPTION
### Description

Refactor logic that hard codes UMNOPROF for Kore ATT

### Steps to Test
Test any tinker-like app with Kore ATT SIM on the R410 05.12 firmware, and ensure UMNOPROF is set to 2 (ATT)

### References

- https://github.com/particle-iot/device-os/pull/2317
- https://github.com/particle-iot/device-os/pull/2318

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
