### PR TITLE
Increase BLE operation timeout.

### DIFF
--- a/hal/src/nRF52840/ble_hal.cpp
+++ b/hal/src/nRF52840/ble_hal.cpp
@@ -94,7 +94,7 @@ const hal_ble_attr_handle_t SERVICES_TOP_END_HANDLE = 0xFFFF;
 constexpr size_t BLE_EVT_DATA_POOL_SIZE = 2048;
 
 // Timeout for a BLE procedure.
-constexpr uint32_t BLE_OPERATION_TIMEOUT_MS = 30000;
+constexpr uint32_t BLE_OPERATION_TIMEOUT_MS = 60000;
 // Delay for GATT Client to send the ATT MTU exchanging request.
 constexpr uint32_t BLE_ATT_MTU_EXCHANGE_DELAY_MS = 800;
 
@@ -3916,9 +3916,10 @@ int hal_ble_stack_deinit(void* reserved) {
     BleLock lk;
     LOG_DEBUG(TRACE, "hal_ble_stack_deinit().");
     CHECK_TRUE(BleObject::getInstance().initialized(), SYSTEM_ERROR_INVALID_STATE);
-    CHECK(BleObject::getInstance().broadcaster()->stopAdvertising());
     CHECK(BleObject::getInstance().observer()->stopScanning());
     CHECK(BleObject::getInstance().connMgr()->disconnectAll());
+    // Disconnected event may result in re-advertising.
+    CHECK(BleObject::getInstance().broadcaster()->stopAdvertising());
     return SYSTEM_ERROR_NONE;
 }
 


### PR DESCRIPTION
### Problem
BLE device may assert due to timeout when it is connecting/discovering services while the peer device just enters the sleep mode.
### Solution
Increase the BLE operation timeout so that BLE events can be handled properly before assertion.
### Example App
N/A
### References
https://community.particle.io/t/argon-crashing-if-ble-client-deepsleeps/60840/4

---
### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
