### PR TITLE
Additional state for firmware update checks

### DIFF
--- a/system/inc/system_dynalib.h
+++ b/system/inc/system_dynalib.h
@@ -117,6 +117,8 @@ DYNALIB_FN(BASE_IDX1 + 2, system, system_power_management_get_config, int(hal_po
 #define BASE_IDX2 (BASE_IDX1 + 2)
 #endif  // HAL_PLATFORM_POWER_MANAGEMENT
 
+DYNALIB_FN(BASE_IDX2 + 0, system, system_get_update_status, int(void*))
+
 DYNALIB_END(system)
 
 #undef BASE_IDX

--- a/system/inc/system_event.h
+++ b/system/inc/system_event.h
@@ -47,20 +47,21 @@ enum SystemEvents {
     setup_all = wifi_listen,
     network_credentials = 1<<4,
     network_status = 1<<5,
-    cloud_status = 1<<6,             // parameter is 0 for disconnected, 1 for connecting, 8 for connected, 9 for disconnecting. other values reserved.
-    button_status = 1<<7,            // parameter is >0 for time pressed in ms (when released) or 0 for just pressed.
-    firmware_update = 1<<8,          // parameter is 0 for begin, 1 for OTA complete, -1 for error.
-    firmware_update_pending = 1<<9,	// notifies the application that an OTA update is pending and will be delivered when updates are enabled
+    cloud_status = 1<<6,            // parameter is 0 for disconnected, 1 for connecting, 8 for connected, 9 for disconnecting. other values reserved.
+    button_status = 1<<7,           // parameter is >0 for time pressed in ms (when released) or 0 for just pressed.
+    firmware_update = 1<<8,         // parameter is 0 for begin, 1 for OTA complete, -1 for error.
+    firmware_update_pending = 1<<9, // notifies the application that an OTA update is pending and will be delivered when updates are enabled
     reset_pending = 1<<10,          // notifies that the system would like to shutdown (System.resetPending() return true)
     // todo - rename to system_reset, or otherwise avoid common name clashes
-	reset = 1<<11,                  // notifies that the system will now reset on return from this event.
+    reset = 1<<11,                  // notifies that the system will now reset on return from this event.
     button_click = 1<<12,           // generated for every click in series - data is number of clicks in the lower 4 bits.
     button_final_click = 1<<13,     // generated for last click in series - data is the number of clicks in the lower 4 bits.
     time_changed = 1<<14,
     low_battery = 1<<15,            // generated when low battery condition is detected
     battery_state = 1<<16,
     power_source = 1<<17,
-	out_of_memory = 1<<18,			// heap request was not satisfied
+    out_of_memory = 1<<18,          // heap request was not satisfied
+    firmware_update_status = 1<<19, // firmware update status changed
 
     all_events = 0xFFFFFFFFFFFFFFFF
 };

--- a/system/inc/system_update.h
+++ b/system/inc/system_update.h
@@ -151,6 +151,27 @@ typedef enum
 
 } system_flag_t;
 
+/**
+ * Firmware update status.
+ */
+typedef enum {
+    /**
+     * The system will check for firmware updates when the device connects to the Cloud.
+     */
+    SYSTEM_UPDATE_STATUS_UNKNOWN = 0,
+    /**
+     * No firmware update available.
+     */
+    SYSTEM_UPDATE_STATUS_NO_UPDATE = 1,
+    /**
+     * A firmware update is available.
+     */
+    SYSTEM_UPDATE_STATUS_PENDING = 2,
+    /**
+     * A firmware update is in progress.
+     */
+    SYSTEM_UPDATE_STATUS_IN_PROGRESS = 3
+} system_update_status;
 
 void system_shutdown_if_needed();
 void system_pending_shutdown(System_Reset_Reason reason);
@@ -171,6 +192,11 @@ int system_refresh_flag(system_flag_t flag);
  */
 int system_format_diag_data(const uint16_t* id, size_t count, unsigned flags, appender_fn append, void* append_data,
         void* reserved);
+
+/**
+ * Return the firmware update status.
+ */
+int system_get_update_status(void* reserved);
 
 #ifdef __cplusplus
 }

