### PR TITLE
Update pip to last compatible with Python 3.5

### DIFF
--- a/ci/install_gcovr.sh
+++ b/ci/install_gcovr.sh
@@ -24,7 +24,7 @@ pip3 install --upgrade pip==20.3.4
 
 pip3 install requests
 # install latest stable gcovr. Warning: may not support python3.5
-pip3 install gcovr=5.0
+pip3 install gcovr==5.0
 
 # install gcovr latest develop branch
 #pip3 install git+https://github.com/gcovr/gcovr.git

--- a/ci/install_gcovr.sh
+++ b/ci/install_gcovr.sh
@@ -19,9 +19,11 @@ else
   apt-get -qq install git python3-pip libxml2-dev libxslt-dev)
 fi
 
-# upgrade pip to the latest stable version
-pip3 install --upgrade pip
 python3 --version
+
+# upgrade pip to the latest stable version
+pip3 install --upgrade pip==20.3.4
+
 
 pip3 install requests
 # install latest stable gcovr. Warning: may not support python3.5

--- a/ci/install_gcovr.sh
+++ b/ci/install_gcovr.sh
@@ -19,15 +19,20 @@ else
   apt-get -qq install git python3-pip libxml2-dev libxslt-dev)
 fi
 
-
+# get the last version of pip compatible with python 3.5
 pip3 install --upgrade pip==20.3.4 
 
 pip3 install requests
-# install latest stable gcovr. Warning: may not support python3.5
-pip3 install gcovr==5.0
+
+# install a specific gcovr version. May not work if that version isn't compatible with the pip3 version
+# pip3 install gcovr==5.0
+
+# install latest stable gcovr version
+pip3 install gcovr
 
 # install gcovr latest develop branch
-#pip3 install git+https://github.com/gcovr/gcovr.git
+# pip3 install git+https://github.com/gcovr/gcovr.git
+
 # FIXME: MarkupSafe is broken on python3.5
 ln -s /usr/local/lib/python3.5/dist-packages/MarkupSafe-0.0.0.dist-info /usr/local/lib/python3.5/dist-packages/MarkupSafe-2.0.0.dist-info
 

--- a/ci/install_gcovr.sh
+++ b/ci/install_gcovr.sh
@@ -19,6 +19,8 @@ else
   apt-get -qq install git python3-pip libxml2-dev libxslt-dev)
 fi
 
+python3 --version
+
 # get the last version of pip compatible with python 3.5
 pip3 install --upgrade pip==20.3.4 
 
@@ -28,10 +30,10 @@ pip3 install requests
 # pip3 install gcovr==5.0
 
 # install latest stable gcovr version
-pip3 install gcovr
+# pip3 install gcovr
 
-# install gcovr latest develop branch
-# pip3 install git+https://github.com/gcovr/gcovr.git
+# install gcovr latest develop branch directly from github
+pip3 install git+https://github.com/gcovr/gcovr.git
 
 # FIXME: MarkupSafe is broken on python3.5
 ln -s /usr/local/lib/python3.5/dist-packages/MarkupSafe-0.0.0.dist-info /usr/local/lib/python3.5/dist-packages/MarkupSafe-2.0.0.dist-info

--- a/ci/install_gcovr.sh
+++ b/ci/install_gcovr.sh
@@ -20,7 +20,7 @@ else
 fi
 
 
-pip3 install --upgrade pip
+pip3 install --upgrade pip==20.3.4 
 
 pip3 install requests
 # install latest stable gcovr. Warning: may not support python3.5

--- a/ci/install_gcovr.sh
+++ b/ci/install_gcovr.sh
@@ -19,6 +19,9 @@ else
   apt-get -qq install git python3-pip libxml2-dev libxslt-dev)
 fi
 
+# upgrade pip to the latest stable version
+pip3 install --upgrade pip
+python3 --version
 
 pip3 install requests
 # install latest stable gcovr. Warning: may not support python3.5

--- a/ci/install_gcovr.sh
+++ b/ci/install_gcovr.sh
@@ -22,18 +22,20 @@ fi
 python3 --version
 
 # get the last version of pip compatible with python 3.5
-pip3 install --upgrade pip==20.3.4 
+# pip3 install --upgrade pip==20.3.4 
+
+pip3 --version
 
 pip3 install requests
 
 # install a specific gcovr version. May not work if that version isn't compatible with the pip3 version
-# pip3 install gcovr==5.0
+pip3 install gcovr==5.0
 
 # install latest stable gcovr version
 # pip3 install gcovr
 
 # install gcovr latest develop branch directly from github
-pip3 install git+https://github.com/gcovr/gcovr.git
+# pip3 install git+https://github.com/gcovr/gcovr.git
 
 # FIXME: MarkupSafe is broken on python3.5
 ln -s /usr/local/lib/python3.5/dist-packages/MarkupSafe-0.0.0.dist-info /usr/local/lib/python3.5/dist-packages/MarkupSafe-2.0.0.dist-info

--- a/ci/install_gcovr.sh
+++ b/ci/install_gcovr.sh
@@ -19,15 +19,13 @@ else
   apt-get -qq install git python3-pip libxml2-dev libxslt-dev)
 fi
 
-python3 --version
 
-# upgrade pip to the latest stable version
-pip3 install --upgrade pip==20.3.4
-
+pip3 install --upgrade pip
 
 pip3 install requests
 # install latest stable gcovr. Warning: may not support python3.5
-pip3 install gcovr
+pip3 install gcovr=5.0
+
 # install gcovr latest develop branch
 #pip3 install git+https://github.com/gcovr/gcovr.git
 # FIXME: MarkupSafe is broken on python3.5


### PR DESCRIPTION
In order to pull in gcovr dependencies, update pip to the last release version that supported Python 3.5