### PR TITLE
[Gen3] WiFi resolve tests need retries

### DIFF
--- a/user/tests/wiring/no_fixture_wifi/wifi.cpp
+++ b/user/tests/wiring/no_fixture_wifi/wifi.cpp
@@ -25,6 +25,8 @@
 
 #if !HAL_PLATFORM_WIFI_SCAN_ONLY
 
+const auto MAX_RETRIES_RESOLVE_TESTS = 5;
+
 test(WIFI_00_connect)
 {
     WiFi.on();
@@ -35,19 +37,27 @@ test(WIFI_00_connect)
 
 test(WIFI_01_resolve_3_levels)
 {
-    IPAddress address = WiFi.resolve("pool.ntp.org");
-    assertNotEqual(address, 0);
-
-    // ensure the version field is set
+    IPAddress address = {};
+    for (int i=0; i<MAX_RETRIES_RESOLVE_TESTS && !address.version(); i++) {
+        // Break out of the loop if address.version() is not 0,
+        // as a valid address has a non-zero version() value
+        address = WiFi.resolve("pool.ntp.org");
+    }
     assertNotEqual(address.version(), 0);
-
+    assertNotEqual(address, 0);
     IPAddress compare = IPAddress(address[0], address[1], address[2], address[3]);
     assertTrue(compare==address);
 }
 
 test(WIFI_02_resolve_4_levels)
 {
-    IPAddress address = WiFi.resolve("north-america.pool.ntp.org");
+    IPAddress address = {};
+    for (int i=0; i<MAX_RETRIES_RESOLVE_TESTS && !address.version(); i++) {
+        // Break out of the loop if address.version() is not 0,
+        // as a valid address has a non-zero version() value
+        address = WiFi.resolve("north-america.pool.ntp.org");
+    }
+    assertNotEqual(address.version(), 0);
     assertNotEqual(address, 0);
 }
 


### PR DESCRIPTION
### Problem

WiFi.resolve() tests sometimes fail when run with a new connection

### Solution

Add retries 

### Steps to Test

Run `wiring/no_fixture_wifi` on device-os test runner and ensure tests pass.
```
  No fixture wifi
    argon
      systemThread=disabled
        ✓ WIFI_00_connect (26.7s)
        ✓ WIFI_01_resolve_3_levels (5.8s)
        ✓ WIFI_02_resolve_4_levels
        ✓ WIFI_03_resolve
        ✓ WIFI_04_config
        ✓ WIFI_05_scan (4.8s)
        ✓ WIFI_06_restore_connection
        ✓ WIFI_11_scan_returns_zero_result_or_error_when_wifi_is_off (6.9s)
        ✓ WIFI_12_restore_connection
        ✓ WIFI_13_wifi_class_methods_work_correctly_when_wifi_interface_is_off (2.9s)
      systemThread=enabled
        ✓ WIFI_00_connect (19.3s)
        ✓ WIFI_01_resolve_3_levels (5.8s)
        ✓ WIFI_02_resolve_4_levels (5.8s)
        ✓ WIFI_03_resolve (5.8s)
        ✓ WIFI_04_config
        ✓ WIFI_05_scan (4.8s)
        ✓ WIFI_06_restore_connection
        ✓ WIFI_11_scan_returns_zero_result_or_error_when_wifi_is_off (5.6s)
        ✓ WIFI_12_restore_connection
        ✓ WIFI_13_wifi_class_methods_work_correctly_when_wifi_interface_is_off (1.6s)
```

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
