### PR TITLE
[test] fix listening network tests

### DIFF
--- a/user/tests/wiring/no_fixture/network.cpp
+++ b/user/tests/wiring/no_fixture/network.cpp
@@ -19,6 +19,11 @@
 #include "unit-test/unit-test.h"
 
 test(NETWORK_00_UDP_begin_does_not_leak_sockets_without_calling_stop) {
+    // 15 min gives the device time to go through a 10 min timeout & power cycle
+    const system_tick_t WAIT_TIMEOUT = 15 * 60 * 1000;
+    Network.on();
+    Network.connect();
+    waitFor(Network.ready, WAIT_TIMEOUT);
     // Arbitrary number that is large enough to showcase the issue
 #if PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION
     // There is a limited number of sockets available on Electrons, since we are using
@@ -41,6 +46,11 @@ test(NETWORK_00_UDP_begin_does_not_leak_sockets_without_calling_stop) {
 }
 
 test(NETWORK_01_UDP_sockets_can_be_read_with_timeout) {
+    // 15 min gives the device time to go through a 10 min timeout & power cycle
+    const system_tick_t WAIT_TIMEOUT = 15 * 60 * 1000;
+    Network.on();
+    Network.connect();
+    waitFor(Network.ready, WAIT_TIMEOUT);
     auto udp = std::make_unique<UDP>();
     assertTrue((bool)udp);
 


### PR DESCRIPTION
### Problem

NETWORK_00 and NETWORK_01 tests which are in the beginning of the test suite depend on the previous tests to establish a cloud connection. If a cloud connection was not established successfully in the previous tests, these tests immediately fail.

### Solution

Reduce dependency by adding API to connect to Network and add relevant scope guards to ensure listening mode is disabled in LISTENING_XX tests.

### Steps to Test

Run on-device tests


### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
