### PR TITLE
feature/sc-106692/devtools-bundleignore

### DIFF
--- a/.bundleignore
+++ b/.bundleignore
@@ -1,13 +1,17 @@
 **/.git
+**/*.zip
 /ci
 /docs
 /misc
+/test
 /build/target
+/third_party/ambd_sdk/ambd_sdk/doc
+/third_party/ambd_sdk/ambd_sdk/tools
+/third_party/ambd_sdk/ambd_sdk/component/common/example/
 /third_party/nrf5_sdk/nrf5_sdk/examples
 /third_party/nrf5_sdk/nrf5_sdk/components/802_15_4
 /third_party/nrf5_sdk/nrf5_sdk/components/toolchain/cmsis/dsp
 /third_party/freertos/freertos/FreeRTOS/Demo
+/third_party/freertos/freertos/FreeRTOS-Plus
 /user/applications/tinker/target
-/.workbench/manifest.json
-/.workbench/intellisense/asom.json
 


### PR DESCRIPTION
### Problem

With the addition of the RealTek SDK, the Device OS' toolchain bundle's filesize has grown to ~292M (up from ~49M)

### Solution

Ignore unused files via updated `.bundleignore` entries. 

### Steps to Test



### References

https://app.shortcut.com/particle/story/106692
https://github.com/particle-iot/cli/pull/138#issuecomment-1186295974
https://github.com/particle-iot/device-os/pull/2326

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [x] Added to CHANGELOG.md after merging (add links to docs and issues)
