### PR TITLE
[services] Fixes jsmnerr_t issues in jsmn

### DIFF
--- a/services/inc/jsmn.h
+++ b/services/inc/jsmn.h
@@ -1,28 +1,26 @@
-/*
- * MIT License
- *
- * Copyright (c) 2010 Serge Zaitsev
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-#ifndef JSMN_H
-#define JSMN_H
+/*Copyright (c) 2010 Serge A. Zaitsev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#ifndef __JSMN_H_
+#define __JSMN_H_
 
 #include <stddef.h>
 
@@ -30,78 +28,70 @@
 extern "C" {
 #endif
 
-#ifdef JSMN_STATIC
-#define JSMN_API static
-#else
-#define JSMN_API extern
-#endif
-
 /**
  * JSON type identifier. Basic types are:
- * 	o Object
- * 	o Array
- * 	o String
- * 	o Other primitive: number, boolean (true/false) or null
+ *  o Object
+ *  o Array
+ *  o String
+ *  o Other primitive: number, boolean (true/false) or null
  */
 typedef enum {
-  JSMN_UNDEFINED = 0,
-  JSMN_OBJECT = 1,
-  JSMN_ARRAY = 2,
-  JSMN_STRING = 3,
-  JSMN_PRIMITIVE = 4
+    JSMN_PRIMITIVE = 0,
+    JSMN_OBJECT = 1,
+    JSMN_ARRAY = 2,
+    JSMN_STRING = 3
 } jsmntype_t;
 
-enum jsmnerr {
-  /* Not enough tokens were provided */
-  JSMN_ERROR_NOMEM = -1,
-  /* Invalid character inside JSON string */
-  JSMN_ERROR_INVAL = -2,
-  /* The string is not a full JSON packet, more bytes expected */
-  JSMN_ERROR_PART = -3
-};
+typedef enum {
+    /* Not enough tokens were provided */
+    JSMN_ERROR_NOMEM = -1,
+    /* Invalid character inside JSON string */
+    JSMN_ERROR_INVAL = -2,
+    /* The string is not a full JSON packet, more bytes expected */
+    JSMN_ERROR_PART = -3
+} jsmnerr_t;
 
 /**
  * JSON token description.
- * type		type (object, array, string etc.)
- * start	start position in JSON data string
- * end		end position in JSON data string
+ * @param       type    type (object, array, string etc.)
+ * @param       start   start position in JSON data string
+ * @param       end     end position in JSON data string
  */
