### PR TITLE
Fixes the power leakage issue on the ESP32 module.

### DIFF
--- a/hal/network/ncp_client/esp32/esp32_ncp_client.cpp
+++ b/hal/network/ncp_client/esp32/esp32_ncp_client.cpp
@@ -115,6 +115,7 @@ Esp32NcpClient::~Esp32NcpClient() {
 int Esp32NcpClient::init(const NcpClientConfig& conf) {
     // Make sure ESP32 is powered down
     HAL_Pin_Mode(ESPBOOT, OUTPUT);
+    HAL_GPIO_Write(ESPBOOT, 1);
 #if PLATFORM_ID == PLATFORM_ARGON
     HAL_Pin_Mode(ESPEN, OUTPUT_OPEN_DRAIN);
 #elif PLATFORM_ID == PLATFORM_ASOM || PLATFORM_ID == PLATFORM_TRACKER


### PR DESCRIPTION
### Problem
On the ESP32 based platforms, if it is running the application with MANUAL mode and then goes into sleep mode without touching the network/modem functionality, it will draw ~300uA, which is violate the expected ~80uA.

### Solution
Output high level on the ESPBOOT pin after booting up.

### Steps to Test
Which unit/integration/application tests are applicable to this code change? (At minimum a test of some kind should be provided)

### Example App
```c
#include "Particle.h"

SYSTEM_MODE(MANUAL);
SystemSleepConfiguration config;

void setup(){
}

void loop() {     
    config.mode(SystemSleepMode::ULTRA_LOW_POWER)
    .duration(1min);
    delay(1s);
    System.sleep(config);
}
```

### References
N/A

---
### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
