### PR TITLE
[build] force -Wreturn-type to always trigger an error

### DIFF
--- a/build/module-defaults.mk
+++ b/build/module-defaults.mk
@@ -50,6 +50,7 @@ CFLAGS += -MD -MP -MF $@.d
 CFLAGS += -ffunction-sections -fdata-sections -Wall -Wno-switch -Wno-error=deprecated-declarations -fmessage-length=0
 CFLAGS += -fno-strict-aliasing
 CFLAGS += -DSPARK=1 -DPARTICLE=1
+CFLAGS += -Werror=return-type
 
 CFLAGS += -Wundef
 


### PR DESCRIPTION
### Problem

Starting with GCC 9 not returning a value from a function declared to return non-void type will cause a hardfault. This is easily overlooked in applications where warnings are not promoted to errors by defaults.

### Solution

Force -Wreturn-type to always trigger an error even if building applications where warnings are not promoted to errors.

### Steps to Test

Test app should fail to build with an error.

### Example App

```c++
int test() {
}

/* executes once at startup */
void setup() {
	Log.info("%d", test());
}

/* executes continuously after setup() runs */
void loop() {

}
```

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
