### PR TITLE
[Argon / Tracker] ESP32 MAC and firmware version caching; [Gen 3] Fixes non-MBR-based bootloader updates

### DIFF
--- a/hal/network/lwip/esp32/esp32_ncp_util.cpp
+++ b/hal/network/lwip/esp32/esp32_ncp_util.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+// FIXME
+#undef LOG_COMPILE_TIME_LEVEL
+
+#include "network/ncp/wifi/ncp.h"
+#include "network/ncp/wifi/wifi_network_manager.h"
+#include "network/ncp/wifi/wifi_ncp_client.h"
+#include "network/ncp/ncp_client.h"
+#include "system_cache.h"
+#include "check.h"
+#include <algorithm>
+
+namespace particle {
+
+using namespace particle::services;
+
+int wifiNcpUpdateCachedInfo(uint16_t version, MacAddress mac) {
+    uint16_t cached = 0;
+    int versionRes = SystemCache::instance().get(SystemCacheKey::WIFI_NCP_FIRMWARE_VERSION, &cached, sizeof(cached));
+    if (versionRes != sizeof(cached) || cached != version) {
+        LOG(INFO, "Updating ESP32 cached module version to %u", version);
+        versionRes = SystemCache::instance().set(SystemCacheKey::WIFI_NCP_FIRMWARE_VERSION, &version, sizeof(version));
+    }
+    MacAddress cachedMac = {};
+    int macRes = SystemCache::instance().get(SystemCacheKey::WIFI_NCP_MAC_ADDRESS, cachedMac.data, sizeof(cachedMac.data));
+    if (macRes != sizeof(cachedMac.data) || cachedMac != mac) {
+        char macStr[MAC_ADDRESS_STRING_SIZE + 1] = {};
+        macAddressToString(mac, macStr, sizeof(macStr));
+        LOG(INFO, "Updating ESP32 cached MAC to %s", macStr);
+        macRes = SystemCache::instance().set(SystemCacheKey::WIFI_NCP_MAC_ADDRESS, mac.data, sizeof(mac.data));
+    }
+    return std::min(macRes, versionRes);
+}
+
+int wifiNcpGetCachedMacAddress(MacAddress* ncpMac) {
+    MacAddress mac = INVALID_MAC_ADDRESS;
+    int res = SystemCache::instance().get(SystemCacheKey::WIFI_NCP_MAC_ADDRESS, mac.data, sizeof(mac.data));
+    if (res != sizeof(mac.data)) {
+        return SYSTEM_ERROR_BAD_DATA;
+    }
+    if (ncpMac) {
+        *ncpMac = mac;
+    }
+    return 0;
+}
+
+int wifiNcpGetCachedModuleVersion(uint16_t* ncpVersion) {
+    uint16_t version = 0;
+    int res = SystemCache::instance().get(SystemCacheKey::WIFI_NCP_FIRMWARE_VERSION, &version, sizeof(version));
+    if (res != sizeof(version)) {
+        return SYSTEM_ERROR_BAD_DATA;
+    }
+    LOG(TRACE, "Cached ESP32 NCP firmware version: %d", (int)version);
+    if (ncpVersion) {
+        *ncpVersion = version;
+    }
+    return 0;
+}
+
+int wifiNcpInvalidateInfoCache() {
+    LOG(TRACE, "Invalidating cached ESP32 NCP info");
+    int versionError = SystemCache::instance().del(SystemCacheKey::WIFI_NCP_FIRMWARE_VERSION);
+    int macError = SystemCache::instance().del(SystemCacheKey::WIFI_NCP_MAC_ADDRESS);
+    return std::min(macError, versionError);
+}
+
+} // particle

--- a/hal/network/lwip/esp32/esp32ncpnetif.h
+++ b/hal/network/lwip/esp32/esp32ncpnetif.h
@@ -74,7 +74,8 @@ private:
     static err_t initCb(netif *netif);
     err_t initInterface();
 
-    int queryMacAddress();
+    int queryMacAddress(MacAddress& mac);
+    int configureMacAddress();
     
     static void loop(void* arg);
 

--- a/hal/network/ncp/wifi/ncp.h
+++ b/hal/network/ncp/wifi/ncp.h
@@ -27,6 +27,6 @@ WifiNetworkManager* wifiNetworkManager();
 int wifiNcpGetCachedMacAddress(MacAddress* mac);
 int wifiNcpGetCachedModuleVersion(uint16_t* version);
 int wifiNcpInvalidateInfoCache();
-int wifiNcpUpdateCachedInfo(uint16_t version, MacAddress mac);
+int wifiNcpUpdateInfoCache(uint16_t version, MacAddress mac);
 
 } // particle

--- a/hal/network/ncp/wifi/ncp.h
+++ b/hal/network/ncp/wifi/ncp.h
@@ -18,9 +18,15 @@
 #pragma once
 
 #include "wifi_network_manager.h"
