### PR TITLE
Add ability to set and scan extended advertisement size (when using Coded PHY)

### DIFF
--- a/hal/src/nRF52840/ble_hal.cpp
+++ b/hal/src/nRF52840/ble_hal.cpp
@@ -327,7 +327,7 @@ private:
     volatile hal_ble_auto_adv_cfg_t autoAdvCfg_;    /**< Automatic advertising configuration. */
     uint8_t advHandle_;                             /**< Advertising handle. */
     hal_ble_adv_params_t advParams_;                /**< Current advertising parameters. */
-    uint8_t advData_[BLE_MAX_SCAN_REPORT_BUF_LEN];  /**< Current advertising data. */
+    uint8_t advData_[BLE_MAX_ADV_DATA_LEN_EXT];     /**< Current advertising data. */
     size_t advDataLen_;                             /**< Current advertising data length. */
     uint8_t scanRespData_[BLE_MAX_ADV_DATA_LEN];    /**< Current scan response data. */
     size_t scanRespDataLen_;                        /**< Current scan response data length. */
@@ -391,7 +391,7 @@ private:
     volatile bool isScanning_;                              /**< If it is scanning or not. */
     hal_ble_scan_params_t scanParams_;                      /**< BLE scanning parameters. */
     os_semaphore_t scanSemaphore_;                          /**< Semaphore to wait until the scan procedure completed. */
-    uint8_t scanReportBuff_[BLE_MAX_SCAN_REPORT_BUF_LEN];   /**< Buffer to hold the scanned report data. */
+    uint8_t scanReportBuff_[BLE_MAX_ADV_DATA_LEN_EXT];   /**< Buffer to hold the scanned report data. */
     ble_data_t bleScanData_;                                /**< BLE scanned data. */
     hal_ble_on_scan_result_cb_t scanResultCallback_;        /**< Callback function on scan result. */
     void* context_;                                         /**< Context of the scan result callback function. */
