### PR TITLE
Updates C++ standard version to C++17 (gnu variant)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ jobs:
             cd $HOME/device-os
             git submodule update --init --recursive
             if [ -z "$CIRCLE_TAG" ]; then
-              export ARTIFACT_TAG=$(echo "$CIRCLE_BRANCH" | tr '[:upper:]' '[:lower:]' | sed 's,/,-,g')-$(git rev-parse --short HEAD)
+              export ARTIFACT_TAG=$(echo "$CIRCLE_BRANCH" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-zA-Z0-9]/-/g')-$(git rev-parse --short HEAD)
             else
               export ARTIFACT_TAG=$CIRCLE_TAG
             fi

--- a/build/lang-std.mk
+++ b/build/lang-std.mk
@@ -1,5 +1,5 @@
-# Set C++ version to C++14 globally and set C version to C11
-CPPFLAGS += -std=gnu++14
+# Set C++ version to C++17 globally and set C version to C11
+CPPFLAGS += -std=gnu++17
 CONLYFLAGS += -std=gnu11
 
 # NOTE: Keep this in sync with test/CMakeLists.txt

--- a/platform/MCU/STM32F2xx/CMSIS/Include/core_cmFunc.h
+++ b/platform/MCU/STM32F2xx/CMSIS/Include/core_cmFunc.h
@@ -49,7 +49,7 @@
  */
 __STATIC_INLINE uint32_t __get_CONTROL(void)
 {
-  register uint32_t __regControl         __ASM("control");
+  uint32_t __regControl         __ASM("control");
   return(__regControl);
 }
 
@@ -62,7 +62,7 @@ __STATIC_INLINE uint32_t __get_CONTROL(void)
  */
 __STATIC_INLINE void __set_CONTROL(uint32_t control)
 {
-  register uint32_t __regControl         __ASM("control");
+  uint32_t __regControl         __ASM("control");
   __regControl = control;
 }
 
@@ -75,7 +75,7 @@ __STATIC_INLINE void __set_CONTROL(uint32_t control)
  */
 __STATIC_INLINE uint32_t __get_IPSR(void)
 {
-  register uint32_t __regIPSR          __ASM("ipsr");
+  uint32_t __regIPSR          __ASM("ipsr");
   return(__regIPSR);
 }
 
@@ -88,7 +88,7 @@ __STATIC_INLINE uint32_t __get_IPSR(void)
  */
 __STATIC_INLINE uint32_t __get_APSR(void)
 {
-  register uint32_t __regAPSR          __ASM("apsr");
+  uint32_t __regAPSR          __ASM("apsr");
   return(__regAPSR);
 }
 
@@ -101,7 +101,7 @@ __STATIC_INLINE uint32_t __get_APSR(void)
  */
 __STATIC_INLINE uint32_t __get_xPSR(void)
 {
-  register uint32_t __regXPSR          __ASM("xpsr");
+  uint32_t __regXPSR          __ASM("xpsr");
   return(__regXPSR);
 }
 
@@ -114,7 +114,7 @@ __STATIC_INLINE uint32_t __get_xPSR(void)
  */
 __STATIC_INLINE uint32_t __get_PSP(void)
 {
-  register uint32_t __regProcessStackPointer  __ASM("psp");
+  uint32_t __regProcessStackPointer  __ASM("psp");
   return(__regProcessStackPointer);
 }
 
@@ -127,7 +127,7 @@ __STATIC_INLINE uint32_t __get_PSP(void)
  */
 __STATIC_INLINE void __set_PSP(uint32_t topOfProcStack)
 {
-  register uint32_t __regProcessStackPointer  __ASM("psp");
+  uint32_t __regProcessStackPointer  __ASM("psp");
   __regProcessStackPointer = topOfProcStack;
 }
 
@@ -140,7 +140,7 @@ __STATIC_INLINE void __set_PSP(uint32_t topOfProcStack)
  */
 __STATIC_INLINE uint32_t __get_MSP(void)
 {
-  register uint32_t __regMainStackPointer     __ASM("msp");
+  uint32_t __regMainStackPointer     __ASM("msp");
   return(__regMainStackPointer);
 }
 
@@ -153,7 +153,7 @@ __STATIC_INLINE uint32_t __get_MSP(void)
  */
 __STATIC_INLINE void __set_MSP(uint32_t topOfMainStack)
 {
-  register uint32_t __regMainStackPointer     __ASM("msp");
+  uint32_t __regMainStackPointer     __ASM("msp");
   __regMainStackPointer = topOfMainStack;
 }
 
