### PR TITLE
[gen3] ble: fix unintialized scan_phys in default scan parameters

### DIFF
--- a/hal/src/nRF52840/ble_hal.cpp
+++ b/hal/src/nRF52840/ble_hal.cpp
@@ -344,6 +344,7 @@ public:
     Observer()
             : observerInitialized_(false),
               isScanning_(false),
+              scanParams_{},
               scanSemaphore_(nullptr),
               scanResultCallback_(nullptr),
               context_(nullptr),
@@ -355,6 +356,7 @@ public:
         scanParams_.interval = BLE_DEFAULT_SCANNING_INTERVAL;
         scanParams_.window = BLE_DEFAULT_SCANNING_WINDOW;
         scanParams_.timeout = BLE_DEFAULT_SCANNING_TIMEOUT;
+        scanParams_.scan_phys = BLE_PHYS_AUTO;
         bleScanData_.p_data = scanReportBuff_;
         bleScanData_.len = sizeof(scanReportBuff_);
     }

--- a/user/tests/wiring/ble_central_peripheral/ble_central/central.cpp
+++ b/user/tests/wiring/ble_central_peripheral/ble_central/central.cpp
@@ -65,9 +65,9 @@ test(BLE_01_Central_Scan_And_Connect) {
 
     size_t wait = 20; // Scanning for 20s.
     while (!BLE.connected() && wait > 0) {
-        size_t count = BLE.scan(results, SCAN_RESULT_COUNT);
+        int count = BLE.scan(results, SCAN_RESULT_COUNT);
         if (count > 0) {
-            for (uint8_t i = 0; i < count; i++) {
+            for (int i = 0; i < count; i++) {
                 BleUuid foundServiceUUID;
                 size_t svcCount = results[i].advertisingData().serviceUUID(&foundServiceUUID, 1);
                 if (svcCount > 0 && foundServiceUUID == "6E400000-B5A3-F393-E0A9-E50E24DCCA9E") {


### PR DESCRIPTION
### Problem

`scan_phys` in default BLE scan parameters are not initialized.

### Solution

Initialize correctly.

### Steps to Test

Run `wiring/ble*` tests.

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
