### PR TITLE
chore/ci-less-frequent-cross-platform-build-checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,6 @@ jobs:
   build-for-windows:
     executor:
       name: win/default
-      size: xlarge
     parameters:
       tasks:
         type: string
@@ -412,7 +411,24 @@ commands:
           paths:
             - tested-platforms
 workflows:
-  build-and-test:
+  test-build-system:
+    when:
+      or:
+        - matches:
+            pattern: "^main$"
+            value: << pipeline.git.branch >>
+        - matches:
+            pattern: "^master$"
+            value: << pipeline.git.branch >>
+        - matches:
+            pattern: "^develop$"
+            value: << pipeline.git.branch >>
+        - matches:
+            pattern: "^test/v.*"
+            value: << pipeline.git.branch >>
+        - matches:
+            pattern: "^release/.*"
+            value: << pipeline.git.branch >>
     jobs:
       - setup-workspace:
           <<: *tag_filters
@@ -447,6 +463,8 @@ workflows:
             - build-for-windows
             - build-for-ubuntu
             - build-for-darwin
+  build-and-test:
+    jobs:
       - build-and-test:
           <<: *tag_filters
           context:


### PR DESCRIPTION
### Problem

Cross-platform build system CI checks are running more frequently than we'd like or need.

### Solution

Only run cross-platform build system CI check against specific branches like:

```
^main$
^master$
^develop$
^test/v.*
^release/.*
```

### Steps to Test

1. Create a branch named like `release/this-is-a-test`
2. Rebase against this branch and push to remote
3. Verify that the `test-build-system` is triggered and runs in CircleCI
4. Create a branch named `test/this-should-not-trigger-workflow`
5. Rebase against this branch and push to remote
6. Verify that the `test-build-system` is NOT triggered in CircleCI

 ([CI Pipeline](https://app.circleci.com/pipelines/github/particle-iot/device-os?filter=all)) 

### References

https://app.circleci.com/pipelines/github/particle-iot/device-os?filter=all

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
