### PR TITLE
Add missing DYNALIB_FNs for os_thread_{wait,notify}

### DIFF
--- a/hal/inc/hal_dynalib_concurrent.h
+++ b/hal/inc/hal_dynalib_concurrent.h
@@ -71,6 +71,9 @@ DYNALIB_FN(32, hal_concurrent, os_semaphore_take, int(os_semaphore_t, system_tic
 DYNALIB_FN(33, hal_concurrent, os_semaphore_give, int(os_semaphore_t, bool))
 DYNALIB_FN(34, hal_concurrent, os_scheduler_get_state, os_scheduler_state_t(void*))
 DYNALIB_FN(35, hal_concurrent, os_queue_peek, int(os_queue_t, void* item, system_tick_t, void*))
+
+DYNALIB_FN(36, hal_concurrent, os_thread_wait, os_thread_notify_t(system_tick_t, void*))
+DYNALIB_FN(37, hal_concurrent, os_thread_notify, int(os_thread_t, void*))
 #endif // PLATFORM_THREADING
 
 DYNALIB_END(hal_concurrent)
@@ -78,4 +81,3 @@ DYNALIB_END(hal_concurrent)
 
 
 #endif	/* HAL_DYNALIB_CONCURRENT_H */
-


### PR DESCRIPTION
### Problem
```
/Users/andrew/code/supply_ventilation//src/DisplayTask.cpp:51: undefined reference to `os_thread_notify'
/Users/andrew/.particle/toolchains/gcc-arm/10.2.1/bin/../lib/gcc/arm-none-eabi/10.2.1/../../../../arm-none-eabi/bin/ld: ../../../build/target/user/platform-6-m/supply_ventilation//libuser.a(DisplayTask.o): in function `DisplayTask::_taskFun()':
/Users/andrew/code/supply_ventilation//src/DisplayTask.cpp:59: undefined reference to `os_thread_wait'
collect2: error: ld returned 1 exit status
```
### Solution
Added missing `DYNALIB_FN` entries for `os_thread_{wait,notify}`

### Steps to Test
I assume existing compilation/tests would break if I

### Example App
N/A

### References

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
