### PR TITLE
Ignore files in lib directory during build

### DIFF
--- a/user/build.mk
+++ b/user/build.mk
@@ -47,7 +47,7 @@ endif
 
 ifeq ($(APPLAYOUT),extended)
 # add vendored libraries to module libraries
-MODULE_LIBSV2 += $(wildcard $(APPROOT)/lib/*)
+MODULE_LIBSV2 += $(call remove_slash,$(dir $(wildcard $(APPROOT)/lib/*/.)))
 SOURCE_PATH := $(APPROOT)/
 USRSRC = src
 endif


### PR DESCRIPTION
### Problem
If the `lib` directory contains a normal file (in my case a Bazel BUILD file), local compilation with Particle Workbench fails with:
```
> Executing task: make -f '/Users/andrew/.particle/toolchains/buildscripts/1.10.0/Makefile' compile-user -s <


:::: COMPILING APPLICATION

user hal-dynalib services-dynalib system-dynalib rt-dynalib wiring communication-dynalib platform wiring_globals
cc1: error: /Users/andrew/code/supply_ventilation/lib/BUILD/src: Not a directory
make[3]: *** [../build/target/user/platform-6-m/supply_ventilation/Adafruit_GFX_RK/src/glcdfont.o] Error 1
make[2]: *** [user] Error 2
make[1]: *** [modules/photon/user-part] Error 2
make: *** [compile-user] Error 2
The terminal process "/bin/bash '-c', 'make -f '/Users/andrew/.particle/toolchains/buildscripts/1.10.0/Makefile' compile-user -s'" terminated with exit code: 2.
```

### Solution
Updates the relevant makefile to only consider directories within the `lib` folder. Derived from: https://stackoverflow.com/questions/13897945/wildcard-to-obtain-list-of-all-directories#comment71990812_13898309

### Steps to Test
I'm not aware of build-specific tests, though I assume the tests themselves run the build which would provide some coverage here. You should be able to repro the problem and fix by:
* Start with a workbench project with v2 libraries.
* Create a file in `lib` (e.g. `touch lib/foo`).
* Attempt to compile and observe error.
* Apply this fix, observe successful compilation.

### Example App
NA 

### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