+#include "addr_util.h"
 
 namespace particle {
 
 WifiNetworkManager* wifiNetworkManager();
+
+int wifiNcpGetCachedMacAddress(MacAddress* mac);
+int wifiNcpGetCachedModuleVersion(uint16_t* version);
+int wifiNcpInvalidateInfoCache();
+int wifiNcpUpdateCachedInfo(uint16_t version, MacAddress mac);
 
 } // particle

--- a/hal/network/ncp/wifi/wifi_ncp_client.h
+++ b/hal/network/ncp/wifi/wifi_ncp_client.h
@@ -28,6 +28,7 @@ public:
     virtual int getNetworkInfo(WifiNetworkInfo* info) = 0;
     virtual int scan(WifiScanCallback callback, void* data) = 0;
     virtual int getMacAddress(MacAddress* addr) = 0;
+    virtual int getFirmwareModuleVersion(uint16_t* version) = 0;
 };
 
 } // particle

--- a/hal/network/ncp_client/esp32/esp32_ncp_client.cpp
+++ b/hal/network/ncp_client/esp32/esp32_ncp_client.cpp
@@ -33,9 +33,9 @@ LOG_SOURCE_CATEGORY("ncp.esp32.client");
 #include "stream_util.h"
 #include "str_util.h"
 #include "check.h"
+#include "ncp.h"
 
 #include <cstdlib>
