### PR TITLE
[Gen 3] LittleFS truncate fix (https://github.com/littlefs-project/littlefs/issues/268)

### DIFF
--- a/bootloader/src/nRF52840/nrf_it.c
+++ b/bootloader/src/nRF52840/nrf_it.c
@@ -85,7 +85,7 @@ void HardFault_Handler(void)
         " ldr r1, [r0, #24]                                         \n"
         " ldr r2, handler2_address_const                            \n"
         " bx r2                                                     \n"
-        " .align 4                                                  \n"
+        " .balign 4                                                 \n"
         " handler2_address_const: .word prvGetRegistersFromStack    \n"
     );
 }

--- a/hal/src/nRF52840/core_hal.c
+++ b/hal/src/nRF52840/core_hal.c
@@ -148,7 +148,7 @@ void HardFault_Handler(void) {
         " ldr r1, [r0, #24]                                         \n"
         " ldr r2, handler2_address_const                            \n"
         " bx r2                                                     \n"
-        " .align 4                                                  \n"
+        " .balign 4                                                 \n"
         " handler2_address_const: .word prvGetRegistersFromStack    \n"
     );
 }

--- a/hal/src/stm32f2xx/core_hal_stm32f2xx.c
+++ b/hal/src/stm32f2xx/core_hal_stm32f2xx.c
@@ -122,7 +122,7 @@ void HardFault_Handler(void)
         " ldr r1, [r0, #24]                                         \n"
         " ldr r2, handler2_address_const                            \n"
         " bx r2                                                     \n"
-        " .align 4                                                  \n"
+        " .balign 4                                                 \n"
         " handler2_address_const: .word prvGetRegistersFromStack    \n"
     );
 }


### PR DESCRIPTION
### Problem

See https://github.com/littlefs-project/littlefs/issues/268

### Solution

1. Use patch from the above PR.
2. Add stress test to `wiring/filesystem` test suite. It fails without the patch on checking the integrity of the data after a truncate, it works fine with the patch.
3. (Minor and unrelated) Use .balign instead of .align in inline assembly, as `.align X` on ARM platforms semantically means 2^X alignment (and on other platforms it's just X alignment). `.balign` always means `X` alignment.

### Steps to Test

- `wiring/filesystem` built out of this branch with 3.2.0-rc.1, `wiring/filesystem` with system-part built out of this branch

### Example App

N/A

### References

- [SC93531]

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
