### PR TITLE
[Gen3] Device unable to enter listening mode with button press

### DIFF
--- a/system/src/system_network_manager_api.cpp
+++ b/system/src/system_network_manager_api.cpp
@@ -365,7 +365,9 @@ int network_listen_sync(network_handle_t network, uint32_t flags, void*) {
 }
 
 void network_listen(network_handle_t network, uint32_t flags, void* reserved) {
-    SYSTEM_THREAD_CONTEXT_ASYNC(network_listen(network, flags, reserved));
+    if (!HAL_IsISR()) {
+        SYSTEM_THREAD_CONTEXT_ASYNC(network_listen(network, flags, reserved));
+    }
     network_listen_sync(network, flags, reserved);
 }
 

--- a/system/system-threading.md
+++ b/system/system-threading.md
@@ -283,6 +283,17 @@ The macro performing a number of steps:
 
  The macros are defined and described in more detail in `system/inc/system_threading.h`.
 
+### Macros and ISRs
+The ASYNC and SYNC calls cannot be performed inside a HAL ISR. The following checks can be used when working with HAL ISR, for example
+```
+void network_listen(network_handle_t network, uint32_t flags, void* reserved) {
+    if (!HAL_IsISR()) {
+        SYSTEM_THREAD_CONTEXT_ASYNC(network_listen(network, flags, reserved));
+    }
+    // other code
+}
+
+```
 
 ### Cloud functions
 


### PR DESCRIPTION
### Problem

Listening mode cannot be entered through MODE button press with system threading enabled

### Solution

ASYNC/SYNC calls related to system threading cannot be performed in HAL ISR. Adjust accordingly.

### Steps to Test

Ensure listening mode can be entered through the following ways with system threading enabled and disabled.
1. User presses SETUP button
2. Application calls Wiring function to enter listening mode
3. USB control request to enter listening mode
4. If there are no credentials in the device

### References

[SC-102872](https://app.shortcut.com/particle/story/102872/unable-to-put-argon-into-listening-mode-through-button-press)
#2419 

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