-#include "system_cache.h"
 
 #define CHECK_PARSER(_expr) \
         ({ \
@@ -74,21 +74,6 @@ void espReset() {
 
 size_t espEscape(const char* src, char* dest, size_t destSize) {
     return escape(src, ",\"\\", '\\', dest, destSize);
-}
-
-int updateCachedNcpFirmwareVersion(uint16_t version) {
-#if HAL_PLATFORM_NCP_COUNT > 1
-    using namespace particle::services;
-
-    uint16_t cached = 0;
-    int r = SystemCache::instance().get(SystemCacheKey::WIFI_NCP_FIRMWARE_VERSION, &cached, sizeof(cached));
-    if (r == sizeof(cached) && cached == version) {
-        return 0;
-    }
-    return SystemCache::instance().set(SystemCacheKey::WIFI_NCP_FIRMWARE_VERSION, &version, sizeof(version));
-#else
-    return 0;
-#endif // HAL_PLATFORM_NCP_COUNT > 0
 }
 
 const auto ESP32_NCP_MAX_MUXER_FRAME_SIZE = 1536;
@@ -292,11 +277,7 @@ int Esp32NcpClient::getFirmwareVersionString(char* buf, size_t size) {
 int Esp32NcpClient::getFirmwareModuleVersion(uint16_t* ver) {
     const NcpClientLock lock(this);
     CHECK(checkParser());
-    const int r = getFirmwareModuleVersionImpl(ver);
-    if (!r) {
-        updateCachedNcpFirmwareVersion(*ver);
-    }
-    return r;
+    return getFirmwareModuleVersionImpl(ver);
 }
 
 int Esp32NcpClient::getFirmwareModuleVersionImpl(uint16_t* ver) {
@@ -491,6 +472,10 @@ int Esp32NcpClient::scan(WifiScanCallback callback, void* data) {
 int Esp32NcpClient::getMacAddress(MacAddress* addr) {
     const NcpClientLock lock(this);
     CHECK(checkParser());
+    return getMacAddressImpl(addr);
+}
+
+int Esp32NcpClient::getMacAddressImpl(MacAddress* addr) {
     auto resp = parser_.sendCommand("AT+GETMAC=0"); // WiFi station
     char addrStr[MAC_ADDRESS_STRING_SIZE + 1] = {};
     int r = CHECK_PARSER(resp.scanf("+GETMAC: \"%32[^\"]\"", addrStr));
@@ -576,7 +561,10 @@ int Esp32NcpClient::waitReady() {
 
 int Esp32NcpClient::initReady() {
     uint16_t mver = 0;
+    MacAddress mac = {};
     CHECK(getFirmwareModuleVersionImpl(&mver));
+    CHECK(getMacAddressImpl(&mac));
+    CHECK(wifiNcpUpdateCachedInfo(mver, mac));
 
     if (mver >= ESP32_NCP_MIN_MVER_WITH_CMUX) {
 #if HAL_PLATFORM_WIFI_NCP_SDIO

--- a/hal/network/ncp_client/esp32/esp32_ncp_client.cpp
+++ b/hal/network/ncp_client/esp32/esp32_ncp_client.cpp
@@ -564,7 +564,7 @@ int Esp32NcpClient::initReady() {
     MacAddress mac = {};
     CHECK(getFirmwareModuleVersionImpl(&mver));
     CHECK(getMacAddressImpl(&mac));
-    CHECK(wifiNcpUpdateCachedInfo(mver, mac));
+    CHECK(wifiNcpUpdateInfoCache(mver, mac));
 
     if (mver >= ESP32_NCP_MIN_MVER_WITH_CMUX) {
 #if HAL_PLATFORM_WIFI_NCP_SDIO

--- a/hal/network/ncp_client/esp32/esp32_ncp_client.h
+++ b/hal/network/ncp_client/esp32/esp32_ncp_client.h
@@ -101,6 +101,7 @@ private:
     void connectionState(NcpConnectionState state);
     void parserError(int error);
     int getFirmwareModuleVersionImpl(uint16_t* ver);
+    int getMacAddressImpl(MacAddress* addr);
     int espOff();
 };
 

--- a/hal/src/nRF52840/bootloader.cpp
+++ b/hal/src/nRF52840/bootloader.cpp
@@ -159,7 +159,7 @@ int DecompressStream::write(const char* buffer, const size_t length)  {
 int bootloader_update(const void* bootloader_image, unsigned length)
 {
     HAL_Bootloader_Lock(false);
-    int result = (FLASH_CopyMemory(FLASH_INTERNAL, (uint32_t)bootloader_image,
+    int result = (FLASH_CopyMemory(FLASH_SERIAL, (uint32_t)bootloader_image,
         FLASH_INTERNAL, BOOTLOADER_ADDR, length, MODULE_FUNCTION_BOOTLOADER,
         MODULE_VERIFY_DESTINATION_IS_START_ADDRESS|MODULE_VERIFY_CRC|MODULE_VERIFY_FUNCTION));
     HAL_Bootloader_Lock(true);
@@ -167,6 +167,8 @@ int bootloader_update(const void* bootloader_image, unsigned length)
 }
 
 #ifdef HAL_REPLACE_BOOTLOADER
+
+#error "This is currently broken due to removal of XIP support"
 
 /**
  * Manages upgrading the bootloader.

--- a/services/inc/addr_util.h
+++ b/services/inc/addr_util.h
@@ -29,6 +29,7 @@ struct MacAddress {
 };
 
 const MacAddress INVALID_MAC_ADDRESS = { { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff } };
+const MacAddress INVALID_ZERO_MAC_ADDRESS = { { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } };
 
 const size_t MAC_ADDRESS_STRING_SIZE = 17;
 

--- a/services/inc/system_cache.h
+++ b/services/inc/system_cache.h
@@ -22,7 +22,8 @@
 namespace particle { namespace services {
 
 enum class SystemCacheKey : uint16_t {
-    WIFI_NCP_FIRMWARE_VERSION = 0x0000
+    WIFI_NCP_FIRMWARE_VERSION = 0x0000,
+    WIFI_NCP_MAC_ADDRESS = 0x0001
 };
 
 class SystemCache {

--- a/services/src/system_cache.cpp
+++ b/services/src/system_cache.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "hal_platform.h"
+#include <limits>
 
 #if HAL_PLATFORM_FILESYSTEM
 
@@ -40,8 +41,8 @@ int SystemCache::get(SystemCacheKey key, void* value, size_t length) {
 }
 
 int SystemCache::set(SystemCacheKey key, const void* value, size_t length) {
-    CHECK_TRUE(length <= sizeof(uint16_t), SYSTEM_ERROR_TOO_LARGE);
-    return tlv_.set(to_underlying(key), (const uint8_t*)value, length);
+    CHECK_TRUE(length <= std::numeric_limits<uint16_t>::max(), SYSTEM_ERROR_TOO_LARGE);
+    return tlv_.set(to_underlying(key), (const uint8_t*)value, length, 0);
 }
 
 int SystemCache::del(SystemCacheKey key) {

--- a/services/src/tlv_file.cpp
+++ b/services/src/tlv_file.cpp
@@ -210,10 +210,15 @@ int TlvFile::del(uint16_t key, int index) {
 
     int ret = 0;
 
+    bool deleted = false;
+
     for (;;) {
         uint16_t dataSize = 0;
         ssize_t pos = find(key, index, &dataSize);
         if (pos < 0) {
+            if (index < 0 && deleted) {
+                return ret;
+            }
             return pos;
         }
 
@@ -279,6 +284,9 @@ int TlvFile::del(uint16_t key, int index) {
             break;
         }
 
+        if (!ret) {
+            deleted = true;
+        }
 
         if (ret || index >= 0) {
             break;


### PR DESCRIPTION
### Problem

1. Some changes in https://github.com/particle-iot/device-os/pull/2302 are now affecting the boot times of ESP32-based devices (mainly Argon) where ESP32 on bootup may be powered on and off multiple times to query version/MAC address.
2. Non-MBR-based bootloader updates are broken after https://github.com/particle-iot/device-os/pull/2302

### Solution

1. Cache both ESP32 fw version and MAC address and use cached values whenever possible
2. Use `SERIAL_FLASH` as source when replacing bootloader without using MBR

### Steps to Test

1. Boot up Argon and Tracker in `SEMI_AUTOMATIC` mode and make sure that ESP32 is not powered on after the version/MAC have been cached
2. Downgrade bootloader using a debugger to < 2.0.0 version while keeping system part etc on this branch. Make sure SMH correctly updates the bootloader.

### Example App

N/A

### References

- https://github.com/particle-iot/device-os/pull/2302

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
