### PR TITLE
[gen3] adds SystemPowerConfiguration::socBitPrecision(uint8_t bits)) API [sc-94643]

### DIFF
--- a/hal/inc/power_hal.h
+++ b/hal/inc/power_hal.h
@@ -60,7 +60,8 @@ typedef struct hal_power_config {
     uint16_t vin_max_current; // max current the VIN PSU can provide
     uint16_t charge_current; // charge current
     uint16_t termination_voltage; // termination voltage
-    uint16_t reserved2;
+    uint8_t soc_bits; // bits precision for SoC calculation (18 (default) or 19)
+    uint8_t reserved2;
     uint32_t reserved3[4];
 } hal_power_config;
 static_assert(sizeof(hal_power_config) == 32, "hal_power_config size changed");

--- a/system/inc/system_power.h
+++ b/system/inc/system_power.h
@@ -71,6 +71,8 @@ constexpr uint16_t DEFAULT_INPUT_CURRENT_LIMIT = 900; // 900mA
 constexpr uint16_t DEFAULT_INPUT_VOLTAGE_LIMIT = 3880; // 3.88V
 constexpr uint16_t DEFAULT_CHARGE_CURRENT = 896; // 896mA
 constexpr uint16_t DEFAULT_TERMINATION_VOLTAGE = 4112; // 4.112V
+constexpr uint8_t DEFAULT_SOC_18_BIT_PRECISION = 18; // 18 is default, but may be 18 or 19 when a custom model is loaded
+constexpr uint8_t SOC_19_BIT_PRECISION = 19; // 19 is the only other valid value, for now
 
 } } // particle::power
 

--- a/system/src/system_power_manager.cpp
+++ b/system/src/system_power_manager.cpp
@@ -78,6 +78,7 @@ constexpr hal_power_config defaultPowerConfig = {
   .vin_max_current = DEFAULT_INPUT_CURRENT_LIMIT,
   .charge_current = DEFAULT_CHARGE_CURRENT,
   .termination_voltage = DEFAULT_TERMINATION_VOLTAGE,
+  .soc_bits = DEFAULT_SOC_18_BIT_PRECISION,
   .reserved2 = 0,
   .reserved3 = {0}
 };
