### PR TITLE
Extended: Merge '[Electron] Optional feature to use HSE/LSI as RTC clock source instead of LSE (external 32KHz XTAL)' to develop

### DIFF
--- a/user/tests/wiring/electron_disable_external_rtc_clock/clock.cpp
+++ b/user/tests/wiring/electron_disable_external_rtc_clock/clock.cpp
@@ -64,7 +64,9 @@ test(02_validate) {
         assertEqual((RCC->BDCR & 0x300), RCC_RTCCLKSource_LSE);
     }
     delay(1000);
-    assertMore(Time.now(), sRtcTime);
+    // FIXME: time seems to default to 2000-01-01 in some cases
+    // when switching from HSE to LSE
+    // assertMore(Time.now(), sRtcTime);
 
     const unsigned testSeconds = 5;
     system_tick_t t0 = 0, t1 = 0;


### PR DESCRIPTION
This PR contains the missed commits ported retroactively from [2.0.2](https://github.com/particle-iot/device-os/commits/v2.0.2) to develop. Please see https://github.com/particle-iot/device-os/pull/2354, https://github.com/particle-iot/device-os/pull/2360

### References

https://github.com/particle-iot/device-os/pull/2354
https://github.com/particle-iot/device-os/pull/2360

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
