### PR TITLE
[deprecation] Adds warning to some deprecated API's that will be removed in Device OS 5.x

### DIFF
--- a/communication/src/spark_protocol_functions.cpp
+++ b/communication/src/spark_protocol_functions.cpp
@@ -289,6 +289,7 @@ system_tick_t spark_protocol_time_last_synced(ProtocolFacade* protocol, time32_t
     return ms;
 }
 
+// Note: This function is deprecated, see Protocol::get_describe_data() for details
 int spark_protocol_get_describe_data(ProtocolFacade* protocol, spark_protocol_describe_data* data, void* reserved)
 {
 	return protocol->get_describe_data(data, reserved);

--- a/hal/inc/adc_hal_compat.h
+++ b/hal/inc/adc_hal_compat.h
@@ -19,12 +19,12 @@
 #define ADC_HAL_COMPAT_H
 
 // Deprecated *dynalib* APIs for backwards compatibility
-inline void __attribute__((deprecated("Use hal_adc_set_sample_time() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_adc_set_sample_time() instead"), always_inline))
 HAL_ADC_Set_Sample_Time(uint8_t sample_time) {
     hal_adc_set_sample_time(sample_time);
 }
 
-inline int32_t __attribute__((deprecated("Use hal_adc_read() instead"), always_inline))
+inline int32_t __attribute__((deprecated("Will be removed in 5.x! Use hal_adc_read() instead"), always_inline))
 HAL_ADC_Read(pin_t pin) {
     return hal_adc_read(pin);
 }

--- a/hal/inc/hal_platform.h
+++ b/hal/inc/hal_platform.h
@@ -263,14 +263,6 @@
 #define HAL_SOCKET_HAL_COMPAT_NO_SOCKADDR (0)
 #endif // HAL_SOCKET_HAL_COMPAT_NO_SOCKADDR
 
-#ifndef HAL_PLATFORM_COMPRESSED_BINARIES
-#define HAL_PLATFORM_COMPRESSED_BINARIES (0)
-#elif HAL_PLATFORM_COMPRESSED_BINARIES
-// TODO: This feature macro was used to enable rudimentary support for compressed firmware
-// binaries, which is incompatible with OTA updates. We need to remove that code
-#warning "HAL_PLATFORM_COMPRESSED_BINARIES is deprecated"
-#endif // HAL_PLATFORM_COMPRESSED_BINARIES
-
 #ifndef HAL_PLATFORM_COMPRESSED_OTA
 #define HAL_PLATFORM_COMPRESSED_OTA (0)
 #endif // HAL_PLATFORM_COMPRESSED_OTA

--- a/hal/inc/i2c_hal_compat.h
+++ b/hal/inc/i2c_hal_compat.h
@@ -18,113 +18,113 @@
 #ifndef I2C_HAL_COMPAT_H
 #define I2C_HAL_COMPAT_H
 
-typedef hal_i2c_mode_t I2C_Mode __attribute__((deprecated("Use hal_i2c_mode_t instead")));
-typedef hal_i2c_interface_t HAL_I2C_Interface __attribute__((deprecated("Use hal_i2c_interface_t instead")));
-typedef hal_i2c_config_t HAL_I2C_Config __attribute__((deprecated("Use hal_i2c_config_t instead")));
-typedef hal_i2c_transmission_config_t HAL_I2C_Transmission_Config __attribute__((deprecated("Use hal_i2c_transmission_config_t instead")));
+typedef hal_i2c_mode_t I2C_Mode __attribute__((deprecated("Will be removed in 5.x! Use hal_i2c_mode_t instead")));
+typedef hal_i2c_interface_t HAL_I2C_Interface __attribute__((deprecated("Will be removed in 5.x! Use hal_i2c_interface_t instead")));
+typedef hal_i2c_config_t HAL_I2C_Config __attribute__((deprecated("Will be removed in 5.x! Use hal_i2c_config_t instead")));
+typedef hal_i2c_transmission_config_t HAL_I2C_Transmission_Config __attribute__((deprecated("Will be removed in 5.x! Use hal_i2c_transmission_config_t instead")));
 
 // Deprecated *dynalib* APIs for backwards compatibility
-inline int __attribute__((deprecated("Use hal_i2c_init() instead"), always_inline))
+inline int __attribute__((deprecated("Will be removed in 5.x! Use hal_i2c_init() instead"), always_inline))
 HAL_I2C_Init(hal_i2c_interface_t i2c, const hal_i2c_config_t* config) {
     return hal_i2c_init(i2c, config);
 }
 
-inline void __attribute__((deprecated("Use hal_i2c_set_speed() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_i2c_set_speed() instead"), always_inline))
 HAL_I2C_Set_Speed(hal_i2c_interface_t i2c, uint32_t speed, void* reserved) {
     hal_i2c_set_speed(i2c, speed, reserved);
 }
 
-inline void __attribute__((deprecated("Use hal_i2c_enable_dma_mode() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_i2c_enable_dma_mode() instead"), always_inline))
 HAL_I2C_Enable_DMA_Mode(hal_i2c_interface_t i2c, bool enable, void* reserved) {
     hal_i2c_enable_dma_mode(i2c, enable, reserved);
 }
 
-inline void __attribute__((deprecated("Use hal_i2c_stretch_clock() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_i2c_stretch_clock() instead"), always_inline))
 HAL_I2C_Stretch_Clock(hal_i2c_interface_t i2c, bool stretch, void* reserved) {
     hal_i2c_stretch_clock(i2c, stretch, reserved);
 }
 
-inline void __attribute__((deprecated("Use hal_i2c_begin() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_i2c_begin() instead"), always_inline))
 HAL_I2C_Begin(hal_i2c_interface_t i2c, hal_i2c_mode_t mode, uint8_t address, void* reserved) {
     hal_i2c_begin(i2c, mode, address, reserved);
 }
 
-inline void __attribute__((deprecated("Use hal_i2c_end() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_i2c_end() instead"), always_inline))
 HAL_I2C_End(hal_i2c_interface_t i2c, void* reserved) {
     hal_i2c_end(i2c, reserved);
 }
 
-inline uint32_t __attribute__((deprecated("Use hal_i2c_request() instead"), always_inline))
+inline uint32_t __attribute__((deprecated("Will be removed in 5.x! Use hal_i2c_request() instead"), always_inline))
 HAL_I2C_Request_Data(hal_i2c_interface_t i2c, uint8_t address, uint8_t quantity, uint8_t stop, void* reserved) {
     return hal_i2c_request(i2c, address, quantity, stop, reserved);
 }
 
-inline int32_t __attribute__((deprecated("Use hal_i2c_request_ex() instead"), always_inline))
+inline int32_t __attribute__((deprecated("Will be removed in 5.x! Use hal_i2c_request_ex() instead"), always_inline))
 HAL_I2C_Request_Data_Ex(hal_i2c_interface_t i2c, const hal_i2c_transmission_config_t* config, void* reserved) {
     return hal_i2c_request_ex(i2c, config, reserved);
 }
 
-inline void __attribute__((deprecated("Use hal_i2c_begin_transmission() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_i2c_begin_transmission() instead"), always_inline))
 HAL_I2C_Begin_Transmission(hal_i2c_interface_t i2c, uint8_t address, const hal_i2c_transmission_config_t* config) {
     hal_i2c_begin_transmission(i2c, address, config);
 }
 
-inline uint8_t __attribute__((deprecated("Use hal_i2c_end_transmission() instead"), always_inline))
+inline uint8_t __attribute__((deprecated("Will be removed in 5.x! Use hal_i2c_end_transmission() instead"), always_inline))
 HAL_I2C_End_Transmission(hal_i2c_interface_t i2c, uint8_t stop, void* reserved) {
     return hal_i2c_end_transmission(i2c, stop, reserved);
 }
 
-inline uint32_t __attribute__((deprecated("Use hal_i2c_write() instead"), always_inline))
+inline uint32_t __attribute__((deprecated("Will be removed in 5.x! Use hal_i2c_write() instead"), always_inline))
 HAL_I2C_Write_Data(hal_i2c_interface_t i2c, uint8_t data, void* reserved) {
     return hal_i2c_write(i2c, data, reserved);
 }
 
-inline int32_t __attribute__((deprecated("Use hal_i2c_available() instead"), always_inline))
+inline int32_t __attribute__((deprecated("Will be removed in 5.x! Use hal_i2c_available() instead"), always_inline))
 HAL_I2C_Available_Data(hal_i2c_interface_t i2c, void* reserved) {
     return hal_i2c_available(i2c, reserved);
 }
 
-inline int32_t __attribute__((deprecated("Use hal_i2c_read() instead"), always_inline))
+inline int32_t __attribute__((deprecated("Will be removed in 5.x! Use hal_i2c_read() instead"), always_inline))
 HAL_I2C_Read_Data(hal_i2c_interface_t i2c, void* reserved) {
     return hal_i2c_read(i2c, reserved);
 }
 
-inline int32_t __attribute__((deprecated("Use hal_i2c_peek() instead"), always_inline))
+inline int32_t __attribute__((deprecated("Will be removed in 5.x! Use hal_i2c_peek() instead"), always_inline))
 HAL_I2C_Peek_Data(hal_i2c_interface_t i2c, void* reserved) {
     return hal_i2c_peek(i2c, reserved);
 }
 
-inline void __attribute__((deprecated("Use hal_i2c_flush() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_i2c_flush() instead"), always_inline))
 HAL_I2C_Flush_Data(hal_i2c_interface_t i2c, void* reserved) {
     hal_i2c_flush(i2c, reserved);
 }
 
-inline bool __attribute__((deprecated("Use hal_i2c_is_enabled() instead"), always_inline))
+inline bool __attribute__((deprecated("Will be removed in 5.x! Use hal_i2c_is_enabled() instead"), always_inline))
 HAL_I2C_Is_Enabled(hal_i2c_interface_t i2c, void* reserved) {
     return hal_i2c_is_enabled(i2c, reserved);
 }
 
-inline void __attribute__((deprecated("Use hal_i2c_set_callback_on_received() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_i2c_set_callback_on_received() instead"), always_inline))
 HAL_I2C_Set_Callback_On_Receive(hal_i2c_interface_t i2c, void (*function)(int), void* reserved) {
     hal_i2c_set_callback_on_received(i2c, function, reserved);
 }
 
-inline void __attribute__((deprecated("Use hal_i2c_set_callback_on_requested() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_i2c_set_callback_on_requested() instead"), always_inline))
 HAL_I2C_Set_Callback_On_Request(hal_i2c_interface_t i2c, void (*function)(void), void* reserved) {
     hal_i2c_set_callback_on_requested(i2c, function, reserved);
 }
 
-inline uint8_t __attribute__((deprecated("Use hal_i2c_reset() instead"), always_inline))
+inline uint8_t __attribute__((deprecated("Will be removed in 5.x! Use hal_i2c_reset() instead"), always_inline))
 HAL_I2C_Reset(hal_i2c_interface_t i2c, uint32_t reserved, void* reserved1) {
     return hal_i2c_reset(i2c, reserved, reserved1);
 }
 
-inline int32_t __attribute__((deprecated("Use hal_i2c_lock() instead"), always_inline))
+inline int32_t __attribute__((deprecated("Will be removed in 5.x! Use hal_i2c_lock() instead"), always_inline))
 HAL_I2C_Acquire(hal_i2c_interface_t i2c, void* reserved) {
     return hal_i2c_lock(i2c, reserved);
 }
 
-inline int32_t __attribute__((deprecated("Use hal_i2c_unlock() instead"), always_inline))
+inline int32_t __attribute__((deprecated("Will be removed in 5.x! Use hal_i2c_unlock() instead"), always_inline))
 HAL_I2C_Release(hal_i2c_interface_t i2c, void* reserved) {
     return hal_i2c_unlock(i2c, reserved);
 }

--- a/hal/inc/pwm_hal_compat.h
+++ b/hal/inc/pwm_hal_compat.h
@@ -19,57 +19,57 @@
 #define PWM_HAL_COMPAT_H
 
 // Deprecated *dynalib* APIs for backwards compatibility
-inline void __attribute__((deprecated("Use hal_pwm_write() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_pwm_write() instead"), always_inline))
 HAL_PWM_Write(uint16_t pin, uint8_t value) {
 	hal_pwm_write(pin, value);
 }
 
-inline void __attribute__((deprecated("Use hal_pwm_write_ext() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_pwm_write_ext() instead"), always_inline))
 HAL_PWM_Write_Ext(uint16_t pin, uint32_t value) {
 	hal_pwm_write_ext(pin, value);
 }
 
-inline void __attribute__((deprecated("Use hal_pwm_write_with_frequency() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_pwm_write_with_frequency() instead"), always_inline))
 HAL_PWM_Write_With_Frequency(uint16_t pin, uint8_t value, uint16_t frequency) {
 	hal_pwm_write_with_frequency(pin, value, frequency);
 }
 
-inline void __attribute__((deprecated("Use hal_pwm_write_with_frequency_ext() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_pwm_write_with_frequency_ext() instead"), always_inline))
 HAL_PWM_Write_With_Frequency_Ext(uint16_t pin, uint32_t value, uint32_t frequency) {
 	hal_pwm_write_with_frequency_ext(pin, value, frequency);
 }
 
-inline uint16_t __attribute__((deprecated("Use hal_pwm_get_frequency() instead"), always_inline))
+inline uint16_t __attribute__((deprecated("Will be removed in 5.x! Use hal_pwm_get_frequency() instead"), always_inline))
 HAL_PWM_Get_Frequency(uint16_t pin) {
 	return hal_pwm_get_frequency(pin);
 }
 
-inline uint32_t __attribute__((deprecated("Use hal_pwm_get_frequency_ext() instead"), always_inline))
+inline uint32_t __attribute__((deprecated("Will be removed in 5.x! Use hal_pwm_get_frequency_ext() instead"), always_inline))
 HAL_PWM_Get_Frequency_Ext(uint16_t pin) {
 	return hal_pwm_get_frequency_ext(pin);
 }
 
-inline uint16_t __attribute__((deprecated("Use hal_pwm_get_analog_value() instead"), always_inline))
+inline uint16_t __attribute__((deprecated("Will be removed in 5.x! Use hal_pwm_get_analog_value() instead"), always_inline))
 HAL_PWM_Get_AnalogValue(uint16_t pin) {
 	return hal_pwm_get_analog_value(pin);
 }
 
-inline uint32_t __attribute__((deprecated("Use hal_pwm_get_analog_value_ext() instead"), always_inline))
+inline uint32_t __attribute__((deprecated("Will be removed in 5.x! Use hal_pwm_get_analog_value_ext() instead"), always_inline))
 HAL_PWM_Get_AnalogValue_Ext(uint16_t pin) {
 	return hal_pwm_get_analog_value_ext(pin);
 }
 
-inline uint32_t __attribute__((deprecated("Use hal_pwm_get_max_frequency() instead"), always_inline))
+inline uint32_t __attribute__((deprecated("Will be removed in 5.x! Use hal_pwm_get_max_frequency() instead"), always_inline))
 HAL_PWM_Get_Max_Frequency(uint16_t pin) {
 	return hal_pwm_get_max_frequency(pin);
 }
 
-inline uint8_t __attribute__((deprecated("Use hal_pwm_get_resolution() instead"), always_inline))
+inline uint8_t __attribute__((deprecated("Will be removed in 5.x! Use hal_pwm_get_resolution() instead"), always_inline))
 HAL_PWM_Get_Resolution(uint16_t pin) {
 	return hal_pwm_get_resolution(pin);
 }
 
-inline void __attribute__((deprecated("Use hal_pwm_set_resolution() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_pwm_set_resolution() instead"), always_inline))
 HAL_PWM_Set_Resolution(uint16_t pin, uint8_t resolution) {
 	hal_pwm_set_resolution(pin, resolution);
 }

--- a/hal/inc/rtc_hal_compat.h
+++ b/hal/inc/rtc_hal_compat.h
@@ -21,26 +21,26 @@
 #include "time_compat.h"
 
 // Deprecated *dynalib* APIs for backwards compatibility
-inline void __attribute__((deprecated("use hal_rtc_init() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! use hal_rtc_init() instead"), always_inline))
 HAL_RTC_Configuration(void) {
     hal_rtc_init();
 }
 
-// There is no replacement for these
-inline time32_t __attribute__((deprecated, always_inline)) HAL_RTC_Get_UnixTime(void) {
+// There is no replacement
+inline time32_t __attribute__((deprecated("Will be removed in 5.x!"), always_inline)) HAL_RTC_Get_UnixTime(void) {
     return hal_rtc_get_unixtime_deprecated();
 }
-
-inline void __attribute__((deprecated, always_inline)) HAL_RTC_Set_UnixTime(time32_t value) {
+// There is no replacement
+inline void __attribute__((deprecated("Will be removed in 5.x!"), always_inline)) HAL_RTC_Set_UnixTime(time32_t value) {
     hal_rtc_set_unixtime_deprecated(value);
 }
 
-inline void __attribute__((deprecated("use hal_rtc_cancel_alarm() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! use hal_rtc_cancel_alarm() instead"), always_inline))
 HAL_RTC_Cancel_UnixAlarm(void) {
     hal_rtc_cancel_alarm();
 }
 
-inline uint8_t __attribute__((deprecated("use hal_rtc_time_is_valid() instead"), always_inline))
+inline uint8_t __attribute__((deprecated("Will be removed in 5.x! use hal_rtc_time_is_valid() instead"), always_inline))
 HAL_RTC_Time_Is_Valid(void* reserved) {
     return (uint8_t)hal_rtc_time_is_valid(reserved);
 }

--- a/hal/inc/spi_hal_compat.h
+++ b/hal/inc/spi_hal_compat.h
@@ -18,103 +18,103 @@
 #ifndef SPI_HAL_COMPAT_H
 #define SPI_HAL_COMPAT_H
 
-typedef hal_spi_interface_t HAL_SPI_Interface __attribute__((deprecated("Use hal_spi_interface_t instead")));
-typedef hal_spi_mode_t SPI_Mode __attribute__((deprecated("Use hal_spi_mode_t instead")));
-typedef hal_spi_transfer_status_t HAL_SPI_TransferStatus __attribute__((deprecated("Use hal_spi_transfer_status_t instead")));
-typedef hal_spi_acquire_config_t HAL_SPI_AcquireConfig __attribute__((deprecated("Use hal_spi_acquire_config_t instead")));
+typedef hal_spi_interface_t HAL_SPI_Interface __attribute__((deprecated("Will be removed in 5.x! Use hal_spi_interface_t instead")));
+typedef hal_spi_mode_t SPI_Mode __attribute__((deprecated("Will be removed in 5.x! Use hal_spi_mode_t instead")));
+typedef hal_spi_transfer_status_t HAL_SPI_TransferStatus __attribute__((deprecated("Will be removed in 5.x! Use hal_spi_transfer_status_t instead")));
+typedef hal_spi_acquire_config_t HAL_SPI_AcquireConfig __attribute__((deprecated("Will be removed in 5.x! Use hal_spi_acquire_config_t instead")));
 
 typedef hal_spi_dma_user_callback HAL_SPI_DMA_UserCallback;
 typedef hal_spi_select_user_callback HAL_SPI_Select_UserCallback;
 
 // Deprecated *dynalib* APIs for backwards compatibility
-inline void __attribute__((deprecated("Use hal_spi_init() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_spi_init() instead"), always_inline))
 HAL_SPI_Init(hal_spi_interface_t spi) {
     hal_spi_init(spi);
 }
 
-inline void __attribute__((deprecated("Use hal_spi_begin() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_spi_begin() instead"), always_inline))
 HAL_SPI_Begin(hal_spi_interface_t spi, uint16_t pin) {
     hal_spi_begin(spi, pin);
 }
 
-inline void __attribute__((deprecated("Use hal_spi_begin_ext() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_spi_begin_ext() instead"), always_inline))
 HAL_SPI_Begin_Ext(hal_spi_interface_t spi, hal_spi_mode_t mode, uint16_t pin, void* reserved) {
     hal_spi_begin_ext(spi, mode, pin, reserved);
 }
 
-inline void __attribute__((deprecated("Use hal_spi_end() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_spi_end() instead"), always_inline))
 HAL_SPI_End(hal_spi_interface_t spi) {
     hal_spi_end(spi);
 }
 
-inline void __attribute__((deprecated("Use hal_spi_set_bit_order() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_spi_set_bit_order() instead"), always_inline))
 HAL_SPI_Set_Bit_Order(hal_spi_interface_t spi, uint8_t order) {
     hal_spi_set_bit_order(spi, order);
 }
 
-inline void __attribute__((deprecated("Use hal_spi_set_data_mode() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_spi_set_data_mode() instead"), always_inline))
 HAL_SPI_Set_Data_Mode(hal_spi_interface_t spi, uint8_t mode) {
     hal_spi_set_data_mode(spi, mode);
 }
 
-inline void __attribute__((deprecated("Use hal_spi_set_clock_divider() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_spi_set_clock_divider() instead"), always_inline))
 HAL_SPI_Set_Clock_Divider(hal_spi_interface_t spi, uint8_t rate) {
     hal_spi_set_clock_divider(spi, rate);
 }
 
-inline uint16_t __attribute__((deprecated("Use hal_spi_transfer() instead"), always_inline))
+inline uint16_t __attribute__((deprecated("Will be removed in 5.x! Use hal_spi_transfer() instead"), always_inline))
 HAL_SPI_Send_Receive_Data(hal_spi_interface_t spi, uint16_t data) {
     return hal_spi_transfer(spi, data);
 }
 
-inline void __attribute__((deprecated("Use hal_spi_transfer_dma() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_spi_transfer_dma() instead"), always_inline))
 HAL_SPI_DMA_Transfer(hal_spi_interface_t spi, void* tx_buffer, void* rx_buffer, uint32_t length, HAL_SPI_DMA_UserCallback userCallback) {
     hal_spi_transfer_dma(spi, tx_buffer, rx_buffer, length, userCallback);
 }
 
-inline bool __attribute__((deprecated("Use hal_spi_is_enabled_deprecated() instead"), always_inline))
+inline bool __attribute__((deprecated("Will be removed in 5.x! Use hal_spi_is_enabled_deprecated() instead"), always_inline))
 HAL_SPI_Is_Enabled_Old() {
     return hal_spi_is_enabled_deprecated();
 }
 
-inline bool __attribute__((deprecated("Use hal_spi_is_enabled() instead"), always_inline))
+inline bool __attribute__((deprecated("Will be removed in 5.x! Use hal_spi_is_enabled() instead"), always_inline))
 HAL_SPI_Is_Enabled(hal_spi_interface_t spi) {
     return hal_spi_is_enabled(spi);
 }
 
-inline void __attribute__((deprecated("Use hal_spi_info() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_spi_info() instead"), always_inline))
 HAL_SPI_Info(hal_spi_interface_t spi, hal_spi_info_t* info, void* reserved) {
     hal_spi_info(spi, info, reserved);
 }
 
-inline void __attribute__((deprecated("Use hal_spi_set_callback_on_selected() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_spi_set_callback_on_selected() instead"), always_inline))
 HAL_SPI_Set_Callback_On_Select(hal_spi_interface_t spi, HAL_SPI_Select_UserCallback cb, void* reserved) {
     hal_spi_set_callback_on_selected(spi, cb, reserved);
 }
 
-inline void __attribute__((deprecated("Use hal_spi_transfer_dma_cancel() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_spi_transfer_dma_cancel() instead"), always_inline))
 HAL_SPI_DMA_Transfer_Cancel(hal_spi_interface_t spi) {
     hal_spi_transfer_dma_cancel(spi);
 }
 
-inline int32_t __attribute__((deprecated("Use hal_spi_transfer_dma_status() instead"), always_inline))
+inline int32_t __attribute__((deprecated("Will be removed in 5.x! Use hal_spi_transfer_dma_status() instead"), always_inline))
 HAL_SPI_DMA_Transfer_Status(hal_spi_interface_t spi, hal_spi_transfer_status_t* st) {
     return hal_spi_transfer_dma_status(spi, st);
 }
 
-inline int32_t __attribute__((deprecated("Use hal_spi_set_settings() instead"), always_inline))
+inline int32_t __attribute__((deprecated("Will be removed in 5.x! Use hal_spi_set_settings() instead"), always_inline))
 HAL_SPI_Set_Settings(hal_spi_interface_t spi, uint8_t set_default, uint8_t clockdiv, uint8_t order, uint8_t mode, void* reserved) {
     return hal_spi_set_settings(spi, set_default, clockdiv, order, mode, reserved);
 }
 
 #if HAL_PLATFORM_SPI_HAL_THREAD_SAFETY
 
-inline int32_t __attribute__((deprecated("Use hal_spi_acquire() instead"), always_inline))
+inline int32_t __attribute__((deprecated("Will be removed in 5.x! Use hal_spi_acquire() instead"), always_inline))
 HAL_SPI_Acquire(hal_spi_interface_t spi, const hal_spi_acquire_config_t* conf) { 
     return hal_spi_acquire(spi, conf);
 }
 
-inline int32_t __attribute__((deprecated("Use hal_spi_release() instead"), always_inline))
+inline int32_t __attribute__((deprecated("Will be removed in 5.x! Use hal_spi_release() instead"), always_inline))
 HAL_SPI_Release(hal_spi_interface_t spi, void* reserved) {
     return hal_spi_release(spi, reserved);
 }

--- a/hal/inc/usart_hal_compat.h
+++ b/hal/inc/usart_hal_compat.h
@@ -18,82 +18,82 @@
 #ifndef USART_HAL_COMPAT_H
 #define USART_HAL_COMPAT_H
 
-typedef hal_usart_ring_buffer_t Ring_Buffer __attribute__((deprecated("Use hal_usart_ring_buffer_t instead")));
-typedef hal_usart_interface_t HAL_USART_Serial __attribute__((deprecated("Use hal_usart_interface_t instead")));
-typedef hal_usart_buffer_config_t HAL_USART_Buffer_Config __attribute__((deprecated("Use hal_usart_buffer_config_t instead")));
+typedef hal_usart_ring_buffer_t Ring_Buffer __attribute__((deprecated("Will be removed in 5.x! Use hal_usart_ring_buffer_t instead")));
+typedef hal_usart_interface_t HAL_USART_Serial __attribute__((deprecated("Will be removed in 5.x! Use hal_usart_interface_t instead")));
+typedef hal_usart_buffer_config_t HAL_USART_Buffer_Config __attribute__((deprecated("Will be removed in 5.x! Use hal_usart_buffer_config_t instead")));
 
 // Deprecated *dynalib* APIs for backwards compatibility
-inline void __attribute__((deprecated("Use hal_usart_init() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_usart_init() instead"), always_inline))
 HAL_USART_Init(hal_usart_interface_t serial, hal_usart_ring_buffer_t *rx_buffer, hal_usart_ring_buffer_t *tx_buffer) {
     hal_usart_init(serial, rx_buffer, tx_buffer);
 }
 
-inline void __attribute__((deprecated("Use hal_usart_begin() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_usart_begin() instead"), always_inline))
 HAL_USART_Begin(hal_usart_interface_t serial, uint32_t baud) {
     hal_usart_begin(serial, baud);
 }
 
-inline void __attribute__((deprecated("Use hal_usart_end() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_usart_end() instead"), always_inline))
 HAL_USART_End(hal_usart_interface_t serial) {
     hal_usart_end(serial);
 }
 
-inline uint32_t __attribute__((deprecated("Use hal_usart_write() instead"), always_inline))
+inline uint32_t __attribute__((deprecated("Will be removed in 5.x! Use hal_usart_write() instead"), always_inline))
 HAL_USART_Write_Data(hal_usart_interface_t serial, uint8_t data) {
     return hal_usart_write(serial, data);
 }
 
-inline int32_t __attribute__((deprecated("Use hal_usart_available_data_for_write() instead"), always_inline))
+inline int32_t __attribute__((deprecated("Will be removed in 5.x! Use hal_usart_available_data_for_write() instead"), always_inline))
 HAL_USART_Available_Data_For_Write(hal_usart_interface_t serial) {
     return hal_usart_available_data_for_write(serial);
 }
 
-inline int32_t __attribute__((deprecated("Use hal_usart_available() instead"), always_inline))
+inline int32_t __attribute__((deprecated("Will be removed in 5.x! Use hal_usart_available() instead"), always_inline))
 HAL_USART_Available_Data(hal_usart_interface_t serial) {
     return hal_usart_available(serial);
 }
 
-inline int32_t __attribute__((deprecated("Use hal_usart_read() instead"), always_inline))
+inline int32_t __attribute__((deprecated("Will be removed in 5.x! Use hal_usart_read() instead"), always_inline))
 HAL_USART_Read_Data(hal_usart_interface_t serial) {
     return hal_usart_read(serial);
 }
 
-inline int32_t __attribute__((deprecated("Use hal_usart_peek() instead"), always_inline))
+inline int32_t __attribute__((deprecated("Will be removed in 5.x! Use hal_usart_peek() instead"), always_inline))
 HAL_USART_Peek_Data(hal_usart_interface_t serial) {
     return hal_usart_peek(serial);
 }
 
-inline void __attribute__((deprecated("Use hal_usart_flush() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_usart_flush() instead"), always_inline))
 HAL_USART_Flush_Data(hal_usart_interface_t serial) {
     hal_usart_flush(serial);
 }
 
-inline bool __attribute__((deprecated("Use hal_usart_is_enabled() instead"), always_inline))
+inline bool __attribute__((deprecated("Will be removed in 5.x! Use hal_usart_is_enabled() instead"), always_inline))
 HAL_USART_Is_Enabled(hal_usart_interface_t serial) {
     return hal_usart_is_enabled(serial);
 }
 
-inline void __attribute__((deprecated("Use hal_usart_half_duplex() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_usart_half_duplex() instead"), always_inline))
 HAL_USART_Half_Duplex(hal_usart_interface_t serial, bool Enable) {
     hal_usart_half_duplex(serial, Enable);
 }
 
-inline void __attribute__((deprecated("Use hal_usart_begin_config() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_usart_begin_config() instead"), always_inline))
 HAL_USART_BeginConfig(hal_usart_interface_t serial, uint32_t baud, uint32_t config, void* reserved) {
     hal_usart_begin_config(serial, baud, config, reserved);
 }
 
-inline uint32_t __attribute__((deprecated("Use hal_usart_write_nine_bits() instead"), always_inline))
+inline uint32_t __attribute__((deprecated("Will be removed in 5.x! Use hal_usart_write_nine_bits() instead"), always_inline))
 HAL_USART_Write_NineBitData(hal_usart_interface_t serial, uint16_t data) {
     return hal_usart_write_nine_bits(serial, data);
 }
 
-inline void __attribute__((deprecated("Use hal_usart_send_break() instead"), always_inline))
+inline void __attribute__((deprecated("Will be removed in 5.x! Use hal_usart_send_break() instead"), always_inline))
 HAL_USART_Send_Break(hal_usart_interface_t serial, void* reserved) {
     hal_usart_send_break(serial, reserved);
 }
 
-inline uint8_t __attribute__((deprecated("Use hal_usart_break_detected() instead"), always_inline))
+inline uint8_t __attribute__((deprecated("Will be removed in 5.x! Use hal_usart_break_detected() instead"), always_inline))
 HAL_USART_Break_Detected(hal_usart_interface_t serial) {
     return hal_usart_break_detected(serial);
 }

--- a/hal/src/nRF52840/bootloader.cpp
+++ b/hal/src/nRF52840/bootloader.cpp
@@ -8,153 +8,9 @@
 #include "check.h"
 #include "stream.h"
 
-#if HAL_PLATFORM_COMPRESSED_BINARIES
-#include "miniz.h"
-#endif
-
 #include <memory>
 
-
 #define BOOTLOADER_ADDR (module_bootloader.start_address)
-
-namespace particle {
-
-#if HAL_PLATFORM_COMPRESSED_BINARIES
-
-class OTAUpdateStream : public OutputStream {
-	size_t destAddress_;
-	size_t endAddress_;
-public:
-	int begin(int size) {
-		destAddress_ = HAL_OTA_FlashAddress();
-		endAddress_ = destAddress_ + size;
-		return HAL_FLASH_Begin(destAddress_, size, nullptr);
-	}
-
-	int write(const char* data, size_t length) override {
-		if (length > endAddress_-destAddress_) {
-			length = endAddress_-destAddress_;
-		}
-		int error = HAL_FLASH_Update((const uint8_t*)data, destAddress_, length, nullptr);
-		if (!error) {
-			destAddress_ += length;
-			return length;
-		}
-		else {
-			return error;
-		}
-	}
-
-	int waitEvent(unsigned flags, unsigned timeout = 0) override {
-		return 0;
-	}
-
-	int availForWrite() override {
-		return endAddress_-destAddress_;
-	}
-
-	int flush() override {
-		return HAL_FLASH_End(nullptr);
-	}
-};
-
-class Deflator {
-
-	tinfl_decompressor inflator;
-
-public:
-	Deflator() {
-		tinfl_init(&inflator);
-	}
-
-	/**
-	 * @param in_buffer [in] The input (compressed) data
-	 * @param in_length [in,out] The number of bytes available in the input stream. When 0, indicates the end of stream. On return, is the number of bytes consumed from the input buffer.
-	 * @param out_buffer [in] The output (uncomprssed) data
-	 * @param out_length [in,out] The number of bytes available in the output buffer.  On return, it is the number of bytes written to the output buffer.
-	 * Returns >0 if more data is needed on input or more data available for output.
-	 * Returns 0 when the compression is done
-	 * Returns <0 on error
-	 */
-	tinfl_status write(const char* in_buffer, size_t& in_length, char* out_buffer, char* next_buffer, size_t& out_length, bool hasMore);
-
-};
-
-tinfl_status Deflator::write(const char* in_buffer, size_t& in_length, char* out_buffer, char* next_buffer, size_t& out_length, bool hasMore) {
-    const int flags = (hasMore ? TINFL_FLAG_HAS_MORE_INPUT : 0) | 0;
-	tinfl_status status = tinfl_decompress(&inflator, (const mz_uint8*)in_buffer, &in_length, (mz_uint8*)out_buffer, (mz_uint8*)next_buffer, &out_length, flags);
-	return status;
-}
-
-
-class DecompressStream : public OutputStream {
-	Deflator deflator_;
-	char* buffer_;
-	size_t length_;
-	OutputStream& output_;
-	size_t out_offset_;
-
-public:
-
-	DecompressStream(char* buffer, size_t length, OutputStream& output)
-: buffer_(buffer), length_(length), output_(output), out_offset_(0) {}
-
-	/**
-	 * Write to the stream.
-	 * @param buffer The compressed data to decompress
-	 * @param length	The amount of data to write
-	 * @returns The number of bytes written from the buffer.
-	 */
-	int write(const char* buffer, size_t length) override;
-
-	int flush() override {
-		int result = write(buffer_, 0);
-		output_.flush();
-		return result;
-	}
-
-	int availForWrite() override {
-		return length_-out_offset_;
-	}
-
-	int waitEvent(unsigned flags, unsigned timeout = 0) override {
-		return 0;
-	}
-
-};
-
-/**
- * Write to the stream.
- * @param buffer The compressed data to decompress
- * @param length	The amount of data to write
- * @returns The number of bytes written from the buffer.
- */
-int DecompressStream::write(const char* buffer, const size_t length)  {
-	bool hasMore = length;
-	size_t consumed = 0;
-	tinfl_status status;
-	do {
-		size_t out_length = length_-out_offset_;
-		size_t in_length = length-consumed;
-		status = deflator_.write(buffer+consumed, in_length, this->buffer_, this->buffer_+out_offset_, out_length, hasMore);
-		if (status<0) {
-			return SYSTEM_ERROR_BAD_DATA;
-		}
-		consumed += in_length;
-		if (out_length) {
-			output_.writeAll(this->buffer_+out_offset_, out_length);
-			out_offset_ = (out_offset_ + out_length) % length_;
-		}
-	}
-	while (status == TINFL_STATUS_HAS_MORE_OUTPUT);
-
-	// exit when Done, or there is an error
-	return (status<TINFL_STATUS_DONE) ? status : consumed;
-}
-
-#endif // HAL_PLATFORM_COMPRESSED_BINARIES
-
-} // namespace particle
 
 int bootloader_update(const void* bootloader_image, unsigned length)
 {
@@ -199,37 +55,11 @@ bool bootloader_update_if_needed()
 {
     bool updated = false;
 
-#if HAL_PLATFORM_COMPRESSED_BINARIES
-    bool requires_update = false;
-
-    uint32_t bootloader_image_size = 0;
-    const char* bootloader_image = (const char*)HAL_Bootloader_Image(&bootloader_image_size, nullptr);
-	const size_t buffer_size = TINFL_LZ_DICT_SIZE;
-	auto output_size = buffer_size;
-	size_t input_size = bootloader_image_size;
-	auto buffer = std::make_unique<char[]>(buffer_size);
-
-	{
-		auto deflator = std::make_unique<Deflator>();
-		deflator->write(bootloader_image, input_size, buffer.get(), buffer.get(), output_size, false);
-		requires_update = bootloader_requires_update((const uint8_t*)buffer.get(), buffer_size);
-	}
-
-    if (requires_update) {
-    	// todo - take from the bootloader module bounds
-        OTAUpdateStream otaUpdateStream;
-        otaUpdateStream.begin(module_bootloader.maximum_size);
-        auto decompress = std::make_unique<DecompressStream>(buffer.get(), buffer_size, otaUpdateStream);
-        decompress->write((const char*)bootloader_image, bootloader_image_size);
-        updated = !decompress->flush();
-    }
-#else // !HAL_PLATFORM_COMPRESSED_BINARIES
     uint32_t bootloader_image_size = 0;
     const uint8_t* bootloader_image = HAL_Bootloader_Image(&bootloader_image_size, nullptr);
     if (bootloader_requires_update(bootloader_image, bootloader_image_size)) {
         updated = bootloader_update(bootloader_image, bootloader_image_size);
     }
-#endif
 
     return updated;
 }

--- a/hal/src/nRF52840/mesh_hal_deprecated.cpp
+++ b/hal/src/nRF52840/mesh_hal_deprecated.cpp
@@ -23,7 +23,8 @@
 
 using namespace particle;
 
-int mesh_select_antenna_deprecated(int antenna, void* reserved) {
-	CHECK(selectRadioAntenna((radio_antenna_type)antenna));
-	return 0;
+int __attribute__((deprecated("Will be removed in 5.x!")))
+mesh_select_antenna_deprecated(int antenna, void* reserved) {
+    CHECK(selectRadioAntenna((radio_antenna_type)antenna));
+    return 0;
 }

--- a/system/src/control/config.cpp
+++ b/system/src/control/config.cpp
@@ -126,9 +126,6 @@ int getNcpFirmwareVersion(ctrl_request* req) {
 
 int getSystemCapabilities(ctrl_request* req) {
     PB(GetSystemCapabilitiesReply) pbRep = {};
-#if HAL_PLATFORM_COMPRESSED_BINARIES
-    pbRep.flags |= PB(SystemCapabilityFlag_COMPRESSED_OTA);
-#endif
     CHECK(encodeReplyMessage(req, PB(GetSystemCapabilitiesReply_fields), &pbRep));
     return 0;
 }

--- a/system/src/control/storage.cpp
+++ b/system/src/control/storage.cpp
@@ -33,9 +33,6 @@
 
 #include "protocol_defs.h" // For UpdateFlag enum
 #include "nanopb_misc.h"
-#if HAL_PLATFORM_COMPRESSED_BINARIES
-#include "miniz.h"
-#endif // HAL_PLATFORM_COMPRESSED_BINARIES
 #include "scope_guard.h"
 #include "check.h"
 
@@ -59,11 +56,6 @@ namespace {
 // TODO: Move handling of compressed firmware binaries to the common system code
 struct FirmwareUpdate {
     FileTransfer::Descriptor descr; // File transfer descriptor
-#if HAL_PLATFORM_COMPRESSED_BINARIES
-    std::unique_ptr<tinfl_decompressor> decomp; // Decompressor context
-    std::unique_ptr<char[]> decompBuf; // Intermediate buffer for decompressed data
-    size_t decompBufOffs; // Offset in the buffer for decompressed data
-#endif // HAL_PLATFORM_COMPRESSED_BINARIES
     size_t bytesLeft; // Number of remaining bytes to receive
     size_t bytesWritten; // Number of bytes written to the OTA section
 };
@@ -121,19 +113,6 @@ int startFirmwareUpdateRequest(ctrl_request* req) {
     CHECK_TRUE(update, SYSTEM_ERROR_NO_MEMORY);
     if (pbReq.format == PB(FileFormat_BIN)) {
         update->descr.file_length = pbReq.size;
-#if HAL_PLATFORM_COMPRESSED_BINARIES
-    } else if (pbReq.format == PB(FileFormat_MINIZ)) {
-        update->decomp.reset(new(std::nothrow) tinfl_decompressor);
-        CHECK_TRUE(update->decomp, SYSTEM_ERROR_NO_MEMORY);
-        tinfl_init(update->decomp.get());
-        update->decompBuf.reset(new(std::nothrow) char[TINFL_LZ_DICT_SIZE]);
-        CHECK_TRUE(update->decompBuf, SYSTEM_ERROR_NO_MEMORY);
-        update->decompBufOffs = 0;
-        // FIXME: The size of the decompressed data is unknown at this point, so we're setting
-        // the target file size to the maximum value to make sure the system erases the entire
-        // OTA section
-        update->descr.file_length = module_ota.maximum_size;
-#endif // HAL_PLATFORM_COMPRESSED_BINARIES
     } else {
         LOG(ERROR, "Unknown binary format: %u", (unsigned)pbReq.format);
         return SYSTEM_ERROR_NOT_SUPPORTED;
@@ -203,46 +182,13 @@ int firmwareUpdateDataRequest(ctrl_request* req) {
         return SYSTEM_ERROR_OUT_OF_RANGE;
     }
 
-#if HAL_PLATFORM_COMPRESSED_BINARIES
-    if (g_update->decomp) {
-        size_t srcOffs = 0;
-        for (;;) {
-            size_t srcBytes = pbData.size - srcOffs;
-            size_t destBytes = TINFL_LZ_DICT_SIZE - g_update->decompBufOffs;
-            const auto stat = tinfl_decompress(g_update->decomp.get(), (const mz_uint8*)pbData.data + srcOffs, &srcBytes,
-                    (mz_uint8*)g_update->decompBuf.get(), (mz_uint8*)g_update->decompBuf.get() + g_update->decompBufOffs,
-                    &destBytes, (g_update->bytesLeft > srcBytes) ? TINFL_FLAG_HAS_MORE_INPUT : 0);
-            if (stat < 0) {
-                return SYSTEM_ERROR_BAD_DATA;
-            }
-            srcOffs += srcBytes;
-            g_update->bytesLeft -= srcBytes;
-            if (destBytes > 0) {
-                g_update->descr.chunk_size = destBytes;
-                const int ret = Spark_Save_Firmware_Chunk(g_update->descr,
-                        (const uint8_t*)g_update->decompBuf.get() + g_update->decompBufOffs, nullptr);
-                if (ret != 0) {
-                    return ret;
-                }
-                g_update->decompBufOffs = (g_update->decompBufOffs + destBytes) % TINFL_LZ_DICT_SIZE;
-                g_update->descr.chunk_address += destBytes;
-                g_update->bytesWritten += destBytes;
-            }
-            if (stat != TINFL_STATUS_HAS_MORE_OUTPUT) {
-                break;
-            }
-        }
-    } else
-#endif // HAL_PLATFORM_COMPRESSED_BINARIES
-    {
-        g_update->descr.chunk_size = pbData.size;
-        const int ret = Spark_Save_Firmware_Chunk(g_update->descr, (const uint8_t*)pbData.data, nullptr);
-        if (ret != 0) {
-            return ret;
-        }
-        g_update->descr.chunk_address += pbData.size;
-        g_update->bytesLeft -= pbData.size;
+    g_update->descr.chunk_size = pbData.size;
+    const int ret = Spark_Save_Firmware_Chunk(g_update->descr, (const uint8_t*)pbData.data, nullptr);
+    if (ret != 0) {
+        return ret;
     }
+    g_update->descr.chunk_address += pbData.size;
+    g_update->bytesLeft -= pbData.size;
 
     guard.dismiss();
     return 0;

--- a/user/tests/wiring/api/adc.cpp
+++ b/user/tests/wiring/api/adc.cpp
@@ -4,6 +4,10 @@
 test(adc_hal_backwards_compatibility)
 {
     // These APIs are exposed to user application.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    // These APIs are known deprecated APIs, we don't need to see this warning in tests
     API_COMPILE(HAL_ADC_Set_Sample_Time(0));
     API_COMPILE(HAL_ADC_Read(0));
+#pragma GCC diagnostic pop
 }

--- a/user/tests/wiring/api/ble.cpp
+++ b/user/tests/wiring/api/ble.cpp
@@ -434,8 +434,12 @@ test(ble_characteristic_class) {
 
     API_COMPILE({ BleCharacteristic c = characteristic; });
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    // These APIs are known deprecated APIs, we don't need to see this warning in tests
     API_COMPILE({ bool ret = characteristic.valid(); (void)ret; });
     API_COMPILE({ bool ret = characteristic.isValid(); (void)ret; });
+#pragma GCC diagnostic pop
 
     API_COMPILE({ BleUuid uuid = characteristic.UUID(); });
 

--- a/user/tests/wiring/api/i2c.cpp
+++ b/user/tests/wiring/api/i2c.cpp
@@ -3,6 +3,9 @@
 
 test(i2c_hal_backwards_compatibility)
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    // These APIs are known deprecated APIs, we don't need to see this warning in tests
     I2C_Mode mode = I2C_MODE_MASTER;
     HAL_I2C_Interface i2c = HAL_I2C_INTERFACE1;
     HAL_I2C_Config config;
@@ -29,5 +32,6 @@ test(i2c_hal_backwards_compatibility)
     API_COMPILE(HAL_I2C_Set_Callback_On_Request(i2c, NULL, NULL));
     API_COMPILE(HAL_I2C_Reset(i2c, 0, NULL));
     API_COMPILE(HAL_I2C_Acquire(i2c, NULL));
-    API_COMPILE(HAL_I2C_Release(i2c, NULL)); 
+    API_COMPILE(HAL_I2C_Release(i2c, NULL));
+#pragma GCC diagnostic pop
 }

--- a/user/tests/wiring/api/pwm.cpp
+++ b/user/tests/wiring/api/pwm.cpp
@@ -4,6 +4,9 @@
 test(pwm_hal_backwards_compatibility)
 {
     // These APIs are exposed to user application.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    // These APIs are known deprecated APIs, we don't need to see this warning in tests
     API_COMPILE(HAL_PWM_Write(0, 0));
     API_COMPILE(HAL_PWM_Write_Ext(0, 0));
     API_COMPILE(HAL_PWM_Write_With_Frequency(0, 0, 0));
@@ -15,4 +18,5 @@ test(pwm_hal_backwards_compatibility)
     API_COMPILE(HAL_PWM_Get_Max_Frequency(0));
     API_COMPILE(HAL_PWM_Get_Resolution(0));
     API_COMPILE(HAL_PWM_Set_Resolution(0, 0));
+#pragma GCC diagnostic pop
 }

--- a/user/tests/wiring/api/rtc.cpp
+++ b/user/tests/wiring/api/rtc.cpp
@@ -21,9 +21,13 @@
 test(rtc_hal_backwards_compatibility) {
     // These APIs are exposed to user application.
     // Deprecated *dynalib* APIs for backwards compatibility
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    // These APIs are known deprecated APIs, we don't need to see this warning in tests
     API_COMPILE(HAL_RTC_Configuration());
     API_COMPILE({ auto v = HAL_RTC_Get_UnixTime(); (void)v; });
     API_COMPILE(HAL_RTC_Set_UnixTime(12345));
     API_COMPILE(HAL_RTC_Cancel_UnixAlarm());
     API_COMPILE({auto v = HAL_RTC_Time_Is_Valid(nullptr); (void)v; });
+#pragma GCC diagnostic pop
 }

--- a/user/tests/wiring/api/spi.cpp
+++ b/user/tests/wiring/api/spi.cpp
@@ -202,6 +202,9 @@ test(spi_lock)
 
 test(spi_hal_backwards_compatibility)
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    // These APIs are known deprecated APIs, we don't need to see this warning in tests
     HAL_SPI_Interface spi = HAL_SPI_INTERFACE1;
     SPI_Mode mode = SPI_MODE_MASTER;
     HAL_SPI_TransferStatus status;
@@ -228,4 +231,5 @@ test(spi_hal_backwards_compatibility)
     API_COMPILE(HAL_SPI_Acquire(spi, &config));
     API_COMPILE(HAL_SPI_Release(spi, NULL));
 #endif
+#pragma GCC diagnostic pop
 }

--- a/user/tests/wiring/api/system.cpp
+++ b/user/tests/wiring/api/system.cpp
@@ -274,6 +274,9 @@ void handler_event_data(system_event_t event, int data)
 
 void handler_event_data_param(system_event_t event, int data, void* param)
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+    // These cases are designed to all fall through
     switch (event) {
     case network_status: {
         switch (data) {
@@ -300,6 +303,7 @@ void handler_event_data_param(system_event_t event, int data, void* param)
     default:
         break;
     }
+#pragma GCC diagnostic pop
 }
 
 class EventsHandler {
@@ -344,8 +348,12 @@ test(system_events)
     API_COMPILE(System.on(my_events, [&]() {}));
 
     API_COMPILE(System.off(my_events));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    // These APIs are known deprecated APIs, we don't need to see this warning in tests
     API_COMPILE(System.off(handler_event_data_param));
     API_COMPILE(System.off(my_events, handler_event_data_param));
+#pragma GCC diagnostic pop
     SystemEventSubscription sub;
     API_COMPILE(sub = System.on(my_events, [&](system_event_t events, int data, void* pointer) {}));
     API_COMPILE(System.off(sub));

--- a/user/tests/wiring/api/usart.cpp
+++ b/user/tests/wiring/api/usart.cpp
@@ -3,9 +3,13 @@
 
 test(usart_hal_backwards_compatibility)
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    // These APIs are known deprecated APIs, we don't need to see this warning in tests
     Ring_Buffer rxBuf, txBuf;
     HAL_USART_Serial serial = HAL_USART_SERIAL1;
     HAL_USART_Buffer_Config config;
+    (void) config;
 
     // These APIs are exposed to user application.
     API_COMPILE(HAL_USART_Init(serial, &rxBuf, &txBuf));
@@ -23,4 +27,5 @@ test(usart_hal_backwards_compatibility)
     API_COMPILE(HAL_USART_Write_NineBitData(serial, 0));
     API_COMPILE(HAL_USART_Send_Break(serial, NULL));
     API_COMPILE(HAL_USART_Break_Detected(serial));
+#pragma GCC diagnostic pop
 }

--- a/wiring/inc/spark_wiring_system.h
+++ b/wiring/inc/spark_wiring_system.h
@@ -598,9 +598,13 @@ public:
     template <typename F, std::enable_if_t<std::is_assignable<SystemOnThreeArgumentFuncPtr*&, F>::value, bool> = true>
     static SystemEventSubscription on(system_event_t events, F&& handler) {
         SystemEventSubscription sub;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Waddress"
+#pragma GCC diagnostic ignored "-Wnonnull-compare"
         if (!handler) {
             return sub;
         }
+#pragma GCC diagnostic pop
         auto callable = static_cast<SystemOnThreeArgumentFuncPtr*>(handler);
         SystemEventContext context = {};
         context.version = SYSTEM_EVENT_CONTEXT_VERSION;


### PR DESCRIPTION
### Problem

There are a number of uppercase HAL APIs that were deprecated and renamed to lowercase.  We would like to remove these uppercase APIs in Device OS 5.x, however customers do not have any way currently to know they will be removed in 5.x.

### Solution

Add this warning to these deprecated messages so customers will be notified during Device OS 4.x releases:
```
Will be removed in 5.x!
```

### Steps to Test

- Clean build `TEST=wiring/api` should show no warnings

### References

[sc-101375](https://app.shortcut.com/particle/story/101375/update-device-os-4-x-deprecation-messages-to-notify-removal-in-5-x)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] (N/A) Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)