### PR TITLE
[gen3] hal: only skip modules that fail integrity check from module info

### DIFF
--- a/hal/src/nRF52840/ota_flash_hal.cpp
+++ b/hal/src/nRF52840/ota_flash_hal.cpp
@@ -187,7 +187,11 @@ int HAL_System_Info(hal_system_info_t* info, bool construct, void* reserved)
                     continue;
                 }
                 bool valid = fetch_module(module, bounds, false, MODULE_VALIDATION_INTEGRITY);
-                valid = valid && (module->validity_checked == module->validity_result);
+                // NOTE: fetch_module may return other validation flags in module->validity_checked
+                // and module->validity_result
+                // Here specifically we are only concerned whether the integrity check passes or not
+                // and skip such 'broken' modules from module info
+                valid = valid && (module->validity_result & MODULE_VALIDATION_INTEGRITY);
                 if (bounds->store == MODULE_STORE_MAIN && bounds->module_function == MODULE_FUNCTION_USER_PART) {
                     if (valid) {
                         user_module_found = true;


### PR DESCRIPTION
### Problem

We've introduced a bug in https://github.com/particle-iot/device-os/pull/2374 in the condition used to skip 'invalid' modules from module info. Due to the behavior of `fetch_module()` it actually returns additional validation flags apart from the ones being requested (in our case only `INTEGRITY` check is of concern).

### Solution

Fix the check to only take into account `MODULE_VALIDATION_INTEGRITY` and add a comment on the behavior of `fetch_module()`.

### Steps to Test

Flash Gen 3 device with Device OS built out of this branch. Update OTA to 3.2.0. The update should succeed. After 3.2.0 application has been flashed, `particle serial inspect` should report user module with unsatisfied dependencies. On `develop`, `particle serial inspect` should not report any user module at all.

### Example App

N/A

### References

- https://github.com/particle-iot/device-os/pull/2374

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
