### PR TITLE
feature/sc-100324/ci-build-cross-platform

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,49 @@ tag_filters: &tag_filters
       only:
         - /.+/
 
+orbs:
+  win: circleci/windows@2.4.0
+
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
 jobs:
+  build-for-windows:
+    executor:
+      name: win/default
+      size: xlarge
+    parameters:
+      tasks:
+        type: string
+    steps:
+      - checkout
+      - run: git submodule update --init --recursive
+      - install-prtcl-windows
+      - test-localcompiler-windows:
+          tasks: << parameters.tasks >>
+  build-for-darwin:
+    macos:
+      xcode: "13.2.1"
+    parameters:
+      tasks:
+        type: string
+    steps:
+      - checkout
+      - run: git submodule update --init --recursive
+      - install-prtcl-darwin
+      - test-localcompiler-nix:
+          tasks: << parameters.tasks >>
+  build-for-ubuntu:
+    machine:
+      image: ubuntu-2004:current
+    parameters:
+      tasks:
+        type: string
+    steps:
+      - checkout
+      - run: git submodule update --init --recursive
+      - install-prtcl-ubuntu
+      - test-localcompiler-nix:
+          tasks: << parameters.tasks >>
   combine-binaries:
     docker:
       - image: alpine:latest
@@ -166,10 +206,83 @@ jobs:
           paths:
             - release
 
+commands:
+  install-prtcl-ubuntu:
+    steps:
+      - run:
+          name: "Install `prtcl` CLI (ubuntu)"
+          command: |
+            sudo apt-get update -q
+            sudo apt-get install -qy zlib1g-dev jq
+            sudo curl https://prtcl.s3.amazonaws.com/install-apt.sh | sh
+            echo ":::: done!"
+  install-prtcl-darwin:
+    steps:
+      - run:
+          name: "Install `prtcl` CLI (darwin)"
+          command: |
+            brew tap particle-iot/brew && brew install prtcl jq
+            echo ":::: done!"
+  install-prtcl-windows:
+    steps:
+      - run:
+          name: "Install `prtcl` CLI (windows)"
+          command: |
+            if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+                echo ":::: Insufficient privileges! Must be Admin"
+                exit 1;
+            }
+
+            $ErrorActionPreference = "Stop"
+            echo ":::: Downloading CLI installer..."
+            Invoke-WebRequest "https://prtcl.s3.amazonaws.com/prtcl-x64.exe" -OutFile "./prtcl-x64.exe"
+
+            echo ":::: Installing CLI..."
+            Start-Process ".\prtcl-x64.exe" -argumentlist "/S" -Wait
+            echo ":::: done!"
+          environment:
+            PRTCL_DISABLE_AUTOUPDATE: "1"
+  test-localcompiler-nix:
+    parameters:
+      tasks:
+        type: string
+    steps:
+      - run:
+          name: "Test Local Compilation Tasks"
+          no_output_timeout: "10m"
+          command: scripts/test-build-tasks.sh ~/project "<< parameters.tasks >>"
+          environment:
+            PRTCL_DISABLE_AUTOUPDATE: "1"
+  test-localcompiler-windows:
+    parameters:
+      tasks:
+        type: string
+    steps:
+      - run:
+          name: "Test Local Compilation Tasks"
+          no_output_timeout: "20m"
+          command: pwsh scripts/test-build-tasks.ps1 $home\project "<< parameters.tasks >>"
+          environment:
+            PRTCL_DISABLE_AUTOUPDATE: "1"
 
 workflows:
   build-and-test:
     jobs:
+      - build-for-windows:
+          <<: *tag_filters
+          matrix:
+            parameters:
+              tasks: ["compile:all clean:all", "compile:user clean:user", "compile:debug clean:debug"]
+      - build-for-ubuntu:
+          <<: *tag_filters
+          matrix:
+            parameters:
+              tasks: ["compile:all clean:all", "compile:user clean:user", "compile:debug clean:debug"]
+      - build-for-darwin:
+          <<: *tag_filters
+          matrix:
+            parameters:
+              tasks: ["compile:all clean:all", "compile:user clean:user", "compile:debug clean:debug"]
       - build-and-test:
           <<: *tag_filters
           context:
@@ -184,3 +297,4 @@ workflows:
           requires:
             - build-and-test
             - combine-binaries
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,77 @@ tag_filters: &tag_filters
 orbs:
   win: circleci/windows@2.4.0
 
+aliases:
+  - &tasks ["compile:all clean:all", "compile:user clean:user", "compile:debug clean:debug"]
+  - &platforms ["photon", "p1", "electron", "argon", "boron", "bsom", "b5som", "tracker"]
+
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
 jobs:
+  setup-workspace:
+    machine:
+      image: ubuntu-2004:current
+    steps:
+      - run:
+          name: "Create Tested Platforms Files in Workspace"
+          command: |
+            mkdir -p $HOME/workspace/tested-platforms
+            ls -la $HOME/workspace
+            ls -la $HOME/workspace/tested-platforms
+            echo ":::: done!"
+      - persist_to_workspace:
+          root: ~/workspace
+          paths:
+            - tested-platforms
+  validate-toolchain-platforms:
+    machine:
+      image: ubuntu-2004:current
+    steps:
+      - attach_workspace:
+          at: ~/workspace
+      - checkout
+      - install-prtcl-ubuntu
+      - run:
+          name: "Check if all toolchain platforms were tested"
+          command: |
+            ls -la $HOME/workspace
+            ls -la $HOME/workspace/tested-platforms
+            echo
+            deviceOSPath=~/project
+            deviceOSSource="source:${deviceOSPath}"
+            toolchain="$(prtcl toolchain:view ${deviceOSSource} --json)"
+            platformsStr=$(echo $toolchain | jq '.platforms' | jq 'map(.name)')
+            platforms=()
+            while read p; do
+                platforms+=($(echo ${p} | tr -d '"'))
+            done < <(echo $platformsStr | jq -c '.[]')
+            echo ":::: Found toolchain platforms: ${platforms[@]}"
+            oses=(
+              'darwin-x64'
+              'ubuntu-x64'
+              'windows-x64'
+            )
+            for os in "${oses[@]}"; do
+              for platform in "${platforms[@]}"; do
+                dir="${HOME}/workspace/tested-platforms"
+                prefix="${os}-${platform}"
+                pattern="${prefix}-*"
+                echo ":::: Checking for results matching '${dir}/${pattern}'"
+                results=$(find $dir -maxdepth 1 -name "${pattern}" -type f)
+                count=0
+                if [ -n "${results}" ]; then
+                  count=$(echo "$results" | wc -l)
+                fi
+                echo ":::: Found ${count} results:"
+                echo "$results"
+                echo
+                if [ $count -lt 1 ]; then
+                  echo ":::: Missing tests for ${platform}!"
+                  exit 1
+                fi
+              done
+            done
+            echo ":::: done!"
   build-for-windows:
     executor:
       name: win/default
@@ -22,17 +90,26 @@ jobs:
     parameters:
       tasks:
         type: string
+      platform:
+        type: string
     steps:
       - checkout
       - run: git submodule update --init --recursive
       - install-prtcl-windows
       - test-localcompiler-windows:
           tasks: << parameters.tasks >>
+          platform: << parameters.platform >>
+      - save-platform-to-workspace:
+          os: windows-x64
+          tasks: << parameters.tasks >>
+          platform: << parameters.platform >>
   build-for-darwin:
     macos:
       xcode: "13.2.1"
     parameters:
       tasks:
+        type: string
+      platform:
         type: string
     steps:
       - checkout
@@ -40,11 +117,18 @@ jobs:
       - install-prtcl-darwin
       - test-localcompiler-nix:
           tasks: << parameters.tasks >>
+          platform: << parameters.platform >>
+      - save-platform-to-workspace:
+          os: darwin-x64
+          tasks: << parameters.tasks >>
+          platform: << parameters.platform >>
   build-for-ubuntu:
     machine:
       image: ubuntu-2004:current
     parameters:
       tasks:
+        type: string
+      platform:
         type: string
     steps:
       - checkout
@@ -52,6 +136,11 @@ jobs:
       - install-prtcl-ubuntu
       - test-localcompiler-nix:
           tasks: << parameters.tasks >>
+          platform: << parameters.platform >>
+      - save-platform-to-workspace:
+          os: ubuntu-x64
+          tasks: << parameters.tasks >>
+          platform: << parameters.platform >>
   combine-binaries:
     docker:
       - image: alpine:latest
@@ -246,43 +335,118 @@ commands:
     parameters:
       tasks:
         type: string
+      platform:
+        type: string
     steps:
       - run:
           name: "Test Local Compilation Tasks"
           no_output_timeout: "10m"
-          command: scripts/test-build-tasks.sh ~/project "<< parameters.tasks >>"
+          command: scripts/test-build-tasks.sh ~/project "<< parameters.platform >>" "<< parameters.tasks >>"
           environment:
             PRTCL_DISABLE_AUTOUPDATE: "1"
   test-localcompiler-windows:
     parameters:
       tasks:
         type: string
+      platform:
+        type: string
     steps:
       - run:
           name: "Test Local Compilation Tasks"
           no_output_timeout: "20m"
-          command: pwsh scripts/test-build-tasks.ps1 $home\project "<< parameters.tasks >>"
+          command: pwsh scripts/test-build-tasks.ps1 $home\project "<< parameters.platform >>" "<< parameters.tasks >>"
           environment:
             PRTCL_DISABLE_AUTOUPDATE: "1"
