### PR TITLE
Device OS 4.0.0-alpha.2 pre release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 4.0.0-alpha.2
+
+> ## :warning: Please note this is in internal release, do not use on production devices!
+
+### FEATURES
+
+- [E404X] Determine flash part at runtime [#2456](https://github.com/particle-iot/device-os/pull/2456)
+- [gen3][quectel] Adds support for BG95-M1, BG95-MF, BG77, and EG91-NAX [#2458](https://github.com/particle-iot/device-os/pull/2458)
+
+### ENHANCEMENTS
+
+- [gen3][esomx] Define E404X platform [#2443](https://github.com/particle-iot/device-os/pull/2443)
+
+### INTERNAL
+
+- [ci] ESOMX board support on HIL / Concourse [#2459](https://github.com/particle-iot/device-os/pull/2459)
+- [workbench] update-device-os-workbench-manifest-json [#2457](https://github.com/particle-iot/device-os/pull/2457)
+- [ci] test-build-system-tune-timeouts [#2455](https://github.com/particle-iot/device-os/pull/2455)
+
+
 ## 4.0.0-alpha.1
 
 > ## :warning: Please note this is in internal release, do not use on production devices!

--- a/build/release.sh
+++ b/build/release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -o errexit -o pipefail -o noclobber -o nounset
 
-VERSION=${VERSION:="4.0.0-alpha.1"}
+VERSION=${VERSION:="4.0.0-alpha.2"}
 
 function display_help ()
 {

--- a/build/version.mk
+++ b/build/version.mk
@@ -1,7 +1,7 @@
-VERSION_STRING = 4.0.0-alpha.1
+VERSION_STRING = 4.0.0-alpha.2
 
 # PRODUCT_FIRMWARE_VERSION reported by default
 # FIXME: Unclear if this is used, PRODUCT_FIRMWARE_VERSION defaults to 65535 every release
-VERSION = 4000
+VERSION = 4001
 
 CFLAGS += -DSYSTEM_VERSION_STRING=$(VERSION_STRING)

--- a/modules/shared/system_module_version.mk
+++ b/modules/shared/system_module_version.mk
@@ -1,6 +1,6 @@
 # Skip to next 100 every vx.N.x release (e.g. 11 for v0.6.2 to 100 for v0.7.0-rc.1),
 # Bump by 1 for every prerelease or release with the same vx.N.* base.
-COMMON_MODULE_VERSION ?= 4000
+COMMON_MODULE_VERSION ?= 4001
 SYSTEM_PART1_MODULE_VERSION ?= $(COMMON_MODULE_VERSION)
 
 RELEASE_080_MODULE_VERSION_BASE ?= 300
@@ -14,13 +14,13 @@ USER_PART_MODULE_VERSION ?= 6
 # Skip to next 100 every vx.N.x release (e.g. 11 for v0.6.2 to 100 for v0.7.0-rc.1),
 # but only if the bootloader has changed since the last vx.N.x release.
 # Bump by 1 for every updated bootloader image for a release with the same vx.N.* base.
-BOOTLOADER_VERSION ?= 1100
+BOOTLOADER_VERSION ?= 1101
 
 # The version of the bootloader that the system firmware requires
 # NOTE: this will force the device into safe mode until this dependency is met, which is why
 # this version usually lags behind the current bootloader version, to avoid non-mandatory updates.
 ifeq ($(PLATFORM_GEN),3)
-BOOTLOADER_DEPENDENCY = 1100
+BOOTLOADER_DEPENDENCY = 1101
 else
 # Some sensible default
 BOOTLOADER_DEPENDENCY = 0

--- a/system/inc/system_version.h
+++ b/system/inc/system_version.h
@@ -189,7 +189,8 @@ extern "C" {
 #define SYSTEM_VERSION_v330RC1        SYSTEM_VERSION_RC(3, 3, 0, 1)
 #define SYSTEM_VERSION_v330         SYSTEM_VERSION_DEFAULT(3, 3, 0)
 #define SYSTEM_VERSION_v400ALPHA1   SYSTEM_VERSION_ALPHA(4, 0, 0, 1)
-#define SYSTEM_VERSION SYSTEM_VERSION_v400ALPHA1
+#define SYSTEM_VERSION_v400ALPHA2   SYSTEM_VERSION_ALPHA(4, 0, 0, 2)
+#define SYSTEM_VERSION SYSTEM_VERSION_v400ALPHA2
 
 /**
  * Previously we would set the least significant byte to 0 for the final release, but to make
@@ -343,6 +344,7 @@ extern "C" {
 #define SYSTEM_VERSION_330RC1
 #define SYSTEM_VERSION_330
 #define SYSTEM_VERSION_400ALPHA1
+#define SYSTEM_VERSION_400ALPHA2
 
 typedef struct __attribute__((packed)) SystemVersionInfo
 {

--- a/system/system-versions.md
+++ b/system/system-versions.md
@@ -155,6 +155,8 @@
 | 1100 | 3300 | 3.3.0-rc.1    |      Photon, P1, Electron, Argon, Boron, B SoM, B5 SoM, Tracker |
 | 1100 | 3301 | 3.3.0         |      Photon, P1, Electron, Argon, Boron, B SoM, B5 SoM, Tracker |
 | 1100 | 4000 | 4.0.0-alpha.1 |      Argon, Boron, B SoM, B5 SoM, Tracker |
+| 1101 | 4001 | 4.0.0-alpha.2 |      Argon, Boron, B SoM, B5 SoM, Tracker, E Som X |
+
 
 [1] For 0.8.0-rc.1, The v101 bootloader was also released in the Github releases as v200. Thus the next released bootloader in the 0.8.x line should be v201. As of 4/5/2018: 22 device had v200 bootloaders.
 


### PR DESCRIPTION
## 4.0.0-alpha.2

> ## :warning: Please note this is in internal release, do not use on production devices!

### FEATURES

- [E404X] Determine flash part at runtime [#2456](https://github.com/particle-iot/device-os/pull/2456)
- [gen3][quectel] Adds support for BG95-M1, BG95-MF, BG77, and EG91-NAX [#2458](https://github.com/particle-iot/device-os/pull/2458)

### ENHANCEMENTS

- [gen3][esomx] Define E404X platform [#2443](https://github.com/particle-iot/device-os/pull/2443)

### INTERNAL

- [ci] ESOMX board support on HIL / Concourse [#2459](https://github.com/particle-iot/device-os/pull/2459)
- [workbench] update-device-os-workbench-manifest-json [#2457](https://github.com/particle-iot/device-os/pull/2457)
- [ci] test-build-system-tune-timeouts [#2455](https://github.com/particle-iot/device-os/pull/2455)
