### PR TITLE
[gen3] hal: fix power leak on Boron

### DIFF
--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -175,7 +175,13 @@ int QuectelNcpClient::init(const NcpClientConfig& conf) {
     ready_ = false;
     registrationTimeout_ = REGISTRATION_TIMEOUT;
     resetRegistrationState();
-    ncpPowerState(modemPowerState() ? NcpPowerState::ON : NcpPowerState::OFF);
+    if (modemPowerState()) {
+        serial_->on(true);
+        ncpPowerState(NcpPowerState::ON);
+    } else {
+        serial_->on(false);
+        ncpPowerState(NcpPowerState::OFF);
+    }
     return SYSTEM_ERROR_NONE;
 }
 

--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -193,7 +193,13 @@ int SaraNcpClient::init(const NcpClientConfig& conf) {
     waitReadyRetries_ = 0;
     registrationTimeout_ = REGISTRATION_TIMEOUT;
     resetRegistrationState();
-    ncpPowerState(modemPowerState() ? NcpPowerState::ON : NcpPowerState::OFF);
+    if (modemPowerState()) {
+        serial_->on(true);
+        ncpPowerState(NcpPowerState::ON);
+    } else {
+        serial_->on(false);
+        ncpPowerState(NcpPowerState::OFF);
+    }
     return SYSTEM_ERROR_NONE;
 }
 


### PR DESCRIPTION
### Problem
Boron entering hibernate mode after startup in MANUAL mode consumes ~700UA current, which beyonds the expected <100uA.  The root cause of the issue is that the modem uart is initialized on startup, while the system sleep API checks that the cellular interface is off so that the modem off procedure is not performed, thus, the modem uart is kept on.
### Solution
Controls the modem uart according to the modem power status after startup.
### Steps to Test
Run the simple example below on a Boron, it should consum <100uA after it enters hibernate mode.
### Example App

```c
#include "Particle.h"

SYSTEM_MODE(MANUAL);

void setup() {   
    delay(10s);

    SystemSleepResult res = System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::HIBERNATE).gpio(D2, RISING));
}

void loop() {

}
```

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