--- a/system/inc/system_update.h
+++ b/system/inc/system_update.h
@@ -162,7 +162,7 @@ typedef enum {
     /**
      * No firmware update available.
      */
-    SYSTEM_UPDATE_STATUS_NO_UPDATE = 1,
+    SYSTEM_UPDATE_STATUS_NOT_AVAILABLE = 1,
     /**
      * A firmware update is available.
      */
@@ -194,7 +194,10 @@ int system_format_diag_data(const uint16_t* id, size_t count, unsigned flags, ap
         void* reserved);
 
 /**
- * Return the firmware update status.
+ * Get the firmware update status.
+ *
+ * @return A value defined by the `system_update_status` enum or a negative result code in case of
+ *         an error.
  */
 int system_get_update_status(void* reserved);
 

--- a/system/src/firmware_update.cpp
+++ b/system/src/firmware_update.cpp
@@ -170,7 +170,7 @@ int FirmwareUpdate::startUpdate(size_t fileSize, const char* fileHash, size_t* p
         }
         SPARK_FLASH_UPDATE = 1; // TODO: Get rid of legacy state variables
         updating_ = true;
-        // Generate a system event
+        // Generate system events
         fileDesc_ = FileTransfer::Descriptor();
         fileDesc_.file_length = fileSize;
         fileDesc_.file_address = HAL_OTA_FlashAddress();
@@ -178,6 +178,7 @@ int FirmwareUpdate::startUpdate(size_t fileSize, const char* fileHash, size_t* p
         fileDesc_.chunk_address = fileDesc_.file_address;
         fileDesc_.store = FileTransfer::Store::FIRMWARE;
         system_notify_event(firmware_update, firmware_update_begin, &fileDesc_);
+        system_notify_event(firmware_update_status, system_get_update_status(nullptr));
     }
     if (partialSize) {
         *partialSize = fileOffset;
@@ -430,6 +431,7 @@ void FirmwareUpdate::endUpdate(bool ok) {
     SPARK_FLASH_UPDATE = 0;
     updating_ = false;
     system_notify_event(firmware_update, ok ? firmware_update_complete : firmware_update_failed, &fileDesc_);
+    system_notify_event(firmware_update_status, system_get_update_status(nullptr));
 }
 
 } // namespace system

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -100,8 +100,13 @@ void systemEventHandler(const char* name, const char* data)
             system_set_flag(SYSTEM_FLAG_OTA_UPDATE_FORCED, flagValue, nullptr);
         }
         else if (isSuffix(name, DEVICE_UPDATES_EVENT, UPDATES_PENDING_EVENT)) {
+            const auto statusBefore = system_get_update_status(nullptr);
             SPARK_UPDATE_PENDING_EVENT_RECEIVED = 1;
             system_set_flag(SYSTEM_FLAG_OTA_UPDATE_PENDING, flagValue, nullptr);
+            const auto statusAfter = system_get_update_status(nullptr);
+            if (statusAfter != statusBefore) {
+                system_notify_event(firmware_update_status, statusAfter);
+            }
         }
     }
     else if (!strncmp(name, CLAIM_EVENTS, strlen(CLAIM_EVENTS))) {

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -67,6 +67,8 @@ using namespace particle;
 using namespace particle::system;
 using particle::protocol::ProtocolError;
 
+extern volatile uint8_t SPARK_UPDATE_PENDING_EVENT_RECEIVED;
+
 namespace particle {
 
 namespace {
@@ -98,6 +100,7 @@ void systemEventHandler(const char* name, const char* data)
             system_set_flag(SYSTEM_FLAG_OTA_UPDATE_FORCED, flagValue, nullptr);
         }
         else if (isSuffix(name, DEVICE_UPDATES_EVENT, UPDATES_PENDING_EVENT)) {
+            SPARK_UPDATE_PENDING_EVENT_RECEIVED = 1;
             system_set_flag(SYSTEM_FLAG_OTA_UPDATE_PENDING, flagValue, nullptr);
         }
     }

--- a/system/src/system_update.cpp
+++ b/system/src/system_update.cpp
@@ -887,6 +887,8 @@ int system_get_update_status(void* reserved) {
     if (system::FirmwareUpdate::instance()->isRunning()) {
         return SYSTEM_UPDATE_STATUS_IN_PROGRESS;
     }
+    // TODO: Ideally, we'd want to have a status that would indicate that a check for updates is in
+    // progress, however there's currently no way for the device to perform such a check proactively
     if (!SPARK_UPDATE_PENDING_EVENT_RECEIVED) {
         return SYSTEM_UPDATE_STATUS_UNKNOWN;
     }
@@ -895,5 +897,5 @@ int system_get_update_status(void* reserved) {
     if (pending) {
         return SYSTEM_UPDATE_STATUS_PENDING;
     }
-    return SYSTEM_UPDATE_STATUS_NO_UPDATE;
+    return SYSTEM_UPDATE_STATUS_NOT_AVAILABLE;
 }

--- a/system/src/system_update.cpp
+++ b/system/src/system_update.cpp
@@ -886,8 +886,6 @@ int system_get_update_status(void* reserved) {
     if (FirmwareUpdate::instance()->isRunning()) {
         return SYSTEM_UPDATE_STATUS_IN_PROGRESS;
     }
-    // TODO: Ideally, we'd want to have a status that would indicate that a check for updates is in
-    // progress, however there's currently no way for the device to perform such a check proactively
     if (!SPARK_UPDATE_PENDING_EVENT_RECEIVED) {
         return SYSTEM_UPDATE_STATUS_UNKNOWN;
     }

--- a/user/tests/wiring/api/system.cpp
+++ b/user/tests/wiring/api/system.cpp
@@ -287,6 +287,7 @@ void handler_event_data_param(system_event_t event, int data, void* param)
         case network_status_disconnected:
             break;
         }
+        break;
     }
     case cloud_status: {
         switch (data) {
@@ -296,6 +297,7 @@ void handler_event_data_param(system_event_t event, int data, void* param)
         case cloud_status_disconnecting:
             break;
         }
+        break;
     }
     default:
         break;
@@ -320,7 +322,7 @@ test(system_events)
                                setup_begin + setup_end + setup_update + network_credentials +
                                network_status + cloud_status + button_status + button_click + button_final_click +
                                reset + reset_pending + firmware_update + firmware_update_pending +
-                               all_events;
+                               firmware_update_status + all_events;
 
     API_COMPILE(System.on(my_events, handler));
     API_COMPILE(System.on(my_events, handler_event));
@@ -359,6 +361,14 @@ test(system_flags)
     API_COMPILE(System.enable(SYSTEM_FLAG_MAX));
     API_COMPILE(System.disable(SYSTEM_FLAG_MAX));
     API_COMPILE(System.enabled(SYSTEM_FLAG_MAX));
+}
+
+test(system_update)
+{
+    int r = 0;
+    API_COMPILE(r = System.updateStatus());
+    API_COMPILE(r == UpdateStatus::UNKNOWN || r == UpdateStatus::NOT_AVAILABLE || r == UpdateStatus::PENDING ||
+            r == UpdateStatus::IN_PROGRESS);
 }
 
 // todo - use platform feature flags

