### PR TITLE
[p2][wifi] Add more complete WiFi network configuration information for P2

### DIFF
--- a/hal/network/ncp_client/realtek/rtl_ncp_client.cpp
+++ b/hal/network/ncp_client/realtek/rtl_ncp_client.cpp
@@ -294,8 +294,7 @@ int RealtekNcpClient::getNetworkInfo(WifiNetworkInfo* info) {
     rtlError = wifi_get_channel(&channel_num);
     if (RTW_SUCCESS != rtlError) {
         LOG(WARN, "wifi_get_channel err: %d", rtlError);
-    }
-    else { 
+    } else { 
         // LOG(INFO, " chan %d\t  ", channel_num );
         info->channel(channel_num);
     }
@@ -304,8 +303,7 @@ int RealtekNcpClient::getNetworkInfo(WifiNetworkInfo* info) {
     rtlError = wext_get_ssid(WLAN0_NAME, (unsigned char *) ssid_buf);
     if (rtlError < 0) {
         LOG(WARN, "wext_get_ssid err: %d", rtlError);
-    }
-    else {
+    } else {
         // LOG(INFO," ssid: %s", ssid_buf);
         info->ssid(ssid_buf);
     }
@@ -314,8 +312,7 @@ int RealtekNcpClient::getNetworkInfo(WifiNetworkInfo* info) {
     rtlError = wifi_get_rssi(&raw_rssi);
     if (rtlError < 0) {
         LOG(WARN, "wifi_get_rssi err: %d", rtlError);
-    }
-    else {
+    } else {
         // LOG(INFO," rssi: %d", raw_rssi);
         info->rssi(raw_rssi);
     }
@@ -324,8 +321,7 @@ int RealtekNcpClient::getNetworkInfo(WifiNetworkInfo* info) {
     rtlError = wext_get_bssid(WLAN0_NAME, bssid_mac.data);
     if (rtlError < 0) {
         LOG(WARN, "wext_get_bssid err: %d", rtlError);
-    }
-    else {
+    } else {
         info->bssid(bssid_mac);
         // uint8_t* bssid_buf = bssid_mac.data;
         // LOG(INFO, " bssid: %02x:%02x:%02x:%02x:%02x:%02x ", bssid_buf[0],  bssid_buf[1],  bssid_buf[2],  bssid_buf[3],  bssid_buf[4],  bssid_buf[5] );

--- a/hal/network/ncp_client/realtek/rtl_ncp_client.cpp
+++ b/hal/network/ncp_client/realtek/rtl_ncp_client.cpp
@@ -288,6 +288,7 @@ int RealtekNcpClient::connect(const char* ssid, const MacAddress& bssid, WifiSec
 
 int RealtekNcpClient::getNetworkInfo(WifiNetworkInfo* info) {
     int rtlError = 0;
+    // LOG(INFO, "RNCP getNetworkInfo");
 
     int channel_num = 0;
     rtlError = wifi_get_channel(&channel_num);
@@ -295,18 +296,18 @@ int RealtekNcpClient::getNetworkInfo(WifiNetworkInfo* info) {
         LOG(WARN, "wifi_get_channel err: %d", rtlError);
     }
     else { 
-        LOG(INFO, " chan %d\t  ", channel_num );
+        // LOG(INFO, " chan %d\t  ", channel_num );
         info->channel(channel_num);
     }
 
-	char essid[33] = {};//32 octets for SSID, plus null terminator
-    rtlError = wext_get_ssid(WLAN0_NAME, (unsigned char *) essid);
+	char ssid_buf[33] = {};//32 octets for SSID, plus null terminator
+    rtlError = wext_get_ssid(WLAN0_NAME, (unsigned char *) ssid_buf);
     if (rtlError < 0) {
         LOG(WARN, "wext_get_ssid err: %d", rtlError);
     }
     else {
-        LOG(INFO," ssid: %s", essid);
-        info->ssid(essid);
+        // LOG(INFO," ssid: %s", ssid_buf);
+        info->ssid(ssid_buf);
     }
     
     int raw_rssi = 0;
@@ -315,19 +316,19 @@ int RealtekNcpClient::getNetworkInfo(WifiNetworkInfo* info) {
         LOG(WARN, "wifi_get_rssi err: %d", rtlError);
     }
     else {
-        LOG(INFO," rssi: %d", raw_rssi);
+        // LOG(INFO," rssi: %d", raw_rssi);
         info->rssi(raw_rssi);
     }
 
     MacAddress bssid_mac = INVALID_ZERO_MAC_ADDRESS;
-    rtlError = wifi_get_ap_bssid((unsigned char *)bssid_mac.data);
+    rtlError = wext_get_bssid(WLAN0_NAME, bssid_mac.data);
     if (rtlError < 0) {
-        LOG(WARN, "wifi_get_ap_bssid err: %d", rtlError);
+        LOG(WARN, "wext_get_bssid err: %d", rtlError);
     }
     else {
-        uint8_t* bssid_buf = bssid_mac.data;
         info->bssid(bssid_mac);
-        LOG(INFO, " bssid: %02x:%02x:%02x:%02x:%02x:%02x ", bssid_buf[0],  bssid_buf[1],  bssid_buf[2],  bssid_buf[3],  bssid_buf[4],  bssid_buf[5] );
+        // uint8_t* bssid_buf = bssid_mac.data;
+        // LOG(INFO, " bssid: %02x:%02x:%02x:%02x:%02x:%02x ", bssid_buf[0],  bssid_buf[1],  bssid_buf[2],  bssid_buf[3],  bssid_buf[4],  bssid_buf[5] );
     }
 
     //TODO reevaluate whether we should error out on any of the sub-queries

--- a/hal/network/ncp_client/realtek/rtl_ncp_client.cpp
+++ b/hal/network/ncp_client/realtek/rtl_ncp_client.cpp
@@ -20,6 +20,7 @@
 LOG_SOURCE_CATEGORY("ncp.rltk.client");
 
 #include "rtl_ncp_client.h"
+#include "addr_util.h"
 
 #include "gpio_hal.h"
 #include "timer_hal.h"
@@ -286,13 +287,51 @@ int RealtekNcpClient::connect(const char* ssid, const MacAddress& bssid, WifiSec
 }
 
 int RealtekNcpClient::getNetworkInfo(WifiNetworkInfo* info) {
-    int raw_rssi = 0;
-    int rtlError = wifi_get_rssi(&raw_rssi);
+    int rtlError = 0;
 
-    if (RTW_SUCCESS == rtlError) {
+    int channel_num = 0;
+    rtlError = wifi_get_channel(&channel_num);
+    if (RTW_SUCCESS != rtlError) {
+        LOG(WARN, "wifi_get_channel err: %d", rtlError);
+    }
+    else { 
+        LOG(INFO, " chan %d\t  ", channel_num );
+        info->channel(channel_num);
+    }
+
+	char essid[33] = {};//32 octets for SSID, plus null terminator
+    rtlError = wext_get_ssid(WLAN0_NAME, (unsigned char *) essid);
+    if (rtlError < 0) {
+        LOG(WARN, "wext_get_ssid err: %d", rtlError);
+    }
+    else {
+        LOG(INFO," ssid: %s", essid);
+        info->ssid(essid);
+    }
+    
+    int raw_rssi = 0;
+    rtlError = wifi_get_rssi(&raw_rssi);
+    if (rtlError < 0) {
+        LOG(WARN, "wifi_get_rssi err: %d", rtlError);
+    }
+    else {
+        LOG(INFO," rssi: %d", raw_rssi);
         info->rssi(raw_rssi);
     }
-    return rtl_error_to_system(rtlError);
+
+    MacAddress bssid_mac = INVALID_ZERO_MAC_ADDRESS;
+    rtlError = wifi_get_ap_bssid((unsigned char *)bssid_mac.data);
+    if (rtlError < 0) {
+        LOG(WARN, "wifi_get_ap_bssid err: %d", rtlError);
+    }
+    else {
+        uint8_t* bssid_buf = bssid_mac.data;
+        info->bssid(bssid_mac);
+        LOG(INFO, " bssid: %02x:%02x:%02x:%02x:%02x:%02x ", bssid_buf[0],  bssid_buf[1],  bssid_buf[2],  bssid_buf[3],  bssid_buf[4],  bssid_buf[5] );
+    }
+
+    //TODO reevaluate whether we should error out on any of the sub-queries
+    return SYSTEM_ERROR_NONE;
 }
 
 int RealtekNcpClient::scan(WifiScanCallback callback, void* data) {


### PR DESCRIPTION
<details>
  <summary>P2 wifi network configuration info provided by the `WiFi.wifi_config()` method was missing </summary>

</details>

### Problem

Provide more complete wifi_config information to the  `WiFi.wifi_config()` method

### Solution

Updated `RealtekNcpClient::getNetworkInfo(WifiNetworkInfo* info)` to fill in provided `WifiNetworkInfo` struct

### Steps to Test

connect to wifi network and verify network information is provided to a user app

### Example App

```c++


#include "Particle.h"


SYSTEM_THREAD(ENABLED);
SYSTEM_MODE(SEMI_AUTOMATIC);


SerialLogHandler logHandler(115200, LOG_LEVEL_INFO);

static void network_check() {
  // fetch the WLanConfig, which typically doesn't change after cloud connection is established
    Log.info("fetch wifi_config...");
    WLanConfig* wifi_cfg = WiFi.wifi_config();

    Log.info("wifi_config uaSSID: '%s' ",  wifi_cfg->uaSSID);

    Log.info("wifi_config BSSID: %02x:%02x:%02x:%02x:%02x:%02x",
        wifi_cfg->BSSID[0],  wifi_cfg->BSSID[1],  wifi_cfg->BSSID[2],  wifi_cfg->BSSID[3],  wifi_cfg->BSSID[4],  wifi_cfg->BSSID[5]);

    const uint8_t* mac_ptr =  wifi_cfg->nw.uaMacAddr;
    Log.info("wifi_config uaMacAddr: %02x:%02x:%02x:%02x:%02x:%02x ",
        mac_ptr[0],  mac_ptr[1],  mac_ptr[2],  mac_ptr[3],  mac_ptr[4],  mac_ptr[5]
    );
        
    //obtain the dynamically changing RSSI
    // this is the only common WiFi class info that can't be obtained via WLanConfig
    Log.info("fetch WiFi.rssi...");
    WiFiSignal wifi_rssi = WiFi.RSSI();
    Log.info("WiFi.rssi: %f",  wifi_rssi.getStrengthValue() );
      
}

void setup() {
    System.enableFeature(FEATURE_RESET_INFO);

    // System.disableFeature(FEATURE_DISABLE_LISTENING_MODE);
    int reason = System.resetReason();
    delay(4000);//wait for usb serial to start
    Log.info("setup start after reset: %d", reason);

    if (!WiFi.hasCredentials()) {
        Log.info("setup creds...");
        WiFi.setCredentials("bogus","nnonsense",WLAN_SEC_WPA2, WLAN_CIPHER_AES);
        delay(500);
    }
}



void loop() {
    
    const uint32_t check_wait_millis = (30 * 1000); // 30 seconds
    static uint32_t loop_count = 0;
    static uint64_t last_netcheck_time = 0;
    uint64_t cur_time = System.millis();
    char buf[128] = {};

    if (!WiFi.hasCredentials()) {
        Log.info("waiting for creds...");
        delay(5000);
        return;
    }

    if (!Particle.connected()) {
        Log.info("Particle connect...");
        delay(3000);
        Particle.connect();
        waitFor(Particle.connected, 30000);
        if (!Particle.connected()) {
            Log.error("Could not connect!");
            return;
        }
    }
    else {
        system_tick_t delta = (uint32_t)(cur_time - last_netcheck_time);
        if (delta >= check_wait_millis) {
          last_netcheck_time = cur_time;
          network_check();
        }
        else {
            delay(1000); // just idle
        }
    }
  
    loop_count++;
}



```


---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
