### PR TITLE
feature/sc-102452/update-device-os-workbench-manifest-json

### DIFF
--- a/.workbench/manifest.json
+++ b/.workbench/manifest.json
@@ -7,7 +7,7 @@
             "compilers": "gcc-arm@10.2.1",
             "tools": "buildtools@1.1.1",
             "scripts": "buildscripts@1.10.0",
-            "debuggers": "openocd@0.11.2-adhoc6ea4372.0"
+            "debuggers": "openocd@0.11.0-particle.4"
         }
     ]
 }


### PR DESCRIPTION
### Problem

`.workbench/manifest.json` uses an older version of the `debuggers` dependency


### Solution

Update the `debuggers` dependency to `openocd@0.11.0-particle.4`


### Steps to Test

Follow the steps to enable the `deviceOS@source` toolchain within Particle Workbench ([docs](https://docs.particle.io/support/particle-tools-faq/workbench/#working-with-a-custom-device-os-build)) - you should be able to compile, flash, and debug all platforms successfully


## Related / Discussions

https://app.shortcut.com/particle/story/102452
https://github.com/particle-iot/firmware-private/pull/332

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
