### PR TITLE
[Gen3] Feature to disable listening mode

### DIFF
--- a/hal/inc/core_hal.h
+++ b/hal/inc/core_hal.h
@@ -224,7 +224,8 @@ typedef enum HAL_Feature {
     FEATURE_WIFI_POWERSAVE_CLOCK,    // [write only] enables/disables the WiFi powersave clock on the TESTMODE pin. This setting is persisted to the DCT.
     FEATURE_ETHERNET_DETECTION,      // [read/write] enables Ethernet FeatherWing detection on boot
     FEATURE_LED_OVERRIDDEN,           // [read/write] override system RGB signaling on boot.
-    FEATURE_DISABLE_EXTERNAL_LOW_SPEED_CLOCK // [read/write] force usage of internal low speed clock
+    FEATURE_DISABLE_EXTERNAL_LOW_SPEED_CLOCK, // [read/write] force usage of internal low speed clock
+    FEATURE_DISABLE_LISTENING_MODE  // [read/write] disables listening mode
 } HAL_Feature;
 
 int HAL_Feature_Set(HAL_Feature feature, bool enabled);

--- a/hal/src/nRF52840/core_hal.c
+++ b/hal/src/nRF52840/core_hal.c
@@ -801,6 +801,9 @@ int HAL_Feature_Set(HAL_Feature feature, bool enabled) {
         case FEATURE_LED_OVERRIDDEN: {
             return Write_Feature_Flag(FEATURE_FLAG_LED_OVERRIDDEN, enabled, NULL);
         }
+        case FEATURE_DISABLE_LISTENING_MODE: {
+            return Write_Feature_Flag(FEATURE_FLAG_DISBLE_LISTENING_MODE, enabled, NULL);
+        }
     }
 
     return -1;
@@ -821,6 +824,10 @@ bool HAL_Feature_Get(HAL_Feature feature) {
         case FEATURE_LED_OVERRIDDEN: {
             bool value = false;
             return (Read_Feature_Flag(FEATURE_FLAG_LED_OVERRIDDEN, &value) == 0) ? value : false;
+        }
+        case FEATURE_DISABLE_LISTENING_MODE: {
+            bool value = false;
+            return (Read_Feature_Flag(FEATURE_FLAG_DISBLE_LISTENING_MODE, &value) == 0) ? value : false;
         }
     }
     return false;

