### PR TITLE
feature/toolchain-bundleignore

### DIFF
--- a/.bundleignore
+++ b/.bundleignore
@@ -1,0 +1,15 @@
+**/.git
+/ci
+/docs
+/misc
+/scripts
+/test
+/build/target
+/third_party/nrf5_sdk/nrf5_sdk/examples
+/third_party/nrf5_sdk/nrf5_sdk/components/802_15_4
+/third_party/nrf5_sdk/nrf5_sdk/components/toolchain/cmsis/dsp
+/third_party/freertos/freertos/FreeRTOS/Demo
+/user/applications/tinker/target
+/.workbench/manifest.json
+/.workbench/intellisense/asom.json
+

--- a/.bundleignore
+++ b/.bundleignore
@@ -3,7 +3,6 @@
 /docs
 /misc
 /scripts
-/test
 /build/target
 /third_party/nrf5_sdk/nrf5_sdk/examples
 /third_party/nrf5_sdk/nrf5_sdk/components/802_15_4


### PR DESCRIPTION
### Problem

We need a way to specify files and directories which should be excluded from the toolchain dependency bundle used by the local compiler (as used by Particle Workbench, etc).

### Solution

A `.bundleignore` file stored at the root of the project / repo specifies files and directories which should be excluded from the toolchain bundle. Each line in a `.bundleignore` file specifies a glob pattern (as supported by [`node-glob`](https://github.com/isaacs/node-glob) / [`minimatch`](https://github.com/isaacs/minimatch)). Only the top-level `.bundleignore` file is considered, paths are resolved from the project root - e.g. `foo/**/*.baz` would target `/path/to/project/foo/bar.baz` and `/path/to/project/foo/bar/qux.baz`

### Steps to Test

see: https://github.com/particle-iot/cli/pull/44

### References

https://docs.particle.io/tutorials/developer-tools/workbench/#dependency-manager

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
