### PR TITLE
Make system_version.h compliant with C; Coalesce FreeRTOS task list internals into single location

### DIFF
--- a/modules/shared/nRF52840/part1.ld
+++ b/modules/shared/nRF52840/part1.ld
@@ -232,9 +232,15 @@ SECTIONS
         _sbss = ALIGN(., 4);
         link_bss_location = ALIGN(., 4);
         __bss_start__ = _sbss;
+        /* Store the BSS sections for the RTOS first */
+        __rtos_capture_start = .;
+         *tasks.o(.bss COMMON .bss*)
+         *timers*.o(.bss COMMON .bss*)
+        __rtos_capture_end = .;
         *(.bss*)
         *(COMMON)
         link_bss_end = .;
+
         . = ALIGN(4);
         /* This is used by the startup in order to initialize the .bss secion */
         _ebss = . ;

--- a/system/inc/system_version.h
+++ b/system/inc/system_version.h
@@ -347,8 +347,6 @@ typedef struct __attribute__((packed)) SystemVersionInfo
 
 } SystemVersionInfo;
 
-#define SYSTEM_VERSION_INFO_INIT  { .size = sizeof(SystemVersionInfo) }
-
 int system_version_info(SystemVersionInfo* target, void* reserved);
 
 #ifdef	__cplusplus

--- a/system/inc/system_version.h
+++ b/system/inc/system_version.h
@@ -340,12 +340,10 @@ extern "C" {
 
 typedef struct __attribute__((packed)) SystemVersionInfo
 {
-    uint16_t size = sizeof(SystemVersionInfo);
+    uint16_t size;
     uint16_t reserved;      // use this if you need to.
     uint32_t versionNumber;
     char     versionString[20];
-
-
 
 } SystemVersionInfo;
 

--- a/system/inc/system_version.h
+++ b/system/inc/system_version.h
@@ -347,6 +347,8 @@ typedef struct __attribute__((packed)) SystemVersionInfo
 
 } SystemVersionInfo;
 
