### PR TITLE
[gen3] Dummy setup code should not return error

### DIFF
--- a/hal/src/nRF52840/device_code.cpp
+++ b/hal/src/nRF52840/device_code.cpp
@@ -22,6 +22,7 @@
 #include "str_util.h"
 #include "preprocessor.h"
 #include "debug.h"
+#include "system_error.h"
 
 #include "dct.h"
 
@@ -59,6 +60,8 @@ int get_device_setup_code(char* code, size_t size) {
             // Return a dummy setup code
             codeSize = std::min(sizeof(setupCode), size);
             memset(code, 'X', codeSize);
+            // Overwrite return error as this is a valid case
+            ret = SYSTEM_ERROR_NONE;
         }
     } else {
         codeSize = std::min(sizeof(setupCode), size);


### PR DESCRIPTION
### Problem

API call to get device setup code `get_device_setup_code()` returns an error when dummy setup code is set, although it's a valid case.

### Solution

Overwrite return error when dummy code is return as setup code

### Steps to Test

- Clear OTP so that setup code is empty
- Test that dummy setup code `XXXXXX` is returned and the device didn't crash.

### Example App

```c
void setup() {
  /* A minimal example app is super helpful 
   * for testing new features and fixes. 
   * A link to a Docs PR is even better!
   */
}

void loop() {

}
```

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