--- a/wiring/inc/spark_wiring_system.h
+++ b/wiring/inc/spark_wiring_system.h
@@ -87,6 +87,30 @@ enum WakeupReason {
     WAKEUP_REASON_UNKNOWN = 4
 };
 
+/**
+ * Firmware update status.
+ */
+enum class UpdateStatus: int {
+    /**
+     * The system will check for firmware updates when the device connects to the Cloud.
+     */
+    UNKNOWN = SYSTEM_UPDATE_STATUS_UNKNOWN,
+    /**
+     * No firmware update available.
+     */
+    NOT_AVAILABLE = SYSTEM_UPDATE_STATUS_NOT_AVAILABLE,
+    /**
+     * A firmware update is available.
+     */
+    PENDING = SYSTEM_UPDATE_STATUS_PENDING,
+    /**
+     * A firmware update is in progress.
+     */
+    IN_PROGRESS = SYSTEM_UPDATE_STATUS_IN_PROGRESS
+};
+
+PARTICLE_DEFINE_ENUM_COMPARISON_OPERATORS(UpdateStatus)
+
 struct SleepResult {
     SleepResult() {}
     SleepResult(WakeupReason r, system_error_t e, pin_t p = std::numeric_limits<pin_t>::max());
@@ -618,6 +642,12 @@ public:
     	return get_flag(SYSTEM_FLAG_OTA_UPDATE_FORCED) != 0;
     }
 
+    /**
+     * Get the firmware update status.
+     *
+     * @return A value defined by the `UpdateStatus` enum or a negative result code in case of
+     *         an error.
+     */
     int updateStatus() {
         return system_get_update_status(nullptr /* reserved */);
     }

