### PR TITLE
Register without waiting for CSD connections [sc-96611]

### DIFF
--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -1676,7 +1676,7 @@ void QuectelNcpClient::resetRegistrationState() {
 
 void QuectelNcpClient::checkRegistrationState() {
     if (connState_ != NcpConnectionState::DISCONNECTED) {
-        if ((csd_.registered() && psd_.registered()) || eps_.registered()) {
+        if (psd_.registered() || eps_.registered()) {
             connectionState(NcpConnectionState::CONNECTED);
         } else if (connState_ == NcpConnectionState::CONNECTED) {
             // FIXME: potentially go back into connecting state only when getting into

--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -2171,7 +2171,7 @@ void SaraNcpClient::resetRegistrationState() {
 
 void SaraNcpClient::checkRegistrationState() {
     if (connState_ != NcpConnectionState::DISCONNECTED) {
-        if ((csd_.registered() && psd_.registered()) || eps_.registered()) {
+        if (psd_.registered() || eps_.registered()) {
             if (memoryIssuePresent_ && connState_ != NcpConnectionState::CONNECTED) {
                 registeredTime_ = millis(); // start registered timer for memory issue power off delays
             }


### PR DESCRIPTION
### Problem

Currently on our 2G/3G/Cat-1 devices, we require CSD and PSD connections to be registered before we start a data connection. So if one won't connect, likely the CSD connection... it will block the device from connecting. 

Early on in Electron development I believe we waited for CSD connections so that we could dial out and receive calls to potentially wake on RING indication, but this has never been implemented and currently cannot be used with current SIMs.

### Solution

- Wait for (PSD || EPS) registration instead of ((CSD && PSD) || EPS) for both u-blox & Quectel modems
- ~Disable setting Cellular Global Identity (CGI) for CSD registration since we're not waiting for CSD anymore~
  - After talking this over with Keerthy, we decided that it doesn't hurt to leave this code in since PSD and EPS registration will override this CGI data.  If those are not registered though, at least CSD can offer some CGI info even if we are not connected.
- NOTE: I specifically did not alter the Registration Intervening commands since that seemed like it would cause more disruption, but if CSD is not available at all this would block some of the intervening commands since they also look for CSD && PSD to be in the same state, and in some cases wait for CSD only to be a certain state. Whether or not to reduce these commands to look at PSD and EPS only is up for discussion.
  - For now, we have decided to leave the Registration Intervening commands as-is.

### Steps to Test

Disable CSD connections (Set PSD only) and ensure devices still connect.

u-blox (2G/3G)
```c
// Disable CSD connections, PSD only.
auto resp = parser_.sendCommand("AT+CGCLASS?");
char cgClass[4] = {};
int r = CHECK_PARSER(resp.scanf("+CGCLASS: \"%3[^\"]", cgClass));
r = CHECK_PARSER(resp.readResult());
CHECK_TRUE(r == AtResponse::OK, SYSTEM_ERROR_AT_NOT_OK);
if (strcmp(cgClass, "CG") != 0) {
    CHECK_PARSER_OK(parser_.execCommand("AT+CGCLASS=\"CG\""));
}
```

Quectel (EG91)
```c
CHECK_PARSER(parser_.execCommand("AT+COPS=2")); // Deregister
CHECK_PARSER(parser_.execCommand("AT+QCFG=\"servicedomain\"")); // Check (should be 2: CS and PS domain)
CHECK_PARSER(parser_.execCommand("AT+QCFG=\"servicedomain\",1,1")); // PS only
```

### References

sc-96611

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] (N/A) Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
