### PR TITLE
[test] fixes integration slo/connect_time

### DIFF
--- a/user/tests/integration/slo/connect_time/connect_time.spec.js
+++ b/user/tests/integration/slo/connect_time/connect_time.spec.js
@@ -22,10 +22,12 @@ const THRESHOLDS = {
 	}
 };
 
+// IMPORTANT: Make sure CONNECT_COUNT * PERCENTILE / 100 is a whole number
+// -----------------------------------------------------------------------
+//
 // Number of connection time measurements to make. When changing this parameter, make sure to
 // update the test application accordingly
-const CONNECT_COUNT = 10;
-
+const CONNECT_COUNT = 8;
 // The test uses the Nth percentile of all connection time measurements
 const PERCENTILE = 75;
 
@@ -35,8 +37,10 @@ function percentile(values, p) {
 	if (!values.length) {
 		return NaN;
 	}
-	values = values.slice().sort();
-	const i = Math.floor((values.length - 1) * p / 100);
+	values = values.slice().sort(function(a, b) {
+		return a - b; // default .sort() is alphanumeric and will not sort integers properly
+	});
+	const i = Math.floor((values.length) * p / 100) - 1;
 	return values[i];
 }
 
@@ -53,12 +57,22 @@ before(function() {
 // TODO: The test runner doesn't support resetting the device in a loop from within a test
 for (let i = 1; i <= CONNECT_COUNT; ++i) {
 	test(`cloud_connect_time_from_cold_boot_${i.toString().padStart(2, '0')}`, async () => {
+		// dump any failure logs from this test
+		let testLog = await fetchLog();
+		if (testLog.length) {
+			console.log(testLog);
+		}
 		await device.reset(); // Reset the device before running the next test
 	});
 }
 
 for (let i = 1; i <= CONNECT_COUNT; ++i) {
 	test(`cloud_connect_time_from_warm_boot_${i.toString().padStart(2, '0')}`, async () => {
+		// dump any failure logs from this test
+		let testLog = await fetchLog();
+		if (testLog.length) {
+			console.log(testLog);
+		}
 		await device.reset();
 	});
 }


### PR DESCRIPTION
### Problem

Integration test `connect_time/slo` was failing intermittently on various devices for a number of reasons:

1. The test is designed to run cold boot and warm boot 10 times each, and take the 75th percentile result to compare to the SLO for each test case.  If any individual test failed, it would count towards the total number of tests as a failure, even if the individual test was one of the 25th percentile outliers.
2. Every test in the test runner suite has a 10 minute timeout value, so if the device `waitFor()` timeouts exceed that, the test will result in a failure and we won't know what was really failing in the test.
3. The test was running 10 test cases, and looking for a 75th percentile SLO which is not evenly divisible within 10 test cases, so the math was actually calculating the 70th percentile instead of 75th.
4. If a test failed before setting the `stats` object, the resulting test would be saved as 0s which is technically passing.
5. `stats.coldBootCount` and `stats.warmBootCount` were not incremented if the test exited early.
6. Javascript `.sort()` defaults to alphanumeric string sort and will not sort integers properly
7. There was a potential index error with where the 75th percentile was calculated `const i = Math.floor((values.length-1) * p / 100)`
8. The cold boot test was attempting to power off the NCP before it was on.  This was causing longer power off delays due to no AT interface being available.  R510 was resorting to a lengthy emergency hard power off sequence.

### Solution

1. Do not assertTrue() on each individual test in the connect_time test suite.  Each test will show as pass, and log a failure statement if something should fail.  assertTrue only on the overall 75th percentile calculation.
2. Change the `WAIT_FOR_TIMEOUT` to an overall `TEST_MAX_TIMEOUT` and make sure it's just shy of the 10 minute test timeout.  As the test progresses, successive waitFor()'s should use whatever time is remaining for the test, up to `TEST_MAX_TIMEOUT`.
3. Change the number of tests to be evenly divisible for our required `PERCENTILE` (e.g. `CONNECT_COUNT * PERCENTILE / 100` should be a whole number).  In this case we'll reduce the number of tests to 8 which will speed it up a little as well.
4. Set the test result to `TEST_MAX_TIMEOUT` at the beginning of the test in case of early exit.
5. increment `stats.coldBootCount` and `stats.warmBootCount` at the beginning of the test in case of early exit.
6. Add `.sort()` compare function for integers to properly sort the array
7. Fix index error by calculating percentage first, then adjust for zero based index last. `const i = Math.floor((values.length) * p / 100) - 1`
8. Power on the NCP first for the cold boot test, then turn it off to prepare for cold boot timing.  This speeds up the cold boot time on R510 by about 30 seconds.  There is a noticeable speed up on R410 as well.

### Steps to Test

- run `slo/connect_time` integration tests and cause more or less failures by removing the antenna (faster if you force the tests to exit early in code)
- e.g.
    ```
    device-os/user/tests/integration $ device-os-test build bsom slo/connect_time -v
    device-os/user/tests/integration $ device-os-test run bsom slo/connect_time -v
    ```

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] (N/A) Added documentation
- [x] Added to CHANGELOG.md after merging (add links to docs and issues)
