### PR TITLE
Enable OTA updates on the GCC platform

### DIFF
--- a/build/module-defaults.mk
+++ b/build/module-defaults.mk
@@ -55,6 +55,8 @@ endif
 ifneq ($(PLATFORM_ID),3)
 CFLAGS += -Wimplicit-fallthrough=2
 CFLAGS += -Wno-expansion-to-defined -Wno-cast-function-type
+else
+CFLAGS += -Wno-unknown-warning-option
 endif
 CFLAGS += -Wno-unused-parameter
 CFLAGS += -Wno-error=type-limits

--- a/ci/build_boost.sh
+++ b/ci/build_boost.sh
@@ -5,5 +5,5 @@ fi
 
 pushd $BOOST_ROOT
 ./bootstrap.sh
-./b2 --with-iostreams --with-thread --with-system --with-program_options --with-random --with-regex --threading=multi toolset=$toolset
+./b2 --with-iostreams --with-thread --with-system --with-program_options --with-random --with-regex --with-json --threading=multi toolset=$toolset
 popd

--- a/hal/src/gcc/boost_json.h
+++ b/hal/src/gcc/boost_json.h
@@ -1,0 +1,4 @@
+// Disabling -Wundef via a pragma is broken in GCC:
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53431
+#pragma GCC system_header
+#include <boost/json.hpp>

--- a/hal/src/gcc/core_hal.cpp
+++ b/hal/src/gcc/core_hal.cpp
@@ -136,16 +136,21 @@ const char* eeprom_bin = "eeprom.bin";
 
 extern "C" int main(int argc, char* argv[])
 {
-    log_set_callbacks(log_message_callback, log_write_callback, log_enabled_callback, nullptr);
-    if (read_device_config(argc, argv)) {
-    		// init the eeprom so that a file of size 0 can be used to trigger the save.
-    		HAL_EEPROM_Init();
-    		if (exists_file(eeprom_bin)) {
-    			GCC_EEPROM_Load(eeprom_bin);
-    		}
-			app_setup_and_loop();
-	}
-    return 0;
+    try {
+        log_set_callbacks(log_message_callback, log_write_callback, log_enabled_callback, nullptr);
+        if (read_device_config(argc, argv)) {
+                // init the eeprom so that a file of size 0 can be used to trigger the save.
+                HAL_EEPROM_Init();
+                if (exists_file(eeprom_bin)) {
+                    GCC_EEPROM_Load(eeprom_bin);
+                }
+                app_setup_and_loop();
+        }
+        return 0;
+    } catch (const std::exception& e) {
+        std::cerr << "Error: " << e.what() << std::endl;
+        return 1;
+    }
 }
 
 class GCCStartup {

--- a/hal/src/gcc/core_hal.cpp
+++ b/hal/src/gcc/core_hal.cpp
@@ -235,7 +235,7 @@ void HAL_Core_System_Reset(void)
                 if (args[i] == "--describe") {
                     args.erase(args.begin() + i);
                     if (i < args.size()) {
-                        args.erase(args.begin() + i);
+                        args.erase(args.begin() + i); // Remove the next argument
                     }
                     continue;
                 }
@@ -256,7 +256,7 @@ void HAL_Core_System_Reset(void)
         exit(1);
     }
 #else
-    LOG(INFO, "Resetting device");
+    LOG(INFO, "Resetting device (not supported)");
     exit(0);
 #endif
 }

--- a/hal/src/gcc/core_hal.cpp
+++ b/hal/src/gcc/core_hal.cpp
@@ -45,6 +45,7 @@
 #include "eeprom_hal.h"
 #include "rtc_hal.h"
 
+using namespace particle;
 using std::cout;
 
 static LoggerOutputLevel log_level = NO_LOG_LEVEL;

--- a/hal/src/gcc/core_hal.cpp
+++ b/hal/src/gcc/core_hal.cpp
@@ -248,7 +248,7 @@ void HAL_Core_System_Reset(void)
             argv.push_back(arg.data());
         }
         argv.push_back(nullptr);
-        LOG(INFO, "Resetting device");
+        LOG(INFO, "Resetting device\n\n\n");
         execvp(argv[0], argv.data());
         throw std::runtime_error("Failed to reset device"); // execvp() failed
     } catch (const std::exception& e) {

--- a/hal/src/gcc/device_config.cpp
+++ b/hal/src/gcc/device_config.cpp
@@ -301,6 +301,10 @@ bool read_device_config(int argc, char* argv[])
     }
 
     deviceConfig.read(parser.config);
+    deviceConfig.argv.clear();
+    for (int i = 0; i < argc; ++i) {
+        deviceConfig.argv.push_back(argv[i]);
+    }
     return true;
 }
 

