### PR TITLE
Free malloc'ed memory

### DIFF
--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -2450,8 +2450,10 @@ private:
                 }
                 result.scanResponse().get(BleAdvertisingDataType::MANUFACTURER_SPECIFIC_DATA, buf, srLen);
                 if (!memcmp(buf, filterCustomData, srLen)) {
+                    free(buf);
                     return true;
                 }
+                free(buf);
             }
             if (advLen == filterCustomDatalen) {
                 uint8_t* buf = (uint8_t*)malloc(advLen);
@@ -2461,8 +2463,10 @@ private:
                 }
                 result.advertisingData().get(BleAdvertisingDataType::MANUFACTURER_SPECIFIC_DATA, buf, advLen);
                 if (!memcmp(buf, filterCustomData, advLen)) {
+                    free(buf);
                     return true;
                 }
+                free(buf);
             }
             LOG_DEBUG(TRACE, "Custom data mismatched.");
             return false;

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -2444,29 +2444,35 @@ private:
             }
             if (srLen == filterCustomDatalen) {
                 uint8_t* buf = (uint8_t*)malloc(srLen);
+                SCOPE_GUARD({
+                    if (buf) {
+                        free(buf);
+                    }
+                });
                 if (!buf) {
                     LOG(ERROR, "Failed to allocate memory!");
                     return false;
                 }
                 result.scanResponse().get(BleAdvertisingDataType::MANUFACTURER_SPECIFIC_DATA, buf, srLen);
                 if (!memcmp(buf, filterCustomData, srLen)) {
-                    free(buf);
                     return true;
                 }
-                free(buf);
             }
             if (advLen == filterCustomDatalen) {
                 uint8_t* buf = (uint8_t*)malloc(advLen);
+                SCOPE_GUARD({
+                    if (buf) {
+                        free(buf);
+                    }
+                });
                 if (!buf) {
                     LOG(ERROR, "Failed to allocate memory!");
                     return false;
                 }
                 result.advertisingData().get(BleAdvertisingDataType::MANUFACTURER_SPECIFIC_DATA, buf, advLen);
                 if (!memcmp(buf, filterCustomData, advLen)) {
-                    free(buf);
                     return true;
                 }
-                free(buf);
             }
             LOG_DEBUG(TRACE, "Custom data mismatched.");
             return false;


### PR DESCRIPTION
### Problem

Seems like a bug that the memory is allocated with malloc but never freed. I didn't run a test to check if there was an actual memory leak, so I might have missed how it's freed. I did test that this new code compiles and the function works as expected (re-ran the `ble_scanner_broadcaster` tests)

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
