### PR TITLE
[p2] Flash supports page write and other fixes

### DIFF
--- a/hal/src/rtl872x/exflash_hal.cpp
+++ b/hal/src/rtl872x/exflash_hal.cpp
@@ -113,14 +113,24 @@ static bool is_block_erased(uintptr_t addr, size_t size);
 
 __attribute__((section(".ram.text"), noinline))
 static int perform_write(uintptr_t addr, const uint8_t* data, size_t size) {
+    // There seems to be an alignment check inside FLASH_TxData256B()
+    static __attribute__((aligned(32))) uint8_t aligned_buffer[256];
+
+    // To prevent being interrupted by auto mode reading, the user mode operation
+    // should be protected until it is finished.
+    // For more protections, please refer to AN0400 Ameba-D Application Note Chapter 18 Flash Operation
+    __disable_irq();
+
     // XXX: No way of knowing whether the write operation succeeded or not
     for (size_t b = 0; b < size;) {
-        size_t rem = MIN(8, (size - b));
-        // XXX: do not use 12 byte writes, sometimes we get deadlocked
-        // TxData256 doesn't seem to work
-        FLASH_TxData12B(addr + b, (uint8_t)rem, (uint8_t*)data + b);
+        size_t rem = MIN(256, (size - b));
+        memcpy(aligned_buffer, (uint8_t*)data + b, rem);
+        FLASH_TxData256B(addr + b, rem,  aligned_buffer);
         b += rem;
     }
+
+    __enable_irq();
+
     return SYSTEM_ERROR_NONE;
 }
 

--- a/hal/src/rtl872x/exflash_hal.cpp
+++ b/hal/src/rtl872x/exflash_hal.cpp
@@ -116,11 +116,6 @@ static int perform_write(uintptr_t addr, const uint8_t* data, size_t size) {
     // There seems to be an alignment check inside FLASH_TxData256B()
     static __attribute__((aligned(32))) uint8_t aligned_buffer[256];
 
-    // To prevent being interrupted by auto mode reading, the user mode operation
-    // should be protected until it is finished.
-    // For more protections, please refer to AN0400 Ameba-D Application Note Chapter 18 Flash Operation
-    __disable_irq();
-
     // XXX: No way of knowing whether the write operation succeeded or not
     for (size_t b = 0; b < size;) {
         size_t rem = MIN(256, (size - b));
@@ -128,8 +123,6 @@ static int perform_write(uintptr_t addr, const uint8_t* data, size_t size) {
         FLASH_TxData256B(addr + b, rem,  aligned_buffer);
         b += rem;
     }
-
-    __enable_irq();
 
     return SYSTEM_ERROR_NONE;
 }

--- a/user/tests/wiring/no_fixture_spi/spix.cpp
+++ b/user/tests/wiring/no_fixture_spi/spix.cpp
@@ -136,12 +136,13 @@ test(SPIX_03_SPI_Begin_With_Mode)
 
     // HAL_SPI_INTERFACE1 does not support slave mode on NRF52840
 #if HAL_PLATFORM_RTL872X
-    SPI.begin(SPI_MODE_SLAVE);
-    querySpiInfo(HAL_SPI_INTERFACE1, &info);
+    // HAL_SPI_INTERFACE1  does not support slave mode on P2
+    SPI1.begin(SPI_MODE_SLAVE);
+    querySpiInfo(HAL_SPI_INTERFACE2, &info);
     assertTrue(info.enabled);
     assertEqual(info.mode, SPI_MODE_SLAVE);
 #if PLATFORM_ID == PLATFORM_P2
-    assertEqual(info.ss_pin, S3);
+    assertEqual(info.ss_pin, D5);
 #else
 #error "Unknown platform!"
 #endif

--- a/user/tests/wiring/spi_master_slave/spi_master/spi_master.cpp
+++ b/user/tests/wiring/spi_master_slave/spi_master/spi_master.cpp
@@ -142,17 +142,17 @@
  *********************************************************************************************
  *
  * P2 Wiring diagrams
- * 
+ *
  * SPI1/SPI1                       SPI/SPI1 (SPI can't be used as slave)
  * Master: SPI1  (USE_SPI=SPI1)    Master: SPI (USE_SPI=SPI)
  * Slave:  SPI1  (USE_SPI=SPI1)    Slave:  SPI1 (USE_SPI=SPI1)
- * 
+ *
  * Master             Slave       Master              Slave
  * CS   D5 <-------> D5 CS        CS   S3 <---------> D5 CS
- * MISO D4 <-------> D3 MISO      MISO S1 <---------> D3 MISO
- * MOSI D3 <-------> D2 MOSI      MOSI S0 <---------> D2 MOSI
- * SCK  D2 <-------> D4 SCK       SCK  S2 <---------> D4 SCK
- * 
+ * MISO D3 <-------> D3 MISO      MISO S1 <---------> D3 MISO
+ * MOSI D2 <-------> D2 MOSI      MOSI S0 <---------> D2 MOSI
+ * SCK  D4 <-------> D4 SCK       SCK  S2 <---------> D4 SCK
+ *
  *********************************************************************************************
  */
 
@@ -163,7 +163,7 @@ static uint8_t SPI_Master_Rx_Buffer[TRANSFER_LENGTH_2];
 static uint8_t SPI_Master_Rx_Buffer_Supper[1024];
 static volatile uint8_t DMA_Completed_Flag = 0;
 
-static const char* txString = 
+static const char* txString =
 "urjlU1tW177HwJsR6TylreMKge225qyLaIizW5IhXHkWgTGpH2fZtm2Od20Ne3Q81fxfUl7zoFaF\
 Z6smPzkpTGNSxGg7TCEiE2f19951tKxjFCB4Se86R4CaWW2YZF0mogirgsu2qRMGe4mC9QlJkCgXP\
 bgSVV1mc2xsZcu4bj0pbmPIhxkuyAHe4cVK3gLpWEGTadtAn2k66rOFNBdfPaE0cUY3wwXlVQ9yDl\
@@ -565,7 +565,7 @@ test(25_SPI_Master_Slave_Master_Reception)
     MY_SPI.transfer(nullptr, SPI_Master_Rx_Buffer_Supper, strlen(txString), SPI_DMA_Completed_Callback);
     while(DMA_Completed_Flag == 0);
     digitalWrite(MY_CS, HIGH);
-    
+
     // Serial.printf("Length: %d\r\n", strlen((const char *)SPI_Master_Rx_Buffer_Supper));
     // for (size_t len = 0; len < strlen((const char *)SPI_Master_Rx_Buffer_Supper); len++) {
     //     Serial.printf("%c", SPI_Master_Rx_Buffer_Supper[len]);


### PR DESCRIPTION
### Problem
1. To improve firmware download speed, we need to make use of `FLASH_TxData256B()`

2. We're using 80MHz in the P2 flash clock configuration while MX25R32 requires up to 60MHz clock speed.
<img width="548" alt="Screen Shot 2022-07-13 at 15 10 48" src="https://user-images.githubusercontent.com/7424522/178672929-9d25be6e-e74d-4262-8b12-03a3cfe7675e.png">

3. Minor fixes for SPI unit test

**NOTE: This PR requires updating the prebootloader!**

### Steps to Test

1. Run `usb-dfu` to update DVOS to confirm the speed is improved
1. Update the prebootloader to observe the flash clock with an oscilloscope
1. Run the unit test `wiring/no_fixture_spi`

### References



---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