--- a/hal/src/gcc/device_config.cpp
+++ b/hal/src/gcc/device_config.cpp
@@ -160,6 +160,24 @@ size_t hex2bin(const std::string& hex, uint8_t* dest, size_t destLen)
 
 } // namespace
 
+int Describe::systemModuleVersion() const {
+    int version = MODULE_VERSION;
+
+    if (!isValid()) {
+        return version;
+    }
+
+    for (auto& module: modules_) {
+        if (module.function() == MODULE_FUNCTION_SYSTEM_PART) {
+            if (module.version() < version) {
+                version = module.version();
+            }
+        }
+    }
+
+    return version;
+}
+
 std::string Describe::toString() const {
     if (!isValid()) {
         throw std::runtime_error("Cannot serialize an invalid object");

--- a/hal/src/gcc/device_config.cpp
+++ b/hal/src/gcc/device_config.cpp
@@ -161,11 +161,11 @@ size_t hex2bin(const std::string& hex, uint8_t* dest, size_t destLen)
 } // namespace
 
 int Describe::systemModuleVersion() const {
-    int version = MODULE_VERSION;
-
     if (!isValid()) {
-        return version;
+        return MODULE_VERSION;
     }
+
+    auto version = std::numeric_limits<decltype(module_info_t::module_version)>::max();
 
     for (auto& module: modules_) {
         if (module.function() == MODULE_FUNCTION_SYSTEM_PART || module.function() == MODULE_FUNCTION_MONO_FIRMWARE) {

--- a/hal/src/gcc/device_config.cpp
+++ b/hal/src/gcc/device_config.cpp
@@ -168,7 +168,7 @@ int Describe::systemModuleVersion() const {
     }
 
     for (auto& module: modules_) {
-        if (module.function() == MODULE_FUNCTION_SYSTEM_PART) {
+        if (module.function() == MODULE_FUNCTION_SYSTEM_PART || module.function() == MODULE_FUNCTION_MONO_FIRMWARE) {
             if (module.version() < version) {
                 version = module.version();
             }

--- a/hal/src/gcc/device_config.h
+++ b/hal/src/gcc/device_config.h
@@ -240,9 +240,10 @@ struct Configuration
     std::string device_key;
     std::string server_key;
     std::string describe;
-    uint16_t log_level = 0;
-    ProtocolFactory protocol = PROTOCOL_LIGHTSSL;
+    uint16_t log_level;
+    ProtocolFactory protocol;
     uint16_t platform_id;
+    uint16_t product_version;
 };
 
 /**
@@ -257,6 +258,7 @@ struct DeviceConfig
     uint8_t server_key[1024];
     ProtocolFactory protocol;
     uint16_t platform_id;
+    uint16_t product_version;
 
     void read(Configuration& configuration);
 

--- a/hal/src/gcc/device_config.h
+++ b/hal/src/gcc/device_config.h
@@ -250,6 +250,7 @@ struct Configuration
  */
 struct DeviceConfig
 {
+    std::vector<std::string> argv;
     particle::config::Describe describe;
     uint8_t device_id[12];
     uint8_t device_key[1024];

--- a/hal/src/gcc/device_config.h
+++ b/hal/src/gcc/device_config.h
@@ -161,7 +161,7 @@ public:
     }
 
     // Expects a binary string
-    ModuleInfo& hash(std::string_view hash) {
+    ModuleInfo& hash(const std::string& hash) {
         hash_ = hash;
         return *this;
     }
@@ -212,7 +212,7 @@ public:
     }
 
     std::string toString() const;
-    static Describe fromString(std::string_view str);
+    static Describe fromString(const std::string& str);
 
 private:
     Modules modules_;

--- a/hal/src/gcc/device_config.h
+++ b/hal/src/gcc/device_config.h
@@ -21,8 +21,204 @@
 #include <string>
 #include <stdexcept>
 #include <cstring>
+#include <vector>
+#include <optional>
+
 #include "filesystem.h"
 #include "spark_protocol_functions.h"
+#include "module_info.h"
+
+namespace particle {
+
+namespace config {
+
+class ModuleDependencyInfo {
+public:
+    ModuleDependencyInfo() :
+            func_(MODULE_FUNCTION_NONE),
+            index_(0),
+            version_(0) {
+    }
+
+    ModuleDependencyInfo& function(module_function_t func) {
+        func_ = func;
+        return *this;
+    }
+
+    module_function_t function() const {
+        return func_;
+    }
+
+    ModuleDependencyInfo& index(int index) {
+        index_ = index;
+        return *this;
+    }
+
+    int index() const {
+        return index_;
+    }
+
+    ModuleDependencyInfo& version(int version) {
+        version_ = version;
+        return *this;
+    }
+
+    int version() const {
+        return version_;
+    }
+
+private:
+    module_function_t func_;
+    int index_;
+    int version_;
+};
+
+class ModuleInfo {
+public:
+    using Dependencies = std::vector<ModuleDependencyInfo>;
+
+    ModuleInfo() :
+            func_(MODULE_FUNCTION_NONE),
+            storage_(MODULE_STORE_MAIN),
+            maxSize_(0),
+            index_(0),
+            version_(0),
+            validChecked_(0),
+            validResult_(0) {
+    }
+
+    ModuleInfo& function(module_function_t func) {
+        func_ = func;
+        return *this;
+    }
+
+    module_function_t function() const {
+        return func_;
+    }
+
+    ModuleInfo& index(int index) {
+        index_ = index;
+        return *this;
+    }
+
+    int index() const {
+        return index_;
+    }
+
+    ModuleInfo& version(int version) {
+        version_ = version;
+        return *this;
+    }
+
+    int version() const {
+        return version_;
+    }
+
+    ModuleInfo& dependencies(const Dependencies& deps) {
+        deps_ = deps;
+        return *this;
+    }
+
+    const Dependencies& dependencies() const {
+        return deps_;
+    }
+
+    ModuleInfo& storage(module_store_t storage) {
+        storage_ = storage;
+        return *this;
+    }
+
+    module_store_t storage() const {
+        return storage_;
+    }
+
+    ModuleInfo& maximumSize(size_t size) {
+        maxSize_ = size;
+        return *this;
+    }
+
+    size_t maximumSize() const {
+        return maxSize_;
+    }
+
+    ModuleInfo& validityChecked(int flags) {
+        validChecked_ = flags;
+        return *this;
+    }
+
+    int validityChecked() const {
+        return validChecked_;
+    }
+
+    ModuleInfo& validityResult(int flags) {
+        validResult_ = flags;
+        return *this;
+    }
+
+    int validityResult() const {
+        return validResult_;
+    }
+
+    ModuleInfo& hash(std::string_view hash) {
+        hash_ = hash;
+        return *this;
+    }
+
+    const std::string& hash() const {
+        return hash_;
+    }
+
+private:
+    Dependencies deps_;
+    std::string hash_;
+    module_function_t func_;
+    module_store_t storage_;
+    size_t maxSize_;
+    int index_;
+    int version_;
+    int validChecked_;
+    int validResult_;
+};
+
+class Describe {
+public:
+    using Modules = std::vector<ModuleInfo>;
+
+    Describe() = default;
+
+    Describe& platformId(int platformId) {
+        platformId_ = platformId;
+        return *this;
+    }
+
+    int platformId() const {
+        return platformId_.value_or(0);
+    }
+
+    Describe& modules(const Modules& modules) {
+        modules_ = modules;
+        return *this;
+    }
+
+    const Modules& modules() const {
+        return modules_;
+    }
+
+    bool isValid() const {
+        return platformId_.has_value();
+    }
+
+    std::string toString() const;
+    static Describe fromString(std::string_view str);
+
+private:
+    Modules modules_;
+    std::optional<int> platformId_;
+};
+
+} // namespace config
+
+} // namespace particle
 
 /**
  * Reads the device configuration and returns true if the device should start.
@@ -32,7 +228,6 @@
  */
 bool read_device_config(int argc, char* argv[]);
 
-
 /**
  * The external configuration data.
  */
@@ -41,18 +236,18 @@ struct Configuration
     std::string device_id;
     std::string device_key;
     std::string server_key;
-    std::string module_info;
+    std::string describe;
     uint16_t log_level = 0;
     ProtocolFactory protocol = PROTOCOL_LIGHTSSL;
     int platform_id;
 };
-
 
 /**
  * The device configuration in internal form.
  */
 struct DeviceConfig
 {
+    particle::config::Describe describe;
     uint8_t device_id[12];
     uint8_t device_key[1024];
     uint8_t server_key[1024];
@@ -72,7 +267,5 @@ struct DeviceConfig
 
     ProtocolFactory get_protocol() { return protocol; }
 };
-
-
 
 extern DeviceConfig deviceConfig;

--- a/hal/src/gcc/device_config.h
+++ b/hal/src/gcc/device_config.h
@@ -24,15 +24,6 @@
 #include "filesystem.h"
 #include "spark_protocol_functions.h"
 
-extern const char* DEVICE_ID;
-extern const char* DEVICE_PRIVATE_KEY;
-extern const char* SERVER_PUBLIC_KEY;
-
-
-std::string get_configuration_value(const char* name);
-
-void read_config_file(const char* config_name, void* data, size_t length);
-
 /**
  * Reads the device configuration and returns true if the device should start.
  * @param argc
@@ -50,7 +41,7 @@ struct Configuration
     std::string device_id;
     std::string device_key;
     std::string server_key;
-    std::string periph_directory;
+    std::string module_info;
     uint16_t log_level = 0;
     ProtocolFactory protocol = PROTOCOL_LIGHTSSL;
     int platform_id;
@@ -67,8 +58,6 @@ struct DeviceConfig
     uint8_t server_key[1024];
     ProtocolFactory protocol;
     int platform_id;
-
-    size_t hex2bin(const std::string& hex, uint8_t* dest, size_t destLen);
 
     void read(Configuration& configuration);
 

--- a/hal/src/gcc/device_config.h
+++ b/hal/src/gcc/device_config.h
@@ -160,11 +160,13 @@ public:
         return validResult_;
     }
 
+    // Expects a binary string
     ModuleInfo& hash(std::string_view hash) {
         hash_ = hash;
         return *this;
     }
 
+    // Returns a binary string
     const std::string& hash() const {
         return hash_;
     }

--- a/hal/src/gcc/device_config.h
+++ b/hal/src/gcc/device_config.h
@@ -211,6 +211,8 @@ public:
         return platformId_.has_value();
     }
 
+    int systemModuleVersion() const;
+
     std::string toString() const;
     static Describe fromString(const std::string& str);
 

--- a/hal/src/gcc/device_config.h
+++ b/hal/src/gcc/device_config.h
@@ -20,9 +20,10 @@
 
 #include <string>
 #include <stdexcept>
-#include <cstring>
 #include <vector>
 #include <optional>
+#include <cstring>
+#include <cstdint>
 
 #include "filesystem.h"
 #include "spark_protocol_functions.h"
@@ -49,28 +50,28 @@ public:
         return func_;
     }
 
-    ModuleDependencyInfo& index(int index) {
+    ModuleDependencyInfo& index(uint8_t index) {
         index_ = index;
         return *this;
     }
 
-    int index() const {
+    uint8_t index() const {
         return index_;
     }
 
-    ModuleDependencyInfo& version(int version) {
+    ModuleDependencyInfo& version(uint16_t version) {
         version_ = version;
         return *this;
     }
 
-    int version() const {
+    uint16_t version() const {
         return version_;
     }
 
 private:
     module_function_t func_;
-    int index_;
-    int version_;
+    uint8_t index_;
+    uint16_t version_;
 };
 
 class ModuleInfo {
@@ -79,7 +80,7 @@ public:
 
     ModuleInfo() :
             func_(MODULE_FUNCTION_NONE),
-            storage_(MODULE_STORE_MAIN),
+            store_(MODULE_STORE_MAIN),
             maxSize_(0),
             index_(0),
             version_(0),
@@ -96,21 +97,21 @@ public:
         return func_;
     }
 
-    ModuleInfo& index(int index) {
+    ModuleInfo& index(uint8_t index) {
         index_ = index;
         return *this;
     }
 
-    int index() const {
+    uint8_t index() const {
         return index_;
     }
 
-    ModuleInfo& version(int version) {
+    ModuleInfo& version(uint16_t version) {
         version_ = version;
         return *this;
     }
 
-    int version() const {
+    uint16_t version() const {
         return version_;
     }
 
@@ -123,39 +124,39 @@ public:
         return deps_;
     }
 
-    ModuleInfo& storage(module_store_t storage) {
-        storage_ = storage;
+    ModuleInfo& store(module_store_t store) {
+        store_ = store;
         return *this;
     }
 
-    module_store_t storage() const {
-        return storage_;
+    module_store_t store() const {
+        return store_;
     }
 
-    ModuleInfo& maximumSize(size_t size) {
+    ModuleInfo& maximumSize(uint32_t size) {
         maxSize_ = size;
         return *this;
     }
 
-    size_t maximumSize() const {
+    uint32_t maximumSize() const {
         return maxSize_;
     }
 
-    ModuleInfo& validityChecked(int flags) {
+    ModuleInfo& validityChecked(uint16_t flags) {
         validChecked_ = flags;
         return *this;
     }
 
-    int validityChecked() const {
+    uint16_t validityChecked() const {
         return validChecked_;
     }
 
-    ModuleInfo& validityResult(int flags) {
+    ModuleInfo& validityResult(uint16_t flags) {
         validResult_ = flags;
         return *this;
     }
 
-    int validityResult() const {
+    uint16_t validityResult() const {
         return validResult_;
     }
 
@@ -172,12 +173,12 @@ private:
     Dependencies deps_;
     std::string hash_;
     module_function_t func_;
-    module_store_t storage_;
-    size_t maxSize_;
-    int index_;
-    int version_;
-    int validChecked_;
-    int validResult_;
+    module_store_t store_;
+    uint32_t maxSize_;
+    uint8_t index_;
+    uint16_t version_;
+    uint16_t validChecked_;
+    uint16_t validResult_;
 };
 
 class Describe {
@@ -186,12 +187,12 @@ public:
 
     Describe() = default;
 
-    Describe& platformId(int platformId) {
+    Describe& platformId(uint16_t platformId) {
         platformId_ = platformId;
         return *this;
     }
 
-    int platformId() const {
+    uint16_t platformId() const {
         return platformId_.value_or(0);
     }
 
@@ -213,7 +214,7 @@ public:
 
 private:
     Modules modules_;
-    std::optional<int> platformId_;
+    std::optional<uint16_t> platformId_;
 };
 
 } // namespace config
@@ -239,7 +240,7 @@ struct Configuration
     std::string describe;
     uint16_t log_level = 0;
     ProtocolFactory protocol = PROTOCOL_LIGHTSSL;
-    int platform_id;
+    uint16_t platform_id;
 };
 
 /**
@@ -252,7 +253,7 @@ struct DeviceConfig
     uint8_t device_key[1024];
     uint8_t server_key[1024];
     ProtocolFactory protocol;
-    int platform_id;
+    uint16_t platform_id;
 
     void read(Configuration& configuration);
 

--- a/hal/src/gcc/eeprom_hal.cpp
+++ b/hal/src/gcc/eeprom_hal.cpp
@@ -23,6 +23,8 @@
 #include <string.h>
 #include <string>
 
+using namespace particle;
+
 /*
  * Implements eeprom either as a transient storage,
  * or as a persisted storage, depending upon if the file exists.

--- a/hal/src/gcc/filesystem.cpp
+++ b/hal/src/gcc/filesystem.cpp
@@ -1,13 +1,13 @@
-#include <string>
-#include <string.h>
-#include <stddef.h>
 #include <cstdio>
 #include <stdexcept>
+#include <fstream>
+
 #include "service_debug.h"
 #include "filesystem.h"
 
 const char* rootDir = NULL;
 
+using namespace particle;
 using namespace std;
 
 void set_root_dir(const char* dir) {
@@ -29,6 +29,20 @@ bool exists_file(const char* filename)
 	} else {
 		return false;
 	}
+}
+
+std::string read_file(const std::string& filename)
+{
+    std::ifstream in(filename, std::ios::in | std::ios::binary);
+    in.seekg(0, std::ios::end);
+    auto size = in.tellg();
+    if (size == (std::ifstream::pos_type)-1) {
+        throw std::runtime_error("Failed to determine file size");
+    }
+    in.seekg(0);
+    std::string str(size, '\0');
+    in.read(&str[0], size);
+    return str;
 }
 
 void read_file(const char* filename, void* data, size_t length)

--- a/hal/src/gcc/filesystem.cpp
+++ b/hal/src/gcc/filesystem.cpp
@@ -19,11 +19,11 @@ bool exists_file(const char* filename)
 
 std::string read_file(const std::string& filename)
 {
-    std::ifstream in(filename, std::ios::in | std::ios::binary);
+    std::ifstream in(filename, std::ios::binary);
     in.seekg(0, std::ios::end);
     auto size = in.tellg();
     if (size == (std::ifstream::pos_type)-1) {
-        throw std::runtime_error("Failed to determine file size");
+        throw std::runtime_error("Failed to read file");
     }
     in.seekg(0);
     std::string str(size, '\0');

--- a/hal/src/gcc/filesystem.cpp
+++ b/hal/src/gcc/filesystem.cpp
@@ -1,9 +1,15 @@
 #include <cstdio>
 #include <stdexcept>
 #include <fstream>
+#include <filesystem>
+#include <random>
+
+#include <boost/algorithm/hex.hpp>
 
 #include "service_debug.h"
 #include "filesystem.h"
+
+namespace fs = std::filesystem;
 
 namespace particle {
 
@@ -20,14 +26,20 @@ bool exists_file(const char* filename)
 std::string read_file(const std::string& filename)
 {
     std::ifstream in(filename, std::ios::binary);
+    if (in.fail()) {
+        throw std::runtime_error("Failed to open file");
+    }
     in.seekg(0, std::ios::end);
     auto size = in.tellg();
     if (size == (std::ifstream::pos_type)-1) {
         throw std::runtime_error("Failed to read file");
     }
-    in.seekg(0);
     std::string str(size, '\0');
+    in.seekg(0);
     in.read(&str[0], size);
+    if (in.fail()) {
+        throw std::runtime_error("Failed to read file");
+    }
     return str;
 }
 
@@ -45,6 +57,17 @@ void read_file(const char* filename, void* data, size_t length)
     }
 }
 
+void write_file(const std::string& filename, const std::string& data)
+{
+    std::ofstream out(filename, std::ios::binary | std::ios::trunc);
+    if (out.fail()) {
+        throw std::runtime_error("Failed to create file");
+    }
+    out.write(data.data(), data.size());
+    if (out.fail()) {
+        throw std::runtime_error("Failed to write to file");
+    }
+}
 
 void write_file(const char* filename, const void* data, size_t length)
 {
@@ -58,6 +81,18 @@ void write_file(const char* filename, const void* data, size_t length)
     {
         throw std::invalid_argument(std::string("unable to write file '") + filename + "'");
     }
+}
+
+std::string temp_file_name(const std::string& prefix, const std::string& suffix)
+{
+    std::random_device rd;
+    std::uniform_int_distribution<int> dist(0, 255);
+    std::string rand(16, '\0');
+    for (size_t i = 0; i < rand.size(); ++i) {
+        rand[i] = dist(rd);
+    }
+    auto path = fs::temp_directory_path().append(prefix + boost::algorithm::hex(rand) + suffix);
+    return path.string();
 }
 
 } // namespace particle

--- a/hal/src/gcc/filesystem.cpp
+++ b/hal/src/gcc/filesystem.cpp
@@ -25,22 +25,15 @@ bool exists_file(const char* filename)
 
 std::string read_file(const std::string& filename)
 {
-    std::ifstream in(filename, std::ios::binary);
-    if (in.fail()) {
-        throw std::runtime_error("Failed to open file");
-    }
+    std::ifstream in;
+    in.exceptions(std::ios::badbit | std::ios::failbit);
+    in.open(filename, std::ios::binary);
     in.seekg(0, std::ios::end);
-    auto size = in.tellg();
-    if (size == (std::ifstream::pos_type)-1) {
-        throw std::runtime_error("Failed to read file");
-    }
-    std::string str(size, '\0');
+    size_t size = in.tellg();
     in.seekg(0);
-    in.read(&str[0], size);
-    if (in.fail()) {
-        throw std::runtime_error("Failed to read file");
-    }
-    return str;
+    std::string data(size, '\0');
+    in.read(data.data(), size);
+    return data;
 }
 
 void read_file(const char* filename, void* data, size_t length)
@@ -59,14 +52,10 @@ void read_file(const char* filename, void* data, size_t length)
 
 void write_file(const std::string& filename, const std::string& data)
 {
-    std::ofstream out(filename, std::ios::binary | std::ios::trunc);
-    if (out.fail()) {
-        throw std::runtime_error("Failed to create file");
-    }
+    std::ofstream out;
+    out.exceptions(std::ios::badbit | std::ios::failbit);
+    out.open(filename, std::ios::binary | std::ios::trunc);
     out.write(data.data(), data.size());
-    if (out.fail()) {
-        throw std::runtime_error("Failed to write to file");
-    }
 }
 
 void write_file(const char* filename, const void* data, size_t length)
@@ -87,11 +76,11 @@ std::string temp_file_name(const std::string& prefix, const std::string& suffix)
 {
     std::random_device rd;
     std::uniform_int_distribution<int> dist(0, 255);
-    std::string rand(16, '\0');
+    std::string rand(8, '\0');
     for (size_t i = 0; i < rand.size(); ++i) {
         rand[i] = dist(rd);
     }
-    auto path = fs::temp_directory_path().append(prefix + boost::algorithm::hex(rand) + suffix);
+    auto path = fs::temp_directory_path().append(prefix + boost::algorithm::hex_lower(rand) + suffix);
     return path.string();
 }
 

--- a/hal/src/gcc/filesystem.cpp
+++ b/hal/src/gcc/filesystem.cpp
@@ -5,30 +5,16 @@
 #include "service_debug.h"
 #include "filesystem.h"
 
-const char* rootDir = NULL;
-
-using namespace particle;
-using namespace std;
-
-void set_root_dir(const char* dir) {
-    rootDir = dir;
-}
+namespace particle {
 
 bool exists_file(const char* filename)
 {
-    char buf[256];
-    buf[0] = 0;
-    if (rootDir) {
-        strcpy(buf, rootDir);
-        strcat(buf, "/");
+    if (FILE *file = fopen(filename, "r")) {
+        fclose(file);
+        return true;
+    } else {
+        return false;
     }
-    strcat(buf, filename);
-    if (FILE *file = fopen(buf, "r")) {
-		fclose(file);
-		return true;
-	} else {
-		return false;
-	}
 }
 
 std::string read_file(const std::string& filename)
@@ -47,44 +33,31 @@ std::string read_file(const std::string& filename)
 
 void read_file(const char* filename, void* data, size_t length)
 {
-    char buf[256];
-    buf[0] = 0;
-    if (rootDir) {
-        strcpy(buf, rootDir);
-        strcat(buf, "/");
-    }
-    strcat(buf, filename);
-    FILE *f = fopen(buf, "rb");
+    FILE *f = fopen(filename, "rb");
     if (f!=NULL) {
         length = fread(data, 1, length, f);
-        INFO("read file %s length %d", buf, length);
+        INFO("read file %s length %d", filename, length);
         fclose(f);
     }
     else
     {
-        throw invalid_argument(string("unable to read file '") + buf + "'");
+        throw std::invalid_argument(std::string("unable to read file '") + filename + "'");
     }
 }
 
 
 void write_file(const char* filename, const void* data, size_t length)
 {
-    char buf[256];
-    buf[0] = 0;
-    if (rootDir) {
-        strcpy(buf, rootDir);
-        strcat(buf, "/");
-    }
-    strcat(buf, filename);
-    FILE *f = fopen(buf, "wb");
+    FILE *f = fopen(filename, "wb");
     if (f!=NULL) {
         length = fwrite(data, 1, length, f);
-        INFO("written file %s length %d", buf, length);
+        INFO("written file %s length %d", filename, length);
         fclose(f);
     }
     else
     {
-        throw invalid_argument(string("unable to write file '") + buf + "'");
+        throw std::invalid_argument(std::string("unable to write file '") + filename + "'");
     }
 }
 
+} // namespace particle

--- a/hal/src/gcc/filesystem.h
+++ b/hal/src/gcc/filesystem.h
@@ -17,9 +17,6 @@ void read_file(const char* filename, void* data, size_t length);
 void write_file(const char* filename, const void* data, size_t length);
 bool exists_file(const char* filename);
 
-
-void set_root_dir(const char* dir);
-
 } // namespace particle
 
 #endif	/* FILESYSTEM_H */

--- a/hal/src/gcc/filesystem.h
+++ b/hal/src/gcc/filesystem.h
@@ -9,6 +9,7 @@
 #define	FILESYSTEM_H
 
 #include <string>
+#include <cstddef>
 
 namespace particle {
 

--- a/hal/src/gcc/filesystem.h
+++ b/hal/src/gcc/filesystem.h
@@ -14,10 +14,11 @@ namespace particle {
 
 std::string read_file(const std::string& filename);
 void read_file(const char* filename, void* data, size_t length);
+void write_file(const std::string& filename, const std::string& data);
 void write_file(const char* filename, const void* data, size_t length);
 bool exists_file(const char* filename);
+std::string temp_file_name(const std::string& prefix = "", const std::string& suffix = "");
 
 } // namespace particle
 
 #endif	/* FILESYSTEM_H */
-

--- a/hal/src/gcc/filesystem.h
+++ b/hal/src/gcc/filesystem.h
@@ -8,8 +8,11 @@
 #ifndef FILESYSTEM_H
 #define	FILESYSTEM_H
 
-#include <stddef.h>
+#include <string>
 
+namespace particle {
+
+std::string read_file(const std::string& filename);
 void read_file(const char* filename, void* data, size_t length);
 void write_file(const char* filename, const void* data, size_t length);
 bool exists_file(const char* filename);
@@ -17,6 +20,7 @@ bool exists_file(const char* filename);
 
 void set_root_dir(const char* dir);
 
+} // namespace particle
 
 #endif	/* FILESYSTEM_H */
 

--- a/hal/src/gcc/include.mk
+++ b/hal/src/gcc/include.mk
@@ -20,7 +20,7 @@ LIBS += boost_system-mgw48-mt-1_57 ws2_32 wsock32
 else
 LIBS += boost_system
 endif
-LIBS += boost_program_options boost_random boost_thread
+LIBS += boost_program_options boost_random boost_thread boost_json
 
 LIB_DIRS += $(BOOST_ROOT)/stage/lib
 

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -1105,7 +1105,7 @@ void Spark_Protocol_Init(void)
         registerSystemSubscriptions();
 
 #if PLATFORM_ID == PLATFORM_GCC
-        bool isCellular = (udp && deviceConfig.platform_id != PLATFORM_ARGON);
+        bool isCellular = (udp && deviceConfig.platform_id != PLATFORM_GCC && deviceConfig.platform_id != PLATFORM_ARGON);
         protocol::connection_properties_t connProp = {};
         connProp.size = sizeof(connProp);
         connProp.keepalive_source = protocol::KeepAliveSource::SYSTEM;

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -1090,8 +1090,13 @@ void Spark_Protocol_Init(void)
         }
 #endif // HAL_PLATFORM_COMPRESSED_OTA
 
+#if PLATFORM_ID != PLATFORM_GCC
         spark_protocol_set_connection_property(sp, protocol::Connection::SYSTEM_MODULE_VERSION, MODULE_VERSION,
                 nullptr, nullptr);
+#else
+        spark_protocol_set_connection_property(sp, protocol::Connection::SYSTEM_MODULE_VERSION, deviceConfig.describe.systemModuleVersion(),
+                nullptr, nullptr);
+#endif // PLATFORM_ID != PLATFORM_GCC
         spark_protocol_set_connection_property(sp, protocol::Connection::MAX_BINARY_SIZE, HAL_OTA_FlashLength(),
                 nullptr, nullptr);
         spark_protocol_set_connection_property(sp, protocol::Connection::OTA_CHUNK_SIZE, HAL_OTA_ChunkSize(),
@@ -1105,7 +1110,7 @@ void Spark_Protocol_Init(void)
         registerSystemSubscriptions();
 
 #if PLATFORM_ID == PLATFORM_GCC
-        bool isCellular = (udp && deviceConfig.platform_id != PLATFORM_GCC && deviceConfig.platform_id != PLATFORM_ARGON);
+        bool isCellular = (udp && deviceConfig.platform_id != PLATFORM_GCC && deviceConfig.platform_id != PLATFORM_ARGON && deviceConfig.platform_id != PLATFORM_P2);
         protocol::connection_properties_t connProp = {};
         connProp.size = sizeof(connProp);
         connProp.keepalive_source = protocol::KeepAliveSource::SYSTEM;

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -1107,8 +1107,7 @@ void Spark_Protocol_Init(void)
         registerSystemSubscriptions();
 
 #if PLATFORM_ID == PLATFORM_GCC
-        bool isCellular = (platformId == PLATFORM_GCC || platformId == PLATFORM_BORON || platformId == PLATFORM_BSOM ||
-                platformId == PLATFORM_B5SOM || platformId == PLATFORM_TRACKER || platformId == PLATFORM_ESOMX);
+        bool isCellular = (udp && platformId != PLATFORM_ARGON);
         protocol::connection_properties_t connProp = {};
         connProp.size = sizeof(connProp);
         connProp.keepalive_source = protocol::KeepAliveSource::SYSTEM;

--- a/system/src/system_cloud_internal.h
+++ b/system/src/system_cloud_internal.h
@@ -224,10 +224,6 @@ int getCloudVariableInfo(size_t index, const char** name, int* type = nullptr);
 size_t cloudFunctionCount();
 int getCloudFunctionInfo(size_t index, const char** name);
 
-#if PLATFORM_ID == PLATFORM_GCC
-int platformIdOverride();
-#endif
-
 } // namespace particle
 
 #ifdef __cplusplus

--- a/wiring/inc/spark_wiring_version.h
+++ b/wiring/inc/spark_wiring_version.h
@@ -42,9 +42,9 @@ struct __ApplicationProductVersion {
 #undef PRODUCT_ID
 #endif
 
-#if PLATFORM_ID != PLATFORM_GCC
 #define PRODUCT_ID(x) _Pragma ("GCC error \"The PRODUCT_ID macro must be removed from your firmware source code. \
 The same compiled firmware binary may be used in multiple products that share the same platform and functionality.\"")
+
 /*
  * PRODUCT_ID and PRODUCT_VERSION will be added to the beginning of the suffix by the linker.
  *
@@ -69,6 +69,7 @@ The same compiled firmware binary may be used in multiple products that share th
  * }
  *
  */
+#if PLATFORM_ID != PLATFORM_GCC
 #define PRODUCT_VERSION(x) \
         __ApplicationProductVersion __appProductVersion(x); \
         __attribute__((externally_visible, section(".modinfo.product_version"))) uint16_t __system_product_version = (x); \
@@ -76,8 +77,8 @@ The same compiled firmware binary may be used in multiple products that share th
         __ApplicationProductID __appProductID(PLATFORM_ID); \
         __attribute__((externally_visible, section(".modinfo.product_id"))) uint16_t __system_product_id = (PLATFORM_ID);
 #else
-#define PRODUCT_ID(x)
-#define PRODUCT_VERSION(x)
+#define PRODUCT_VERSION(x) _Pragma ("GCC warning \"The PRODUCT_VERSION macro is ignored on the GCC platform. \
+Use the --product_version argument instead.\"")
 #endif // PLATFORM_ID != PLATFORM_GCC
 
 #endif	/* SPARK_WIRING_VERSION_H */


### PR DESCRIPTION
### Problem

The GCC platform only supports on-demand OTA updates which prevents us from using it for testing multistage and product updates.

### Solution

- Allow overriding the describe message sent by the virtual device and preserve the module info between device "resets" during an update.
- Allow setting the product version via command line arguments.

### Steps to Test

- Build a test application and run it with a `--describe` argument followed by the path to the device's describe message in JSON format.
- Flash a user application requiring a higher version of Device OS than what is specified in the describe data to the virtual device.
- Validate that the virtual device receives all necessary modules and gets "updated" to the target Device OS version.

### References

- sc-106316