-
+  save-platform-to-workspace:
+    parameters:
+      os:
+        type: string
+      tasks:
+        type: string
+      platform:
+        type: string
+    steps:
+      - attach_workspace:
+          at: ~/workspace
+      - when:
+          condition:
+            or:
+              - equal: [ 'ubuntu-x64', << parameters.os >> ]
+              - equal: [ 'darwin-x64', << parameters.os >> ]
+          steps:
+            - run:
+                name: "Save Platform to Workspace (*nix)"
+                command: |
+                  os="<< parameters.os >>"
+                  tasks="<< parameters.tasks >>"
+                  platform="<< parameters.platform >>"
+                  dir="${HOME}/workspace/tested-platforms"
+                  filename="${os}-${platform}-$(echo $tasks | tr -d ' ":')"
+                  filepath="${dir}/${filename}"
+                  echo ":::: Adding: ${filepath}"
+                  touch $filepath
+                  ls -la $dir
+                  echo ":::: done!"
+      - when:
+          condition:
+            and:
+              - equal: [ 'windows-x64', << parameters.os >> ]
+          steps:
+            - run:
+                name: "Save Platform to Workspace (windows)"
+                shell: powershell.exe
+                command: |
+                  $ErrorActionPreference = "Stop"
+                  $os = "<< parameters.os >>"
+                  $tasks = "<< parameters.tasks >>"
+                  $platform = "<< parameters.platform >>"
+                  $dir = "$($home)\workspace\tested-platforms"
+                  $filename = "$($os)-$($platform)-$($tasks -replace '[ :"]','')"
+                  $filepath = "$($dir)\$($filename)"
+                  echo ":::: Adding: $($filepath)"
+                  New-Item $filepath -type file
+                  Get-ChildItem -Force $dir
+                  echo ":::: done!"
+      - persist_to_workspace:
+          root: ~/workspace
+          paths:
+            - tested-platforms
 workflows:
   build-and-test:
     jobs:
+      - setup-workspace:
+          <<: *tag_filters
       - build-for-windows:
           <<: *tag_filters
           matrix:
             parameters:
-              tasks: ["compile:all clean:all", "compile:user clean:user", "compile:debug clean:debug"]
+              tasks: *tasks
+              platform: *platforms
+          requires:
+            - setup-workspace
       - build-for-ubuntu:
           <<: *tag_filters
           matrix:
             parameters:
-              tasks: ["compile:all clean:all", "compile:user clean:user", "compile:debug clean:debug"]
+              tasks: *tasks
+              platform: *platforms
+          requires:
+            - setup-workspace
       - build-for-darwin:
           <<: *tag_filters
           matrix:
             parameters:
-              tasks: ["compile:all clean:all", "compile:user clean:user", "compile:debug clean:debug"]
+              tasks: *tasks
+              platform: *platforms
+          requires:
+            - setup-workspace
+      - validate-toolchain-platforms:
+          <<: *tag_filters
+          requires:
+            - setup-workspace
+            - build-for-windows
+            - build-for-ubuntu
+            - build-for-darwin
       - build-and-test:
           <<: *tag_filters
           context:

