### PR TITLE
Print debug info in integration tests

### DIFF
--- a/user/tests/integration/communication/events/events.spec.js
+++ b/user/tests/integration/communication/events/events.spec.js
@@ -13,7 +13,7 @@ test('get_max_event_data_size', async function() {
 	const data = await this.particle.receiveEvent('max_event_data_size');
 	maxEventDataSize = Number.parseInt(data);
 	expect(maxEventDataSize).to.be.above(622); // Maximum supported size of event data in pre-3.0.0 Device OS
-	this.particle.log.verbose('Particle.maxEventDataSize() returned', maxEventDataSize);
+	console.log('Particle.maxEventDataSize() returned', maxEventDataSize);
 });
 
 test('verify_max_event_data_size', async function() {

--- a/user/tests/integration/communication/functions/functions.spec.js
+++ b/user/tests/integration/communication/functions/functions.spec.js
@@ -25,7 +25,7 @@ test('get_max_function_argument_size', async function() {
 	const data = await this.particle.receiveEvent('max_function_argument_size');
 	maxFunctionArgumentSize = Number.parseInt(data);
 	expect(maxFunctionArgumentSize).to.be.above(622); // Maximum supported size of a function argument in pre-3.0.0 Device OS
-	this.particle.log.verbose('Particle.maxFunctionArgumentSize() returned', maxFunctionArgumentSize);
+	console.log('Particle.maxFunctionArgumentSize() returned', maxFunctionArgumentSize);
 });
 
 test('call_function_and_check_return_value', async function() {

--- a/user/tests/integration/communication/variables/variables.spec.js
+++ b/user/tests/integration/communication/variables/variables.spec.js
@@ -89,7 +89,7 @@ test('get_max_variable_value_size', async function() {
 	const data = await this.particle.receiveEvent('max_variable_value_size');
 	maxVariableValueSize = Number.parseInt(data);
 	expect(maxVariableValueSize).to.be.above(794); // Maximum supported size of a variable value in pre-3.0.0 Device OS
-	this.particle.log.verbose('Particle.maxVariableValueSize() returned', maxVariableValueSize);
+	console.log('Particle.maxVariableValueSize() returned', maxVariableValueSize);
 });
 
 test('verify_max_variable_value_size', async function() {


### PR DESCRIPTION
### Problem

Verbose logs in integration tests are disabled by default.

### Solution

Use `console.log()` to print debug info.

### Steps to Test

Run `communication/*` integration tests.
