### PR TITLE
fix the issue that BLE setup fails on Wi-Fi platform.

### DIFF
--- a/hal/network/lwip/esp32/esp32ncpnetif.cpp
+++ b/hal/network/lwip/esp32/esp32ncpnetif.cpp
@@ -182,6 +182,11 @@ void Esp32NcpNetif::loop(void* arg) {
         self->wifiMan_->ncpClient()->enable(); // Make sure the client is enabled
         os_semaphore_take(self->netifSemaphore_, timeout, false);
 
+        // FIXME: this is run before any other actions is taken to make sure that this
+        // thread is not performing any state changes if something has acquired an exclusive
+        // lock to the NCP Client.
+        self->wifiMan_->ncpClient()->processEvents();
+
         // We shouldn't be enforcing state on boot!
         if (self->lastNetifEvent_ != NetifEvent::None) {
             if (self->expectedNcpState_ == NcpState::ON && self->wifiMan_->ncpClient()->ncpState() != NcpState::ON) {
@@ -211,8 +216,6 @@ void Esp32NcpNetif::loop(void* arg) {
                 }
             }
         }
-
-        self->wifiMan_->ncpClient()->processEvents();
     }
 
     self->downImpl();

--- a/system/src/control/wifi_new.cpp
+++ b/system/src/control/wifi_new.cpp
@@ -106,6 +106,10 @@ int joinNewNetwork(ctrl_request* req) {
     CHECK(ncpClient->on());
     CHECK(ncpClient->disconnect());
     CHECK(wifiMgr->connect(dSsid.data));
+    // Note: we directly call into the NCP client's connect() function and bypass the system network manager.
+    // We need to disconnect the connection here to succeed the setup process, otherwise, the network manager
+    // won't do that for us due to the improvement that has been introduced in netif.
+    CHECK(ncpClient->disconnect());
     oldConfGuard.dismiss();
     return 0;
 }


### PR DESCRIPTION
### Problem
BLE setup process fails on Wi-Fi platform. We directly call into the NCP client's `connect()` function and bypass the system network manager. We need to disconnect the connection after Wi-Fi credentials is verified to succeed the setup process, otherwise, the network manager won't do that for us due to the improvement that has been introduced in netif.
### Solution
Synchronize the NCP Client / NcpNetif and system network manager state after Wi-Fi credential is set.
### Example App
N/A
### References
N/A

---
### Completeness
- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