@@ -1090,7 +1090,7 @@ int BleObject::Broadcaster::setAdvertisingData(const uint8_t* buf, size_t len) {
     // It is invalid to provide the same data buffers while advertising.
     CHECK(suspend());
     if (buf != nullptr) {
-        len = std::min(len, (size_t)BLE_MAX_SCAN_REPORT_BUF_LEN);
+        len = std::min(len, (size_t)BLE_MAX_ADV_DATA_LEN_EXT);
         memcpy(advData_, buf, len);
     } else {
         len = 0;

--- a/hal/src/nRF52840/ble_hal.cpp
+++ b/hal/src/nRF52840/ble_hal.cpp
@@ -391,7 +391,7 @@ private:
     volatile bool isScanning_;                              /**< If it is scanning or not. */
     hal_ble_scan_params_t scanParams_;                      /**< BLE scanning parameters. */
     os_semaphore_t scanSemaphore_;                          /**< Semaphore to wait until the scan procedure completed. */
-    uint8_t scanReportBuff_[BLE_MAX_ADV_DATA_LEN_EXT];   /**< Buffer to hold the scanned report data. */
+    uint8_t scanReportBuff_[BLE_MAX_SCAN_REPORT_BUF_LEN];   /**< Buffer to hold the scanned report data. */
     ble_data_t bleScanData_;                                /**< BLE scanned data. */
     hal_ble_on_scan_result_cb_t scanResultCallback_;        /**< Callback function on scan result. */
     void* context_;                                         /**< Context of the scan result callback function. */

--- a/hal/src/nRF52840/ble_hal.cpp
+++ b/hal/src/nRF52840/ble_hal.cpp
@@ -329,7 +329,7 @@ private:
     hal_ble_adv_params_t advParams_;                /**< Current advertising parameters. */
     uint8_t advData_[BLE_MAX_ADV_DATA_LEN_EXT];     /**< Current advertising data. */
     size_t advDataLen_;                             /**< Current advertising data length. */
-    uint8_t scanRespData_[BLE_MAX_ADV_DATA_LEN];    /**< Current scan response data. */
+    uint8_t scanRespData_[BLE_MAX_SCAN_REPORT_BUF_LEN];    /**< Current scan response data. */
     size_t scanRespDataLen_;                        /**< Current scan response data length. */
     int8_t txPower_;                                /**< TX Power. */
     bool advPending_;                               /**< Advertising is pending. */
@@ -391,7 +391,7 @@ private:
     volatile bool isScanning_;                              /**< If it is scanning or not. */
     hal_ble_scan_params_t scanParams_;                      /**< BLE scanning parameters. */
     os_semaphore_t scanSemaphore_;                          /**< Semaphore to wait until the scan procedure completed. */
-    uint8_t scanReportBuff_[BLE_MAX_SCAN_REPORT_BUF_LEN];   /**< Buffer to hold the scanned report data. */
+    uint8_t scanReportBuff_[BLE_MAX_ADV_DATA_LEN_EXT];      /**< Buffer to hold the scanned report data. */
     ble_data_t bleScanData_;                                /**< BLE scanned data. */
     hal_ble_on_scan_result_cb_t scanResultCallback_;        /**< Callback function on scan result. */
     void* context_;                                         /**< Context of the scan result callback function. */
@@ -1429,7 +1429,7 @@ int BleObject::Observer::startScanning(hal_ble_on_scan_result_cb_t callback, voi
     scanResultCallback_ = callback;
     context_ = context;
     int ret = sd_ble_gap_scan_start(&bleGapScanParams, &bleScanData_);
-    // LOG_DEBUG(TRACE,"Ret code sd_ble_scan_start: %d", ret);  // Uncomment to get error code from starting scan
+    LOG_DEBUG(TRACE,"Ret code sd_ble_scan_start: %d", ret);  // Uncomment to get error code from starting scan
     CHECK_NRF_RETURN(ret, nrf_system_error(ret));
     isScanning_ = true;
     // If timeout is set to 0, it should scan indefinitely

--- a/hal/src/nRF52840/ble_hal.cpp
+++ b/hal/src/nRF52840/ble_hal.cpp
@@ -327,7 +327,7 @@ private:
     volatile hal_ble_auto_adv_cfg_t autoAdvCfg_;    /**< Automatic advertising configuration. */
     uint8_t advHandle_;                             /**< Advertising handle. */
     hal_ble_adv_params_t advParams_;                /**< Current advertising parameters. */
-    uint8_t advData_[BLE_MAX_ADV_DATA_LEN];         /**< Current advertising data. */
+    uint8_t advData_[BLE_MAX_SCAN_REPORT_BUF_LEN];  /**< Current advertising data. */
     size_t advDataLen_;                             /**< Current advertising data length. */
     uint8_t scanRespData_[BLE_MAX_ADV_DATA_LEN];    /**< Current scan response data. */
     size_t scanRespDataLen_;                        /**< Current scan response data length. */
@@ -1090,7 +1090,7 @@ int BleObject::Broadcaster::setAdvertisingData(const uint8_t* buf, size_t len) {
     // It is invalid to provide the same data buffers while advertising.
     CHECK(suspend());
     if (buf != nullptr) {
-        len = std::min(len, (size_t)BLE_MAX_ADV_DATA_LEN);
+        len = std::min(len, (size_t)BLE_MAX_SCAN_REPORT_BUF_LEN);
         memcpy(advData_, buf, len);
     } else {
         len = 0;

--- a/hal/src/nRF52840/ble_hal_impl.h
+++ b/hal/src/nRF52840/ble_hal_impl.h
@@ -81,6 +81,8 @@
 /* Maximum length of the buffer to store scan report data */
 #define BLE_MAX_SCAN_REPORT_BUF_LEN                 BLE_GAP_SCAN_BUFFER_EXTENDED_MAX_SUPPORTED  /* Must support extended length for CODED_PHY scanning */
 
+#define BLE_MAX_ADV_DATA_SIZE_EXTENDED_CONNECTABLE  BLE_GAP_ADV_SET_DATA_SIZE_EXTENDED_CONNECTABLE_MAX_SUPPORTED
+
 /* Connection Parameters limits */
 #define BLE_CONN_PARAMS_SLAVE_LATENCY_ERR           5
 #define BLE_CONN_PARAMS_TIMEOUT_ERR                 100

--- a/hal/src/nRF52840/ble_hal_impl.h
+++ b/hal/src/nRF52840/ble_hal_impl.h
@@ -79,9 +79,9 @@
 #define BLE_MAX_ADV_DATA_LEN                        BLE_GAP_ADV_SET_DATA_SIZE_MAX
 
 /* Maximum length of the buffer to store scan report data */
-#define BLE_MAX_SCAN_REPORT_BUF_LEN                 BLE_GAP_SCAN_BUFFER_EXTENDED_MAX_SUPPORTED  /* Must support extended length for CODED_PHY scanning */
+#define BLE_MAX_ADV_DATA_LEN_EXT                    BLE_GAP_SCAN_BUFFER_EXTENDED_MAX_SUPPORTED  /* Must support extended length for CODED_PHY scanning */
 
-#define BLE_MAX_ADV_DATA_SIZE_EXTENDED_CONNECTABLE  BLE_GAP_ADV_SET_DATA_SIZE_EXTENDED_CONNECTABLE_MAX_SUPPORTED
+#define BLE_MAX_ADV_DATA_LEN_EXT_CONNECTABLE        BLE_GAP_ADV_SET_DATA_SIZE_EXTENDED_CONNECTABLE_MAX_SUPPORTED
 
 /* Connection Parameters limits */
 #define BLE_CONN_PARAMS_SLAVE_LATENCY_ERR           5

--- a/hal/src/nRF52840/ble_hal_impl.h
+++ b/hal/src/nRF52840/ble_hal_impl.h
@@ -79,8 +79,10 @@
 #define BLE_MAX_ADV_DATA_LEN                        BLE_GAP_ADV_SET_DATA_SIZE_MAX
 
 /* Maximum length of the buffer to store scan report data */
-#define BLE_MAX_ADV_DATA_LEN_EXT                    BLE_GAP_SCAN_BUFFER_EXTENDED_MAX_SUPPORTED  /* Must support extended length for CODED_PHY scanning */
+#define BLE_MAX_SCAN_REPORT_BUF_LEN                 BLE_GAP_ADV_SET_DATA_SIZE_MAX
 
+/* Maximum length for CODED_PHY */
+#define BLE_MAX_ADV_DATA_LEN_EXT                    BLE_GAP_SCAN_BUFFER_EXTENDED_MAX_SUPPORTED
 #define BLE_MAX_ADV_DATA_LEN_EXT_CONNECTABLE        BLE_GAP_ADV_SET_DATA_SIZE_EXTENDED_CONNECTABLE_MAX_SUPPORTED
 
 /* Connection Parameters limits */

--- a/user/tests/wiring/ble_scanner_broadcaster/ble_broadcaster/broadcaster.cpp
+++ b/user/tests/wiring/ble_scanner_broadcaster/ble_broadcaster/broadcaster.cpp
@@ -17,7 +17,8 @@ typedef enum {
     CMD_ADV_DEVICE_NAME,
     CMD_ADV_APPEARANCE,
     CMD_ADV_CUSTOM_DATA,
-    CMD_ADV_CODED_PHY
+    CMD_ADV_CODED_PHY,
+    CMD_ADV_EXTENDED
 } TestCommand;
 TestCommand cmd = CMD_UNKNOWN;
 
@@ -99,6 +100,21 @@ test(BLE_Broadcaster_06_Advertise_On_Coded_Phy) {
     BleAdvertisingData data;
     data.appendLocalName("CODED_PHY");
     assertEqual(data.deviceName(), String("CODED_PHY"));
+    int ret = BLE.advertise(&data);
+    assertEqual(ret, 0);
+    assertTrue(BLE.advertising());
+}
+
+test(BLE_Broadcaster_07_Advertise_Extended) {
+    assertTrue(BLE.connected());
+    assertTrue(waitFor([&]{ return cmd == CMD_ADV_EXTENDED; }, 60000));
+
+    assertEqual(BLE.setAdvertisingPhy(BlePhy::BLE_PHYS_CODED), 0);
+    // Make the advert 5 less than maximum to account for flags, type, and size
+    uint8_t buf[BLE_MAX_ADV_DATA_SIZE_EXTENDED_CONNECTABLE - 5];
+    memset(buf, 0x35, BLE_MAX_ADV_DATA_SIZE_EXTENDED_CONNECTABLE - 5);
+    BleAdvertisingData data;
+    data.appendCustomData(buf, BLE_MAX_ADV_DATA_SIZE_EXTENDED_CONNECTABLE - 5);
     int ret = BLE.advertise(&data);
     assertEqual(ret, 0);
     assertTrue(BLE.advertising());

--- a/user/tests/wiring/ble_scanner_broadcaster/ble_broadcaster/broadcaster.cpp
+++ b/user/tests/wiring/ble_scanner_broadcaster/ble_broadcaster/broadcaster.cpp
@@ -111,10 +111,10 @@ test(BLE_Broadcaster_07_Advertise_Extended) {
 
     assertEqual(BLE.setAdvertisingPhy(BlePhy::BLE_PHYS_CODED), 0);
     // Make the advert 5 less than maximum to account for flags, type, and size
-    uint8_t buf[BLE_MAX_ADV_DATA_SIZE_EXTENDED_CONNECTABLE - 5];
-    memset(buf, 0x35, BLE_MAX_ADV_DATA_SIZE_EXTENDED_CONNECTABLE - 5);
+    uint8_t buf[BLE_MAX_ADV_DATA_LEN_EXT_CONNECTABLE - 5];
+    memset(buf, 0x35, BLE_MAX_ADV_DATA_LEN_EXT_CONNECTABLE - 5);
     BleAdvertisingData data;
-    data.appendCustomData(buf, BLE_MAX_ADV_DATA_SIZE_EXTENDED_CONNECTABLE - 5);
+    data.appendCustomData(buf, BLE_MAX_ADV_DATA_LEN_EXT_CONNECTABLE - 5);
     int ret = BLE.advertise(&data);
     assertEqual(ret, 0);
     assertTrue(BLE.advertising());

--- a/user/tests/wiring/ble_scanner_broadcaster/ble_scanner/scanner.cpp
+++ b/user/tests/wiring/ble_scanner_broadcaster/ble_scanner/scanner.cpp
@@ -17,7 +17,8 @@ typedef enum {
     CMD_ADV_DEVICE_NAME,
     CMD_ADV_APPEARANCE,
     CMD_ADV_CUSTOM_DATA,
-    CMD_ADV_CODED_PHY
+    CMD_ADV_CODED_PHY,
+    CMD_ADV_EXTENDED
 } TestCommand;
 
 const char* peerServiceUuid = "6E400000-B5A3-F393-E0A9-E50E24DCCA9E";
@@ -236,6 +237,23 @@ test(BLE_Scanner_10_Scan_On_Coded_Phy) {
     assertEqual(BLE.setScanPhy(BlePhy::BLE_PHYS_1MBPS), 0);
     results = BLE.scanWithFilter(BleScanFilter().deviceName("CODED_PHY"));
     assertEqual(results.size(), 0);
+}
+
+test(BLE_Scanner_11_Scan_Extended) {
+    assertTrue(BLE.connected());
+
+    int ret;
+    TestCommand cmd = CMD_ADV_EXTENDED;
+    ret = peerCharWriteWoRsp.setValue((const uint8_t*)&cmd, 1);
+    assertEqual(ret, 1);
+
+    delay(1s);
+
+    assertEqual(BLE.setScanPhy(BlePhy::BLE_PHYS_CODED), 0);
+    uint8_t buf[BLE_MAX_ADV_DATA_SIZE_EXTENDED_CONNECTABLE - 5];
+    memset(buf, 0x35, BLE_MAX_ADV_DATA_SIZE_EXTENDED_CONNECTABLE - 5);
+    Vector<BleScanResult> results = BLE.scanWithFilter(BleScanFilter().customData(buf, BLE_MAX_ADV_DATA_SIZE_EXTENDED_CONNECTABLE - 5));
+    assertEqual(results.size(), 1);
 }
 
 #endif // #if Wiring_BLE == 1

--- a/user/tests/wiring/ble_scanner_broadcaster/ble_scanner/scanner.cpp
+++ b/user/tests/wiring/ble_scanner_broadcaster/ble_scanner/scanner.cpp
@@ -250,9 +250,9 @@ test(BLE_Scanner_11_Scan_Extended) {
     delay(1s);
 
     assertEqual(BLE.setScanPhy(BlePhy::BLE_PHYS_CODED), 0);
-    uint8_t buf[BLE_MAX_ADV_DATA_SIZE_EXTENDED_CONNECTABLE - 5];
-    memset(buf, 0x35, BLE_MAX_ADV_DATA_SIZE_EXTENDED_CONNECTABLE - 5);
-    Vector<BleScanResult> results = BLE.scanWithFilter(BleScanFilter().customData(buf, BLE_MAX_ADV_DATA_SIZE_EXTENDED_CONNECTABLE - 5));
+    uint8_t buf[BLE_MAX_ADV_DATA_LEN_EXT_CONNECTABLE - 5];
+    memset(buf, 0x35, BLE_MAX_ADV_DATA_LEN_EXT_CONNECTABLE - 5);
+    Vector<BleScanResult> results = BLE.scanWithFilter(BleScanFilter().customData(buf, BLE_MAX_ADV_DATA_LEN_EXT_CONNECTABLE - 5));
     assertEqual(results.size(), 1);
 }
 

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -493,8 +493,6 @@ private:
     static size_t locate(const uint8_t* buf, size_t len, BleAdvertisingDataType type, size_t* offset);
 
     Vector<uint8_t> selfData_;
-    //uint8_t selfData_[BLE_MAX_ADV_DATA_LEN];
-    //size_t selfLen_;
 };
 
 

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -492,8 +492,9 @@ private:
     Vector<BleUuid> serviceUUID(BleAdvertisingDataType type) const;
     static size_t locate(const uint8_t* buf, size_t len, BleAdvertisingDataType type, size_t* offset);
 
-    uint8_t selfData_[BLE_MAX_ADV_DATA_LEN];
-    size_t selfLen_;
+    Vector<uint8_t> selfData_;
+    //uint8_t selfData_[BLE_MAX_ADV_DATA_LEN];
+    //size_t selfLen_;
 };
 
 

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -581,7 +581,7 @@ size_t BleAdvertisingData::set(const uint8_t* buf, size_t len) {
     }
     selfData_.clear();
     len = std::min(len, (size_t)BLE_MAX_ADV_DATA_LEN_EXT);
-    selfData_.append(buf, len);
+    CHECK_TRUE(selfData_.append(buf, len), 0);
     return selfData_.size();
 }
 

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -2425,8 +2425,8 @@ private:
         size_t filterCustomDatalen;
         const uint8_t* filterCustomData = filter_.customData(&filterCustomDatalen);
         if (filterCustomData != nullptr && filterCustomDatalen > 0) {
-            size_t srLen = result.scanResponse().get(BleAdvertisingDataType::MANUFACTURER_SPECIFIC_DATA, nullptr, sizeof(size_t));
-            size_t advLen = result.advertisingData().get(BleAdvertisingDataType::MANUFACTURER_SPECIFIC_DATA, nullptr, sizeof(size_t));
+            size_t srLen = result.scanResponse().get(BleAdvertisingDataType::MANUFACTURER_SPECIFIC_DATA, nullptr, filterCustomDatalen);
+            size_t advLen = result.advertisingData().get(BleAdvertisingDataType::MANUFACTURER_SPECIFIC_DATA, nullptr, filterCustomDatalen);
             if (srLen != filterCustomDatalen && advLen != filterCustomDatalen) {
                 LOG_DEBUG(TRACE, "Custom data mismatched.");
                 return false;


### PR DESCRIPTION
### Problem

Now that 3.1 supports Coded PHY, we should also support scanning for advertisements that are up to 255 bytes instead of 31 bytes. 

### Solution

This PR changes `BleAdvertisingData's` buffer for advertisement data from an array with fixed size of 31, to a Vector. I selected this rather than an array of 255 bytes to save RAM, since an instance of `BleAdvertisingData` is created for every `BleScanResult`. 

For the Broadcaster, this PR changes the fixed size array from 31 (BLE_MAX_ADV_DATA_LEN) to 255 (BLE_MAX_SCAN_REPORT_BUF_LEN). Since there's a single instance of the Broadcaster, I think this is ok, although we could make this a Vector as well.

### Steps to Test

Added tests in `user/tests/wiring/ble_scanner_broadcaster` for both the Broadcaster and the Scanner.

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
