### PR TITLE
[gen3] suppress certain reviewed GCC warnings [sc-100940]

### DIFF
--- a/bootloader/src/nRF52840/usbd_dfu_mal.cpp
+++ b/bootloader/src/nRF52840/usbd_dfu_mal.cpp
@@ -47,8 +47,11 @@ int InternalFlashMal::deInit() {
 
 bool InternalFlashMal::validate(uintptr_t addr, size_t len) {
     uintptr_t end = addr + len;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtype-limits"
     if ((addr >= INTERNAL_FLASH_START_ADD && addr <= INTERNAL_FLASH_END_ADDR) &&
         (end >= INTERNAL_FLASH_START_ADD && end <= INTERNAL_FLASH_END_ADDR))
+#pragma GCC diagnostic pop
     {
         return true;
     }
@@ -127,8 +130,11 @@ int DcdMal::deInit() {
 
 bool DcdMal::validate(uintptr_t addr, size_t len) {
     uintptr_t end = addr + len;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtype-limits"
     if ((addr >= DCD_START_ADD && addr <= DCD_END_ADDR) &&
         (end >= DCD_START_ADD && end <= DCD_END_ADDR))
+#pragma GCC diagnostic pop
     {
         return true;
     }
@@ -192,8 +198,11 @@ bool ExternalFlashMal::validate(uintptr_t addr, size_t len) {
     addr -= offset_;
 
     uintptr_t end = addr + len;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtype-limits"
     if ((addr >= EXTERNAL_FLASH_START_ADD && addr <= EXTERNAL_FLASH_END_ADDR) &&
         (end >= EXTERNAL_FLASH_START_ADD && end <= EXTERNAL_FLASH_END_ADDR))
+#pragma GCC diagnostic pop
     {
         return true;
     }

--- a/platform/MCU/nRF52840/src/flash_mal.c
+++ b/platform/MCU/nRF52840/src/flash_mal.c
@@ -270,13 +270,19 @@ bool FLASH_CheckValidAddressRange(flash_device_t flashDeviceID, uint32_t startAd
 
     if (flashDeviceID == FLASH_INTERNAL)
     {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtype-limits"
         return (startAddress >= 0x00000000 && endAddress <= 0x100000) ||
                (startAddress >= 0x12000000 && endAddress <= 0x20000000);
+#pragma GCC diagnostic pop
     }
     else if (flashDeviceID == FLASH_SERIAL)
     {
 #ifdef USE_SERIAL_FLASH
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtype-limits"
         return startAddress >= 0x00000000 && endAddress <= EXTERNAL_FLASH_SIZE;
+#pragma GCC diagnostic pop
 #else
         return false;
 #endif


### PR DESCRIPTION
## Problem

There are a few lingering warnings when compiling Device OS

### User/System
```
MCU/nRF52840/src/flash_mal.c: In function 'FLASH_CheckValidAddressRange':
MCU/nRF52840/src/flash_mal.c:273:30: warning: comparison of unsigned expression in '>= 0' is always true [-Wtype-limits]
  273 |         return (startAddress >= 0x00000000 && endAddress <= 0x100000) ||
      |                              ^~
MCU/nRF52840/src/flash_mal.c:279:29: warning: comparison of unsigned expression in '>= 0' is always true [-Wtype-limits]
  279 |         return startAddress >= 0x00000000 && endAddress <= EXTERNAL_FLASH_SIZE;
      |                             ^~
```

### Bootloader
```
MCU/nRF52840/src/flash_mal.c: In function 'FLASH_CheckValidAddressRange':
MCU/nRF52840/src/flash_mal.c:273:30: warning: comparison of unsigned expression in '>= 0' is always true [-Wtype-limits]
  273 |         return (startAddress >= 0x00000000 && endAddress <= 0x100000) ||
      |                              ^~
MCU/nRF52840/src/flash_mal.c:279:29: warning: comparison of unsigned expression in '>= 0' is always true [-Wtype-limits]
  279 |         return startAddress >= 0x00000000 && endAddress <= EXTERNAL_FLASH_SIZE;
      |                             ^~
src/nRF52840/usbd_dfu_mal.cpp: In member function 'virtual bool particle::usbd::dfu::mal::InternalFlashMal::validate(uintptr_t, size_t)':
src/nRF52840/usbd_dfu_mal.cpp:50:15: warning: comparison of unsigned expression in '>= 0' is always true [-Wtype-limits]
   50 |     if ((addr >= INTERNAL_FLASH_START_ADD && addr <= INTERNAL_FLASH_END_ADDR) &&
src/nRF52840/usbd_dfu_mal.cpp:51:14: warning: comparison of unsigned expression in '>= 0' is always true [-Wtype-limits]
   51 |         (end >= INTERNAL_FLASH_START_ADD && end <= INTERNAL_FLASH_END_ADDR))
src/nRF52840/usbd_dfu_mal.cpp: In member function 'virtual bool particle::usbd::dfu::mal::DcdMal::validate(uintptr_t, size_t)':
src/nRF52840/usbd_dfu_mal.cpp:130:15: warning: comparison of unsigned expression in '>= 0' is always true [-Wtype-limits]
  130 |     if ((addr >= DCD_START_ADD && addr <= DCD_END_ADDR) &&
src/nRF52840/usbd_dfu_mal.cpp:131:14: warning: comparison of unsigned expression in '>= 0' is always true [-Wtype-limits]
  131 |         (end >= DCD_START_ADD && end <= DCD_END_ADDR))
src/nRF52840/usbd_dfu_mal.cpp: In member function 'virtual bool particle::usbd::dfu::mal::ExternalFlashMal::validate(uintptr_t, size_t)':
src/nRF52840/usbd_dfu_mal.cpp:195:15: warning: comparison of unsigned expression in '>= 0' is always true [-Wtype-limits]
  195 |     if ((addr >= EXTERNAL_FLASH_START_ADD && addr <= EXTERNAL_FLASH_END_ADDR) &&
src/nRF52840/usbd_dfu_mal.cpp:196:14: warning: comparison of unsigned expression in '>= 0' is always true [-Wtype-limits]
  196 |         (end >= EXTERNAL_FLASH_START_ADD && end <= EXTERNAL_FLASH_END_ADDR))
```

## Solution

Add a pragma to suppress the warning after reviewing the code.  Changing the code would require updating the bootloader which is an unnecessary change.  Leaving the check for lower bound is fine as it might not be 0 in the future.

```
#pragma GCC diagnostic push
#pragma GCC diagnostic ignored "-Wtype-limits"
// code generating the warning
#pragma GCC diagnostic pop
```

## Steps to Test

Compile Device OS for Gen3 platforms and ensure warnings are removed.

### References

[sc-100940](https://app.shortcut.com/particle/story/100940/gen3-fix-device-os-warnings)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
