### PR TITLE
[linker] make sure that FreeRTOS task/timer symbols are coalesced in bss section, disable LTO for FreeRTOS sources as well

### DIFF
--- a/build/arm-tools.mk
+++ b/build/arm-tools.mk
@@ -95,8 +95,9 @@ CFLAGS += -DARM_CPU_$(shell echo $(ARM_CPU) | tr '-' '_' | tr 'a-z' 'A-Z')
 #
 # -fno-use-cxa-atexit makes sure that destructors for statically created C++ objects are never called,
 # which saves us some flash space.
-CPPFLAGS += -flto -ffat-lto-objects -DPARTICLE_COMPILE_LTO_FAT -fno-use-cxa-atexit
-CONLYFLAGS += -flto -ffat-lto-objects -DPARTICLE_COMPILE_LTO_FAT
+LTO_FLAGS = -flto -ffat-lto-objects -DPARTICLE_COMPILE_LTO_FAT
+CPPFLAGS += $(LTO_FLAGS) -fno-use-cxa-atexit
+CONLYFLAGS += $(LTO_FLAGS)
 LDFLAGS += -fno-use-cxa-atexit
 
 ifeq ($(COMPILE_LTO),y)

--- a/build/arm/linker/linker_freertos_task_symbols.ld
+++ b/build/arm/linker/linker_freertos_task_symbols.ld
@@ -1,0 +1,4 @@
+__rtos_capture_start = .;
+*tasks.o(.bss COMMON .bss*)
+*timers*.o(.bss COMMON .bss*)
+__rtos_capture_end = .;

--- a/modules/shared/nRF52840/linker_system_part1_common.ld
+++ b/modules/shared/nRF52840/linker_system_part1_common.ld
@@ -127,6 +127,10 @@ SECTIONS
         . = ALIGN(4);
         /* This is used by the startup in order to initialize the .bss secion */
         link_bss_location = .;
+
+        /* Coalesces FreeRTOS symbols into a single location for some tooling */
+        INCLUDE linker_freertos_task_symbols.ld
+
         *(.bss*)
         *(COMMON)
         . = ALIGN(4);

--- a/modules/shared/rtl872x/linker_system_part1_common.ld
+++ b/modules/shared/rtl872x/linker_system_part1_common.ld
@@ -183,6 +183,10 @@ SECTIONS
         . = ALIGN(4);
         /* This is used by the startup in order to initialize the .bss secion */
         link_bss_location = .;
+
+        /* Coalesces FreeRTOS symbols into a single location for some tooling */
+        INCLUDE linker_freertos_task_symbols.ld
+
         *(.bss*)
         *(.image2.ram.bss*)
         *(.image2.net.ram.bss*)

--- a/third_party/freertos/build.mk
+++ b/third_party/freertos/build.mk
@@ -13,13 +13,3 @@ CSRC += $(TARGET_FREERTOS_SRC_PATH)/timers.c
 ifneq ("$(PLATFORM_FREERTOS)","")
 TARGET_FREERTOS_PORT_PATH = $(TARGET_FREERTOS_SRC_PATH)/portable/GCC/$(PLATFORM_FREERTOS)
 endif
-
-# FIXME
-ifeq ($(SOFTDEVICE_PRESENT),y)
-# We are building these in nrf5_sdk
-# CSRC += $(TARGET_NRF5_SDK_PATH)/nrf5_sdk/external/freertos/portable/GCC/nrf52/port.c
-# CSRC += $(TARGET_NRF5_SDK_PATH)/nrf5_sdk/external/freertos/portable/CMSIS/nrf52/port_cmsis.c
-# CSRC += $(TARGET_NRF5_SDK_PATH)/nrf5_sdk/external/freertos/portable/CMSIS/nrf52/port_cmsis_systick.c
-else
-# CSRC += $(call target_files,$(TARGET_FREERTOS_PORT_PATH)/,*.c)
-endif

--- a/third_party/freertos/makefile
+++ b/third_party/freertos/makefile
@@ -18,3 +18,7 @@ DEPENDENCIES += dynalib services third_party/ambd_sdk
 
 PROJECT_ROOT ?= ../..
 include ../../build/arm-tlm.mk
+
+# Disable LTO for FreeRTOS sources to keep some of the symbols in a single coalescent location
+CONLYFLAGS_ORIGINAL := $(CONLYFLAGS)
+CONLYFLAGS = $(filter-out $(LTO_FLAGS),$(CONLYFLAGS_ORIGINAL))


### PR DESCRIPTION
### Problem

Due to refactoring of linker files in #1953 (and those changes actually coming after P2 merge) we lost a quirk in linker files which coalesced FreeRTOS task/timer symbols into a single location in .bss for some of the tooling that we use (#2399). This also wasn't really working with LTO enabled as is the case with Gen 3 system part builds.

### Solution

Fix that.

### Steps to Test

Build out of this branch, check system-part map files, `pxCurrentTCB` and other FreeRTOS symbols should be located in `.bss` section between `__rtos_capture_start` and `__rtos_capture_end`.

### Example App

N/A

### References

- #2399
- #1852

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