-typedef struct jsmntok {
-  jsmntype_t type;
-  int start;
-  int end;
-  int size;
+typedef struct {
+    jsmntype_t type;
+    int start;
+    int end;
+    int size;
 #ifdef JSMN_PARENT_LINKS
-  int parent;
+    int parent;
 #endif
 } jsmntok_t;
 
 /**
  * JSON parser. Contains an array of token blocks available. Also stores
- * the string being parsed now and current position in that string.
+ * the string being parsed now and current position in that string
  */
-typedef struct jsmn_parser {
-  unsigned int pos;     /* offset in the JSON string */
-  unsigned int toknext; /* next token to allocate */
-  int toksuper;         /* superior token node, e.g. parent object or array */
+typedef struct {
+    unsigned size;
+    unsigned int pos; /* offset in the JSON string */
+    unsigned int toknext; /* next token to allocate */
+    int toksuper; /* superior token node, e.g parent object or array */
 } jsmn_parser;
 
 /**
  * Create JSON parser over an array of tokens
  */
-JSMN_API void jsmn_init(jsmn_parser *parser, void* reserved);
+void jsmn_init(jsmn_parser *parser, void* reserved);
 
 /**
- * Run JSON parser. It parses a JSON data string into and array of tokens, each
- * describing
+ * Run JSON parser. It parses a JSON data string into and array of tokens, each describing
  * a single JSON object.
  */
-JSMN_API int jsmn_parse(jsmn_parser *parser, const char *js, const size_t len,
-                        jsmntok_t *tokens, const unsigned int num_tokens,
-						void* reserved);
+jsmnerr_t jsmn_parse(jsmn_parser *parser, const char *js, size_t len,
+        jsmntok_t *tokens, unsigned int num_tokens, void* reserved);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* JSMN_H */
+#endif /* __JSMN_H_ */

--- a/services/inc/jsmn.h
+++ b/services/inc/jsmn.h
@@ -1,26 +1,28 @@
-/*Copyright (c) 2010 Serge A. Zaitsev
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-*/
-
-#ifndef __JSMN_H_
-#define __JSMN_H_
+/*
+ * MIT License
+ *
+ * Copyright (c) 2010 Serge Zaitsev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef JSMN_H
+#define JSMN_H
 
 #include <stddef.h>
 
@@ -28,70 +30,78 @@ THE SOFTWARE.
 extern "C" {
 #endif
 
+#ifdef JSMN_STATIC
+#define JSMN_API static
+#else
+#define JSMN_API extern
+#endif
+
 /**
  * JSON type identifier. Basic types are:
- *  o Object
- *  o Array
- *  o String
- *  o Other primitive: number, boolean (true/false) or null
+ * 	o Object
+ * 	o Array
+ * 	o String
+ * 	o Other primitive: number, boolean (true/false) or null
  */
 typedef enum {
-    JSMN_PRIMITIVE = 0,
-    JSMN_OBJECT = 1,
-    JSMN_ARRAY = 2,
-    JSMN_STRING = 3
+  JSMN_UNDEFINED = 0,
+  JSMN_OBJECT = 1,
+  JSMN_ARRAY = 2,
+  JSMN_STRING = 3,
+  JSMN_PRIMITIVE = 4
 } jsmntype_t;
 
-typedef enum {
-    /* Not enough tokens were provided */
-    JSMN_ERROR_NOMEM = -1,
-    /* Invalid character inside JSON string */
-    JSMN_ERROR_INVAL = -2,
-    /* The string is not a full JSON packet, more bytes expected */
-    JSMN_ERROR_PART = -3
-} jsmnerr_t;
+enum jsmnerr {
+  /* Not enough tokens were provided */
+  JSMN_ERROR_NOMEM = -1,
+  /* Invalid character inside JSON string */
+  JSMN_ERROR_INVAL = -2,
+  /* The string is not a full JSON packet, more bytes expected */
+  JSMN_ERROR_PART = -3
+};
 
 /**
  * JSON token description.
- * @param       type    type (object, array, string etc.)
- * @param       start   start position in JSON data string
- * @param       end     end position in JSON data string
+ * type		type (object, array, string etc.)
+ * start	start position in JSON data string
+ * end		end position in JSON data string
  */
-typedef struct {
-    jsmntype_t type;
-    int start;
-    int end;
-    int size;
+typedef struct jsmntok {
+  jsmntype_t type;
+  int start;
+  int end;
+  int size;
 #ifdef JSMN_PARENT_LINKS
-    int parent;
+  int parent;
 #endif
 } jsmntok_t;
 
 /**
  * JSON parser. Contains an array of token blocks available. Also stores
- * the string being parsed now and current position in that string
+ * the string being parsed now and current position in that string.
  */
-typedef struct {
-    unsigned size;
-    unsigned int pos; /* offset in the JSON string */
-    unsigned int toknext; /* next token to allocate */
-    int toksuper; /* superior token node, e.g parent object or array */
+typedef struct jsmn_parser {
+  unsigned int pos;     /* offset in the JSON string */
+  unsigned int toknext; /* next token to allocate */
+  int toksuper;         /* superior token node, e.g. parent object or array */
 } jsmn_parser;
 
 /**
  * Create JSON parser over an array of tokens
  */
-void jsmn_init(jsmn_parser *parser, void* reserved);
+JSMN_API void jsmn_init(jsmn_parser *parser, void* reserved);
 
 /**
- * Run JSON parser. It parses a JSON data string into and array of tokens, each describing
+ * Run JSON parser. It parses a JSON data string into and array of tokens, each
+ * describing
  * a single JSON object.
  */
-jsmnerr_t jsmn_parse(jsmn_parser *parser, const char *js, size_t len,
-        jsmntok_t *tokens, unsigned int num_tokens, void* reserved);
+JSMN_API int jsmn_parse(jsmn_parser *parser, const char *js, const size_t len,
+                        jsmntok_t *tokens, const unsigned int num_tokens,
+						void* reserved);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* __JSMN_H_ */
+#endif /* JSMN_H */

--- a/services/inc/jsmn.h
+++ b/services/inc/jsmn.h
@@ -87,7 +87,7 @@ void jsmn_init(jsmn_parser *parser, void* reserved);
  * Run JSON parser. It parses a JSON data string into and array of tokens, each describing
  * a single JSON object.
  */
-jsmnerr_t jsmn_parse(jsmn_parser *parser, const char *js, size_t len,
+int jsmn_parse(jsmn_parser *parser, const char *js, size_t len,
         jsmntok_t *tokens, unsigned int num_tokens, void* reserved);
 
 #ifdef __cplusplus

--- a/services/inc/jsmn_compat.h
+++ b/services/inc/jsmn_compat.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "jsmn.h"
+#include <assert.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+// Due to usage of -fshort-enums we were exporting jsmn_parse() which in fact was only
+// returning an int8_t, preventing parsing of relatively large JSONs. This is now fixed
+// in the upstream version of jsmn library and also in our "fork" contained within Device OS
+// sources in services.
+// For compatibility purposes, we are still exporting such a variant of jsmn_parse().
+jsmnerr_t jsmn_parse_deprecated(jsmn_parser *parser, const char *js, size_t len,
+        jsmntok_t *tokens, unsigned int num_tokens, void* reserved);
+
+#ifdef DYNALIB_EXPORT
+static_assert(sizeof(jsmnerr_t) == sizeof(int8_t), "size of jsmnerr_t used for compat jsmn_parse changed");
+#endif // DYNALIB_EXPORT
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus

--- a/services/inc/jsmn_compat.h
+++ b/services/inc/jsmn_compat.h
@@ -33,9 +33,9 @@ extern "C" {
 jsmnerr_t jsmn_parse_deprecated(jsmn_parser *parser, const char *js, size_t len,
         jsmntok_t *tokens, unsigned int num_tokens, void* reserved);
 
-#ifdef DYNALIB_EXPORT
+#if defined(DYNALIB_EXPORT) && defined(MODULAR_FIRMWARE) && MODULAR_FIRMWARE
 static_assert(sizeof(jsmnerr_t) == sizeof(int8_t), "size of jsmnerr_t used for compat jsmn_parse changed");
-#endif // DYNALIB_EXPORT
+#endif // defined(DYNALIB_EXPORT) && defined(MODULAR_FIRMWARE) && MODULAR_FIRMWARE
 
 #ifdef __cplusplus
 }

--- a/services/inc/services_dynalib.h
+++ b/services/inc/services_dynalib.h
@@ -56,7 +56,7 @@ DYNALIB_FN(12, services, set_logger_output, void(debug_output_fn, LoggerOutputLe
 DYNALIB_FN(13, services, panic_, void(ePanicCode, void*, void(*)(uint32_t)))
 
 DYNALIB_FN(14, services, jsmn_init, void(jsmn_parser*, void*))
-DYNALIB_FN(15, services, jsmn_parse, int(jsmn_parser*, const char*, size_t, jsmntok_t*, unsigned int, void*))
+DYNALIB_FN(15, services, jsmn_parse_deprecated, jsmnerr_t(jsmn_parser*, const char*, size_t, jsmntok_t*, unsigned int, void*))
 DYNALIB_FN(16, services, log_print_, void(int, int, const char*, const char*, const char*, ...)) // Deprecated
 DYNALIB_FN(17, services, LED_RGB_SetChangeHandler, void(led_update_handler_fn, void*))
 DYNALIB_FN(18, services, log_print_direct_, void(int, void*, const char*, ...)) // Deprecated
@@ -113,6 +113,7 @@ DYNALIB_FN(55, services, pb_encode_varint, bool(pb_ostream_t*, pb_uint64_t))
 DYNALIB_FN(BASE_IDX + 0, services, set_system_error_message, void(const char*, ...))
 DYNALIB_FN(BASE_IDX + 1, services, clear_system_error_message, void())
 DYNALIB_FN(BASE_IDX + 2, services, get_system_error_message, const char*(int))
+DYNALIB_FN(BASE_IDX + 3, services, jsmn_parse, int(jsmn_parser*, const char*, size_t, jsmntok_t*, unsigned int, void*))
 
 DYNALIB_END(services)
 

--- a/services/inc/services_dynalib.h
+++ b/services/inc/services_dynalib.h
@@ -56,7 +56,7 @@ DYNALIB_FN(12, services, set_logger_output, void(debug_output_fn, LoggerOutputLe
 DYNALIB_FN(13, services, panic_, void(ePanicCode, void*, void(*)(uint32_t)))
 
 DYNALIB_FN(14, services, jsmn_init, void(jsmn_parser*, void*))
-DYNALIB_FN(15, services, jsmn_parse, jsmnerr_t(jsmn_parser*, const char*, size_t, jsmntok_t*, unsigned int, void*))
+DYNALIB_FN(15, services, jsmn_parse, int(jsmn_parser*, const char*, size_t, jsmntok_t*, unsigned int, void*))
 DYNALIB_FN(16, services, log_print_, void(int, int, const char*, const char*, const char*, ...)) // Deprecated
 DYNALIB_FN(17, services, LED_RGB_SetChangeHandler, void(led_update_handler_fn, void*))
 DYNALIB_FN(18, services, log_print_direct_, void(int, void*, const char*, ...)) // Deprecated

--- a/services/src/jsmn.c
+++ b/services/src/jsmn.c
@@ -56,7 +56,7 @@ static void jsmn_fill_token(jsmntok_t *token, jsmntype_t type,
 /**
  * Fills next available token with JSON primitive.
  */
-static jsmnerr_t jsmn_parse_primitive(jsmn_parser *parser, const char *js,
+static int jsmn_parse_primitive(jsmn_parser *parser, const char *js,
         size_t len, jsmntok_t *tokens, size_t num_tokens) {
     jsmntok_t *token;
     int start;
@@ -105,7 +105,7 @@ found:
 /**
  * Filsl next token with JSON string.
  */
-static jsmnerr_t jsmn_parse_string(jsmn_parser *parser, const char *js,
+static int jsmn_parse_string(jsmn_parser *parser, const char *js,
         size_t len, jsmntok_t *tokens, size_t num_tokens) {
     jsmntok_t *token;
 
@@ -172,9 +172,9 @@ static jsmnerr_t jsmn_parse_string(jsmn_parser *parser, const char *js,
 /**
  * Parse JSON string and fill tokens.
  */
-jsmnerr_t jsmn_parse(jsmn_parser *parser, const char *js, size_t len,
+int jsmn_parse(jsmn_parser *parser, const char *js, size_t len,
         jsmntok_t *tokens, unsigned int num_tokens, void* reserved) {
-    jsmnerr_t r;
+    int r;
     int i;
     jsmntok_t *token;
     int count = 0;

--- a/services/src/jsmn.c
+++ b/services/src/jsmn.c
@@ -1,333 +1,392 @@
 /*
-Copyright (c) 2010 Serge A. Zaitsev
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-*/
+ * MIT License
+ *
+ * Copyright (c) 2010 Serge Zaitsev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 
 #include <stdlib.h>
 
 #include "jsmn.h"
 
+
 /**
- * Allocates a fresh unused token from the token pull.
+ * Allocates a fresh unused token from the token pool.
  */
-static jsmntok_t *jsmn_alloc_token(jsmn_parser *parser,
-        jsmntok_t *tokens, size_t num_tokens) {
-    jsmntok_t *tok;
-    if (parser->toknext >= num_tokens) {
-        return NULL;
-    }
-    tok = &tokens[parser->toknext++];
-    tok->start = tok->end = -1;
-    tok->size = 0;
+static jsmntok_t *jsmn_alloc_token(jsmn_parser *parser, jsmntok_t *tokens,
+                                   const size_t num_tokens) {
+  jsmntok_t *tok;
+  if (parser->toknext >= num_tokens) {
+    return NULL;
+  }
+  tok = &tokens[parser->toknext++];
+  tok->start = tok->end = -1;
+  tok->size = 0;
 #ifdef JSMN_PARENT_LINKS
-    tok->parent = -1;
+  tok->parent = -1;
 #endif
-    return tok;
+  return tok;
 }
 
 /**
  * Fills token type and boundaries.
  */
-static void jsmn_fill_token(jsmntok_t *token, jsmntype_t type,
-                            int start, int end) {
-    token->type = type;
-    token->start = start;
-    token->end = end;
-    token->size = 0;
+static void jsmn_fill_token(jsmntok_t *token, const jsmntype_t type,
+                            const int start, const int end) {
+  token->type = type;
+  token->start = start;
+  token->end = end;
+  token->size = 0;
 }
 
 /**
  * Fills next available token with JSON primitive.
  */
-static jsmnerr_t jsmn_parse_primitive(jsmn_parser *parser, const char *js,
-        size_t len, jsmntok_t *tokens, size_t num_tokens) {
-    jsmntok_t *token;
-    int start;
+static int jsmn_parse_primitive(jsmn_parser *parser, const char *js,
+                                const size_t len, jsmntok_t *tokens,
+                                const size_t num_tokens) {
+  jsmntok_t *token;
+  int start;
 
-    start = parser->pos;
+  start = parser->pos;
 
-    for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
-        switch (js[parser->pos]) {
+  for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+    switch (js[parser->pos]) {
 #ifndef JSMN_STRICT
-            /* In strict mode primitive must be followed by "," or "}" or "]" */
-            case ':':
+    /* In strict mode primitive must be followed by "," or "}" or "]" */
+    case ':':
 #endif
-            case '\t' : case '\r' : case '\n' : case ' ' :
-            case ','  : case ']'  : case '}' :
-                goto found;
-        }
-        if (js[parser->pos] < 32 || js[parser->pos] >= 127) {
-            parser->pos = start;
-            return JSMN_ERROR_INVAL;
-        }
+    case '\t':
+    case '\r':
+    case '\n':
+    case ' ':
+    case ',':
+    case ']':
+    case '}':
+      goto found;
+    default:
+                   /* to quiet a warning from gcc*/
+      break;
     }
+    if (js[parser->pos] < 32 || js[parser->pos] >= 127) {
+      parser->pos = start;
+      return JSMN_ERROR_INVAL;
+    }
+  }
 #ifdef JSMN_STRICT
-    /* In strict mode primitive must be followed by a comma/object/array */
-    parser->pos = start;
-    return JSMN_ERROR_PART;
+  /* In strict mode primitive must be followed by a comma/object/array */
+  parser->pos = start;
+  return JSMN_ERROR_PART;
 #endif
 
 found:
-    if (tokens == NULL) {
-        parser->pos--;
-        return 0;
-    }
-    token = jsmn_alloc_token(parser, tokens, num_tokens);
-    if (token == NULL) {
-        parser->pos = start;
-        return JSMN_ERROR_NOMEM;
-    }
-    jsmn_fill_token(token, JSMN_PRIMITIVE, start, parser->pos);
-#ifdef JSMN_PARENT_LINKS
-    token->parent = parser->toksuper;
-#endif
+  if (tokens == NULL) {
     parser->pos--;
     return 0;
+  }
+  token = jsmn_alloc_token(parser, tokens, num_tokens);
+  if (token == NULL) {
+    parser->pos = start;
+    return JSMN_ERROR_NOMEM;
+  }
+  jsmn_fill_token(token, JSMN_PRIMITIVE, start, parser->pos);
+#ifdef JSMN_PARENT_LINKS
+  token->parent = parser->toksuper;
+#endif
+  parser->pos--;
+  return 0;
 }
 
 /**
- * Filsl next token with JSON string.
+ * Fills next token with JSON string.
  */
-static jsmnerr_t jsmn_parse_string(jsmn_parser *parser, const char *js,
-        size_t len, jsmntok_t *tokens, size_t num_tokens) {
-    jsmntok_t *token;
+static int jsmn_parse_string(jsmn_parser *parser, const char *js,
+                             const size_t len, jsmntok_t *tokens,
+                             const size_t num_tokens) {
+  jsmntok_t *token;
 
-    int start = parser->pos;
+  int start = parser->pos;
 
-    parser->pos++;
+  parser->pos++;
 
-    /* Skip starting quote */
-    for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
-        char c = js[parser->pos];
+  /* Skip starting quote */
+  for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+    char c = js[parser->pos];
 
-        /* Quote: end of string */
-        if (c == '\"') {
-            if (tokens == NULL) {
-                return 0;
-            }
-            token = jsmn_alloc_token(parser, tokens, num_tokens);
-            if (token == NULL) {
-                parser->pos = start;
-                return JSMN_ERROR_NOMEM;
-            }
-            jsmn_fill_token(token, JSMN_STRING, start+1, parser->pos);
+    /* Quote: end of string */
+    if (c == '\"') {
+      if (tokens == NULL) {
+        return 0;
+      }
+      token = jsmn_alloc_token(parser, tokens, num_tokens);
+      if (token == NULL) {
+        parser->pos = start;
+        return JSMN_ERROR_NOMEM;
+      }
+      jsmn_fill_token(token, JSMN_STRING, start + 1, parser->pos);
 #ifdef JSMN_PARENT_LINKS
-            token->parent = parser->toksuper;
+      token->parent = parser->toksuper;
 #endif
-            return 0;
-        }
-
-        /* Backslash: Quoted symbol expected */
-        if (c == '\\' && parser->pos + 1 < len) {
-            int i;
-            parser->pos++;
-            switch (js[parser->pos]) {
-                /* Allowed escaped symbols */
-                case '\"': case '/' : case '\\' : case 'b' :
-                case 'f' : case 'r' : case 'n'  : case 't' :
-                    break;
-                /* Allows escaped symbol \uXXXX */
-                case 'u':
-                    parser->pos++;
-                    for(i = 0; i < 4 && parser->pos < len && js[parser->pos] != '\0'; i++) {
-                        /* If it isn't a hex character we have an error */
-                        if(!((js[parser->pos] >= 48 && js[parser->pos] <= 57) || /* 0-9 */
-                                    (js[parser->pos] >= 65 && js[parser->pos] <= 70) || /* A-F */
-                                    (js[parser->pos] >= 97 && js[parser->pos] <= 102))) { /* a-f */
-                            parser->pos = start;
-                            return JSMN_ERROR_INVAL;
-                        }
-                        parser->pos++;
-                    }
-                    parser->pos--;
-                    break;
-                /* Unexpected symbol */
-                default:
-                    parser->pos = start;
-                    return JSMN_ERROR_INVAL;
-            }
-        }
+      return 0;
     }
-    parser->pos = start;
-    return JSMN_ERROR_PART;
+
+    /* Backslash: Quoted symbol expected */
+    if (c == '\\' && parser->pos + 1 < len) {
+      int i;
+      parser->pos++;
+      switch (js[parser->pos]) {
+      /* Allowed escaped symbols */
+      case '\"':
+      case '/':
+      case '\\':
+      case 'b':
+      case 'f':
+      case 'r':
+      case 'n':
+      case 't':
+        break;
+      /* Allows escaped symbol \uXXXX */
+      case 'u':
+        parser->pos++;
+        for (i = 0; i < 4 && parser->pos < len && js[parser->pos] != '\0';
+             i++) {
+          /* If it isn't a hex character we have an error */
+          if (!((js[parser->pos] >= 48 && js[parser->pos] <= 57) ||   /* 0-9 */
+                (js[parser->pos] >= 65 && js[parser->pos] <= 70) ||   /* A-F */
+                (js[parser->pos] >= 97 && js[parser->pos] <= 102))) { /* a-f */
+            parser->pos = start;
+            return JSMN_ERROR_INVAL;
+          }
+          parser->pos++;
+        }
+        parser->pos--;
+        break;
+      /* Unexpected symbol */
+      default:
+        parser->pos = start;
+        return JSMN_ERROR_INVAL;
+      }
+    }
+  }
+  parser->pos = start;
+  return JSMN_ERROR_PART;
 }
 
 /**
  * Parse JSON string and fill tokens.
  */
-jsmnerr_t jsmn_parse(jsmn_parser *parser, const char *js, size_t len,
-        jsmntok_t *tokens, unsigned int num_tokens, void* reserved) {
-    jsmnerr_t r;
-    int i;
-    jsmntok_t *token;
-    int count = 0;
+JSMN_API int jsmn_parse(jsmn_parser *parser, const char *js, const size_t len,
+                        jsmntok_t *tokens, const unsigned int num_tokens,
+						void* reserved) {
+  int r;
+  int i;
+  jsmntok_t *token;
+  int count = parser->toknext;
 
-    for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
-        char c;
-        jsmntype_t type;
+  for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+    char c;
+    jsmntype_t type;
 
-        c = js[parser->pos];
-        switch (c) {
-            case '{': case '[':
-                count++;
-                if (tokens == NULL) {
-                    break;
-                }
-                token = jsmn_alloc_token(parser, tokens, num_tokens);
-                if (token == NULL)
-                    return JSMN_ERROR_NOMEM;
-                if (parser->toksuper != -1) {
-                    tokens[parser->toksuper].size++;
-#ifdef JSMN_PARENT_LINKS
-                    token->parent = parser->toksuper;
-#endif
-                }
-                token->type = (c == '{' ? JSMN_OBJECT : JSMN_ARRAY);
-                token->start = parser->pos;
-                parser->toksuper = parser->toknext - 1;
-                break;
-            case '}': case ']':
-                if (tokens == NULL)
-                    break;
-                type = (c == '}' ? JSMN_OBJECT : JSMN_ARRAY);
-#ifdef JSMN_PARENT_LINKS
-                if (parser->toknext < 1) {
-                    return JSMN_ERROR_INVAL;
-                }
-                token = &tokens[parser->toknext - 1];
-                for (;;) {
-                    if (token->start != -1 && token->end == -1) {
-                        if (token->type != type) {
-                            return JSMN_ERROR_INVAL;
-                        }
-                        token->end = parser->pos + 1;
-                        parser->toksuper = token->parent;
-                        break;
-                    }
-                    if (token->parent == -1) {
-                        break;
-                    }
-                    token = &tokens[token->parent];
-                }
-#else
-                for (i = parser->toknext - 1; i >= 0; i--) {
-                    token = &tokens[i];
-                    if (token->start != -1 && token->end == -1) {
-                        if (token->type != type) {
-                            return JSMN_ERROR_INVAL;
-                        }
-                        parser->toksuper = -1;
-                        token->end = parser->pos + 1;
-                        break;
-                    }
-                }
-                /* Error if unmatched closing bracket */
-                if (i == -1) return JSMN_ERROR_INVAL;
-                for (; i >= 0; i--) {
-                    token = &tokens[i];
-                    if (token->start != -1 && token->end == -1) {
-                        parser->toksuper = i;
-                        break;
-                    }
-                }
-#endif
-                break;
-            case '\"':
-                r = jsmn_parse_string(parser, js, len, tokens, num_tokens);
-                if (r < 0) return r;
-                count++;
-                if (parser->toksuper != -1 && tokens != NULL)
-                    tokens[parser->toksuper].size++;
-                break;
-            case '\t' : case '\r' : case '\n' : case ' ':
-                break;
-            case ':':
-                parser->toksuper = parser->toknext - 1;
-                break;
-            case ',':
-                if (tokens != NULL &&
-                        tokens[parser->toksuper].type != JSMN_ARRAY &&
-                        tokens[parser->toksuper].type != JSMN_OBJECT) {
-#ifdef JSMN_PARENT_LINKS
-                    parser->toksuper = tokens[parser->toksuper].parent;
-#else
-                    for (i = parser->toknext - 1; i >= 0; i--) {
-                        if (tokens[i].type == JSMN_ARRAY || tokens[i].type == JSMN_OBJECT) {
-                            if (tokens[i].start != -1 && tokens[i].end == -1) {
-                                parser->toksuper = i;
-                                break;
-                            }
-                        }
-                    }
-#endif
-                }
-                break;
+    c = js[parser->pos];
+    switch (c) {
+    case '{':
+    case '[':
+      count++;
+      if (tokens == NULL) {
+        break;
+      }
+      token = jsmn_alloc_token(parser, tokens, num_tokens);
+      if (token == NULL) {
+        return JSMN_ERROR_NOMEM;
+      }
+      if (parser->toksuper != -1) {
+        jsmntok_t *t = &tokens[parser->toksuper];
 #ifdef JSMN_STRICT
-            /* In strict mode primitives are: numbers and booleans */
-            case '-': case '0': case '1' : case '2': case '3' : case '4':
-            case '5': case '6': case '7' : case '8': case '9':
-            case 't': case 'f': case 'n' :
-                /* And they must not be keys of the object */
-                if (tokens != NULL) {
-                    jsmntok_t *t = &tokens[parser->toksuper];
-                    if (t->type == JSMN_OBJECT ||
-                            (t->type == JSMN_STRING && t->size != 0)) {
-                        return JSMN_ERROR_INVAL;
-                    }
-                }
-#else
-            /* In non-strict mode every unquoted value is a primitive */
-            default:
-#endif
-                r = jsmn_parse_primitive(parser, js, len, tokens, num_tokens);
-                if (r < 0) return r;
-                count++;
-                if (parser->toksuper != -1 && tokens != NULL)
-                    tokens[parser->toksuper].size++;
-                break;
-
-#ifdef JSMN_STRICT
-            /* Unexpected char in strict mode */
-            default:
-                return JSMN_ERROR_INVAL;
-#endif
+        /* In strict mode an object or array can't become a key */
+        if (t->type == JSMN_OBJECT) {
+          return JSMN_ERROR_INVAL;
         }
-    }
+#endif
+        t->size++;
+#ifdef JSMN_PARENT_LINKS
+        token->parent = parser->toksuper;
+#endif
+      }
+      token->type = (c == '{' ? JSMN_OBJECT : JSMN_ARRAY);
+      token->start = parser->pos;
+      parser->toksuper = parser->toknext - 1;
+      break;
+    case '}':
+    case ']':
+      if (tokens == NULL) {
+        break;
+      }
+      type = (c == '}' ? JSMN_OBJECT : JSMN_ARRAY);
+#ifdef JSMN_PARENT_LINKS
+      if (parser->toknext < 1) {
+        return JSMN_ERROR_INVAL;
+      }
+      token = &tokens[parser->toknext - 1];
+      for (;;) {
+        if (token->start != -1 && token->end == -1) {
+          if (token->type != type) {
+            return JSMN_ERROR_INVAL;
+          }
+          token->end = parser->pos + 1;
+          parser->toksuper = token->parent;
+          break;
+        }
+        if (token->parent == -1) {
+          if (token->type != type || parser->toksuper == -1) {
+            return JSMN_ERROR_INVAL;
+          }
+          break;
+        }
+        token = &tokens[token->parent];
+      }
+#else
+      for (i = parser->toknext - 1; i >= 0; i--) {
+        token = &tokens[i];
+        if (token->start != -1 && token->end == -1) {
+          if (token->type != type) {
+            return JSMN_ERROR_INVAL;
+          }
+          parser->toksuper = -1;
+          token->end = parser->pos + 1;
+          break;
+        }
+      }
+      /* Error if unmatched closing bracket */
+      if (i == -1) {
+        return JSMN_ERROR_INVAL;
+      }
+      for (; i >= 0; i--) {
+        token = &tokens[i];
+        if (token->start != -1 && token->end == -1) {
+          parser->toksuper = i;
+          break;
+        }
+      }
+#endif
+      break;
+    case '\"':
+      r = jsmn_parse_string(parser, js, len, tokens, num_tokens);
+      if (r < 0) {
+        return r;
+      }
+      count++;
+      if (parser->toksuper != -1 && tokens != NULL) {
+        tokens[parser->toksuper].size++;
+      }
+      break;
+    case '\t':
+    case '\r':
+    case '\n':
+    case ' ':
+      break;
+    case ':':
+      parser->toksuper = parser->toknext - 1;
+      break;
+    case ',':
+      if (tokens != NULL && parser->toksuper != -1 &&
+          tokens[parser->toksuper].type != JSMN_ARRAY &&
+          tokens[parser->toksuper].type != JSMN_OBJECT) {
+#ifdef JSMN_PARENT_LINKS
+        parser->toksuper = tokens[parser->toksuper].parent;
+#else
+        for (i = parser->toknext - 1; i >= 0; i--) {
+          if (tokens[i].type == JSMN_ARRAY || tokens[i].type == JSMN_OBJECT) {
+            if (tokens[i].start != -1 && tokens[i].end == -1) {
+              parser->toksuper = i;
+              break;
+            }
+          }
+        }
+#endif
+      }
+      break;
+#ifdef JSMN_STRICT
+    /* In strict mode primitives are: numbers and booleans */
+    case '-':
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
+    case 't':
+    case 'f':
+    case 'n':
+      /* And they must not be keys of the object */
+      if (tokens != NULL && parser->toksuper != -1) {
+        const jsmntok_t *t = &tokens[parser->toksuper];
+        if (t->type == JSMN_OBJECT ||
+            (t->type == JSMN_STRING && t->size != 0)) {
+          return JSMN_ERROR_INVAL;
+        }
+      }
+#else
+    /* In non-strict mode every unquoted value is a primitive */
+    default:
+#endif
+      r = jsmn_parse_primitive(parser, js, len, tokens, num_tokens);
+      if (r < 0) {
+        return r;
+      }
+      count++;
+      if (parser->toksuper != -1 && tokens != NULL) {
+        tokens[parser->toksuper].size++;
+      }
+      break;
 
+#ifdef JSMN_STRICT
+    /* Unexpected char in strict mode */
+    default:
+      return JSMN_ERROR_INVAL;
+#endif
+    }
+  }
+
+  if (tokens != NULL) {
     for (i = parser->toknext - 1; i >= 0; i--) {
-        /* Unmatched opened object or array */
-        if (tokens[i].start != -1 && tokens[i].end == -1) {
-            return JSMN_ERROR_PART;
-        }
+      /* Unmatched opened object or array */
+      if (tokens[i].start != -1 && tokens[i].end == -1) {
+        return JSMN_ERROR_PART;
+      }
     }
+  }
 
-    return count;
+  return count;
 }
 
 /**
- * Creates a new parser based over a given  buffer with an array of tokens
+ * Creates a new parser based over a given buffer with an array of tokens
  * available.
  */
-void jsmn_init(jsmn_parser *parser, void* reserved) {
-    parser->pos = 0;
-    parser->toknext = 0;
-    parser->toksuper = -1;
+JSMN_API void jsmn_init(jsmn_parser *parser, void* reserved) {
+  parser->pos = 0;
+  parser->toknext = 0;
+  parser->toksuper = -1;
 }
 

--- a/services/src/jsmn.c
+++ b/services/src/jsmn.c
@@ -1,392 +1,333 @@
 /*
- * MIT License
- *
- * Copyright (c) 2010 Serge Zaitsev
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
+Copyright (c) 2010 Serge A. Zaitsev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
 
 #include <stdlib.h>
 
 #include "jsmn.h"
 
-
 /**
- * Allocates a fresh unused token from the token pool.
+ * Allocates a fresh unused token from the token pull.
  */
-static jsmntok_t *jsmn_alloc_token(jsmn_parser *parser, jsmntok_t *tokens,
-                                   const size_t num_tokens) {
-  jsmntok_t *tok;
-  if (parser->toknext >= num_tokens) {
-    return NULL;
-  }
-  tok = &tokens[parser->toknext++];
-  tok->start = tok->end = -1;
-  tok->size = 0;
+static jsmntok_t *jsmn_alloc_token(jsmn_parser *parser,
+        jsmntok_t *tokens, size_t num_tokens) {
+    jsmntok_t *tok;
+    if (parser->toknext >= num_tokens) {
+        return NULL;
+    }
+    tok = &tokens[parser->toknext++];
+    tok->start = tok->end = -1;
+    tok->size = 0;
 #ifdef JSMN_PARENT_LINKS
-  tok->parent = -1;
+    tok->parent = -1;
 #endif
-  return tok;
+    return tok;
 }
 
 /**
  * Fills token type and boundaries.
  */
-static void jsmn_fill_token(jsmntok_t *token, const jsmntype_t type,
-                            const int start, const int end) {
-  token->type = type;
-  token->start = start;
-  token->end = end;
-  token->size = 0;
+static void jsmn_fill_token(jsmntok_t *token, jsmntype_t type,
+                            int start, int end) {
+    token->type = type;
+    token->start = start;
+    token->end = end;
+    token->size = 0;
 }
 
 /**
  * Fills next available token with JSON primitive.
  */
-static int jsmn_parse_primitive(jsmn_parser *parser, const char *js,
-                                const size_t len, jsmntok_t *tokens,
-                                const size_t num_tokens) {
-  jsmntok_t *token;
-  int start;
+static jsmnerr_t jsmn_parse_primitive(jsmn_parser *parser, const char *js,
+        size_t len, jsmntok_t *tokens, size_t num_tokens) {
+    jsmntok_t *token;
+    int start;
 
-  start = parser->pos;
+    start = parser->pos;
 
-  for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
-    switch (js[parser->pos]) {
+    for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+        switch (js[parser->pos]) {
 #ifndef JSMN_STRICT
-    /* In strict mode primitive must be followed by "," or "}" or "]" */
-    case ':':
+            /* In strict mode primitive must be followed by "," or "}" or "]" */
+            case ':':
 #endif
-    case '\t':
-    case '\r':
-    case '\n':
-    case ' ':
-    case ',':
-    case ']':
-    case '}':
-      goto found;
-    default:
-                   /* to quiet a warning from gcc*/
-      break;
+            case '\t' : case '\r' : case '\n' : case ' ' :
+            case ','  : case ']'  : case '}' :
+                goto found;
+        }
+        if (js[parser->pos] < 32 || js[parser->pos] >= 127) {
+            parser->pos = start;
+            return JSMN_ERROR_INVAL;
+        }
     }
-    if (js[parser->pos] < 32 || js[parser->pos] >= 127) {
-      parser->pos = start;
-      return JSMN_ERROR_INVAL;
-    }
-  }
 #ifdef JSMN_STRICT
-  /* In strict mode primitive must be followed by a comma/object/array */
-  parser->pos = start;
-  return JSMN_ERROR_PART;
+    /* In strict mode primitive must be followed by a comma/object/array */
+    parser->pos = start;
+    return JSMN_ERROR_PART;
 #endif
 
 found:
-  if (tokens == NULL) {
+    if (tokens == NULL) {
+        parser->pos--;
+        return 0;
+    }
+    token = jsmn_alloc_token(parser, tokens, num_tokens);
+    if (token == NULL) {
+        parser->pos = start;
+        return JSMN_ERROR_NOMEM;
+    }
+    jsmn_fill_token(token, JSMN_PRIMITIVE, start, parser->pos);
+#ifdef JSMN_PARENT_LINKS
+    token->parent = parser->toksuper;
+#endif
     parser->pos--;
     return 0;
-  }
-  token = jsmn_alloc_token(parser, tokens, num_tokens);
-  if (token == NULL) {
-    parser->pos = start;
-    return JSMN_ERROR_NOMEM;
-  }
-  jsmn_fill_token(token, JSMN_PRIMITIVE, start, parser->pos);
-#ifdef JSMN_PARENT_LINKS
-  token->parent = parser->toksuper;
-#endif
-  parser->pos--;
-  return 0;
 }
 
 /**
- * Fills next token with JSON string.
+ * Filsl next token with JSON string.
  */
-static int jsmn_parse_string(jsmn_parser *parser, const char *js,
-                             const size_t len, jsmntok_t *tokens,
-                             const size_t num_tokens) {
-  jsmntok_t *token;
+static jsmnerr_t jsmn_parse_string(jsmn_parser *parser, const char *js,
+        size_t len, jsmntok_t *tokens, size_t num_tokens) {
+    jsmntok_t *token;
 
-  int start = parser->pos;
+    int start = parser->pos;
 
-  parser->pos++;
+    parser->pos++;
 
-  /* Skip starting quote */
-  for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
-    char c = js[parser->pos];
+    /* Skip starting quote */
+    for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+        char c = js[parser->pos];
 
-    /* Quote: end of string */
-    if (c == '\"') {
-      if (tokens == NULL) {
-        return 0;
-      }
-      token = jsmn_alloc_token(parser, tokens, num_tokens);
-      if (token == NULL) {
-        parser->pos = start;
-        return JSMN_ERROR_NOMEM;
-      }
-      jsmn_fill_token(token, JSMN_STRING, start + 1, parser->pos);
+        /* Quote: end of string */
+        if (c == '\"') {
+            if (tokens == NULL) {
+                return 0;
+            }
+            token = jsmn_alloc_token(parser, tokens, num_tokens);
+            if (token == NULL) {
+                parser->pos = start;
+                return JSMN_ERROR_NOMEM;
+            }
+            jsmn_fill_token(token, JSMN_STRING, start+1, parser->pos);
 #ifdef JSMN_PARENT_LINKS
-      token->parent = parser->toksuper;
+            token->parent = parser->toksuper;
 #endif
-      return 0;
-    }
-
-    /* Backslash: Quoted symbol expected */
-    if (c == '\\' && parser->pos + 1 < len) {
-      int i;
-      parser->pos++;
-      switch (js[parser->pos]) {
-      /* Allowed escaped symbols */
-      case '\"':
-      case '/':
-      case '\\':
-      case 'b':
-      case 'f':
-      case 'r':
-      case 'n':
-      case 't':
-        break;
-      /* Allows escaped symbol \uXXXX */
-      case 'u':
-        parser->pos++;
-        for (i = 0; i < 4 && parser->pos < len && js[parser->pos] != '\0';
-             i++) {
-          /* If it isn't a hex character we have an error */
-          if (!((js[parser->pos] >= 48 && js[parser->pos] <= 57) ||   /* 0-9 */
-                (js[parser->pos] >= 65 && js[parser->pos] <= 70) ||   /* A-F */
-                (js[parser->pos] >= 97 && js[parser->pos] <= 102))) { /* a-f */
-            parser->pos = start;
-            return JSMN_ERROR_INVAL;
-          }
-          parser->pos++;
+            return 0;
         }
-        parser->pos--;
-        break;
-      /* Unexpected symbol */
-      default:
-        parser->pos = start;
-        return JSMN_ERROR_INVAL;
-      }
+
+        /* Backslash: Quoted symbol expected */
+        if (c == '\\' && parser->pos + 1 < len) {
+            int i;
+            parser->pos++;
+            switch (js[parser->pos]) {
+                /* Allowed escaped symbols */
+                case '\"': case '/' : case '\\' : case 'b' :
+                case 'f' : case 'r' : case 'n'  : case 't' :
+                    break;
+                /* Allows escaped symbol \uXXXX */
+                case 'u':
+                    parser->pos++;
+                    for(i = 0; i < 4 && parser->pos < len && js[parser->pos] != '\0'; i++) {
+                        /* If it isn't a hex character we have an error */
+                        if(!((js[parser->pos] >= 48 && js[parser->pos] <= 57) || /* 0-9 */
+                                    (js[parser->pos] >= 65 && js[parser->pos] <= 70) || /* A-F */
+                                    (js[parser->pos] >= 97 && js[parser->pos] <= 102))) { /* a-f */
+                            parser->pos = start;
+                            return JSMN_ERROR_INVAL;
+                        }
+                        parser->pos++;
+                    }
+                    parser->pos--;
+                    break;
+                /* Unexpected symbol */
+                default:
+                    parser->pos = start;
+                    return JSMN_ERROR_INVAL;
+            }
+        }
     }
-  }
-  parser->pos = start;
-  return JSMN_ERROR_PART;
+    parser->pos = start;
+    return JSMN_ERROR_PART;
 }
 
 /**
  * Parse JSON string and fill tokens.
  */
-JSMN_API int jsmn_parse(jsmn_parser *parser, const char *js, const size_t len,
-                        jsmntok_t *tokens, const unsigned int num_tokens,
-						void* reserved) {
-  int r;
-  int i;
-  jsmntok_t *token;
-  int count = parser->toknext;
+jsmnerr_t jsmn_parse(jsmn_parser *parser, const char *js, size_t len,
+        jsmntok_t *tokens, unsigned int num_tokens, void* reserved) {
+    jsmnerr_t r;
+    int i;
+    jsmntok_t *token;
+    int count = 0;
 
-  for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
-    char c;
-    jsmntype_t type;
+    for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+        char c;
+        jsmntype_t type;
 
-    c = js[parser->pos];
-    switch (c) {
-    case '{':
-    case '[':
-      count++;
-      if (tokens == NULL) {
-        break;
-      }
-      token = jsmn_alloc_token(parser, tokens, num_tokens);
-      if (token == NULL) {
-        return JSMN_ERROR_NOMEM;
-      }
-      if (parser->toksuper != -1) {
-        jsmntok_t *t = &tokens[parser->toksuper];
+        c = js[parser->pos];
+        switch (c) {
+            case '{': case '[':
+                count++;
+                if (tokens == NULL) {
+                    break;
+                }
+                token = jsmn_alloc_token(parser, tokens, num_tokens);
+                if (token == NULL)
+                    return JSMN_ERROR_NOMEM;
+                if (parser->toksuper != -1) {
+                    tokens[parser->toksuper].size++;
+#ifdef JSMN_PARENT_LINKS
+                    token->parent = parser->toksuper;
+#endif
+                }
+                token->type = (c == '{' ? JSMN_OBJECT : JSMN_ARRAY);
+                token->start = parser->pos;
+                parser->toksuper = parser->toknext - 1;
+                break;
+            case '}': case ']':
+                if (tokens == NULL)
+                    break;
+                type = (c == '}' ? JSMN_OBJECT : JSMN_ARRAY);
+#ifdef JSMN_PARENT_LINKS
+                if (parser->toknext < 1) {
+                    return JSMN_ERROR_INVAL;
+                }
+                token = &tokens[parser->toknext - 1];
+                for (;;) {
+                    if (token->start != -1 && token->end == -1) {
+                        if (token->type != type) {
+                            return JSMN_ERROR_INVAL;
+                        }
+                        token->end = parser->pos + 1;
+                        parser->toksuper = token->parent;
+                        break;
+                    }
+                    if (token->parent == -1) {
+                        break;
+                    }
+                    token = &tokens[token->parent];
+                }
+#else
+                for (i = parser->toknext - 1; i >= 0; i--) {
+                    token = &tokens[i];
+                    if (token->start != -1 && token->end == -1) {
+                        if (token->type != type) {
+                            return JSMN_ERROR_INVAL;
+                        }
+                        parser->toksuper = -1;
+                        token->end = parser->pos + 1;
+                        break;
+                    }
+                }
+                /* Error if unmatched closing bracket */
+                if (i == -1) return JSMN_ERROR_INVAL;
+                for (; i >= 0; i--) {
+                    token = &tokens[i];
+                    if (token->start != -1 && token->end == -1) {
+                        parser->toksuper = i;
+                        break;
+                    }
+                }
+#endif
+                break;
+            case '\"':
+                r = jsmn_parse_string(parser, js, len, tokens, num_tokens);
+                if (r < 0) return r;
+                count++;
+                if (parser->toksuper != -1 && tokens != NULL)
+                    tokens[parser->toksuper].size++;
+                break;
+            case '\t' : case '\r' : case '\n' : case ' ':
+                break;
+            case ':':
+                parser->toksuper = parser->toknext - 1;
+                break;
+            case ',':
+                if (tokens != NULL &&
+                        tokens[parser->toksuper].type != JSMN_ARRAY &&
+                        tokens[parser->toksuper].type != JSMN_OBJECT) {
+#ifdef JSMN_PARENT_LINKS
+                    parser->toksuper = tokens[parser->toksuper].parent;
+#else
+                    for (i = parser->toknext - 1; i >= 0; i--) {
+                        if (tokens[i].type == JSMN_ARRAY || tokens[i].type == JSMN_OBJECT) {
+                            if (tokens[i].start != -1 && tokens[i].end == -1) {
+                                parser->toksuper = i;
+                                break;
+                            }
+                        }
+                    }
+#endif
+                }
+                break;
 #ifdef JSMN_STRICT
-        /* In strict mode an object or array can't become a key */
-        if (t->type == JSMN_OBJECT) {
-          return JSMN_ERROR_INVAL;
-        }
-#endif
-        t->size++;
-#ifdef JSMN_PARENT_LINKS
-        token->parent = parser->toksuper;
-#endif
-      }
-      token->type = (c == '{' ? JSMN_OBJECT : JSMN_ARRAY);
-      token->start = parser->pos;
-      parser->toksuper = parser->toknext - 1;
-      break;
-    case '}':
-    case ']':
-      if (tokens == NULL) {
-        break;
-      }
-      type = (c == '}' ? JSMN_OBJECT : JSMN_ARRAY);
-#ifdef JSMN_PARENT_LINKS
-      if (parser->toknext < 1) {
-        return JSMN_ERROR_INVAL;
-      }
-      token = &tokens[parser->toknext - 1];
-      for (;;) {
-        if (token->start != -1 && token->end == -1) {
-          if (token->type != type) {
-            return JSMN_ERROR_INVAL;
-          }
-          token->end = parser->pos + 1;
-          parser->toksuper = token->parent;
-          break;
-        }
-        if (token->parent == -1) {
-          if (token->type != type || parser->toksuper == -1) {
-            return JSMN_ERROR_INVAL;
-          }
-          break;
-        }
-        token = &tokens[token->parent];
-      }
+            /* In strict mode primitives are: numbers and booleans */
+            case '-': case '0': case '1' : case '2': case '3' : case '4':
+            case '5': case '6': case '7' : case '8': case '9':
+            case 't': case 'f': case 'n' :
+                /* And they must not be keys of the object */
+                if (tokens != NULL) {
+                    jsmntok_t *t = &tokens[parser->toksuper];
+                    if (t->type == JSMN_OBJECT ||
+                            (t->type == JSMN_STRING && t->size != 0)) {
+                        return JSMN_ERROR_INVAL;
+                    }
+                }
 #else
-      for (i = parser->toknext - 1; i >= 0; i--) {
-        token = &tokens[i];
-        if (token->start != -1 && token->end == -1) {
-          if (token->type != type) {
-            return JSMN_ERROR_INVAL;
-          }
-          parser->toksuper = -1;
-          token->end = parser->pos + 1;
-          break;
-        }
-      }
-      /* Error if unmatched closing bracket */
-      if (i == -1) {
-        return JSMN_ERROR_INVAL;
-      }
-      for (; i >= 0; i--) {
-        token = &tokens[i];
-        if (token->start != -1 && token->end == -1) {
-          parser->toksuper = i;
-          break;
-        }
-      }
+            /* In non-strict mode every unquoted value is a primitive */
+            default:
 #endif
-      break;
-    case '\"':
-      r = jsmn_parse_string(parser, js, len, tokens, num_tokens);
-      if (r < 0) {
-        return r;
-      }
-      count++;
-      if (parser->toksuper != -1 && tokens != NULL) {
-        tokens[parser->toksuper].size++;
-      }
-      break;
-    case '\t':
-    case '\r':
-    case '\n':
-    case ' ':
-      break;
-    case ':':
-      parser->toksuper = parser->toknext - 1;
-      break;
-    case ',':
-      if (tokens != NULL && parser->toksuper != -1 &&
-          tokens[parser->toksuper].type != JSMN_ARRAY &&
-          tokens[parser->toksuper].type != JSMN_OBJECT) {
-#ifdef JSMN_PARENT_LINKS
-        parser->toksuper = tokens[parser->toksuper].parent;
-#else
-        for (i = parser->toknext - 1; i >= 0; i--) {
-          if (tokens[i].type == JSMN_ARRAY || tokens[i].type == JSMN_OBJECT) {
-            if (tokens[i].start != -1 && tokens[i].end == -1) {
-              parser->toksuper = i;
-              break;
-            }
-          }
-        }
-#endif
-      }
-      break;
-#ifdef JSMN_STRICT
-    /* In strict mode primitives are: numbers and booleans */
-    case '-':
-    case '0':
-    case '1':
-    case '2':
-    case '3':
-    case '4':
-    case '5':
-    case '6':
-    case '7':
-    case '8':
-    case '9':
-    case 't':
-    case 'f':
-    case 'n':
-      /* And they must not be keys of the object */
-      if (tokens != NULL && parser->toksuper != -1) {
-        const jsmntok_t *t = &tokens[parser->toksuper];
-        if (t->type == JSMN_OBJECT ||
-            (t->type == JSMN_STRING && t->size != 0)) {
-          return JSMN_ERROR_INVAL;
-        }
-      }
-#else
-    /* In non-strict mode every unquoted value is a primitive */
-    default:
-#endif
-      r = jsmn_parse_primitive(parser, js, len, tokens, num_tokens);
-      if (r < 0) {
-        return r;
-      }
-      count++;
-      if (parser->toksuper != -1 && tokens != NULL) {
-        tokens[parser->toksuper].size++;
-      }
-      break;
+                r = jsmn_parse_primitive(parser, js, len, tokens, num_tokens);
+                if (r < 0) return r;
+                count++;
+                if (parser->toksuper != -1 && tokens != NULL)
+                    tokens[parser->toksuper].size++;
+                break;
 
 #ifdef JSMN_STRICT
-    /* Unexpected char in strict mode */
-    default:
-      return JSMN_ERROR_INVAL;
+            /* Unexpected char in strict mode */
+            default:
+                return JSMN_ERROR_INVAL;
 #endif
+        }
     }
-  }
 
-  if (tokens != NULL) {
     for (i = parser->toknext - 1; i >= 0; i--) {
-      /* Unmatched opened object or array */
-      if (tokens[i].start != -1 && tokens[i].end == -1) {
-        return JSMN_ERROR_PART;
-      }
+        /* Unmatched opened object or array */
+        if (tokens[i].start != -1 && tokens[i].end == -1) {
+            return JSMN_ERROR_PART;
+        }
     }
-  }
 
-  return count;
+    return count;
 }
 
 /**
- * Creates a new parser based over a given buffer with an array of tokens
+ * Creates a new parser based over a given  buffer with an array of tokens
  * available.
  */
-JSMN_API void jsmn_init(jsmn_parser *parser, void* reserved) {
-  parser->pos = 0;
-  parser->toknext = 0;
-  parser->toksuper = -1;
+void jsmn_init(jsmn_parser *parser, void* reserved) {
+    parser->pos = 0;
+    parser->toknext = 0;
+    parser->toksuper = -1;
 }
 

--- a/services/src/jsmn_compat.c
+++ b/services/src/jsmn_compat.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2021 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "jsmn_compat.h"
+
+jsmnerr_t jsmn_parse_deprecated(jsmn_parser *parser, const char *js, size_t len,
+        jsmntok_t *tokens, unsigned int num_tokens, void* reserved) {
+    return (jsmnerr_t)jsmn_parse(parser, js, len, tokens, num_tokens, reserved);
+}

--- a/services/src/services_dynalib.c
+++ b/services/src/services_dynalib.c
@@ -25,6 +25,7 @@
 #include "rgbled.h"
 #include "debug.h"
 #include "jsmn.h"
+#include "jsmn_compat.h"
 #include "logging.h"
 #include "system_error.h"
 #include "led_service.h"

--- a/user/tests/wiring/no_fixture/json.cpp
+++ b/user/tests/wiring/no_fixture/json.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "application.h"
+#include "unit-test/unit-test.h"
+#include "random.h"
+
+test(JSON_01_can_parse_more_than_127_tokens) {
+    const size_t bufferSize = 2048;
+    const size_t num = 256;
+    auto buf = std::make_unique<char[]>(bufferSize);
+    assertTrue((bool)buf);
+    memset(buf.get(), 0, bufferSize);
+    JSONBufferWriter w(buf.get(), bufferSize - 1);
+    w.beginArray();
+    Random rand;
+    char c;
+    for (unsigned i = 0; i < num; i++) {
+        rand.genBase32(&c, sizeof(c));
+        w.value(&c, sizeof(c));
+    }
+    w.endArray();
+    assertMore(w.dataSize(), bufferSize / 2);
+
+    auto d = JSONValue::parse(buf.get(), w.dataSize());
+    assertTrue(d.isArray());
+    JSONArrayIterator iter(d);
+    assertEqual(iter.count(), num);
+}

--- a/wiring/src/spark_wiring_json.cpp
+++ b/wiring/src/spark_wiring_json.cpp
@@ -229,6 +229,7 @@ spark::JSONValue spark::JSONValue::parseCopy(const char *json, size_t size) {
 
 bool spark::JSONValue::tokenize(const char *json, size_t size, jsmntok_t **tokens, size_t *count) {
     jsmn_parser parser;
+    parser.size = sizeof(jsmn_parser);
     jsmn_init(&parser, nullptr);
     const int n = jsmn_parse(&parser, json, size, nullptr, 0, nullptr); // Get number of tokens
     if (n <= 0) {

--- a/wiring/src/spark_wiring_json.cpp
+++ b/wiring/src/spark_wiring_json.cpp
@@ -229,7 +229,6 @@ spark::JSONValue spark::JSONValue::parseCopy(const char *json, size_t size) {
 
 bool spark::JSONValue::tokenize(const char *json, size_t size, jsmntok_t **tokens, size_t *count) {
     jsmn_parser parser;
-    parser.size = sizeof(jsmn_parser);
     jsmn_init(&parser, nullptr);
     const int n = jsmn_parse(&parser, json, size, nullptr, 0, nullptr); // Get number of tokens
     if (n <= 0) {


### PR DESCRIPTION
### Problem

(based on https://github.com/particle-iot/device-os/tree/fix/jsmn-library-updates)

Due to usage of `-fshort-enums` we were exporting `jsmn_parse()` which in fact was only returning an `int8_t`, preventing parsing of relatively large JSONs. This is now fixed in the upstream version of jsmn library (returns in `int`) and also in our "fork" contained within Device OS sources in services.

We will sync up with the upstream jsmn at a later point.

### Solution

1. Update `jsmn` fork sources to return `int` and not use `jsmnerr_t` directly
2. Add `jsmn_parse_deprecated()` with old signature for dynalib compatibility purposes

### Steps to Test

N/A

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
