### PR TITLE
[R510] AT command timeouts after warm boot

### DIFF
--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -1457,6 +1457,7 @@ int SaraNcpClient::getAppFirmwareVersion() {
 }
 
 int SaraNcpClient::initReady(ModemState state) {
+    CHECK(waitAtResponse(5000));
     fwVersion_ = getAppFirmwareVersion();
     // L0.0.00.00.05.06,A.02.00 has a memory issue
     memoryIssuePresent_ = (ncpId() == PLATFORM_NCP_SARA_R410) ? (fwVersion_ == UBLOX_NCP_R4_APP_FW_VERSION_MEMORY_LEAK_ISSUE) : false;


### PR DESCRIPTION
### Problem

Some of R510 warm boots take longer than expected and failing SLO criteria. In one of the runs with debugging enabled, it is noticed a run that took 115sec during warm boot (expected <30s) was blocked at ATI9 command for 90sec (which is default AT command timeout) and was causing the additional delays. It's next command though, works. 

### Solution

Add additional AT-OK checks at init() which helps if there was an internal race condition that could block the AT interface.

### Steps to Test

### Example App

Apply warm resets on any test app where cellular is initialized

### References

[SC90828](https://app.shortcut.com/particle/story/90828/r510-at-command-timeouts-during-warm-boot)

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