@@ -166,7 +166,7 @@ __STATIC_INLINE void __set_MSP(uint32_t topOfMainStack)
  */
 __STATIC_INLINE uint32_t __get_PRIMASK(void)
 {
-  register uint32_t __regPriMask         __ASM("primask");
+  uint32_t __regPriMask         __ASM("primask");
   return(__regPriMask);
 }
 
@@ -179,7 +179,7 @@ __STATIC_INLINE uint32_t __get_PRIMASK(void)
  */
 __STATIC_INLINE void __set_PRIMASK(uint32_t priMask)
 {
-  register uint32_t __regPriMask         __ASM("primask");
+  uint32_t __regPriMask         __ASM("primask");
   __regPriMask = (priMask);
 }
 
@@ -210,7 +210,7 @@ __STATIC_INLINE void __set_PRIMASK(uint32_t priMask)
  */
 __STATIC_INLINE uint32_t  __get_BASEPRI(void)
 {
-  register uint32_t __regBasePri         __ASM("basepri");
+  uint32_t __regBasePri         __ASM("basepri");
   return(__regBasePri);
 }
 
@@ -223,7 +223,7 @@ __STATIC_INLINE uint32_t  __get_BASEPRI(void)
  */
 __STATIC_INLINE void __set_BASEPRI(uint32_t basePri)
 {
-  register uint32_t __regBasePri         __ASM("basepri");
+  uint32_t __regBasePri         __ASM("basepri");
   __regBasePri = (basePri & 0xff);
 }
 
@@ -236,7 +236,7 @@ __STATIC_INLINE void __set_BASEPRI(uint32_t basePri)
  */
 __STATIC_INLINE uint32_t __get_FAULTMASK(void)
 {
-  register uint32_t __regFaultMask       __ASM("faultmask");
+  uint32_t __regFaultMask       __ASM("faultmask");
   return(__regFaultMask);
 }
 
@@ -249,7 +249,7 @@ __STATIC_INLINE uint32_t __get_FAULTMASK(void)
  */
 __STATIC_INLINE void __set_FAULTMASK(uint32_t faultMask)
 {
-  register uint32_t __regFaultMask       __ASM("faultmask");
+  uint32_t __regFaultMask       __ASM("faultmask");
   __regFaultMask = (faultMask & (uint32_t)1);
 }
 
@@ -267,7 +267,7 @@ __STATIC_INLINE void __set_FAULTMASK(uint32_t faultMask)
 __STATIC_INLINE uint32_t __get_FPSCR(void)
 {
 #if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-  register uint32_t __regfpscr         __ASM("fpscr");
+  uint32_t __regfpscr         __ASM("fpscr");
   return(__regfpscr);
 #else
    return(0);
@@ -284,7 +284,7 @@ __STATIC_INLINE uint32_t __get_FPSCR(void)
 __STATIC_INLINE void __set_FPSCR(uint32_t fpscr)
 {
 #if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
-  register uint32_t __regfpscr         __ASM("fpscr");
+  uint32_t __regfpscr         __ASM("fpscr");
   __regfpscr = (fpscr);
 #endif
 }
@@ -409,7 +409,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_xPSR(void)
  */
 __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_PSP(void)
 {
-  register uint32_t result;
+  uint32_t result;
 
   __ASM volatile ("MRS %0, psp\n"  : "=r" (result) );
   return(result);
@@ -436,7 +436,7 @@ __attribute__( ( always_inline ) ) __STATIC_INLINE void __set_PSP(uint32_t topOf
  */
 __attribute__( ( always_inline ) ) __STATIC_INLINE uint32_t __get_MSP(void)
 {
-  register uint32_t result;
+  uint32_t result;
 
   __ASM volatile ("MRS %0, msp\n" : "=r" (result) );
   return(result);

--- a/test/unit_tests/CMakeLists.txt
+++ b/test/unit_tests/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.2)
 project(unit_tests)
 
 # NOTE: Keep this in sync with lang-std.mk
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS ON)
 


### PR DESCRIPTION
### Description

1. Updates C++ standard version to C++17 (gnu variant)
2. Fixes branch name escape logic for CircleCI/Docker.
3. Bumps `nrf5_sdk` to a version with C++17-related `register` fixes.

### Steps to Test

N/A, CI should succeed

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
