### PR TITLE
feature/sc-98414/toolchain-buildscripts-v1.11.0

### DIFF
--- a/.workbench/manifest.json
+++ b/.workbench/manifest.json
@@ -6,8 +6,46 @@
             "firmware": "deviceOS@source",
             "compilers": "gcc-arm@10.2.1",
             "tools": "buildtools@1.1.1",
-            "scripts": "buildscripts@1.10.0",
+            "scripts": "buildscripts@1.11.0",
             "debuggers": "openocd@0.11.0-particle.4"
         }
-    ]
+    ],
+    "scripts": {
+        "windows": {
+            "x64": [
+                {
+                    "name": "buildscripts",
+                    "version": "1.11.0",
+                    "main": ".",
+                    "url": "https://binaries.particle.io/buildscripts/windows/x64/v1.11.0.tar.gz",
+                    "sha256": "941b864f276f0c45253233b7ad8a65868daae9690abb2258c231858a29312c42"
+                }
+            ],
+            "x86": []
+        },
+        "darwin": {
+            "x64": [
+                {
+                    "name": "buildscripts",
+                    "version": "1.11.0",
+                    "main": ".",
+                    "url": "https://binaries.particle.io/buildscripts/darwin/x64/v1.11.0.tar.gz",
+                    "sha256": "941b864f276f0c45253233b7ad8a65868daae9690abb2258c231858a29312c42"
+                }
+            ],
+            "x86": []
+        },
+        "linux": {
+            "x64": [
+                {
+                    "name": "buildscripts",
+                    "version": "1.11.0",
+                    "main": ".",
+                    "url": "https://binaries.particle.io/buildscripts/linux/x64/v1.11.0.tar.gz",
+                    "sha256": "941b864f276f0c45253233b7ad8a65868daae9690abb2258c231858a29312c42"
+                }
+            ],
+            "x86": []
+        }
+    }
 }


### PR DESCRIPTION
### Problem

We'll need to use modular debug builds for the Device OS `v4.x` and `v5.x` lines in order to improve end-user UX and to ultimately support the `p2` platform

### Solution

Update `.workbench/manifest.json` file with the new `buildscripts@1.11.0` dependency which enables modular debug builds

### Steps to Test

1. Follow the [installation instructions](https://github.com/particle-iot/cli/tree/main/packages/cli#installation) for CLI-vNext (aka "Delorean")
2. Verify the `device@source` toolchain uses the `buildscripts@1.11.0` dependency: `prtcl toolchain:view source:/path/to/device-os-repo` (consult `--help` if you need)
3. If you had previously installed the `buildscripts@1.11.0` dependency, remove it: `rm -rf ~/.particle/toolchains/buildscripts/1.11.0`
4. Follow the steps to enable the `deviceOS@source` toolchain within Particle Workbench ([docs](https://docs.particle.io/troubleshooting/guides/build-tools-troubleshooting/troubleshooting-the-particle-workbench/#working-with-a-custom-deviceos-build))
5. Follow the guide to debug Gen3 hardware ([docs](https://docs.particle.io/getting-started/developer-tools/workbench/#debugging-3rd-generation-))
6. Attempt to debug a supported Particle device (repeat for each: `argon`, `boron`, etc)


### References

https://app.shortcut.com/particle/story/98414/workbench-support-to-debug-modular-firmware
https://github.com/particle-iot/firmware-private/pull/388
https://github.com/particle-iot/cli/pull/137

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [x] Added to CHANGELOG.md after merging (add links to docs and issues)