+#define SYSTEM_VERSION_INFO_INIT  { .size = sizeof(SystemVersionInfo) }
+
 int system_version_info(SystemVersionInfo* target, void* reserved);
 
 #ifdef	__cplusplus

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -722,6 +722,8 @@ size_t system_interpolate_cloud_server_hostname(const char* var, size_t var_len,
         size_t id_len = deviceID.length();
 
         SystemVersionInfo sys_ver;
+        sys_ver.size = sizeof(SystemVersionInfo);
+
         system_version_info(&sys_ver, nullptr);
         uint8_t mv = BYTE_N(sys_ver.versionNumber, 3);
         String majorVer = String::format(".v%d", mv);

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -721,7 +721,7 @@ size_t system_interpolate_cloud_server_hostname(const char* var, size_t var_len,
         String deviceID = spark_deviceID();
         size_t id_len = deviceID.length();
 
-        SystemVersionInfo sys_ver = SYSTEM_VERSION_INFO_INIT;
+        SystemVersionInfo sys_ver = { sizeof(SystemVersionInfo), 0, 0, {0} };
 
         system_version_info(&sys_ver, nullptr);
         uint8_t mv = BYTE_N(sys_ver.versionNumber, 3);

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -721,7 +721,8 @@ size_t system_interpolate_cloud_server_hostname(const char* var, size_t var_len,
         String deviceID = spark_deviceID();
         size_t id_len = deviceID.length();
 
-        SystemVersionInfo sys_ver = { sizeof(SystemVersionInfo), 0, 0, {0} };
+        SystemVersionInfo sys_ver = {};
+        sys_ver.size = sizeof(SystemVersionInfo);
 
         system_version_info(&sys_ver, nullptr);
         uint8_t mv = BYTE_N(sys_ver.versionNumber, 3);

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -721,8 +721,7 @@ size_t system_interpolate_cloud_server_hostname(const char* var, size_t var_len,
         String deviceID = spark_deviceID();
         size_t id_len = deviceID.length();
 
-        SystemVersionInfo sys_ver;
-        sys_ver.size = sizeof(SystemVersionInfo);
+        SystemVersionInfo sys_ver = SYSTEM_VERSION_INFO_INIT;
 
         system_version_info(&sys_ver, nullptr);
         uint8_t mv = BYTE_N(sys_ver.versionNumber, 3);

--- a/test/unit_tests/system/string_interpolate.cpp
+++ b/test/unit_tests/system/string_interpolate.cpp
@@ -110,8 +110,7 @@ public:
                 String deviceID = spark_deviceID();
                 size_t id_len = deviceID.length();
 
-                SystemVersionInfo sys_ver;
-                sys_ver.size = sizeof(SystemVersionInfo);
+                SystemVersionInfo sys_ver = SYSTEM_VERSION_INFO_INIT;
 
                 system_version_info(&sys_ver, nullptr);
                 uint8_t mv = BYTE_N(sys_ver.versionNumber, 3);
@@ -165,7 +164,7 @@ SCENARIO("can interpolate a simple ID into a larger buffer")
     {
         Mocks mocks;
         mock_system_version = SYSTEM_VERSION_DEFAULT(4, 5, 6);
-        SystemVersionInfo sys_ver;
+        SystemVersionInfo sys_ver = SYSTEM_VERSION_INFO_INIT;
         char buf[40];
         char expected_buf[] = "abc123412341234123412341234.v4.123";
         size_t written;
@@ -188,7 +187,7 @@ SCENARIO("can interpolate a simple ID into a buffer that is exactly the size req
     {
         Mocks mocks;
         mock_system_version = SYSTEM_VERSION_DEFAULT(4, 5, 6);
-        SystemVersionInfo sys_ver;
+        SystemVersionInfo sys_ver = SYSTEM_VERSION_INFO_INIT;
         char buf[35];
         char expected_buf[] = "abc123412341234123412341234.v4.123";
         size_t written;
@@ -212,8 +211,7 @@ TEST_CASE("testing system_interpolate_cloud_server_hostname") {
 
     SECTION("[UDP] Server public address is updated with major system version v1") {
         mock_system_version = SYSTEM_VERSION_DEFAULT(1, 2, 3);
-        SystemVersionInfo sys_ver;
-        sys_ver.size = sizeof(SystemVersionInfo);
+        SystemVersionInfo sys_ver = SYSTEM_VERSION_INFO_INIT;
 
         int major_version = get_major_version(&sys_ver);
         int major_version_size = get_major_version_size(major_version) + 2;
@@ -238,8 +236,7 @@ TEST_CASE("testing system_interpolate_cloud_server_hostname") {
     SECTION("[UDP-MESH] Server public address is updated with major system version v2") {
 
         mock_system_version = SYSTEM_VERSION_DEFAULT(2, 3, 4);
-        SystemVersionInfo sys_ver;
-        sys_ver.size = sizeof(SystemVersionInfo);
+        SystemVersionInfo sys_ver = SYSTEM_VERSION_INFO_INIT;
 
         int major_version = get_major_version(&sys_ver);
         int major_version_size = get_major_version_size(major_version) + 2;
@@ -264,8 +261,7 @@ TEST_CASE("testing system_interpolate_cloud_server_hostname") {
     SECTION("[UDP-MESH] Server public address is updated with major system version v255") {
 
         mock_system_version = SYSTEM_VERSION_DEFAULT(255, 3, 4);
-        SystemVersionInfo sys_ver;
-        sys_ver.size = sizeof(SystemVersionInfo);
+        SystemVersionInfo sys_ver = SYSTEM_VERSION_INFO_INIT;
 
         int major_version = get_major_version(&sys_ver);
         int major_version_size = get_major_version_size(major_version) + 2;
@@ -290,7 +286,7 @@ TEST_CASE("testing system_interpolate_cloud_server_hostname") {
     SECTION("[TCP] Server public address is NOT updated with major system version") {
 
         mock_system_version = SYSTEM_VERSION_DEFAULT(9, 1, 1);
-        SystemVersionInfo sys_ver;
+        SystemVersionInfo sys_ver = SYSTEM_VERSION_INFO_INIT;
 
         char expected_buf[] = "device.spark.io";
         memcpy(&server_addr, backup_tcp_public_server_address, sizeof(backup_tcp_public_server_address));
@@ -308,7 +304,7 @@ TEST_CASE("testing system_interpolate_cloud_server_hostname") {
     SECTION("system_string_interpolate() returns when passed a null pointer") {
 
         mock_system_version = SYSTEM_VERSION_DEFAULT(1, 2, 3);
-        SystemVersionInfo sys_ver;
+        SystemVersionInfo sys_ver = SYSTEM_VERSION_INFO_INIT;
 
         char tmphost[sizeof(server_addr.domain) + 32] = {};
         string_interpolate_source_t fn = system_interpolate_cloud_server_hostname;
@@ -322,9 +318,8 @@ TEST_CASE("testing system_interpolate_cloud_server_hostname") {
     SECTION("system_string_interpolate() cannot force a buffer overflow") {
 
         mock_system_version = SYSTEM_VERSION_DEFAULT(255, 2, 3);
-        SystemVersionInfo sys_ver;
-        sys_ver.size = sizeof(SystemVersionInfo);
-    
+        SystemVersionInfo sys_ver = SYSTEM_VERSION_INFO_INIT;
+
         int major_version = get_major_version(&sys_ver);
         int major_version_size = get_major_version_size(major_version) + 2;
 
@@ -372,8 +367,7 @@ TEST_CASE("testing system_interpolate_cloud_server_hostname") {
     SECTION("system_string_interpolate() $id token can be anywhere in the string") {
 
         mock_system_version = SYSTEM_VERSION_DEFAULT(255, 2, 3);
-        SystemVersionInfo sys_ver;
-        sys_ver.size = sizeof(SystemVersionInfo);
+        SystemVersionInfo sys_ver = SYSTEM_VERSION_INFO_INIT;
 
         int major_version = get_major_version(&sys_ver);
         int major_version_size = get_major_version_size(major_version) + 2;

--- a/test/unit_tests/system/string_interpolate.cpp
+++ b/test/unit_tests/system/string_interpolate.cpp
@@ -111,6 +111,8 @@ public:
                 size_t id_len = deviceID.length();
 
                 SystemVersionInfo sys_ver;
+                sys_ver.size = sizeof(SystemVersionInfo);
+
                 system_version_info(&sys_ver, nullptr);
                 uint8_t mv = BYTE_N(sys_ver.versionNumber, 3);
                 String majorVer = String::format(".v%d", mv);
@@ -211,6 +213,8 @@ TEST_CASE("testing system_interpolate_cloud_server_hostname") {
     SECTION("[UDP] Server public address is updated with major system version v1") {
         mock_system_version = SYSTEM_VERSION_DEFAULT(1, 2, 3);
         SystemVersionInfo sys_ver;
+        sys_ver.size = sizeof(SystemVersionInfo);
+
         int major_version = get_major_version(&sys_ver);
         int major_version_size = get_major_version_size(major_version) + 2;
 
@@ -235,6 +239,8 @@ TEST_CASE("testing system_interpolate_cloud_server_hostname") {
 
         mock_system_version = SYSTEM_VERSION_DEFAULT(2, 3, 4);
         SystemVersionInfo sys_ver;
+        sys_ver.size = sizeof(SystemVersionInfo);
+
         int major_version = get_major_version(&sys_ver);
         int major_version_size = get_major_version_size(major_version) + 2;
 
@@ -259,6 +265,8 @@ TEST_CASE("testing system_interpolate_cloud_server_hostname") {
 
         mock_system_version = SYSTEM_VERSION_DEFAULT(255, 3, 4);
         SystemVersionInfo sys_ver;
+        sys_ver.size = sizeof(SystemVersionInfo);
+
         int major_version = get_major_version(&sys_ver);
         int major_version_size = get_major_version_size(major_version) + 2;
 
@@ -315,6 +323,8 @@ TEST_CASE("testing system_interpolate_cloud_server_hostname") {
 
         mock_system_version = SYSTEM_VERSION_DEFAULT(255, 2, 3);
         SystemVersionInfo sys_ver;
+        sys_ver.size = sizeof(SystemVersionInfo);
+    
         int major_version = get_major_version(&sys_ver);
         int major_version_size = get_major_version_size(major_version) + 2;
 
@@ -363,6 +373,8 @@ TEST_CASE("testing system_interpolate_cloud_server_hostname") {
 
         mock_system_version = SYSTEM_VERSION_DEFAULT(255, 2, 3);
         SystemVersionInfo sys_ver;
+        sys_ver.size = sizeof(SystemVersionInfo);
+
         int major_version = get_major_version(&sys_ver);
         int major_version_size = get_major_version_size(major_version) + 2;
 

--- a/test/unit_tests/system/string_interpolate.cpp
+++ b/test/unit_tests/system/string_interpolate.cpp
@@ -110,7 +110,8 @@ public:
                 String deviceID = spark_deviceID();
                 size_t id_len = deviceID.length();
 
-                SystemVersionInfo sys_ver = { sizeof(SystemVersionInfo), 0, 0, {0} };
+                SystemVersionInfo sys_ver = {};
+                sys_ver.size = sizeof(SystemVersionInfo);
 
                 system_version_info(&sys_ver, nullptr);
                 uint8_t mv = BYTE_N(sys_ver.versionNumber, 3);
@@ -164,7 +165,8 @@ SCENARIO("can interpolate a simple ID into a larger buffer")
     {
         Mocks mocks;
         mock_system_version = SYSTEM_VERSION_DEFAULT(4, 5, 6);
-        SystemVersionInfo sys_ver = { sizeof(SystemVersionInfo), 0, 0, {0} };
+        SystemVersionInfo sys_ver = {};
+        sys_ver.size = sizeof(SystemVersionInfo);
         char buf[40];
         char expected_buf[] = "abc123412341234123412341234.v4.123";
         size_t written;
@@ -187,7 +189,8 @@ SCENARIO("can interpolate a simple ID into a buffer that is exactly the size req
     {
         Mocks mocks;
         mock_system_version = SYSTEM_VERSION_DEFAULT(4, 5, 6);
-        SystemVersionInfo sys_ver ={ sizeof(SystemVersionInfo), 0, 0, {0} };
+        SystemVersionInfo sys_ver = {};
+        sys_ver.size = sizeof(SystemVersionInfo);
         char buf[35];
         char expected_buf[] = "abc123412341234123412341234.v4.123";
         size_t written;
@@ -211,7 +214,8 @@ TEST_CASE("testing system_interpolate_cloud_server_hostname") {
 
     SECTION("[UDP] Server public address is updated with major system version v1") {
         mock_system_version = SYSTEM_VERSION_DEFAULT(1, 2, 3);
-        SystemVersionInfo sys_ver = { sizeof(SystemVersionInfo), 0, 0, {0} };
+        SystemVersionInfo sys_ver = {};
+        sys_ver.size = sizeof(SystemVersionInfo);
 
         int major_version = get_major_version(&sys_ver);
         int major_version_size = get_major_version_size(major_version) + 2;
@@ -236,7 +240,8 @@ TEST_CASE("testing system_interpolate_cloud_server_hostname") {
     SECTION("[UDP-MESH] Server public address is updated with major system version v2") {
 
         mock_system_version = SYSTEM_VERSION_DEFAULT(2, 3, 4);
-        SystemVersionInfo sys_ver = { sizeof(SystemVersionInfo), 0, 0, {0} };
+        SystemVersionInfo sys_ver = {};
+        sys_ver.size = sizeof(SystemVersionInfo);
 
         int major_version = get_major_version(&sys_ver);
         int major_version_size = get_major_version_size(major_version) + 2;
@@ -261,7 +266,8 @@ TEST_CASE("testing system_interpolate_cloud_server_hostname") {
     SECTION("[UDP-MESH] Server public address is updated with major system version v255") {
 
         mock_system_version = SYSTEM_VERSION_DEFAULT(255, 3, 4);
-        SystemVersionInfo sys_ver = { sizeof(SystemVersionInfo), 0, 0, {0} };
+        SystemVersionInfo sys_ver = {};
+        sys_ver.size = sizeof(SystemVersionInfo);
 
         int major_version = get_major_version(&sys_ver);
         int major_version_size = get_major_version_size(major_version) + 2;
@@ -286,7 +292,8 @@ TEST_CASE("testing system_interpolate_cloud_server_hostname") {
     SECTION("[TCP] Server public address is NOT updated with major system version") {
 
         mock_system_version = SYSTEM_VERSION_DEFAULT(9, 1, 1);
-        SystemVersionInfo sys_ver = { sizeof(SystemVersionInfo), 0, 0, {0} };
+        SystemVersionInfo sys_ver = {};
+        sys_ver.size = sizeof(SystemVersionInfo);
 
         char expected_buf[] = "device.spark.io";
         memcpy(&server_addr, backup_tcp_public_server_address, sizeof(backup_tcp_public_server_address));
@@ -304,7 +311,8 @@ TEST_CASE("testing system_interpolate_cloud_server_hostname") {
     SECTION("system_string_interpolate() returns when passed a null pointer") {
 
         mock_system_version = SYSTEM_VERSION_DEFAULT(1, 2, 3);
-        SystemVersionInfo sys_ver = { sizeof(SystemVersionInfo), 0, 0, {0} };
+        SystemVersionInfo sys_ver = {};
+        sys_ver.size = sizeof(SystemVersionInfo);
 
         char tmphost[sizeof(server_addr.domain) + 32] = {};
         string_interpolate_source_t fn = system_interpolate_cloud_server_hostname;
@@ -318,7 +326,8 @@ TEST_CASE("testing system_interpolate_cloud_server_hostname") {
     SECTION("system_string_interpolate() cannot force a buffer overflow") {
 
         mock_system_version = SYSTEM_VERSION_DEFAULT(255, 2, 3);
-        SystemVersionInfo sys_ver = { sizeof(SystemVersionInfo), 0, 0, {0} };
+        SystemVersionInfo sys_ver = {};
+        sys_ver.size = sizeof(SystemVersionInfo);
 
         int major_version = get_major_version(&sys_ver);
         int major_version_size = get_major_version_size(major_version) + 2;
@@ -367,7 +376,8 @@ TEST_CASE("testing system_interpolate_cloud_server_hostname") {
     SECTION("system_string_interpolate() $id token can be anywhere in the string") {
 
         mock_system_version = SYSTEM_VERSION_DEFAULT(255, 2, 3);
-        SystemVersionInfo sys_ver = { sizeof(SystemVersionInfo), 0, 0, {0} };
+        SystemVersionInfo sys_ver = {};
+        sys_ver.size = sizeof(SystemVersionInfo);
 
         int major_version = get_major_version(&sys_ver);
         int major_version_size = get_major_version_size(major_version) + 2;

--- a/test/unit_tests/system/string_interpolate.cpp
+++ b/test/unit_tests/system/string_interpolate.cpp
@@ -110,7 +110,7 @@ public:
                 String deviceID = spark_deviceID();
                 size_t id_len = deviceID.length();
 
-                SystemVersionInfo sys_ver = SYSTEM_VERSION_INFO_INIT;
+                SystemVersionInfo sys_ver = { sizeof(SystemVersionInfo), 0, 0, {0} };
 
                 system_version_info(&sys_ver, nullptr);
                 uint8_t mv = BYTE_N(sys_ver.versionNumber, 3);
@@ -164,7 +164,7 @@ SCENARIO("can interpolate a simple ID into a larger buffer")
     {
         Mocks mocks;
         mock_system_version = SYSTEM_VERSION_DEFAULT(4, 5, 6);
-        SystemVersionInfo sys_ver = SYSTEM_VERSION_INFO_INIT;
+        SystemVersionInfo sys_ver = { sizeof(SystemVersionInfo), 0, 0, {0} };
         char buf[40];
         char expected_buf[] = "abc123412341234123412341234.v4.123";
         size_t written;
@@ -187,7 +187,7 @@ SCENARIO("can interpolate a simple ID into a buffer that is exactly the size req
     {
         Mocks mocks;
         mock_system_version = SYSTEM_VERSION_DEFAULT(4, 5, 6);
-        SystemVersionInfo sys_ver = SYSTEM_VERSION_INFO_INIT;
+        SystemVersionInfo sys_ver ={ sizeof(SystemVersionInfo), 0, 0, {0} };
         char buf[35];
         char expected_buf[] = "abc123412341234123412341234.v4.123";
         size_t written;
@@ -211,7 +211,7 @@ TEST_CASE("testing system_interpolate_cloud_server_hostname") {
 
     SECTION("[UDP] Server public address is updated with major system version v1") {
         mock_system_version = SYSTEM_VERSION_DEFAULT(1, 2, 3);
-        SystemVersionInfo sys_ver = SYSTEM_VERSION_INFO_INIT;
+        SystemVersionInfo sys_ver = { sizeof(SystemVersionInfo), 0, 0, {0} };
 
         int major_version = get_major_version(&sys_ver);
         int major_version_size = get_major_version_size(major_version) + 2;
@@ -236,7 +236,7 @@ TEST_CASE("testing system_interpolate_cloud_server_hostname") {
     SECTION("[UDP-MESH] Server public address is updated with major system version v2") {
 
         mock_system_version = SYSTEM_VERSION_DEFAULT(2, 3, 4);
-        SystemVersionInfo sys_ver = SYSTEM_VERSION_INFO_INIT;
+        SystemVersionInfo sys_ver = { sizeof(SystemVersionInfo), 0, 0, {0} };
 
         int major_version = get_major_version(&sys_ver);
         int major_version_size = get_major_version_size(major_version) + 2;
@@ -261,7 +261,7 @@ TEST_CASE("testing system_interpolate_cloud_server_hostname") {
     SECTION("[UDP-MESH] Server public address is updated with major system version v255") {
 
         mock_system_version = SYSTEM_VERSION_DEFAULT(255, 3, 4);
-        SystemVersionInfo sys_ver = SYSTEM_VERSION_INFO_INIT;
+        SystemVersionInfo sys_ver = { sizeof(SystemVersionInfo), 0, 0, {0} };
 
         int major_version = get_major_version(&sys_ver);
         int major_version_size = get_major_version_size(major_version) + 2;
@@ -286,7 +286,7 @@ TEST_CASE("testing system_interpolate_cloud_server_hostname") {
     SECTION("[TCP] Server public address is NOT updated with major system version") {
 
         mock_system_version = SYSTEM_VERSION_DEFAULT(9, 1, 1);
-        SystemVersionInfo sys_ver = SYSTEM_VERSION_INFO_INIT;
+        SystemVersionInfo sys_ver = { sizeof(SystemVersionInfo), 0, 0, {0} };
 
         char expected_buf[] = "device.spark.io";
         memcpy(&server_addr, backup_tcp_public_server_address, sizeof(backup_tcp_public_server_address));
@@ -304,7 +304,7 @@ TEST_CASE("testing system_interpolate_cloud_server_hostname") {
     SECTION("system_string_interpolate() returns when passed a null pointer") {
 
         mock_system_version = SYSTEM_VERSION_DEFAULT(1, 2, 3);
-        SystemVersionInfo sys_ver = SYSTEM_VERSION_INFO_INIT;
+        SystemVersionInfo sys_ver = { sizeof(SystemVersionInfo), 0, 0, {0} };
 
         char tmphost[sizeof(server_addr.domain) + 32] = {};
         string_interpolate_source_t fn = system_interpolate_cloud_server_hostname;
@@ -318,7 +318,7 @@ TEST_CASE("testing system_interpolate_cloud_server_hostname") {
     SECTION("system_string_interpolate() cannot force a buffer overflow") {
 
         mock_system_version = SYSTEM_VERSION_DEFAULT(255, 2, 3);
-        SystemVersionInfo sys_ver = SYSTEM_VERSION_INFO_INIT;
+        SystemVersionInfo sys_ver = { sizeof(SystemVersionInfo), 0, 0, {0} };
 
         int major_version = get_major_version(&sys_ver);
         int major_version_size = get_major_version_size(major_version) + 2;
@@ -367,7 +367,7 @@ TEST_CASE("testing system_interpolate_cloud_server_hostname") {
     SECTION("system_string_interpolate() $id token can be anywhere in the string") {
 
         mock_system_version = SYSTEM_VERSION_DEFAULT(255, 2, 3);
-        SystemVersionInfo sys_ver = SYSTEM_VERSION_INFO_INIT;
+        SystemVersionInfo sys_ver = { sizeof(SystemVersionInfo), 0, 0, {0} };
 
         int major_version = get_major_version(&sys_ver);
         int major_version_size = get_major_version_size(major_version) + 2;

--- a/test/unit_tests/system/system_task.cpp
+++ b/test/unit_tests/system/system_task.cpp
@@ -57,8 +57,7 @@ SCENARIO("Backoff period should increase exponentially from 1s to 128s", "[syste
 
 SCENARIO("System version info is retrieved", "[system,version]") {
 
-    SystemVersionInfo info;
-    info.size = sizeof(SystemVersionInfo);
+    SystemVersionInfo info = SYSTEM_VERSION_INFO_INIT;
 
     int size = system_version_info(&info, nullptr);
     REQUIRE(size==sizeof(info));

--- a/test/unit_tests/system/system_task.cpp
+++ b/test/unit_tests/system/system_task.cpp
@@ -58,7 +58,7 @@ SCENARIO("Backoff period should increase exponentially from 1s to 128s", "[syste
 SCENARIO("System version info is retrieved", "[system,version]") {
 
     SystemVersionInfo info = {};
-    sys_ver.size = sizeof(SystemVersionInfo);
+    info.size = sizeof(SystemVersionInfo);
 
     int size = system_version_info(&info, nullptr);
     REQUIRE(size==sizeof(info));

--- a/test/unit_tests/system/system_task.cpp
+++ b/test/unit_tests/system/system_task.cpp
@@ -57,7 +57,7 @@ SCENARIO("Backoff period should increase exponentially from 1s to 128s", "[syste
 
 SCENARIO("System version info is retrieved", "[system,version]") {
 
-    SystemVersionInfo info = SYSTEM_VERSION_INFO_INIT;
+    SystemVersionInfo info = { sizeof(SystemVersionInfo), 0, 0, {0} };
 
     int size = system_version_info(&info, nullptr);
     REQUIRE(size==sizeof(info));

--- a/test/unit_tests/system/system_task.cpp
+++ b/test/unit_tests/system/system_task.cpp
@@ -58,6 +58,7 @@ SCENARIO("Backoff period should increase exponentially from 1s to 128s", "[syste
 SCENARIO("System version info is retrieved", "[system,version]") {
 
     SystemVersionInfo info;
+    info.size = sizeof(SystemVersionInfo);
 
     int size = system_version_info(&info, nullptr);
     REQUIRE(size==sizeof(info));

--- a/test/unit_tests/system/system_task.cpp
+++ b/test/unit_tests/system/system_task.cpp
@@ -57,7 +57,8 @@ SCENARIO("Backoff period should increase exponentially from 1s to 128s", "[syste
 
 SCENARIO("System version info is retrieved", "[system,version]") {
 
-    SystemVersionInfo info = { sizeof(SystemVersionInfo), 0, 0, {0} };
+    SystemVersionInfo info = {};
+    sys_ver.size = sizeof(SystemVersionInfo);
 
     int size = system_version_info(&info, nullptr);
     REQUIRE(size==sizeof(info));

--- a/wiring/inc/spark_wiring_system.h
+++ b/wiring/inc/spark_wiring_system.h
@@ -670,12 +670,16 @@ public:
 
     String version() {
         SystemVersionInfo info;
+        info.size = sizeof(SystemVersionInfo);
+
         system_version_info(&info, nullptr);
         return String(info.versionString);
     }
 
     uint32_t versionNumber() {
         SystemVersionInfo info;
+        info.size = sizeof(SystemVersionInfo);
+
         system_version_info(&info, nullptr);
         return info.versionNumber;
     }

--- a/wiring/inc/spark_wiring_system.h
+++ b/wiring/inc/spark_wiring_system.h
@@ -669,14 +669,16 @@ public:
 #endif
 
     String version() {
-        SystemVersionInfo info = { sizeof(SystemVersionInfo), 0, 0, {0} };
+        SystemVersionInfo info = {};
+        info.size = sizeof(SystemVersionInfo);
 
         system_version_info(&info, nullptr);
         return String(info.versionString);
     }
 
     uint32_t versionNumber() {
-        SystemVersionInfo info =  { sizeof(SystemVersionInfo), 0, 0, {0} };
+        SystemVersionInfo info = {};
+        info.size = sizeof(SystemVersionInfo);
 
         system_version_info(&info, nullptr);
         return info.versionNumber;

--- a/wiring/inc/spark_wiring_system.h
+++ b/wiring/inc/spark_wiring_system.h
@@ -669,16 +669,14 @@ public:
 #endif
 
     String version() {
-        SystemVersionInfo info;
-        info.size = sizeof(SystemVersionInfo);
+        SystemVersionInfo info = SYSTEM_VERSION_INFO_INIT;
 
         system_version_info(&info, nullptr);
         return String(info.versionString);
     }
 
     uint32_t versionNumber() {
-        SystemVersionInfo info;
-        info.size = sizeof(SystemVersionInfo);
+        SystemVersionInfo info = SYSTEM_VERSION_INFO_INIT;
 
         system_version_info(&info, nullptr);
         return info.versionNumber;

--- a/wiring/inc/spark_wiring_system.h
+++ b/wiring/inc/spark_wiring_system.h
@@ -669,14 +669,14 @@ public:
 #endif
 
     String version() {
-        SystemVersionInfo info = SYSTEM_VERSION_INFO_INIT;
+        SystemVersionInfo info = { sizeof(SystemVersionInfo), 0, 0, {0} };
 
         system_version_info(&info, nullptr);
         return String(info.versionString);
     }
 
     uint32_t versionNumber() {
-        SystemVersionInfo info = SYSTEM_VERSION_INFO_INIT;
+        SystemVersionInfo info =  { sizeof(SystemVersionInfo), 0, 0, {0} };
 
         system_version_info(&info, nullptr);
         return info.versionNumber;


### PR DESCRIPTION
Remove initialisation of size field and move this into the code to remain compliant with the API.

Allows C files to access the constants and version API in system_version.h