--- a/.workbench/manifest.json
+++ b/.workbench/manifest.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "toolchains": [
         {
-            "platforms": [6, 8, 10, 12, 13, 22, 23, 25, 26],
+            "platforms": [6, 8, 10, 12, 13, 23, 25, 26],
             "firmware": "deviceOS@source",
             "compilers": "gcc-arm@10.2.1",
             "tools": "buildtools@1.1.1",
@@ -34,11 +34,6 @@
         {
             "id": 13,
             "name": "boron",
-            "generation": 3
-        },
-        {
-            "id": 22,
-            "name": "asom",
             "generation": 3
         },
         {

--- a/scripts/test-build-tasks.ps1
+++ b/scripts/test-build-tasks.ps1
@@ -1,0 +1,64 @@
+param (
+	[Parameter(Mandatory = $true, Position = 0)][string]$deviceOSPath,
+	[Parameter(Mandatory = $false, Position = 1)][string]$taksList
+)
+
+function run(){
+	if ($args.Count -eq 0) {
+		throw "Must supply some arguments."
+	}
+
+	$command = $args[0]
+	$commandArgs = @()
+	if ($args.Count -gt 1) {
+		$commandArgs = $args[1..($args.Count - 1)]
+	}
+
+	& $command $commandArgs
+	$result = $LASTEXITCODE
+
+	if ($result -ne 0) {
+		throw "$command $commandArgs exited with code $result."
+	}
+}
+
+$ErrorActionPreference = "Stop"
+$deviceOSSource="source:${deviceOSPath}"
+$tinkerPath="$($deviceOSPath)\user\applications\tinker\"
+$toolchain = run prtcl toolchain:view $deviceOSSource --json
+
+if ($taksList){
+	$tasks = $taksList.split(' ')
+} else {
+	$tasks = @(
+		'compile:user'
+		'clean:user'
+		'compile:all'
+		'clean:all'
+		'compile:debug'
+		'clean:debug'
+	)
+}
+
+echo ":::: Using prtcl $(prtcl version)"
+echo ":::: Using Device OS at $($deviceOSPath)"
+
+run prtcl toolchain:install $deviceOSSource --quiet
+
+$json = $toolchain | ConvertFrom-Json
+foreach ($platform in $json.platforms){
+	echo ":::: Testing build tasks for $($platform.name)"
+	echo ""
+
+	foreach ($task in $tasks){
+		run prtcl $task $deviceOSSource $platform.name $tinkerPath --quiet
+
+		if ($LASTEXITCODE -ne 0){
+			throw "Failure! Exit code is $LASTEXITCODE"
+		}
+	}
+}
+
+echo ":::: done!"
+exit 0
+

--- a/scripts/test-build-tasks.sh
+++ b/scripts/test-build-tasks.sh
@@ -1,0 +1,66 @@
+#! /bin/bash
+set -eu
+
+# utils
+hasCmd(){
+	command -v "$1" > /dev/null
+}
+
+# check args and prompt if missing
+if [ $# -lt 1 ]; then
+	echo ":::: Error: Missing script arguments!"
+	echo ":::: Fix: \`deviceOSPath\` is required - e.g. \`~/path/to/device-os\`"
+	echo ":::: Usage: <script> <deviceOSPath> [<tasks>]"
+	exit 1
+fi
+
+# check for required dependencies
+if ! hasCmd prtcl; then
+	echo ':::: Your system does not have the `prtcl` cli'
+	echo ':::: To install, see: https://github.com/particle-iot/cli/tree/main/packages/cli#installation'
+	exit 1
+fi
+
+if ! hasCmd jq; then
+	echo ':::: Your system does not have the `jq` command'
+	echo ':::: To install, see: https://stedolan.github.io/jq/download/'
+	exit 1
+fi
+
+# run the required local compilation tasks
+deviceOSPath=$1
+deviceOSSource="source:${deviceOSPath}"
+tinkerPath="${deviceOSPath}/user/applications/tinker/"
+toolchain="$(prtcl toolchain:view ${deviceOSSource} --json)"
+platforms=$(echo $toolchain | jq '.platforms' | jq 'map(.name)')
+
+if [ $# -gt 1 ]; then
+	declare -a tasks=($2)
+else
+	tasks=(
+		'compile:user'
+		'clean:user'
+		'compile:all'
+		'clean:all'
+		'compile:debug'
+		'clean:debug'
+	)
+fi
+
+echo ":::: Using prtcl $(prtcl version)"
+echo ":::: Using Device OS at ${deviceOSPath}"
+
+prtcl toolchain:install ${deviceOSSource} --quiet
+
+echo $platforms | jq -c '.[]' | while read p; do
+	platform=$(echo ${p} | tr -d '"')
+	echo ":::: Testing build tasks for ${platform}"
+	echo
+
+	for task in "${tasks[@]}"; do
+		prtcl ${task} ${deviceOSSource} ${platform} ${tinkerPath} --quiet
+	done
+done
+
+echo ":::: done!"
+


### PR DESCRIPTION
### Problem

Device OS' build system drives local compilation of user firmware in a number of Particle's user-facing and internal developer tools - most notably Particle Workbench. Currently prior to releasing, the build system is tested on Linux / Ubuntu which means bugs and regressions are much harder to proactively catch on other supported platforms (Windows and macOS).

### Solution

Add a series of checks to the CI/CD system such that key local compilation tasks are regularly tested to ensure they work across all supported environments (Windows, Linux / Ubuntu, and macOS)

### Steps to Test

1. Using macOS, run the test script included in this PR: `./scripts/test-build-tasks.sh ~/path/to/device-os`
2. ...do the same thing using a compatible Ubuntu environment
3. Using Windows, run the test script: `.\scripts/test-build-tasks.ps1 $home\project`
4. Review the [updated CI/CD pipeline](https://github.com/particle-iot/device-os/blob/feature/sc-100324/ci-build-cross-platform/.circleci/config.yml#L18-L42)
5. Observe the [latest CI run in CircleCI](https://app.circleci.com/pipelines/github/particle-iot/device-os/431/workflows/4552f97f-3607-470c-871b-b896c1920826)

**outcome**

Scripts should run properly - exiting on error and otherwise reporting success. CI configuration changes should make sense and do what you expect.


### References

https://app.shortcut.com/particle/story/100324/add-ci-job-s-to-validate-device-os-builds-on-all-supported-oses-windows-linux-ubuntu-and-macos

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
