### PR TITLE
[ci] generate public CF url in slack notification

### DIFF
--- a/ci/cf_generate_message.sh
+++ b/ci/cf_generate_message.sh
@@ -18,12 +18,14 @@ if [ "${CF_PULL_REQUEST_NUMBER}" != "" ]; then
     RESULT_ADDITIONAL=" (<https://github.com/${CF_REPO_OWNER}/${CF_REPO_NAME}/pull/${CF_PULL_REQUEST_NUMBER}|PR ${CF_PULL_REQUEST_NUMBER}>)"
 fi
 
+CF_BUILD_URL_PUBLIC=$(echo "${CF_BUILD_URL}" | sed -e 's|/build/|/public/accounts/particle/builds/|')
+
 BASE_BLOCK=$(cat <<EOF
 {
     "type": "section",
     "text": {
         "type": "mrkdwn",
-        "text": "Build <${CF_BUILD_URL}|${CF_BUILD_ID}> of <${CF_COMMIT_URL}|${CF_BRANCH}>${RESULT_ADDITIONAL} by ${CF_BUILD_INITIATOR} ${RESULT_STATUS} in ${RESULT_TIME_ELAPSED}"
+        "text": "Build <${CF_BUILD_URL_PUBLIC}|${CF_BUILD_ID}> of <${CF_COMMIT_URL}|${CF_BRANCH}>${RESULT_ADDITIONAL} by ${CF_BUILD_INITIATOR} ${RESULT_STATUS} in ${RESULT_TIME_ELAPSED}"
     }
 }
 EOF


### PR DESCRIPTION
### Problem

`$CF_BUILD_URL` generated by CF contains a private URL requiring CF sign-in even though we have public build logs enabled on CF.

### Solution

Patch it.

### Steps to Test

Take a look at Device OS bots channel for build logs out of this branch/PR - the URL should be public and viewable without sign-in.

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
