### PR TITLE
[nrf52840] platform: we only need to erase user application when building in modular

### DIFF
--- a/platform/MCU/nRF52840/src/flash_mal.c
+++ b/platform/MCU/nRF52840/src/flash_mal.c
@@ -385,6 +385,7 @@ int FLASH_CopyMemory(flash_device_t sourceDeviceID, uint32_t sourceAddress,
     }
 #endif // SOFTDEVICE_MBR_UPDATES
 
+#ifdef MODULAR_FIRMWARE
     // Make sure to invalidate the compat application, otherwise we'll keep booting into the compat application
     // as it takes precedence
     if (module_function == MODULE_FUNCTION_USER_PART && destinationAddress == USER_FIRMWARE_IMAGE_LOCATION) {
@@ -392,6 +393,7 @@ int FLASH_CopyMemory(flash_device_t sourceDeviceID, uint32_t sourceAddress,
             return FLASH_ACCESS_RESULT_ERROR;
         }
     }
+#endif // MODULAR_FIRMWARE
 
     if (!FLASH_EraseMemory(destinationDeviceID, destinationAddress, dest_size)) {
         return FLASH_ACCESS_RESULT_ERROR;


### PR DESCRIPTION
### Problem

Monolithic builds are broken on Gen 3 platforms.

### Solution

This is a side-effect of a feature introduced in https://github.com/particle-iot/device-os/pull/2322 to invalidate 128KB application in the bootloader when detecting a write into the 256KB user app area.

### Steps to Test

Monolithic builds should work.

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
