### PR TITLE
Prevent ICCID errors by using CFUN=4 instead of CFUN=0

### DIFF
--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -548,7 +548,7 @@ int QuectelNcpClient::getIccid(char* buf, size_t size) {
     auto retCfun = CHECK_PARSER(respCfun.scanf("+CFUN: %d", &cfunVal));
     CHECK_PARSER_OK(respCfun.readResult());
     if (retCfun == 1 && cfunVal == 0) {
-        CHECK_PARSER_OK(parser_.execCommand(QUECTEL_CFUN_TIMEOUT, "AT+CFUN=4"));
+        CHECK_PARSER_OK(parser_.execCommand(QUECTEL_CFUN_TIMEOUT, "AT+CFUN=4,0"));
     }
 
     auto res = getIccidImpl(buf, size);

--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -542,7 +542,24 @@ int QuectelNcpClient::getIccid(char* buf, size_t size) {
     const NcpClientLock lock(this);
     CHECK(checkParser());
 
-    return getIccidImpl(buf, size);
+    // ICCID command errors if CFUN is 0. Run CFUN=4 before reading ICCID.
+    auto respCfun = parser_.sendCommand(QUECTEL_CFUN_TIMEOUT, "AT+CFUN?");
+    int cfunVal = -1;
+    auto retCfun = CHECK_PARSER(respCfun.scanf("+CFUN: %d", &cfunVal));
+    CHECK_PARSER_OK(respCfun.readResult());
+    if (retCfun == 1 && cfunVal == 0) {
+        CHECK_PARSER_OK(parser_.execCommand(QUECTEL_CFUN_TIMEOUT, "AT+CFUN=4"));
+    }
+
+    auto res = getIccidImpl(buf, size);
+
+    // Modify CFUN back to 0 if it was changed previously,
+    // as CFUN:0 is needed to prevent long reg problems on certain SIMs
+    if (cfunVal == 0) {
+        CHECK_PARSER_OK(parser_.execCommand(QUECTEL_CFUN_TIMEOUT, "AT+CFUN=0,0"));
+    }
+
+    return res;
 }
 
 int QuectelNcpClient::getImei(char* buf, size_t size) {

--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -565,7 +565,25 @@ int SaraNcpClient::getIccidImpl(char* buf, size_t size) {
 int SaraNcpClient::getIccid(char* buf, size_t size) {
     const NcpClientLock lock(this);
     CHECK(checkParser());
-    return getIccidImpl(buf, size);
+
+    // ICCID command errors if CFUN is 0. Run CFUN=4 before reading ICCID.
+    auto respCfun = parser_.sendCommand(UBLOX_CFUN_TIMEOUT, "AT+CFUN?");
+    int cfunVal = -1;
+    auto retCfun = CHECK_PARSER(respCfun.scanf("+CFUN: %d", &cfunVal));
+    CHECK_PARSER_OK(respCfun.readResult());
+    if (retCfun == 1 && cfunVal == 0) {
+        CHECK_PARSER_OK(parser_.execCommand(UBLOX_CFUN_TIMEOUT, "AT+CFUN=4"));
+    }
+
+    auto res = getIccidImpl(buf, size);
+
+    // Modify CFUN back to 0 if it was changed previously,
+    // as CFUN:0 is needed to prevent long reg problems on certain SIMs
+    if (cfunVal == 0) {
+        CHECK_PARSER_OK(parser_.execCommand(UBLOX_CFUN_TIMEOUT, "AT+CFUN=0,0"));
+    }
+
+    return res;
 }
 
 int SaraNcpClient::getImei(char* buf, size_t size) {

--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -572,7 +572,7 @@ int SaraNcpClient::getIccid(char* buf, size_t size) {
     auto retCfun = CHECK_PARSER(respCfun.scanf("+CFUN: %d", &cfunVal));
     CHECK_PARSER_OK(respCfun.readResult());
     if (retCfun == 1 && cfunVal == 0) {
-        CHECK_PARSER_OK(parser_.execCommand(UBLOX_CFUN_TIMEOUT, "AT+CFUN=4"));
+        CHECK_PARSER_OK(parser_.execCommand(UBLOX_CFUN_TIMEOUT, "AT+CFUN=4,0"));
     }
 
     auto res = getIccidImpl(buf, size);


### PR DESCRIPTION
### Problem

ICCID is not obtained when queried through `particle serial identify` in listening mode
```
blah@MacBook-Pro ~ $ particle serial identify

Your device id is e00fce68835b20e067d53c87
Your system firmware version is 3.0.0
```

### Solution

This is the because the AT command that reads ICCID errors out in CFUN=0 state but it's OK in CFUN:4 or CFUN:1 state.
- Run CFUN=4 if the modem is in CFUN=0 state

### Steps to Test

- Run any tinker like app. The modem doesn't need to connect to cloud for this test
- Put the module in listening mode
- Run `particle serial identify`
- The module should give SIM info as well

```
blah@MacBook-Pro ~ $ particle serial identify

Your device id is e00fce68835b20e067d53c87
Your IMEI is 865284045753088
Your ICCID is 89010303300014910310
Your system firmware version is 3.0.0
```

### References

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