--- a/wiring/inc/spark_wiring_system.h
+++ b/wiring/inc/spark_wiring_system.h
@@ -618,6 +618,10 @@ public:
     	return get_flag(SYSTEM_FLAG_OTA_UPDATE_FORCED) != 0;
     }
 
+    int updateStatus() {
+        return system_get_update_status(nullptr /* reserved */);
+    }
+
     inline void enableReset() {
         set_flag(SYSTEM_FLAG_RESET_ENABLED, true);
     }


### PR DESCRIPTION
### Problem

`System.updatesPending()` can only return `true` or `false` and it's impossible to tell whether `false` means that an update is indeed not available or that the system hasn't performed a check for updates yet.

### Solution

Introduce a separate method, `System.updateStatus()`, that returns one of the values defined by the `UpdateStatus` enum:
- `UNKNOWN` – The system will check for firmware updates when the device connects to the cloud.
- `NOT_AVAILABLE` – No firmware update available.
- `PENDING` – A firmware update is available.
- `IN_PROGRESS` – A firmware update is in progress.

In addition to `System.updateStatus()`, update status changes are also reported via `firmware_update_status` system events.

### Steps to Test

1. Flash the example product app to a device and connect to the device via the CLI's serial console. Make sure to set the app's `PRODUCT_ID` to your product ID.
2. Verify via the log that `System.updateStatus()` initially returns `UNKNOWN` and that the `NOT_AVAILABLE` status is reported via both `System.updateStatus()` and a `firmware_update_status` event shortly after the cloud connection is established.
3. Release a new version of the product firmware with IOTA enabled. Verify via the log that the update status has changed to `PENDING`.
4. Enable updates by clicking the setup button. Verify via the log that the update status has changed to `IN_PROGRESS`.

### Example App

```cpp
#include "application.h"

SYSTEM_MODE(SEMI_AUTOMATIC)
SYSTEM_THREAD(ENABLED)

PRODUCT_ID(...) // FIXME
PRODUCT_VERSION(1)

namespace {

const SerialLogHandler logHandler(LOG_LEVEL_WARN, {
    { "app", LOG_LEVEL_ALL }
});

int lastStatus = std::numeric_limits<int>::min();
volatile bool toggleUpdates = false;

void systemEventHandler(system_event_t event, int value, void* data)
{
    switch (event) {
    case firmware_update_status: {
        switch (value) {
        case (int)UpdateStatus::UNKNOWN:
            Log.info("firmware_update_status: UNKNOWN");
            break;
        case (int)UpdateStatus::NOT_AVAILABLE:
            Log.info("firmware_update_status: NOT_AVAILABLE");
            break;
        case (int)UpdateStatus::PENDING:
            Log.info("firmware_update_status: PENDING");
            break;
        case (int)UpdateStatus::IN_PROGRESS:
            Log.info("firmware_update_status: IN_PROGRESS");
            break;
        default:
            break;
        }
        break;
    }
    case button_final_click: {
        if (value == 1) { // 1 click
            toggleUpdates = true;
        }
        break;
    }
    default:
        break;
    }
}

} // namespace

void setup() {
    System.on(firmware_update_status, systemEventHandler);
    System.on(button_final_click, systemEventHandler);
    System.disableUpdates();
    waitUntil(Serial.isConnected);
    Particle.connect();
}

void loop() {
    const int status = System.updateStatus();
    if (lastStatus != status) {
        lastStatus = status;
        if (status < 0) {
            Log.error("System.updateStatus() failed: %d", status);
        } else {
            switch (status) {
            case (int)UpdateStatus::UNKNOWN:
                Log.info("System.updateStatus(): UNKNOWN");
                break;
            case (int)UpdateStatus::NOT_AVAILABLE:
                Log.info("System.updateStatus(): NOT_AVAILABLE");
                break;
            case (int)UpdateStatus::PENDING:
                Log.info("System.updateStatus(): PENDING");
                break;
            case (int)UpdateStatus::IN_PROGRESS:
                Log.info("System.updateStatus(): IN_PROGRESS");
                break;
            default:
                break;
            }
        }
    }
    if (toggleUpdates) {
        toggleUpdates = false;
        if (System.updatesEnabled()) {
            System.disableUpdates();
            Log.info("Firmware updates disabled");
        } else {
            System.enableUpdates();
            Log.info("Firmware updates enabled");
        }
    }
}
```

### References

- [ch62095]
