### PR TITLE
[test] improves wiring/no_fixture_long_running NETWORK_XX test timing

### DIFF
--- a/user/tests/wiring/no_fixture_long_running/network.cpp
+++ b/user/tests/wiring/no_fixture_long_running/network.cpp
@@ -68,7 +68,8 @@ bool udpEchoTest(UDP* udp, const IPAddress& ip, uint16_t port, const uint8_t* se
 } // anonymous
 
 test(NETWORK_01_LargePacketsDontCauseIssues_ResolveMtu) {
-    const system_tick_t WAIT_TIMEOUT = 10 * 60 * 1000;
+    // 15 min gives the device time to go through a 10 min timeout & power cycle
+    const system_tick_t WAIT_TIMEOUT = 15 * 60 * 1000;
 
     Network.on();
     Network.connect();
@@ -179,7 +180,8 @@ test(NETWORK_01_LargePacketsDontCauseIssues_ResolveMtu) {
 #if HAL_PLATFORM_NCP_AT || HAL_PLATFORM_CELLULAR
 
 test(NETWORK_02_network_connection_recovers_after_ncp_failure) {
-    const system_tick_t WAIT_TIMEOUT = 10 * 60 * 1000;
+    // 15 min gives the device time to go through a 10 min timeout & power cycle
+    const system_tick_t WAIT_TIMEOUT = 15 * 60 * 1000;
     const system_tick_t NCP_FAILURE_TIMEOUT = 15000;
 
     Network.on();
@@ -230,7 +232,8 @@ test(NETWORK_02_network_connection_recovers_after_ncp_failure) {
 static bool s_networkStatusChanged = false;
 
 test(NETWORK_03_network_connection_recovers_after_ncp_uart_sleep) {
-    const system_tick_t WAIT_TIMEOUT = 10 * 60 * 1000;
+    // 15 min gives the device time to go through a 10 min timeout & power cycle
+    const system_tick_t WAIT_TIMEOUT = 15 * 60 * 1000;
 
     SCOPE_GUARD({
         Particle.disconnect();

--- a/user/tests/wiring/no_fixture_long_running/no_fixture_long_running.spec.js
+++ b/user/tests/wiring/no_fixture_long_running/no_fixture_long_running.spec.js
@@ -1,4 +1,4 @@
 suite('No fixture long running');
 
 platform('gen2', 'gen3');
-timeout(20 * 60 * 1000);
+timeout(32 * 60 * 1000);


### PR DESCRIPTION
### Problem

`wiring/no_fixture_long_running` NETWORK_02 and possibly 01 or 03 can fail when a device takes longer than expected to register.  We test connect_time cold/warm boots separately with a 75th percentile criteria after 8 runs.  Here, we only run through once and it would be kind of lengthy to run this test 8 or even 4 times.


### Solution

Instead of running multiple times and taking a percentile of runs, like 3 out of 4, if we increase the wait time from 10 minutes to 15 minutes, we give Device OS a chance to go through it's 10 minute "Resetting the modem due to the network registration timeout", and a bit extra in case of other network related timers causing an issue.

### Steps to Test

- run `wiring/no_fixture_long_running` NETWORK_02 in a loop on multiple devices at once while logging the output.

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