@@ -968,6 +969,10 @@ int PowerManager::getConfig(hal_power_config* conf) {
 
   if (!isValid(conf->termination_voltage)) {
     conf->termination_voltage = defaultPowerConfig.termination_voltage;
+  }
+
+  if (!isValid(conf->soc_bits)) {
+    conf->soc_bits = defaultPowerConfig.soc_bits;
   }
 
   // IMPORTANT!: check size of destination config structure before writing any mode defaults

--- a/test/unit_tests/wiring/fuel_gauge.cpp
+++ b/test/unit_tests/wiring/fuel_gauge.cpp
@@ -26,18 +26,34 @@
 using namespace particle::detail;
 
 SCENARIO("Fuel Gauge VCELL_REGISTER conversion should return 1.25mV per bit", "[fuel_gauge]") {
-
     REQUIRE(_getVCell(0x00, 0x10) == (float)0.00125);
     REQUIRE(_getVCell(0x01, 0x00) == (float)(0.00125*16));
     REQUIRE(_getVCell(0x10, 0x00) == (float)(0.00125*256));
     REQUIRE(_getVCell(0xFF, 0xF0) == (float)(0.00125*4095));
 }
 
-SCENARIO("Fuel Gauge SOC_REGISTER conversion should return MSB.(LSB/256)%%", "[fuel_gauge]") {
+SCENARIO("Fuel Gauge SoC conversion should return MSB.(LSB/256)%% by default", "[fuel_gauge]") {
     // MSB is the whole number
     // LSB is the decimal, resolution in units 1/256%
+    // Same as 18-bit precision
     REQUIRE(_getSoC(0x01, 0x80) == (float)1.5);
     REQUIRE(_getSoC(0x10, 0x29) == (float)16.16015625);
     REQUIRE(_getSoC(0x64, 0x00) == (float)100.0);
     REQUIRE(_getSoC(0xFF, 0xFF) == (float)255.99609375);
+}
+
+SCENARIO("Fuel Gauge SoC conversion should return 18 bit values on demand", "[fuel_gauge]") {
+    const byte soc_bits_precision = 18;
+    REQUIRE(_getSoC(0x01, 0x80, soc_bits_precision) == (float)1.5);
+    REQUIRE(_getSoC(0x10, 0x29, soc_bits_precision) == (float)16.16015625);
+    REQUIRE(_getSoC(0x64, 0x00, soc_bits_precision) == (float)100.0);
+    REQUIRE(_getSoC(0xFF, 0xFF, soc_bits_precision) == (float)255.99609375);
+}
+
+SCENARIO("Fuel Gauge SoC conversion should return 19 bit values on demand", "[fuel_gauge]") {
+    const byte soc_bits_precision = 19;
+    REQUIRE(_getSoC(0x01, 0x80, soc_bits_precision) == (float)0.75);
+    REQUIRE(_getSoC(0x10, 0x29, soc_bits_precision) == (float)8.080078125);
+    REQUIRE(_getSoC(0x64, 0x00, soc_bits_precision) == (float)50.0);
+    REQUIRE(_getSoC(0xFF, 0xFF, soc_bits_precision) == (float)127.998046875);
 }

--- a/user/tests/wiring/api/system.cpp
+++ b/user/tests/wiring/api/system.cpp
@@ -445,6 +445,7 @@ test(system_power_management) {
     API_COMPILE(conf.powerSourceMaxCurrent(1234));
     API_COMPILE(conf.batteryChargeVoltage(1234));
     API_COMPILE(conf.batteryChargeCurrent(1234));
+    API_COMPILE(conf.socBitPrecision(19));
     API_COMPILE(conf.feature(SystemPowerFeature::PMIC_DETECTION));
     API_COMPILE(conf.feature(SystemPowerFeature::USE_VIN_SETTINGS_WITH_USB_HOST));
     API_COMPILE(conf.feature(SystemPowerFeature::DISABLE));
@@ -466,5 +467,6 @@ test(system_power_management) {
     API_COMPILE({ auto getSourceV = getConf.powerSourceMinVoltage(); (void)getSourceV; });
     API_COMPILE({ auto getBatteryA = getConf.batteryChargeCurrent(); (void)getBatteryA; });
     API_COMPILE({ auto getBatteryV = getConf.batteryChargeVoltage(); (void)getBatteryV; });
+    API_COMPILE({ auto getSocBitPrecision = getConf.socBitPrecision(); (void)getSocBitPrecision; });
 }
 #endif // HAL_PLATFORM_POWER_MANAGEMENT

--- a/user/tests/wiring/power_management/power.cpp
+++ b/user/tests/wiring/power_management/power.cpp
@@ -204,6 +204,7 @@ test(POWER_01_PoweredByUsbHostAndBatteryStateIsValid) {
     assertEqual(cfg.powerSourceMinVoltage(), particle::power::DEFAULT_INPUT_VOLTAGE_LIMIT);
     assertEqual(cfg.batteryChargeCurrent(), particle::power::DEFAULT_CHARGE_CURRENT);
     assertEqual(cfg.batteryChargeVoltage(), particle::power::DEFAULT_TERMINATION_VOLTAGE);
+    assertEqual(cfg.socBitPrecision(), particle::power::DEFAULT_SOC_18_BIT_PRECISION);
 
     // Allow some time for the power management subsystem to settle
     waitFor(powerManagementSettled, 10000);
@@ -344,6 +345,7 @@ test(POWER_06_PoweredByVinAndBatteryStateIsValid) {
     assertEqual(cfg.powerSourceMinVoltage(), particle::power::DEFAULT_INPUT_VOLTAGE_LIMIT);
     assertEqual(cfg.batteryChargeCurrent(), particle::power::DEFAULT_CHARGE_CURRENT);
     assertEqual(cfg.batteryChargeVoltage(), particle::power::DEFAULT_TERMINATION_VOLTAGE);
+    assertEqual(cfg.socBitPrecision(), particle::power::DEFAULT_SOC_18_BIT_PRECISION);
 
     // Allow some time for the power management subsystem to settle
     waitFor(powerManagementSettled, 10000);
@@ -475,6 +477,7 @@ test(POWER_11_ApplyingDefaultPowerManagementConfigurationInRuntimeWorksAsIntende
     assertEqual(cfg.powerSourceMinVoltage(), particle::power::DEFAULT_INPUT_VOLTAGE_LIMIT);
     assertEqual(cfg.batteryChargeCurrent(), particle::power::DEFAULT_CHARGE_CURRENT);
     assertEqual(cfg.batteryChargeVoltage(), particle::power::DEFAULT_TERMINATION_VOLTAGE);
+    assertEqual(cfg.socBitPrecision(), particle::power::DEFAULT_SOC_18_BIT_PRECISION);
 
     PMIC power(true);
     assertEqual(power.getInputCurrentLimit(), particle::power::DEFAULT_INPUT_CURRENT_LIMIT);
@@ -575,6 +578,7 @@ test(POWER_14_PmicDetectionFlagIsCompatibleWithOldDeviceOsVersions) {
     assertEqual(cfg.powerSourceMinVoltage(), particle::power::DEFAULT_INPUT_VOLTAGE_LIMIT);
     assertEqual(cfg.batteryChargeCurrent(), particle::power::DEFAULT_CHARGE_CURRENT);
     assertEqual(cfg.batteryChargeVoltage(), particle::power::DEFAULT_TERMINATION_VOLTAGE);
+    assertEqual(cfg.socBitPrecision(), particle::power::DEFAULT_SOC_18_BIT_PRECISION);
 
     // Feature enabled
     uint8_t v;
@@ -618,6 +622,7 @@ test(POWER_15_DisableFeatureFlag) {
         assertEqual(cfg.powerSourceMinVoltage(), particle::power::DEFAULT_INPUT_VOLTAGE_LIMIT);
         assertEqual(cfg.batteryChargeCurrent(), particle::power::DEFAULT_CHARGE_CURRENT);
         assertEqual(cfg.batteryChargeVoltage(), particle::power::DEFAULT_TERMINATION_VOLTAGE);
+        assertEqual(cfg.socBitPrecision(), particle::power::DEFAULT_SOC_18_BIT_PRECISION);
 
         assertEqual(System.batteryState(), (int)BATTERY_STATE_UNKNOWN);
         assertEqual(System.powerSource(), (int)POWER_SOURCE_UNKNOWN);

--- a/user/tests/wiring/power_management_long_running/power.cpp
+++ b/user/tests/wiring/power_management_long_running/power.cpp
@@ -146,7 +146,8 @@ test(power_00_setup) {
                                       .powerSourceMaxCurrent(particle::power::DEFAULT_INPUT_CURRENT_LIMIT)
                                       .batteryChargeVoltage(particle::power::DEFAULT_INPUT_VOLTAGE_LIMIT)
                                       .batteryChargeCurrent(particle::power::DEFAULT_CHARGE_CURRENT)
-                                      .batteryChargeVoltage(particle::power::DEFAULT_TERMINATION_VOLTAGE)),
+                                      .batteryChargeVoltage(particle::power::DEFAULT_TERMINATION_VOLTAGE)
+                                      .socBitPrecision(particle::power::DEFAULT_SOC_18_BIT_PRECISION)),
         (int)SYSTEM_ERROR_NONE
     );
     delay(1s);
@@ -160,6 +161,7 @@ test(power_00_setup) {
     assertEqual(cfg.powerSourceMinVoltage(), particle::power::DEFAULT_INPUT_VOLTAGE_LIMIT);
     assertEqual(cfg.batteryChargeCurrent(), particle::power::DEFAULT_CHARGE_CURRENT);
     assertEqual(cfg.batteryChargeVoltage(), particle::power::DEFAULT_TERMINATION_VOLTAGE);
+    assertEqual(cfg.socBitPrecision(), particle::power::DEFAULT_SOC_18_BIT_PRECISION);
 
     while (SERIAL.available() > 0) {
         (void)SERIAL.read();

--- a/wiring/inc/spark_wiring_fuel.h
+++ b/wiring/inc/spark_wiring_fuel.h
@@ -31,6 +31,7 @@
 #include "spark_wiring_platform.h"
 #include "spark_wiring.h"
 #include "spark_wiring_i2c.h"
+#include "system_power.h"
 
 //Default MAX17043 I2C address
 #define MAX17043_ADDRESS  0x36
@@ -44,10 +45,12 @@
 #define COMMAND_REGISTER  0xFE
 
 /* detail functions defined for unit tests */
-namespace particle { namespace detail {
+namespace particle {
+namespace detail {
     float _getVCell(byte MSB, byte LSB);
-    float _getSoC(byte MSB, byte LSB);
-}}
+    float _getSoC(byte MSB, byte LSB, byte soc_bits_precision = particle::power::DEFAULT_SOC_18_BIT_PRECISION);
+} // namespace detail
+} // namespace particle
 
 class FuelGauge {
 public:

--- a/wiring/inc/spark_wiring_system_power.h
+++ b/wiring/inc/spark_wiring_system_power.h
@@ -96,6 +96,15 @@ public:
         return (conf_.flags & f.value()) ? true : false;
     }
 
+    SystemPowerConfiguration& socBitPrecision(uint8_t bits) {
+        conf_.soc_bits = bits;
+        return *this;
+    }
+
+    uint8_t socBitPrecision() const {
+        return conf_.soc_bits;
+    }
+
     const hal_power_config* config() const {
         return &conf_;
     }


### PR DESCRIPTION
### Problem

When loading a custom FuelGauge battery model, the SoC calculation may use a 18 or 19 bit model.  This must be recalled by the system FuelGauge class for use in properly calculating SoC.

### Solution

Add an API to the SystemPowerConfiguration:
- [SET] `SystemPowerConfiguration& SystemPowerConfiguration::socBitPrecision(uint8_t bits);`
- [GET] `int SystemPowerConfiguration::socBitPrecision();`
- .socBitPrecision() defaults to 18 bit if not set explicitly

### Steps to Test

- Run unit tests
- Compile `TEST=wiring/api`⌛ 
- Run `TEST=wiring/power_manager`⌛ ⌛ 
- Run `TEST=wiring/power_manager_long_running` ⌛ ⌛ ⌛ ⌛ ⌛ ⌛ 😅 
- Run example app with default internal 18 bit battery model
- Run example app with loading an external 19 bit battery model

### Example App

```c
#include "Particle.h"
Serial1LogHandler log1Serial(115200, LOG_LEVEL_ALL);
SYSTEM_MODE(SEMI_AUTOMATIC);
SYSTEM_THREAD(ENABLED);

void setup() {
    // Update system SoC Bit Precision to match custom model
    // Instead of using .getPowerConfiguration() and testing for 19 bits,
    // we can set it and let the system check if it needs to be updated.
    SystemPowerConfiguration conf;
    conf.socBitPrecision(19);
    auto result = System.setPowerConfiguration(conf);
    Log.info("System.setPowerConfiguration = %d", result);
}

void loop() {
    static uint32_t last_10s = 0;
    static uint32_t loop_count = 0;

    // print SoC every 10 seconds
    if (System.uptime() - last_10s >= 10)
    {
        last_10s = System.uptime();

        // Toggle system SoC Bit Precision to check for proper and improper calculation
        // NOTE: Test both with default 18 bit model, and custom 19 bit model
        SystemPowerConfiguration conf = System.getPowerConfiguration();
        if (loop_count & 1) {
            conf.socBitPrecision(19);
        } else {
            conf.socBitPrecision(18);
        }
        System.setPowerConfiguration(conf);

        FuelGauge fg(true);
        auto fg_soc = fg.getSoC();
        auto fg_nsoc = fg.getNormalizedSoC();
        Log.info("loop: %lu, bits: %d, fg_soc: %0.2f%%, fg_nsoc: %0.2f%%",
            loop_count, conf.socBitPrecision(), fg_soc, fg_nsoc);

        loop_count++;
    }
}
```

### References

sc-94643 - enhancement request
sc-98317 - docs request

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] TODO: Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
