### PR TITLE
[gen3][esomx] ESOMX board support on HIL / Concourse

### DIFF
--- a/.buildpackrc
+++ b/.buildpackrc
@@ -20,5 +20,5 @@ export PRERELEASE_PLATFORMS=( argon boron bsom b5som tracker )
 # added to both it will be considered a prerelease
 
 # Platforms which require modules to be prebuilt
-export MODULAR_PLATFORMS=( argon boron bsom b5som tracker )
+export MODULAR_PLATFORMS=( argon boron bsom b5som tracker esomx)
 

--- a/build/create_module.py
+++ b/build/create_module.py
@@ -44,6 +44,7 @@ class ModuleFunction(IntEnum):
 class Platform(IntEnum):
     ARGON = 12
     BORON = 13
+    ESOMX = 15
     ASOM = 22
     BSOM = 23
     B5SOM = 25

--- a/build/make_release.sh
+++ b/build/make_release.sh
@@ -7,7 +7,7 @@ function display_help ()
 usage: make_release.sh [--debug] [--help]
                        [--output-directory=<binary_output_directory>]
                        [--platform=<all|argon|asom|boron|bsom...
-                       |b5som|tracker>]
+                       |b5som|tracker|esomx>]
                        [--publish=<semantic_version_string>] [--tests]
 
 Generate the binaries for a versioned release of the Device OS. This utility
@@ -129,7 +129,7 @@ function valid_platform()
     platform=$1
 
     # Validate platform (result of expression returned to caller)
-    [ "$platform" = "all" ] || [ "$platform" = "argon" ] || [ "$platform" = "asom" ] || [ "$platform" = "boron" ] || [ "$platform" = "bsom" ] || [ "$platform" = "b5som" ] || [ "$platform" = "tracker" ]
+    [ "$platform" = "all" ] || [ "$platform" = "argon" ] || [ "$platform" = "asom" ] || [ "$platform" = "boron" ] || [ "$platform" = "bsom" ] || [ "$platform" = "b5som" ] || [ "$platform" = "tracker" ] || [ "$platform" = "esomx" ]
 }
 
 if !(valid_platform $PLATFORM); then
@@ -151,6 +151,7 @@ if [ $PLATFORM = "all" ]; then
 	release_platform "bsom"
 	release_platform "b5som"
 	release_platform "tracker"
+    release_platform "esomx"
 else
 	release_platform "$PLATFORM"
 fi

--- a/build/release-publish.sh
+++ b/build/release-publish.sh
@@ -92,7 +92,7 @@ function valid_platform()
     platform=$1
 
     # Validate platform (result of expression returned to caller)
-    [ "$platform" = "argon" ] || [ "$platform" = "asom" ] || [ "$platform" = "boron" ] || [ "$platform" = "bsom" ] || [ "$platform" = "b5som" ] || [ "$platform" = "tracker" ]
+    [ "$platform" = "argon" ] || [ "$platform" = "asom" ] || [ "$platform" = "boron" ] || [ "$platform" = "bsom" ] || [ "$platform" = "b5som" ] || [ "$platform" = "tracker" ] || [ "$platform" = "esomx" ]
 }
 
 # Identify the absolute directory

--- a/build/release-tests.sh
+++ b/build/release-tests.sh
@@ -7,7 +7,7 @@ usage: release-tests.sh [--dryrun] [--help]
                         [--filename=<test_parameter_file.json>]
                         --output-directory=<binary_output_directory>
                         --platform=<argon|asom|boron|bsom...
-                        |b5som|tracker>
+                        |b5som|tracker|esomx>
                         --version=<semver_version_string>
 
 Generate the testing binaries belonging to a given platform.
@@ -107,7 +107,7 @@ function valid_platform ()
     platform=$1
 
     # Validate platform (result of expression returned to caller)
-    [ "$platform" = "argon" ] || [ "$platform" = "asom" ] || [ "$platform" = "boron" ] || [ "$platform" = "bsom" ] || [ "$platform" = "b5som" ] || [ "$platform" = "tracker" ]
+    [ "$platform" = "argon" ] || [ "$platform" = "asom" ] || [ "$platform" = "boron" ] || [ "$platform" = "bsom" ] || [ "$platform" = "b5som" ] || [ "$platform" = "tracker" ] || [ "$platform" = "esomx" ]
 }
 
 # Handle invalid arguments
@@ -135,6 +135,9 @@ case "$PLATFORM" in
         ;;
     "boron")
         PLATFORM_ID="13"
+        ;;
+    "esomx")
+        PLATFORM_ID="15"
         ;;
     "asom")
         PLATFORM_ID="22"

--- a/build/release.sh
+++ b/build/release.sh
@@ -8,8 +8,8 @@ function display_help ()
     echo '
 usage: release.sh [--output-directory=<binary_output_directory>]
                   (--platform=<argon|asom|boron|bsom...
-                  |b5som>...
-                  | --platform-id=<12|13|22|23|25|26>)
+                  |b5som|esomx>...
+                  | --platform-id=<12|13|15|22|23|25|26>)
                   [--debug] [--help] [--tests]
 
 Generate the binaries for a versioned release of the Device OS. This utility
