### PR TITLE
Fix hardfault handler to SOS again

### DIFF
--- a/bootloader/src/nRF52840/nrf_it.c
+++ b/bootloader/src/nRF52840/nrf_it.c
@@ -83,8 +83,9 @@ void HardFault_Handler(void)
         " mrseq r0, msp                                             \n"
         " mrsne r0, psp                                             \n"
         " ldr r1, [r0, #24]                                         \n"
-        " ldr r2, handler2_address_const                           \n"
+        " ldr r2, handler2_address_const                            \n"
         " bx r2                                                     \n"
+        " .align 4                                                  \n"
         " handler2_address_const: .word prvGetRegistersFromStack    \n"
     );
 }

--- a/bootloader/src/nRF52840/nrf_it.c
+++ b/bootloader/src/nRF52840/nrf_it.c
@@ -83,7 +83,7 @@ void HardFault_Handler(void)
         " mrseq r0, msp                                             \n"
         " mrsne r0, psp                                             \n"
         " ldr r1, [r0, #24]                                         \n"
-        " ldr r2, =handler2_address_const                           \n"
+        " ldr r2, handler2_address_const                           \n"
         " bx r2                                                     \n"
         " handler2_address_const: .word prvGetRegistersFromStack    \n"
     );

--- a/hal/src/nRF52840/core_hal.c
+++ b/hal/src/nRF52840/core_hal.c
@@ -146,7 +146,7 @@ void HardFault_Handler(void) {
         " mrseq r0, msp                                             \n"
         " mrsne r0, psp                                             \n"
         " ldr r1, [r0, #24]                                         \n"
-        " ldr r2, =handler2_address_const                           \n"
+        " ldr r2, handler2_address_const                           \n"
         " bx r2                                                     \n"
         " handler2_address_const: .word prvGetRegistersFromStack    \n"
     );

--- a/hal/src/nRF52840/core_hal.c
+++ b/hal/src/nRF52840/core_hal.c
@@ -146,8 +146,9 @@ void HardFault_Handler(void) {
         " mrseq r0, msp                                             \n"
         " mrsne r0, psp                                             \n"
         " ldr r1, [r0, #24]                                         \n"
-        " ldr r2, handler2_address_const                           \n"
+        " ldr r2, handler2_address_const                            \n"
         " bx r2                                                     \n"
+        " .align 4                                                  \n"
         " handler2_address_const: .word prvGetRegistersFromStack    \n"
     );
 }

--- a/hal/src/stm32f2xx/core_hal_stm32f2xx.c
+++ b/hal/src/stm32f2xx/core_hal_stm32f2xx.c
@@ -120,8 +120,9 @@ void HardFault_Handler(void)
         " mrseq r0, msp                                             \n"
         " mrsne r0, psp                                             \n"
         " ldr r1, [r0, #24]                                         \n"
-        " ldr r2, handler2_address_const                           \n"
+        " ldr r2, handler2_address_const                            \n"
         " bx r2                                                     \n"
+        " .align 4                                                  \n"
         " handler2_address_const: .word prvGetRegistersFromStack    \n"
     );
 }

--- a/hal/src/stm32f2xx/core_hal_stm32f2xx.c
+++ b/hal/src/stm32f2xx/core_hal_stm32f2xx.c
@@ -120,7 +120,7 @@ void HardFault_Handler(void)
         " mrseq r0, msp                                             \n"
         " mrsne r0, psp                                             \n"
         " ldr r1, [r0, #24]                                         \n"
-        " ldr r2, =handler2_address_const                           \n"
+        " ldr r2, handler2_address_const                           \n"
         " bx r2                                                     \n"
         " handler2_address_const: .word prvGetRegistersFromStack    \n"
     );


### PR DESCRIPTION
This fixes the broken hardfault handler as reported in #2380 

I added the `.align 4` line, which I think might be the actual fix for the compiler warning that the commit that introduced the bug intended to address.


It is very easy to test the hard fault handler, so it seems that the compiler warning was 'fixed' in the commit below without any testing! :fearful: 

https://github.com/particle-iot/device-os/commit/7b6e2086af907668d395c63404ecc754ee36fe41

I think that you are actually causing a hardfault in the hardfault handler now, resulting in an endless loop! @avtolstoy @sergeuz 

## Test app:

```cpp
void setup()
{
    int (*bad_instruction)(void) = nullptr;
    bad_instruction();
}

void loop()
{
    HAL_Delay_Milliseconds(1);
}
```