### PR TITLE
linker: Add GCC feature 'build-id' into monolithic firmware

### DIFF
--- a/hal/src/nRF52840/app_no_bootloader.ld
+++ b/hal/src/nRF52840/app_no_bootloader.ld
@@ -155,6 +155,14 @@ SECTIONS
         /* This is used by the startup in order to initialize the .data secion */
     }>APP_FLASH  AT> APP_FLASH
 
+    .note.gnu.build-id :
+    {
+        __start_gnu_build_id_start = .;
+        link_gnu_build_id_location_start = .;
+        KEEP(*(.note.gnu.build-id))
+        link_gnu_build_id_location_end = .;
+    } >APP_FLASH  AT> APP_FLASH
+
     .mem_section_dummy_rom :
     {
     }


### PR DESCRIPTION
### Problem

This PR is to complement #2391 to add GCC feature build-id for monolithic firmware.

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
