### PR TITLE
Listening mode should be allowed to enter when safe mode is requested.

### DIFF
--- a/system/src/system_control_internal.cpp
+++ b/system/src/system_control_internal.cpp
@@ -95,7 +95,7 @@ int SystemControl::init() {
     // is enabled, we need to make sure to call characteristic UUIDs in prov
     // mode system calls for the first time instead of here.
     // See system_ble_prov_mode()
-    if (!HAL_Feature_Get(FEATURE_DISABLE_LISTENING_MODE)) {
+    if (system_mode() == SAFE_MODE || !HAL_Feature_Get(FEATURE_DISABLE_LISTENING_MODE)) {
         const int ret = bleChannel_.init();
         if (ret != 0) {
             return ret;

--- a/system/src/system_listening_mode.cpp
+++ b/system/src/system_listening_mode.cpp
@@ -35,6 +35,7 @@ LOG_SOURCE_CATEGORY("system.listen")
 #include "system_event.h"
 #include "scope_guard.h"
 #include "core_hal.h"
+#include "system_mode.h"
 
 using particle::LEDStatus;
 
@@ -63,7 +64,7 @@ ListeningModeHandler* ListeningModeHandler::instance() {
 }
 
 int ListeningModeHandler::enter(unsigned int timeout) {
-    if (HAL_Feature_Get(FEATURE_DISABLE_LISTENING_MODE)) {
+    if (system_mode() != SAFE_MODE && HAL_Feature_Get(FEATURE_DISABLE_LISTENING_MODE)) {
         return SYSTEM_ERROR_NOT_ALLOWED;
     }
 

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -515,7 +515,9 @@ void Spark_Idle_Events(bool force_events/*=false*/)
 
         system::FirmwareUpdate::instance()->process();
 
-        manage_listening_mode_flag();
+        if (system_mode() != SAFE_MODE) {
+            manage_listening_mode_flag();
+        }
     }
     else
     {
@@ -524,7 +526,9 @@ void Spark_Idle_Events(bool force_events/*=false*/)
 #if HAL_PLATFORM_BLE
     // TODO: Process BLE channel events in a separate thread
     system::SystemControl::instance()->run();
-    manage_ble_prov_mode();
+    if (system_mode() != SAFE_MODE) {
+        manage_ble_prov_mode();
+    }
 #endif
     system_shutdown_if_needed();
 }


### PR DESCRIPTION
### Problem
If Wi-Fi credential is missing and safe mode is requested, device cannot enter listening mode to allow user to configure Wi-Fi credentials. As result device cannot finally connect to the cloud and stay in safe mode.
### Solution
Do not process scenarios that is based on  the `FEATURE_DISABLE_LISTENING_MODE` flag when safe mode is requested.
### Example App

```c
STARTUP( System.enableFeature(FEATURE_DISABLE_LISTENING_MODE) );

void setup() {
  WiFi.clearCredentials();
}

void loop() {

}
```

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [x] Added to CHANGELOG.md after merging (add links to docs and issues)