@@ -218,6 +218,10 @@ elif [ ! -z $PLATFORM ]; then
             PLATFORM_ID="13"
             GEN3=true
             ;;
+        "esomx")
+            PLATFORM_ID="15"
+            GEN3=true
+            ;;
         "asom")
             PLATFORM_ID="22"
             GEN3=true
@@ -247,6 +251,10 @@ else
             ;;
         13)
             PLATFORM="boron"
+            GEN3=true
+            ;;
+        15)
+            PLATFORM="esomx"
             GEN3=true
             ;;
         22)
@@ -305,7 +313,7 @@ rm -rf $ABSOLUTE_TARGET_DIRECTORY/
 #########################
 
 # GEN3
-if [ $PLATFORM_ID -eq 12 ] || [ $PLATFORM_ID -eq 13 ] || [ $PLATFORM_ID -eq 22 ] || [ $PLATFORM_ID -eq 23 ] || [ $PLATFORM_ID -eq 25 ] || [ $PLATFORM_ID -eq 26 ]; then
+if [ $PLATFORM_ID -eq 12 ] || [ $PLATFORM_ID -eq 13 ] || [ $PLATFORM_ID -eq 15 ] || [ $PLATFORM_ID -eq 22 ] || [ $PLATFORM_ID -eq 23 ] || [ $PLATFORM_ID -eq 25 ] || [ $PLATFORM_ID -eq 26 ]; then
     # Configure
     if [ $DEBUG = true ]; then
         cd ../main

--- a/ci/cf_generate_message.sh
+++ b/ci/cf_generate_message.sh
@@ -53,7 +53,7 @@ EOF
 )
 
     fields=""
-    for p in Argon Boron BSoM B5SoM Tracker GCC Newhal; do
+    for p in Argon Boron BSoM B5SoM Tracker ESoMX GCC Newhal; do
         if echo -e "${failures}" | grep -q "PLATFORM=\"${p,,}\""; then
             msg=":scrum_closed: $p\\n"
         else

--- a/ci/enumerate_build_matrix.sh
+++ b/ci/enumerate_build_matrix.sh
@@ -47,12 +47,12 @@ MAKE=runmake
 # define build matrix dimensions
 # "" means execute execute the $MAKE command without that var specified
 DEBUG_BUILD=( y n )
-PLATFORM=( argon boron asom bsom b5som )
-PLATFORM_BOOTLOADER=( argon boron asom bsom b5som tracker )
+PLATFORM=( argon boron asom bsom b5som esomx )
+PLATFORM_BOOTLOADER=( argon boron asom bsom b5som tracker esomx )
 APP=( "" tinker product_id_and_version)
 TEST=( wiring/api wiring/no_fixture wiring/no_fixture_long_running )
 
-MODULAR_PLATFORM=( argon boron asom bsom b5som tracker )
+MODULAR_PLATFORM=( argon boron asom bsom b5som tracker esomx )
 
 filterPlatform PLATFORM
 filterPlatform MODULAR_PLATFORM
@@ -147,7 +147,7 @@ do
   do
     # Gen 3 overflows with modular DEBUG_BUILD=y, so skip those
     if [[ "$db" = "y" ]]; then
-      if [[ "$p" = "argon" ]] || [[ "$p" = "boron" ]] || [[ "$p" = "asom" ]] || [[ "$p" = "bsom" ]] || [[ "$p" = "b5som" ]] || [[ "$p" = "tracker" ]]; then
+      if [[ "$p" = "argon" ]] || [[ "$p" = "boron" ]] || [[ "$p" = "asom" ]] || [[ "$p" = "bsom" ]] || [[ "$p" = "b5som" ]] || [[ "$p" = "tracker" ]] || [[ "$p" = "esomx" ]]; then
         continue
       fi
     fi

--- a/user/tests/wiring/no_fixture_long_running/pwm.cpp
+++ b/user/tests/wiring/no_fixture_long_running/pwm.cpp
@@ -34,6 +34,8 @@ const PinMapping pwm_pins[] = {
         // cause problems if the RGB led is enabled.
         // PWM HAL also is not interrupt safe and RGB pins are modified in SysTick
         PIN(D2), PIN(D3), PIN(D4), PIN(D5), PIN(D6), /* PIN(D7), */ PIN(D8), PIN(A0), PIN(A1), PIN(A2), PIN(A3), PIN(A4), PIN(A5) /* , PIN(RGBR), PIN(RGBG), PIN(RGBB) */
+#elif (PLATFORM_ID == PLATFORM_ESOMX)
+        PIN(D0) // TODO: Other PWM pins
 #else
 #error "Unsupported platform"
 #endif


### PR DESCRIPTION
### Problem

HIL / Concourse need to be updated to support the esomx platform. There are various build scripts used by these tools to compile firmware and tests that need to be updated

### Solution

Update the needed scripts/files to allow building for esomx platform

### Steps to Test

Concourse should be able to build

### Example App

N/A

### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
