### PR TITLE
[u-blox] Handle erroneous -1 AcT response from CEREG and COPS commands on R510

### DIFF
--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -317,6 +317,10 @@ int SaraNcpClient::initParser(Stream* stream) {
         // self->checkRegistrationState();
         // Cellular Global Identity (partial)
         if (r >= 3) {
+            // Check for erroneous R510 AcT value of -1, change to R510 specific Cat-M1 value of 7
+            if (r >= 4 && val[3] == 0xFFFFFFFF) {
+                val[3] = 7; 
+            }
             auto rat = r >= 4 ? static_cast<CellularAccessTechnology>(val[3]) : self->act_;
             switch (rat) {
                 case CellularAccessTechnology::LTE:
@@ -642,7 +646,8 @@ int SaraNcpClient::queryAndParseAtCops(CellularSignalQuality* qual) {
     cgi_.mobile_network_code = static_cast<uint16_t>(::atoi(mobileNetworkCode));
 
     if (ncpId() == PLATFORM_NCP_SARA_R410 || ncpId() == PLATFORM_NCP_SARA_R510) {
-        if (act == particle::to_underlying(CellularAccessTechnology::LTE)) {
+        if (act == particle::to_underlying(CellularAccessTechnology::LTE) || 
+            (act == -1 && ncpId() == PLATFORM_NCP_SARA_R510)) {
             act = particle::to_underlying(CellularAccessTechnology::LTE_CAT_M1);
         }
     }

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -307,6 +307,12 @@ bool MDMParser::modemIsSaraRxFamily() {
     return ((_dev.dev == DEV_SARA_R410) || (_dev.dev == DEV_SARA_R510));
 }
 
+void MDMParser::_fixSaraR510AccessTechnology(void) {
+    if (_dev.dev == DEV_SARA_R510 && _net.act == ACT_UNKNOWN) {
+        _net.act = ACT_LTE_CAT_M1;
+    }
+}
+
 void MDMParser::cancel(void) {
     if (!_cancel_all_operations) {
         MDM_INFO("\r\n[ Modem::cancel ] = = = = = = = = = = = = = = =");
@@ -598,6 +604,7 @@ int MDMParser::waitFinalResp(_CALLBACKPTR cb /* = NULL*/,
                 } else {
                     // +CREG|CGREG: <n>,<stat>[,<lac>,<ci>[,AcT[,<rac>]]] // reply to AT+CREG|AT+CGREG (2,4,5,6 results)
                     // +CREG|CGREG: <stat>[,<lac>,<ci>[,AcT[,<rac>]]]     // URC (1,3,4,5 results)
+                    // +CEREG: <n>,<stat>[,[<tac>],[<ci>],[<AcT>]]
                     b = (int)0xFFFF; c = (int)0xFFFFFFFF; d = -1; mode = -1; // default mode to -1 for safety
                     r = sscanf(cmd, "%31s %d,%d,\"%x\",\"%x\",%d",s,&mode,&a,&b,&c,&d);
                     if (r <= 2) {
@@ -658,6 +665,7 @@ int MDMParser::waitFinalResp(_CALLBACKPTR cb /* = NULL*/,
                             // access technology
                             if (r >= 5) {
                                 _net.act = toCellularAccessTechnology(d);
+                                _fixSaraR510AccessTechnology();
                             }
                         }
                     }
@@ -1913,6 +1921,8 @@ bool MDMParser::registerNet(const char* apn, NetStatus* status, system_tick_t ti
             if (RESP_OK != waitFinalResp(_cbCOPS, &_net, COPS_TIMEOUT)) {
                 goto failure;
             }
+            _fixSaraR510AccessTechnology();
+
             // Only run AT+COPS=0 if currently de-registered, to avoid PLMN reselection
             if (_net.cops != 0 && _net.cops != 1) {
                 sendFormated("AT+COPS=0,2\r\n");
@@ -2031,6 +2041,7 @@ bool MDMParser::checkNetStatus(NetStatus* status /*= NULL*/)
         if (RESP_OK != waitFinalResp(_cbCOPS, &_net, COPS_TIMEOUT)) {
             goto failure;
         }
+        _fixSaraR510AccessTechnology();
         // AT command used to collect signal stregnth is different for R410M radio
         if (_dev.dev == DEV_SARA_R410) {
             sendFormated("AT+UCGED=5\r\n");
@@ -2108,6 +2119,7 @@ bool MDMParser::getSignalStrength(NetStatus &status)
         if (RESP_OK != waitFinalResp(_cbCOPS, &_net, COPS_TIMEOUT)) {
             goto cleanup;
         }
+        _fixSaraR510AccessTechnology();
 
         // +CREG, +CGREG, +COPS do not contain <AcT> for G350 devices.
         // Force _net.act to ACT_GSM to ensure Device Diagnostics and
@@ -2192,6 +2204,7 @@ bool MDMParser::getCellularGlobalIdentity(CellularGlobalIdentity& cgi_) {
     sendFormated("AT+COPS?\r\n");
     if (RESP_OK != waitFinalResp(_cbCOPS, &_net, COPS_TIMEOUT))
         goto failure;
+    _fixSaraR510AccessTechnology();
 
     switch (cgi_.version)
     {

--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -678,6 +678,7 @@ protected:
     void _checkVerboseCxreg(void);
     bool _checkEpsReg(void);
     int _socketError(void);
+    void _fixSaraR510AccessTechnology(void);
     static MDMParser* inst;
     bool _init;
     bool _pwr;


### PR DESCRIPTION
### Problem

The SARAR510 modem can potentially report a -1 value in the Radio Access Technology (RAT or AcT) field of at least two AT commands: `AT+COPS?` and `AT+CEREG?`
This value results in an incorrectly parsed cellular access technology that breaks the signal strength reporting in particle console.

### Solution

Ublox confirmed this is a bug and will be fixed in later modem firmware versions, but a workaround should still detect this problem. 
If a -1 value is parsed from the `CEREG` URC or `COPS` command result, it will be reset to the fixed R510 value of 7. This should ensure the correct cellular access technology value. 

### Steps to Test
You can manually introduce the problem by substituting the COPS and CEREG strings with the -1 values. IE:
```
+CEREG: 2,5,"6a41","07f06011",-1
+COPS: 0,0,"AT&T",-1
```

### Example App

Problem is not introducible via user app, its part of device OS cellular HAL

### References

See [clubhouse ticket](https://app.clubhouse.io/particle/story/79160/r510-rat-value-switches-to-an-invalid-value-1-a-few-minutes-after-registration)

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