--- a/platform/MCU/nRF52840/inc/dct.h
+++ b/platform/MCU/nRF52840/inc/dct.h
@@ -72,7 +72,8 @@ PARTICLE_STATIC_ASSERT(static_ip_config_size, sizeof(static_ip_config_t)==24);
 typedef enum Feature_Flag {
     FEATURE_FLAG_RESET_INFO = 0x01,
     FEATURE_FLAG_ETHERNET_DETECTION = 0x02,
-    FEATURE_FLAG_LED_OVERRIDDEN = 0x04
+    FEATURE_FLAG_LED_OVERRIDDEN = 0x04,
+    FEATURE_FLAG_DISBLE_LISTENING_MODE = 0x08
 } Feature_Flag;
 
 /**

--- a/system/src/system_listening_mode.cpp
+++ b/system/src/system_listening_mode.cpp
@@ -34,6 +34,7 @@ LOG_SOURCE_CATEGORY("system.listen")
 #include "check.h"
 #include "system_event.h"
 #include "scope_guard.h"
+#include "core_hal.h"
 
 using particle::LEDStatus;
 
@@ -62,6 +63,11 @@ ListeningModeHandler* ListeningModeHandler::instance() {
 }
 
 int ListeningModeHandler::enter(unsigned int timeout) {
+    if (HAL_Feature_Get(FEATURE_DISABLE_LISTENING_MODE)) {
+        LOG(ERROR, "Listening mode now allowed");
+        return SYSTEM_ERROR_NOT_ALLOWED;
+    }
+
     if (active_) {
         return SYSTEM_ERROR_INVALID_STATE;
     }

--- a/system/src/system_listening_mode.cpp
+++ b/system/src/system_listening_mode.cpp
@@ -64,7 +64,6 @@ ListeningModeHandler* ListeningModeHandler::instance() {
 
 int ListeningModeHandler::enter(unsigned int timeout) {
     if (HAL_Feature_Get(FEATURE_DISABLE_LISTENING_MODE)) {
-        LOG(ERROR, "Listening mode not allowed");
         return SYSTEM_ERROR_NOT_ALLOWED;
     }
 

--- a/system/src/system_listening_mode.cpp
+++ b/system/src/system_listening_mode.cpp
@@ -64,7 +64,7 @@ ListeningModeHandler* ListeningModeHandler::instance() {
 
 int ListeningModeHandler::enter(unsigned int timeout) {
     if (HAL_Feature_Get(FEATURE_DISABLE_LISTENING_MODE)) {
-        LOG(ERROR, "Listening mode now allowed");
+        LOG(ERROR, "Listening mode not allowed");
         return SYSTEM_ERROR_NOT_ALLOWED;
     }
 

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -465,7 +465,7 @@ void manage_listening_mode_flag() {
     if (particle::system::ListeningModeHandler::instance()->isActive() && HAL_Feature_Get(FEATURE_DISABLE_LISTENING_MODE)) {
         particle::system::ListeningModeHandler::instance()->exit();
     }
-    HAL_Delay_Milliseconds(1);
+    delay(1);
 #endif
 }
 

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -53,7 +53,9 @@
 #include "system_threading.h"
 #include "spark_wiring_interrupts.h"
 #include "spark_wiring_led.h"
+#if HAL_PLATFORM_IFAPI
 #include "system_listening_mode.h"
+#endif
 
 #if HAL_PLATFORM_BLE
 #include "ble_hal.h"
@@ -457,12 +459,14 @@ void manage_cloud_connection(bool force_events)
 }
 
 void manage_listening_mode_flag() {
+#if HAL_PLATFORM_IFAPI
     // If device is in listening mode and 'FEATURE_FLAG_DISABLE_LISTENING_MODE' is enabled,
     // make sure to come out of listening mode
     if (particle::system::ListeningModeHandler::instance()->isActive() && HAL_Feature_Get(FEATURE_DISABLE_LISTENING_MODE)) {
         particle::system::ListeningModeHandler::instance()->exit();
     }
     HAL_Delay_Milliseconds(1);
+#endif
 }
 
 static void process_isr_task_queue()

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -53,6 +53,7 @@
 #include "system_threading.h"
 #include "spark_wiring_interrupts.h"
 #include "spark_wiring_led.h"
+#include "system_listening_mode.h"
 
 #if HAL_PLATFORM_BLE
 #include "ble_hal.h"
@@ -455,6 +456,15 @@ void manage_cloud_connection(bool force_events)
     }
 }
 
+void manage_listening_mode_flag() {
+    // If device is in listening mode and 'FEATURE_FLAG_DISABLE_LISTENING_MODE' is enabled,
+    // make sure to come out of listening mode
+    if (particle::system::ListeningModeHandler::instance()->isActive() && HAL_Feature_Get(FEATURE_DISABLE_LISTENING_MODE)) {
+        particle::system::ListeningModeHandler::instance()->exit();
+    }
+    HAL_Delay_Milliseconds(1);
+}
+
 static void process_isr_task_queue()
 {
     SystemISRTaskQueue.process();
@@ -489,6 +499,8 @@ void Spark_Idle_Events(bool force_events/*=false*/)
         manage_cloud_connection(force_events);
 
         system::FirmwareUpdate::instance()->process();
