### PR TITLE
Add a unit test stub for system_thread_set_state

### DIFF
--- a/user/tests/unit/stubs/system_mode.cpp
+++ b/user/tests/unit/stubs/system_mode.cpp
@@ -2,3 +2,7 @@
 
 void set_system_mode(System_Mode_TypeDef mode) {
 }
+
+void system_thread_set_state(spark::feature::State state, void*)
+{
+}


### PR DESCRIPTION
### Problem
The existing unit test stubs do not include a definition for `system_thread_set_state`. I'm working on unit testing a Particle project and the lack of this stub causes the following error if I call `SYSTEM_THREAD(ENABLED);` in the code under test:
```
dyld: lazy symbol binding failed: Symbol not found: _system_thread_set_state
  Referenced from: /private/var/tmp/_bazel_andrew/a4c7ff0b81f89f303b386f9cf19fd00e/sandbox/darwin-sandbox/570/execroot/__main__/bazel-out/darwin_arm64-fastbuild/bin/tests/tests.runfiles/__main__/tests/../_solib_darwin_arm64//libsrc_Slibparticle-bazel-demo.so
  Expected in: flat namespace

dyld: Symbol not found: _system_thread_set_state
  Referenced from: /private/var/tmp/_bazel_andrew/a4c7ff0b81f89f303b386f9cf19fd00e/sandbox/darwin-sandbox/570/execroot/__main__/bazel-out/darwin_arm64-fastbuild/bin/tests/tests.runfiles/__main__/tests/../_solib_darwin_arm64//libsrc_Slibparticle-bazel-demo.so
  Expected in: flat namespace
```

### Solution
Add a no-op stub for `system_thread_set_state`

### Steps to Test
I wrote a demo project to use Bazel and Google Test with Particle for unit testing. To make it compile successfully, I had to include the changes from this PR as a patch:
https://github.com/metcalf/arduino-particle-bazel-demo/blob/main/tools/io_particle_device_os.patch

### Example App
N/A

### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
