### PR TITLE
Use ncp_id from OTP to determine modem type

### DIFF
--- a/hal/network/ncp/cellular/cellular_hal.cpp
+++ b/hal/network/ncp/cellular/cellular_hal.cpp
@@ -33,6 +33,7 @@
 #include "at_command.h"
 #include "at_response.h"
 #include "cellular_enums_hal.h"
+#include "cellular_ncp_dev_mapping.h"
 
 #include <limits>
 
@@ -193,35 +194,7 @@ int cellular_device_info(CellularDevice* info, void* reserved) {
     CHECK(client->getIccid(info->iccid, sizeof(info->iccid)));
     CHECK(client->getImei(info->imei, sizeof(info->imei)));
     if (info->size >= offsetof(CellularDevice, dev) + sizeof(CellularDevice::dev)) {
-        switch (client->ncpId()) {
-        case PLATFORM_NCP_SARA_U201:
-            info->dev = DEV_SARA_U201;
-            break;
-        case PLATFORM_NCP_SARA_G350:
-            info->dev = DEV_SARA_G350;
-            break;
-        case PLATFORM_NCP_SARA_R410:
-            info->dev = DEV_SARA_R410;
-            break;
-        case PLATFORM_NCP_SARA_R510:
-            info->dev = DEV_SARA_R510;
-            break;
-        case PLATFORM_NCP_QUECTEL_BG96:
-            info->dev = DEV_QUECTEL_BG96;
-            break;
-        case PLATFORM_NCP_QUECTEL_EG91_E:
-            info->dev = DEV_QUECTEL_EG91_E;
-            break;
-        case PLATFORM_NCP_QUECTEL_EG91_NA:
-            info->dev = DEV_QUECTEL_EG91_NA;
-            break;
-        case PLATFORM_NCP_QUECTEL_EG91_EX:
-            info->dev = DEV_QUECTEL_EG91_EX;
-            break;
-        default:
-            info->dev = DEV_UNKNOWN;
-            break;
-        }
+        info->dev = cellular_dev_from_ncp((PlatformNCPIdentifier)client->ncpId());
     }
     if (info->size >= offsetof(CellularDevice, radiofw) + sizeof(CellularDevice::radiofw)) {
         CHECK(client->getFirmwareVersionString(info->radiofw, sizeof(info->radiofw)));

--- a/hal/shared/cellular_ncp_dev_mapping.h
+++ b/hal/shared/cellular_ncp_dev_mapping.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "cellular_enums_hal.h"
+#include "platform_ncp.h"
+
+inline Dev cellular_dev_from_ncp(PlatformNCPIdentifier identifer) {
+    Dev device = DEV_UNKNOWN;
+    switch (identifer) {
+    case PLATFORM_NCP_SARA_U201:
+        device = DEV_SARA_U201;
+        break;
+    case PLATFORM_NCP_SARA_G350:
+        device = DEV_SARA_G350;
+        break;
+    case PLATFORM_NCP_SARA_R410:
+        device = DEV_SARA_R410;
+        break;
+    case PLATFORM_NCP_SARA_R510:
+        device = DEV_SARA_R510;
+        break;
+    case PLATFORM_NCP_QUECTEL_BG96:
+        device = DEV_QUECTEL_BG96;
+        break;
+    case PLATFORM_NCP_QUECTEL_EG91_E:
+        device = DEV_QUECTEL_EG91_E;
+        break;
+    case PLATFORM_NCP_QUECTEL_EG91_NA:
+        device = DEV_QUECTEL_EG91_NA;
+        break;
+    case PLATFORM_NCP_QUECTEL_EG91_EX:
+        device = DEV_QUECTEL_EG91_EX;
+        break;
+    default:
+        device = DEV_UNKNOWN;
+        break;
+    }
+    return device;
+}

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -41,6 +41,8 @@
 #include <mutex>
 #include "net_hal.h"
 #include <limits>
+#include "platform_ncp.h"
+#include "cellular_ncp_dev_mapping.h"
 
 std::recursive_mutex mdm_mutex;
 
@@ -882,9 +884,9 @@ bool MDMParser::_powerOn(void)
     bool retried_after_reset = false;
     int i = MDM_POWER_ON_MAX_ATTEMPTS_BEFORE_RESET; // When modem not responsive on boot, AT/OK tries 25x (for ~30s) before hard reset
 
-    // FIXME: REMOVE THIS BEFORE MERGING!!!!!!
-    _dev.dev = DEV_SARA_R510;
-    MDM_ERROR("Forcing to R510\r\n");
+    auto otp_ncp_id = platform_primary_ncp_identifier();
+    _dev.dev = cellular_dev_from_ncp(otp_ncp_id);
+    LOG(INFO, "NCP ID OTP value: 0x%X _dev.dev set to 0x%X", otp_ncp_id, _dev.dev);
 
     while (i--) {
 

--- a/hal/src/photon/platform_ncp_photon.cpp
+++ b/hal/src/photon/platform_ncp_photon.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Particle Industries, Inc.  All rights reserved.
+ * Copyright (c) 2021 Particle Industries, Inc.  All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -15,41 +15,16 @@
  * License along with this library; if not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "platforms.h"
 #include "platform_ncp.h"
-#include "exflash_hal.h"
-#include "dct.h"
 #include "system_error.h"
 
-namespace {
-
-const uintptr_t NCP_ID_OTP_ADDRESS = 0x00000020;
-
-bool isValidNcpId(uint8_t id) {
-    switch (id) {
-    case PlatformNCPIdentifier::PLATFORM_NCP_SARA_U201:
-    case PlatformNCPIdentifier::PLATFORM_NCP_SARA_G350:
-    case PlatformNCPIdentifier::PLATFORM_NCP_SARA_R410:
-    case PlatformNCPIdentifier::PLATFORM_NCP_SARA_R510:
-        return true;
-    default:
-        return false;
-    }
-}
-
-} // unnamed
-
 PlatformNCPIdentifier platform_primary_ncp_identifier() {
-    // Check the DCT
-    uint8_t ncpId = 0;
-    int r = dct_read_app_data_copy(DCT_NCP_ID_OFFSET, &ncpId, 1);
-    if (r < 0 || !isValidNcpId(ncpId)) {
-        // Check the OTP flash
-        r = hal_exflash_read_special(HAL_EXFLASH_SPECIAL_SECTOR_OTP, NCP_ID_OTP_ADDRESS, &ncpId, 1);
-        if (r < 0 || !isValidNcpId(ncpId)) {
-            ncpId = PlatformNCPIdentifier::PLATFORM_NCP_UNKNOWN;
-        }
-    }
-    return (PlatformNCPIdentifier)ncpId;
+    #if PLATFORM_ID == PLATFORM_PHOTON
+        return PLATFORM_NCP_BROADCOM_BCM9WCDUSI09;
+    #elif PLATFORM_ID == PLATFORM_P1
+        return PLATFORM_NCP_BROADCOM_BCM9WCDUSI14;
+    #endif
 }
 
 int platform_ncp_get_info(int idx, PlatformNCPInfo* info) {

--- a/modules/electron/system-part1/src/cellular_hal.cpp
+++ b/modules/electron/system-part1/src/cellular_hal.cpp
@@ -8,3 +8,4 @@
 #include "../src/electron/inet_hal_new.cpp"
 #include "../src/electron/socket_hal.cpp"
 #include "../shared/cellular_sig_perc_mapping.cpp"
+#include "../src/electron/platform_ncp_electron.cpp"


### PR DESCRIPTION
### Problem

Early boards with the SARA R510 did not have the Network Coprocessor Identifier programed into the OTP memory locations. To work around this SARA R510 was hard coded in the GEN2 modem hal and the GEN3 `platform_primary_ncp_identifier`. 

The latest gen 2 / 3 SARAR510 EVT devices have this data so the workaround should not be needed going forward
 
### Solution

For gen 3, the `platform_primary_ncp_identifier` function already reads the NCP id OTP data.
For gen 2, there is no `platform_ncp_electron` file, but rather it appears the other OTP data (device serial number, secret, etc) is accessible via `deviceid_hal`. I opted to extend the existing gen 2 deviceid hal, but there may be reasons we dont want to do that.  



### Steps to Test

Run example app, some hardware may not have R510 OTP programmed. This case still needs to be detected and handled

### Example App

```c
void setup() {
}

void loop() {
    delay(1000);

    CellularDevice device = {};
    device.size = sizeof(device);
    cellular_device_info(&device, NULL);
    Log.info("Cellular device info: %X IMEI: %s ICCID: %s", device.dev, device.imei, device.iccid);

    #if PLATFORM_GEN == 2
        uint8_t ncpId = 0;
        const size_t OTP_NCP_ID_ADDRESS = 32;
        int err_code = FLASH_ReadOTP(OTP_NCP_ID_ADDRESS, (uint8_t*)&ncpId, sizeof(ncpId));
        if (err_code) {
            Log.info("ERROR: %d", err_code);
        }
        Log.info("NCP ID: 0x%x", ncpId);
    #endif
}
```

### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