+
+        manage_listening_mode_flag();
     }
     else
     {

--- a/user/tests/wiring/no_fixture/listening.cpp
+++ b/user/tests/wiring/no_fixture/listening.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+// TODO: Should we add a test case for the default case? For users that don't touch the flag
+
+test(LISTENING_00_DISABLE_LISTENING_MODE) {
+    System.enableFeature(FEATURE_DISABLE_LISTENING_MODE);
+    Network.listen();
+    HAL_Delay_Milliseconds(500);
+    assertFalse(Network.listening());
+}
+
+test(LISTENING_01_ENABLE_LISTENING_MODE) {
+    System.disableFeature(FEATURE_DISABLE_LISTENING_MODE);
+    Network.listen();
+    HAL_Delay_Milliseconds(500);
+    assertTrue(Network.listening());
+}
+

--- a/user/tests/wiring/no_fixture/listening.cpp
+++ b/user/tests/wiring/no_fixture/listening.cpp
@@ -24,7 +24,7 @@
 test(LISTENING_00_DISABLE_LISTENING_MODE) {
     System.enableFeature(FEATURE_DISABLE_LISTENING_MODE);
     Network.listen();
-    HAL_Delay_Milliseconds(1000); // Time for system thread to enter listening mode, if any
+    delay(1000); // Time for system thread to enter listening mode, if any
     assertFalse(Network.listening());
 }
 
@@ -32,10 +32,10 @@ test(LISTENING_00_DISABLE_LISTENING_MODE) {
 test(LISTENING_01_ENABLE_LISTENING_MODE) {
     System.disableFeature(FEATURE_DISABLE_LISTENING_MODE);
     Network.listen();
-    HAL_Delay_Milliseconds(1000); // Time for system thread to enter listening mode
+    delay(1000); // Time for system thread to enter listening mode
     assertTrue(Network.listening());
     Network.listen(false);
-    HAL_Delay_Milliseconds(1000); // Time for system thread to exit listening mode
+    delay(1000); // Time for system thread to exit listening mode
     assertFalse(Network.listening());
 }
 
@@ -43,9 +43,9 @@ test(LISTENING_01_ENABLE_LISTENING_MODE) {
 // device-os should exit listening mode
 test(LISTENING_02_DISABLE_FLAG_WHILE_IN_LISTENING_MODE) {
     Network.listen();
-    HAL_Delay_Milliseconds(1000); // Time for system thread to enter listening mode
+    delay(1000); // Time for system thread to enter listening mode
     assertTrue(Network.listening());
     System.enableFeature(FEATURE_DISABLE_LISTENING_MODE);
-    HAL_Delay_Milliseconds(1500); // Time for system thread to process the flag
+    delay(1500); // Time for system thread to process the flag
     assertFalse(Network.listening());
 }

--- a/user/tests/wiring/no_fixture/listening.cpp
+++ b/user/tests/wiring/no_fixture/listening.cpp
@@ -23,14 +23,17 @@
 test(LISTENING_00_DISABLE_LISTENING_MODE) {
     System.enableFeature(FEATURE_DISABLE_LISTENING_MODE);
     Network.listen();
-    HAL_Delay_Milliseconds(500);
+    HAL_Delay_Milliseconds(1000); // Time for system thread to enter listening mode, if any
     assertFalse(Network.listening());
 }
 
 test(LISTENING_01_ENABLE_LISTENING_MODE) {
     System.disableFeature(FEATURE_DISABLE_LISTENING_MODE);
     Network.listen();
-    HAL_Delay_Milliseconds(500);
+    HAL_Delay_Milliseconds(1000); // Time for system thread to enter listening mode
     assertTrue(Network.listening());
+    Network.listen(false);
+    HAL_Delay_Milliseconds(1000); // Time for system thread to exit listening mode
+    assertFalse(Network.listening());
 }
 

--- a/user/tests/wiring/no_fixture/listening.cpp
+++ b/user/tests/wiring/no_fixture/listening.cpp
@@ -20,6 +20,7 @@
 
 // TODO: Should we add a test case for the default case? For users that don't touch the flag
 
+// Dot not enter listening mode based on the flag
 test(LISTENING_00_DISABLE_LISTENING_MODE) {
     System.enableFeature(FEATURE_DISABLE_LISTENING_MODE);
     Network.listen();
@@ -27,6 +28,7 @@ test(LISTENING_00_DISABLE_LISTENING_MODE) {
     assertFalse(Network.listening());
 }
 
+// Enter listening mode based on the flag
 test(LISTENING_01_ENABLE_LISTENING_MODE) {
     System.disableFeature(FEATURE_DISABLE_LISTENING_MODE);
     Network.listen();
@@ -37,3 +39,13 @@ test(LISTENING_01_ENABLE_LISTENING_MODE) {
     assertFalse(Network.listening());
 }
 
+// If the flag is enabled while device is in listening mode,
+// device-os should exit listening mode
+test(LISTENING_02_DISABLE_FLAG_WHILE_IN_LISTENING_MODE) {
+    Network.listen();
+    HAL_Delay_Milliseconds(1000); // Time for system thread to enter listening mode
+    assertTrue(Network.listening());
+    System.enableFeature(FEATURE_DISABLE_LISTENING_MODE);
+    HAL_Delay_Milliseconds(1500); // Time for system thread to process the flag
+    assertFalse(Network.listening());
+}


### PR DESCRIPTION
### Description

This PR introduces a feature flag that disables listening mode on Gen3 platform. This feature is originally being introduced to separate listening mode from BLE provisioning mode (a feature that supports BLE connections with custom mobile apps - for more info on provisioning mode, see this \<insert link here when available>). This flag is disabled by default, hence the users who do not wish to use this flag can continue using listening mode without any changes to their user apps and BLE setup processes. Enabling this feature flag can be done similar to any other feature flags. 

An example app that enables this feature looks like the following

```c
#include "Particle.h"

Serial1LogHandler log1Handler(115200, LOG_LEVEL_ALL);
SerialLogHandler logHandler(LOG_LEVEL_ALL);

SYSTEM_MODE(SEMI_AUTOMATIC);
SYSTEM_THREAD(ENABLED);
STARTUP(System.enableFeature(FEATURE_DISABLE_LISTENING_MODE));

void setup() {
  // A call to 'WiFi.listen()' for example, will not work 
}

void loop() {
}

```

### Additional Notes
- There will be a blip in the cloud connection in the following scenarios when attempting to enter listening mode while the listening mode is disabled through the feature flag
    - User presses SETUP button
    - USB control request to enter listening mode
- The device continues into user app when the flag is disabled irrespective of the status of the setup-done flag. This may not be concerning as the flag is disabled through a custom app
- If the device is already in listening mode, and the user app enables the `FEATURE_DISABLE_LISTENING_MODE` flag, the device comes out of listening mode.

### Steps to Test

Listening mode is expected to be entered in the following scenarios:

1. User presses SETUP button
2. Application calls Wiring function to enter listening mode
3. USB control request to enter listening mode
4. If there are no credentials in the device
5. If setup done is not set

### Example Apps
### 1. User presses SETUP button
Assume this device has been previously claimed
```c
#include "Particle.h"

Serial1LogHandler log1Handler(115200, LOG_LEVEL_ALL);
SerialLogHandler logHandler(LOG_LEVEL_ALL);

SYSTEM_MODE(SEMI_AUTOMATIC);
SYSTEM_THREAD(ENABLED);
STARTUP(System.enableFeature(FEATURE_DISABLE_LISTENING_MODE));
void setup() {
    Particle.connect();
    waitUntil(Particle.connected);
    // User presses SETUP button to enter listening mode
    // Device will not enter listening mode and internally returns a `NOT_ALLOWED` system error
    // Expect a blip in the cloud connection as the HAL ISR attempts to tear down the cloud connection
    // but the cloud connection comes back up
}

void loop() {
}
```

Serial1 Log - Full log  
[setup_button_pressed_log.txt](https://github.com/particle-iot/device-os/files/7652569/setup_button_pressed_log.txt)
```
0000038022 [system] INFO: Cloud connected
0000071957 [system.listen] ERROR: Listening mode now allowed
0000071959 [system] TRACE: SPARK_WLAN_RESET || SPARK_WLAN_SLEEP || spark_cloud_socket_closed() || cloud_socket_aborted
0000071971 [comm.dtls] ERROR: mbedtls_ssl_read() failed: -0x4c
0000071975 [comm.protocol] ERROR: Event loop error 34
0000071981 [system] WARN: Communication loop error, closing cloud socket
0000071987 [system] INFO: Cloud: disconnecting
.
.
0000072702 [system] WARN: Cloud handshake failed, code=-220
0000072954 [system] INFO: Cloud: disconnecting
0000072954 [system] INFO: Cloud: disconnected
0000072962 [system.listen] ERROR: Listening mode now allowed
0000072966 [system.listen] ERROR: Listening mode now allowed
.
.
0000073461 [system.listen] ERROR: Listening mode now allowed
0000073467 [system.listen] ERROR: Listening mode now allowed
0000073469 [system] INFO: Cloud: connecting
0000073477 [system] INFO: Read Server Address = type:1,domain:$id.udp-mesh.particle.io
0000073483 [system] INFO: Loaded cloud server address and port from session data
0000073489 [system] TRACE: Address type: 1
0000073495 [system] TRACE: Cloud socket=0, family=2, type=2, protocol=17
0000073501 [system] INFO: Cloud socket=0, connecting to 54.89.110.189#5684
0000073507 [system] TRACE: Cloud socket=0, connected to 54.89.110.189#5684
0000073515 [system] TRACE: Updating cloud keepalive for AF_INET: 25000 -> 25000
0000073521 [system] TRACE: Applying new keepalive interval now
0000073525 [system] INFO: Cloud socket connected
0000073531 [system] INFO: Starting handshake: presense_announce=0
0000073537 [comm.protocol.handshake] INFO: Establish secure connection
.
.
0000074141 [comm.protocol] TRACE: Reply recieved: type=2, code=0
0000074151 [comm.protocol] TRACE: message id 28 complete with code 0.00
0000074157 [comm.protocol] TRACE: rcv'd message type=13
0000074265 [system.listen] ERROR: Listening mode now allowed
0000074267 [system] INFO: Cloud connected

// Some extra log statements

0000074373 [system.listen] ERROR: Listening mode now allowed
0000074477 [system.listen] ERROR: Listening mode now allowed
```

### 2. Application calls Wiring function to enter listening mode

```c
#include "Particle.h"

Serial1LogHandler log1Handler(115200, LOG_LEVEL_ALL);
SerialLogHandler logHandler(LOG_LEVEL_ALL);

SYSTEM_MODE(SEMI_AUTOMATIC);
SYSTEM_THREAD(ENABLED);
STARTUP(System.enableFeature(FEATURE_DISABLE_LISTENING_MODE));
void setup() {
    Particle.connect();
    waitUntil(Particle.connected);
    WiFi.listen();
}

void loop() {
}
````

Serial1 Log - Full log 
[wifi_listen_called.txt](https://github.com/particle-iot/device-os/files/7652594/wifi_listen_called.txt)

```
0000000255 [system] INFO: Device e00fce6819ef5f971ea9563a started
.
0000009808 [ncp.esp32.at] TRACE: < WIFI CONNECTED
0000010757 [ncp.esp32.at] TRACE: < OK
.
0000034472 [system] INFO: Cloud connected
0000034480 [system.listen] ERROR: Listening mode now allowed

```

### 3. USB control request to enter listening mode

```c
#include "Particle.h"

Serial1LogHandler log1Handler(115200, LOG_LEVEL_ALL);
SerialLogHandler logHandler(LOG_LEVEL_ALL);

SYSTEM_MODE(SEMI_AUTOMATIC);
SYSTEM_THREAD(ENABLED);
STARTUP(System.enableFeature(FEATURE_DISABLE_LISTENING_MODE));
void setup() {
    Particle.connect();
    waitUntil(Particle.connected);
    // Run "particle usb listen" on CLI
    // Expect a blip in the cloud connection as the HAL ISR attempts to tear down the cloud connection
    // but the cloud connection comes back up
}

void loop() {
}
```

Serial1 Log - full log 
[particle-usb-listen.txt](https://github.com/particle-iot/device-os/files/7652704/particle-usb-listen.txt)

```
// "particle usb listen" command run on CLI

0001238315 [comm.protocol] TRACE: message id 98 complete with code 0.00
0001238321 [comm.protocol] TRACE: rcv'd message type=13
0001251658 [system.listen] ERROR: Listening mode now allowed
0001251660 [system] TRACE: SPARK_WLAN_RESET || SPARK_WLAN_SLEEP || spark_cloud_socket_closed() || cloud_socket_aborted
0001251671 [comm.dtls] ERROR: mbedtls_ssl_read() failed: -0x4c
0001251677 [comm.protocol] ERROR: Event loop error 34
0001251683 [system] WARN: Communication loop error, closing cloud socket
0001251689 [system] INFO: Cloud: disconnecting
0001251695 [system] INFO: Cloud: disconnected
0001251700 [system] INFO: Cloud: connecting
0001251705 [system] INFO: Read Server Address = type:1,domain:$id.udp-mesh.particle.io
0001251713 [system] INFO: Loaded cloud server address and port from session data
0001251719 [system] TRACE: Address type: 1
0001251720 [system] TRACE: Cloud socket=0, family=2, type=2, protocol=17
0001251731 [system] INFO: Cloud socket=0, connecting to 54.89.110.189#5684
0001251737 [system] TRACE: Cloud socket=0, connected to 54.89.110.189#5684
0001251743 [system] TRACE: Updating cloud keepalive for AF_INET: 25000 -> 25000
0001251749 [system] TRACE: Applying new keepalive interval now
0001251755 [system] INFO: Cloud socket connected
0001251761 [system] INFO: Starting handshake: presense_announce=0
0001251767 [comm.protocol.handshake] INFO: Establish secure connection
0001251778 [comm.dtls] INFO: session has 0 uses
0001251794 [comm.dtls] INFO: (CMPL,RENEG,NO_SESS,ERR) restoreStatus=0
0001251796 [comm.dtls] INFO: out_ctr 0,1,0,0,0,0,0,106, next_coap_id=62
0001251803 [comm.dtls] INFO: restored session from persisted session data. next_msg_id=98
0001251814 [comm.dtls] INFO: session cmd (CLS,DIS,MOV,LOD,SAV): 2
0001252131 [hal] TRACE: Cached ESP32 NCP firmware version: 5
0001252136 [comm.protocol.handshake] INFO: Skipping HELLO message
0001252141 [system] INFO: cloud connected from existing session.
0001252149 [system] INFO: Sending application DESCRIBE
0001252151 [comm.protocol] INFO: Checksum has not changed; not sending application DESCRIBE
0001252158 [system] INFO: Sending subscriptions
0001252163 [comm.protocol] INFO: Checksum has not changed; not sending subscriptions
0001252170 [system] TRACE: Waiting until all handshake messages are processed by the protocol layer
0001252343 [comm.dtls] INFO: session cmd (CLS,DIS,MOV,LOD,SAV): 4
.
.
0001252577 [system] INFO: All handshake messages have been processed
0001252579 [comm.protocol] TRACE: Reply recieved: type=2, code=0
0001252585 [comm.protocol] TRACE: message id 101 complete with code 0.00
0001252591 [comm.protocol] TRACE: rcv'd message type=13
0001252697 [system] INFO: Cloud connected
0001253581 [comm.protocol] TRACE: rcv'd message type=8
```

### 4. If there are no credentials in the device

Simulating a scenario where wifi credentials are lost, and the device attempts to enter listening mode

```c
#include "Particle.h"

Serial1LogHandler log1Handler(115200, LOG_LEVEL_ALL);
SerialLogHandler logHandler(LOG_LEVEL_ALL);

SYSTEM_MODE(SEMI_AUTOMATIC);
SYSTEM_THREAD(ENABLED);
STARTUP(System.enableFeature(FEATURE_DISABLE_LISTENING_MODE));
STARTUP(WiFi.clearCredentials());

void setup() {
    Particle.connect();
    waitUntil(Particle.connected);
}

void loop() {
}
```
Serial1 Log - full log
[wifi-creds-missing.txt](https://github.com/particle-iot/device-os/files/7652743/wifi-creds-missing.txt)
```
0000000288 [system] INFO: Device e00fce6819ef5f971ea9563a started
0000000289 [system] TRACE: Last reset reason: 120 (data: 0x00)
0000000296 [hal] TRACE: Using internal BLE antenna
0000000305 [system.nm] INFO: State changed: NONE -> DISABLED
0000000306 [system.nm] TRACE: Interface 4 power state: 1
0000000319 [comm] INFO: channel inited
0000000426 [system.listen] ERROR: Listening mode now allowed
0000000532 [system.listen] ERROR: Listening mode now allowed
0000000638 [system.listen] ERROR: Listening mode now allowed
.
.
// goes on indefinitely as there is no user intervention
// this is likely where the user detects this behavior and uses provisioning mode to setup credentials
```

### 5. If setup-done is not set

Run an app to configure the setup-done flag to 0. Reset the device.
```c
#include "Particle.h"

Serial1LogHandler log1Handler(115200, LOG_LEVEL_ALL);
SerialLogHandler logHandler(LOG_LEVEL_ALL);

SYSTEM_MODE(SEMI_AUTOMATIC);
SYSTEM_THREAD(ENABLED);
STARTUP(System.enableFeature(FEATURE_DISABLE_LISTENING_MODE));

void setup() {
     // This resets the setup-done flag 
    const uint8_t val = 0x00;
    dct_write_app_data(&val, DCT_SETUP_DONE_OFFSET, 1);
    Particle.connect();
    waitUntil(Particle.connected);
}

void loop() {
}
```
If the flag is not set i.e., listening mode is allowed and enabled, the device enters listening mode. If the flag is set i.e., listening mode is not allowed, the device does not enter listening mode and instead continues to run the setup() function.
Serial1 Log - full log
[setup_flag_not_set.txt](https://github.com/particle-iot/device-os/files/7652974/setup_flag_not_set.txt)
```
0000000448 [system] INFO: Device e00fce6819ef5f971ea9563a started
0000000449 [system] TRACE: Last reset reason: 120 (data: 0x00)
0000000456 [hal] TRACE: Using internal BLE antenna
0000000466 [system.nm] INFO: State changed: NONE -> DISABLED
0000000467 [system.nm] TRACE: Interface 4 power state: 1
0000000482 [comm] INFO: channel inited
// Attempts to enter listening mode but fails as setup-done flag is set to 0
0000000685 [system.listen] ERROR: Listening mode not allowed
.
0000002128 [ncp.esp32.at] TRACE: > AT
0000002129 [ncp.esp32.at] TRACE: < OK
.
0000010182 [ncp.esp32.at] TRACE: < WIFI CONNECTED
0000011126 [ncp.esp32.at] TRACE: < OK
.
0000039233 [system] INFO: Cloud connected
```

### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
