### PR TITLE
Update dependencies for ARM GCC 10.2.1

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -12,12 +12,12 @@ Building the firmware locally requires these dependencies ot be installed:
 #### 1. GCC for ARM Cortex processors
 The Photon uses an ARM Cortex M3 CPU based microcontroller. All of the code is built around the GNU GCC toolchain offered and maintained by ARM.
 
-The build requires version 5.3.1 20160307 or newer of ARM GCC and will print an error
+The build requires version 10.2.1 (10-2020-q4-major) or newer of ARM GCC and will print an error
 message if the version is older than this.
 
 
 **Linux and Windows**:
-- Download and install version 5.3.1 from: https://launchpad.net/gcc-arm-embedded
+- Download and install version 10.2.1 from: https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads/
 
 **OS X** users can install the toolchain with [Homebrew](http://brew.sh/):
 - `brew tap PX4/homebrew-px4`
@@ -27,31 +27,31 @@ message if the version is older than this.
 echo -e "
 require 'formula'
 
-class GccArmNoneEabi53 < Formula
-  homepage 'https://launchpad.net/gcc-arm-embdded'
-  version '20160307'
-  url 'https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q1-update/+download/gcc-arm-none-eabi-5_3-2016q1-20160330-mac.tar.bz2'
-  sha256 '480843ca1ce2d3602307f760872580e999acea0e34ec3d6f8b6ad02d3db409cf'
+class GccArmNoneEabi1021 < Formula
+  homepage 'https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads'
+  version '20201103'
+  url 'https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-mac.tar.bz2'
+  sha256 'bed12de3565d4eb02e7b58be945376eaca79a8ae3ebb785ec7344e7e2db0bdc0'
 
   def install
     ohai 'Copying binaries...'
     system 'cp', '-rv', 'arm-none-eabi', 'bin', 'lib', 'share', \"#{prefix}/\"
   end
-end" > /usr/local/Homebrew/Library/Taps/px4/homebrew-px4/gcc-arm-none-eabi-53.rb
+end" > /usr/local/Homebrew/Library/Taps/px4/homebrew-px4/gcc-arm-none-eabi-1021.rb
 ```
 
 - install it!
 ```
-brew install gcc-arm-none-eabi-53
+brew install gcc-arm-none-eabi-1021
 ```
-- `arm-none-eabi-gcc --version` (should now say v5.3.1)
+- `arm-none-eabi-gcc --version` (should now say: 10.2.1)
 
 If you are upgrading an existing installation you will have to unlink and link your symblinks:
 - `brew update`
-- `brew install gcc-arm-none-eabi-53` (when you run this, it will tell you the following commands)
-- `brew unlink gcc-arm-none-eabi-49` (example)
-- `brew link --overwrite gcc-arm-none-eabi-53` (example)
-- `arm-none-eabi-gcc --version` (should now say v5.3.1)
+- `brew install gcc-arm-none-eabi-1021` (when you run this, it will tell you the following commands)
+- `brew unlink gcc-arm-none-eabi-53` (example)
+- `brew link --overwrite gcc-arm-none-eabi-1021` (example)
+- `arm-none-eabi-gcc --version` (should now say: 10.2.1)
 
 #### 2. Make
 In order to turn your source code into binaries, you will need a tool called `make`. Windows users need to explicitly install `make` on their machines. Make sure you can use it from the terminal window.
@@ -76,5 +76,4 @@ The tool `crc32` is also needed:
  - available in MinGW on Windows
  - available by default on OS X
  - linux users, please check with your package manager. On debian based systems it can be installed via `sudo apt-get install libarchive-zip-perl`
-
 


### PR DESCRIPTION
This documentation change updates the ARM GCC version in dependencies file to 10.2.1. I noticed that what was listed was out of date. Looks like only legacy builds/source versions are stored on launchpad.net now and mainline things are on ARMs official website directly.

![image](https://user-images.githubusercontent.com/1687839/163245279-8c257d03-c79f-483c-aeab-b365fe1c18e1.png)

### What this does
- Updates Formula
- Bumps version requirements
- Links to more current source on: [developer.arm.com](developer.arm.com)


### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
