### PR TITLE
chore/sc-101315/ci-test-build-system-apt-timeout-retry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,6 +300,7 @@ commands:
       - run:
           name: "Install `prtcl` CLI (ubuntu)"
           command: |
+            printf 'Acquire::http::Timeout "30";\nAcquire::ftp::Timeout "30";\nAcquire::Retries "5";\n' | sudo tee /etc/apt/apt.conf.d/99timeout > /dev/null
             sudo apt-get update -q
             sudo apt-get install -qy zlib1g-dev jq
             sudo curl https://prtcl.s3.amazonaws.com/install-apt.sh | sh


### PR DESCRIPTION
### Problem

We've seen a few sporadic failures over in the `test-build-system` CI workflow related to `apt-get install` connection timeouts (ex: [1](https://app.circleci.com/pipelines/github/particle-iot/device-os/631/workflows/0b0a1203-6b3a-4c2f-bfca-300479c67190/jobs/9312), [2](https://app.circleci.com/pipelines/github/particle-iot/device-os/615/workflows/936ff079-bef8-475c-a092-47f07ea82b2a/jobs/8872))

### Solution

Increase `apt` timeout and retry attempts

### Steps to Test

1. Review the [updated CI/CD pipeline](https://github.com/particle-iot/device-os/blob/chore/sc-101315/ci-test-build-system-apt-timeout-retry/.circleci/config.yml#L298-L307)
5. Observe the [latest CI run in CircleCI](https://app.circleci.com/pipelines/github/particle-iot/device-os/637/workflows/60691ccd-5c38-4e7c-b973-b8bbc46967c9)

**outcome**

CI workflow should pass, changes should be appropriate

### References

https://app.shortcut.com/particle/story/101315/device-os-test-build-system-ci-workflow-occasionally-errors
https://debian-handbook.info/browse/el-GR/stable/sect.apt-get.html#sect.apt-config
https://app.circleci.com/pipelines/github/particle-iot/device-os?filter=all

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
