### PR TITLE
[rtl872x] DCache alignment requirement

### DIFF
--- a/bootloader/prebootloader/src/tron/part1/update_handler.c
+++ b/bootloader/prebootloader/src/tron/part1/update_handler.c
@@ -28,7 +28,7 @@
 
 static volatile platform_flash_modules_t* flashModule = NULL;
 static volatile uint16_t bootloaderUpdateReqId = KM0_KM4_IPC_INVALID_REQ_ID;
-static int updateResult = 0;
+static int32_t __attribute__((aligned(32))) updateResult[8];
 
 extern FLASH_InitTypeDef flash_init_para;
 extern CPU_PWR_SEQ HSPWR_OFF_SEQ[];
@@ -86,17 +86,17 @@ void bootloaderUpdateInit(void) {
 
 void bootloaderUpdateProcess(void) {
     // Handle bootloader update
-    updateResult = SYSTEM_ERROR_NONE;
+    updateResult[0] = SYSTEM_ERROR_NONE;
     if (bootloaderUpdateReqId != KM0_KM4_IPC_INVALID_REQ_ID) {
         if (!flashModule) {
-            updateResult = SYSTEM_ERROR_BAD_DATA;
+            updateResult[0] = SYSTEM_ERROR_BAD_DATA;
         } else {
             DCache_Invalidate((uint32_t)flashModule, sizeof(platform_flash_modules_t));
             if (!flash_write_update_info()) {
-                updateResult = SYSTEM_ERROR_INTERNAL;
+                updateResult[0] = SYSTEM_ERROR_INTERNAL;
             }
         }
-        km0_km4_ipc_send_response(KM0_KM4_IPC_CHANNEL_GENERIC, bootloaderUpdateReqId, &updateResult, sizeof(updateResult));
+        km0_km4_ipc_send_response(KM0_KM4_IPC_CHANNEL_GENERIC, bootloaderUpdateReqId, updateResult, sizeof(updateResult));
         bootloaderUpdateReqId = KM0_KM4_IPC_INVALID_REQ_ID;
         flashModule = NULL;
     }

--- a/hal/src/rtl872x/km0_km4_ipc.cpp
+++ b/hal/src/rtl872x/km0_km4_ipc.cpp
@@ -24,6 +24,7 @@ extern "C" {
 #include "check.h"
 #include "static_recursive_mutex.h"
 #include "km0_km4_ipc.h"
+#include "align_util.h"
 
 using namespace particle;
 
@@ -52,6 +53,17 @@ using namespace particle;
 
 
 namespace {
+
+typedef struct km0_km4_ipc_msg_v1_t {
+    uint16_t size;
+    uint16_t version;
+    km0_km4_ipc_msg_type_t type;
+    uint16_t req_id;
+    void* data;                         // WARNING: The data must not be allocated from stack
+    uint32_t data_len;
+    uint32_t data_crc32;                // of data payload
+    uint32_t crc32;
+} km0_km4_ipc_msg_v1_t;
 
 #if MODULE_FUNCTION == MOD_FUNC_BOOTLOADER
 
@@ -102,7 +114,7 @@ StaticRecursiveMutex Km0Km4IpcLock::mutex_;
 
 void km0Km4IpcIntHandler(void *data, uint32_t irqStatus, uint32_t channel) {
     km0_km4_ipc_msg_t* message = (km0_km4_ipc_msg_t*)ipc_get_message_alt(channel);
-    DCache_Invalidate((uint32_t)message, sizeof(km0_km4_ipc_msg_t));
+    DCache_Invalidate((uint32_t)message, message->size);
 
     if (message) {
         Km0Km4IpcClass::getInstance(channel)->processReceivedMessage(message);
@@ -117,6 +129,8 @@ Km0Km4IpcClass* Km0Km4IpcClass::getInstance(uint8_t channel) {
         {KM0_KM4_IPC_CHANNEL_GENERIC},
         // Add more channels if needed
     };
+    static_assert(is_member_aligned_to<32>(ipcs[0].km0Km4IpcMessage_), "alignof doesn't match");
+
     for (auto& ipc : ipcs) {
         if (ipc.channel_ == channel) {
             return &ipc;
@@ -126,10 +140,6 @@ Km0Km4IpcClass* Km0Km4IpcClass::getInstance(uint8_t channel) {
 }
 
 int Km0Km4IpcClass::init() {
-#if defined (ARM_CPU_CORTEX_M33)
-    SPARK_ASSERT(((uint32_t)&km0Km4IpcMessage_ & 0x0000001F) == 0); // Make sure the buffer is 32-byte aligned
-    SPARK_ASSERT((sizeof(km0Km4IpcMessage_)) % 32 == 0);
-#endif
     return SYSTEM_ERROR_NONE;
 }
 
@@ -140,14 +150,23 @@ int Km0Km4IpcClass::sendRequest(km0_km4_ipc_msg_type_t type, void* data, uint32_
     }
     Km0Km4IpcLock lock();
     km0Km4IpcMessage_ = {};
-    km0Km4IpcMessage_.size = sizeof(km0Km4IpcMessage_);
+    km0Km4IpcMessage_.size = sizeof(km0_km4_ipc_msg_t);
     km0Km4IpcMessage_.version = KM0_KM4_IPC_MSG_VERSION;
     km0Km4IpcMessage_.type = type;
     km0Km4IpcMessage_.req_id = reqId_;
+#if defined (ARM_CPU_CORTEX_M33)
+    SPARK_ASSERT(((uint32_t)data & 0x0000001F) == 0); // Make sure the buffer is 32-byte aligned
+    // Length of data should be 32 bytes aligned as well, but no need to send padding data.
+#endif
     km0Km4IpcMessage_.data = data;
     km0Km4IpcMessage_.data_len = len;
     km0Km4IpcMessage_.data_crc32 = Compute_CRC32((const uint8_t*)data, len, nullptr);
-    km0Km4IpcMessage_.crc32 = Compute_CRC32((const uint8_t*)&km0Km4IpcMessage_, sizeof(km0Km4IpcMessage_) - sizeof(km0_km4_ipc_msg_t::crc32), nullptr);
+    if (peerMsgVersion_ == KM0_KM4_IPC_MSG_VERSION_1) {
+        auto msg = reinterpret_cast<km0_km4_ipc_msg_v1_t*>(&km0Km4IpcMessage_);
+        msg->crc32 = Compute_CRC32((const uint8_t*)msg, sizeof(km0_km4_ipc_msg_v1_t) - sizeof(km0_km4_ipc_msg_v1_t::crc32), nullptr);
+    } else {
+        km0Km4IpcMessage_.crc32 = Compute_CRC32((const uint8_t*)&km0Km4IpcMessage_, sizeof(km0_km4_ipc_msg_t) - sizeof(km0_km4_ipc_msg_t::crc32), nullptr);
+    }
     respCallback_ = respCallback;
     respCallbackContext_ = context;
 
@@ -171,14 +190,19 @@ int Km0Km4IpcClass::sendRequest(km0_km4_ipc_msg_type_t type, void* data, uint32_
 int Km0Km4IpcClass::sendResponse(uint16_t reqId, void* data, uint32_t len) {
     Km0Km4IpcLock lock();
     km0Km4IpcMessage_ = {};
-    km0Km4IpcMessage_.size = sizeof(km0Km4IpcMessage_);
+    km0Km4IpcMessage_.size = sizeof(km0_km4_ipc_msg_t);
     km0Km4IpcMessage_.version = KM0_KM4_IPC_MSG_VERSION;
     km0Km4IpcMessage_.type = KM0_KM4_IPC_MSG_RESP;
     km0Km4IpcMessage_.req_id = reqId;
     km0Km4IpcMessage_.data = data;
     km0Km4IpcMessage_.data_len = len;
     km0Km4IpcMessage_.data_crc32 = Compute_CRC32((const uint8_t*)data, len, nullptr);
-    km0Km4IpcMessage_.crc32 = Compute_CRC32((const uint8_t*)&km0Km4IpcMessage_, sizeof(km0Km4IpcMessage_) - sizeof(km0_km4_ipc_msg_t::crc32), nullptr);
+    if (peerMsgVersion_ == KM0_KM4_IPC_MSG_VERSION_1) {
+        auto msg = reinterpret_cast<km0_km4_ipc_msg_v1_t*>(&km0Km4IpcMessage_);
+        msg->crc32 = Compute_CRC32((const uint8_t*)msg, sizeof(km0_km4_ipc_msg_v1_t) - sizeof(km0_km4_ipc_msg_v1_t::crc32), nullptr);
+    } else {
+        km0Km4IpcMessage_.crc32 = Compute_CRC32((const uint8_t*)&km0Km4IpcMessage_, sizeof(km0_km4_ipc_msg_t) - sizeof(km0_km4_ipc_msg_t::crc32), nullptr);
+    }
     DCache_CleanInvalidate((uint32_t)&km0Km4IpcMessage_, sizeof(km0Km4IpcMessage_));
     ipc_send_message_alt(channel_, (uint32_t)(&km0Km4IpcMessage_));
     return SYSTEM_ERROR_NONE;
@@ -216,11 +240,13 @@ int Km0Km4IpcClass::onRequestReceived(km0_km4_ipc_msg_type_t type, km0_km4_ipc_m
 void Km0Km4IpcClass::processReceivedMessage(km0_km4_ipc_msg_t* msg) {
     // necessary
     DCache_Invalidate((uint32_t)msg->data, msg->data_len);
-    if (Compute_CRC32((const uint8_t*)msg, sizeof(km0_km4_ipc_msg_t) - sizeof(km0_km4_ipc_msg_t::crc32), nullptr) != msg->crc32
+    uint32_t crc32 = *((uint32_t*)((uint32_t)msg + msg->size - sizeof(km0_km4_ipc_msg_t::crc32)));
+    if (Compute_CRC32((const uint8_t*)msg, msg->size - sizeof(km0_km4_ipc_msg_t::crc32), nullptr) != crc32
             || (msg->data_len > 0 && (msg->data == nullptr || Compute_CRC32((const uint8_t*)msg->data, msg->data_len, nullptr) != msg->data_crc32))) {
         msg->data = nullptr;
         msg->data_len = 0;
     }
+    peerMsgVersion_ = msg->version;
     // Handler response
     if (msg->type == KM0_KM4_IPC_MSG_RESP && expectedRespReqId_ == msg->req_id) {
         if (respCallback_) {
@@ -239,7 +265,8 @@ void Km0Km4IpcClass::processReceivedMessage(km0_km4_ipc_msg_t* msg) {
 }
 
 Km0Km4IpcClass::Km0Km4IpcClass(uint8_t ipcChannel)
-        : channel_(ipcChannel) {
+        : channel_(ipcChannel),
+          peerMsgVersion_(KM0_KM4_IPC_MSG_VERSION) {
     reqId_ = 0;
     expectedRespReqId_ = KM0_KM4_IPC_INVALID_REQ_ID;
 #if MODULE_FUNCTION == MOD_FUNC_BOOTLOADER

--- a/hal/src/rtl872x/km0_km4_ipc.h
+++ b/hal/src/rtl872x/km0_km4_ipc.h
@@ -21,7 +21,10 @@
 #include <stdint.h>
 #include "module_info.h"
 
-#define KM0_KM4_IPC_MSG_VERSION         1
+#define KM0_KM4_IPC_MSG_VERSION         2
+
+#define KM0_KM4_IPC_MSG_VERSION_1       1
+#define KM0_KM4_IPC_MSG_VERSION_2       KM0_KM4_IPC_MSG_VERSION
 
 // Define more IPC channels if needed
 #define KM0_KM4_IPC_CHANNEL_GENERIC     0
@@ -106,6 +109,7 @@ private:
     km0_km4_ipc_msg_t __attribute__((aligned(32))) km0Km4IpcMessage_;
     km0_km4_ipc_msg_callback_t respCallback_;
     void* respCallbackContext_;
+    uint16_t peerMsgVersion_;
 };
 
 } // namespace::particle

--- a/hal/src/rtl872x/km0_km4_ipc.h
+++ b/hal/src/rtl872x/km0_km4_ipc.h
@@ -48,8 +48,11 @@ typedef struct km0_km4_ipc_msg_t {
     void* data;                         // WARNING: The data must not be allocated from stack
     uint32_t data_len;
     uint32_t data_crc32;                // of data payload
+    uint32_t reserved[2];
     uint32_t crc32;                     // of this struct
 } km0_km4_ipc_msg_t;
+
+static_assert(sizeof(km0_km4_ipc_msg_t) % 32 == 0, "sizeof(km0_km4_ipc_msg_t) should be multiple of 32 bytes");
 
 typedef void (*km0_km4_ipc_msg_callback_t)(km0_km4_ipc_msg_t* msg, void* context);
 
@@ -100,7 +103,7 @@ private:
     // WARNING: it is allocated in static RAM and will be used for all IPC message exchanges.
     // We introduce Km0Km4IpcLock and a "blocked" parameter when sending IPC message to prevent this memory
     // from being overwritten before sending the next IPC message.
-    km0_km4_ipc_msg_t km0Km4IpcMessage_;
+    km0_km4_ipc_msg_t __attribute__((aligned(32))) km0Km4IpcMessage_;
     km0_km4_ipc_msg_callback_t respCallback_;
     void* respCallbackContext_;
 };

--- a/hal/src/rtl872x/spi_hal.cpp
+++ b/hal/src/rtl872x/spi_hal.cpp
@@ -231,7 +231,6 @@ public:
         // Start address of chunk buffer should be 32-byte aligned
         SPARK_ASSERT(((uint32_t)chunkBuffer_.txBuf & 0x1f) == 0);
         SPARK_ASSERT(((uint32_t)chunkBuffer_.rxBuf & 0x1f) == 0);
-        SPARK_ASSERT((CFG_CHUNK_BUF_SIZE) % 32 == 0);
         CHECK_TRUE(validateConfig(rtlSpiIndex_, config), SYSTEM_ERROR_INVALID_ARGUMENT);
 
         if (isEnabled()) {

--- a/hal/src/rtl872x/usart_hal.cpp
+++ b/hal/src/rtl872x/usart_hal.cpp
@@ -461,7 +461,10 @@ public:
                     uart->receiving_ = false;
                     uint8_t temp[MAX_UART_FIFO_SIZE];
                     uint32_t inFifo = UART_ReceiveDataTO(uartInstance, temp, MAX_UART_FIFO_SIZE, 1);
-                    uart->rxBuffer_.put(temp, inFifo);
+                    const ssize_t canWrite = uart->rxBuffer_.space();
+                    if (canWrite > 0) {
+                        uart->rxBuffer_.put(temp, std::min((uint32_t)canWrite, inFifo));
+                    }
                     uart->startReceiver();
                 }
                 break;

--- a/platform/MCU/rtl872x/inc/platform_flash_modules.h
+++ b/platform/MCU/rtl872x/inc/platform_flash_modules.h
@@ -43,6 +43,13 @@ typedef struct platform_flash_modules {
     uint8_t reserved[2];
 } platform_flash_modules_t; //1 module instance => 20 bytes
 
+typedef struct platform_flash_modules_aligned {
+    platform_flash_modules_t module;
+    uint8_t reserved[12];
+} platform_flash_modules_aligned;
+
+static_assert(sizeof(platform_flash_modules_aligned) % 32 == 0, "sizeof(platform_flash_modules_aligned) should be multiple of 32 bytes");
+
 
 #ifdef	__cplusplus
 }

--- a/services/inc/align_util.h
+++ b/services/inc/align_util.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#ifdef	__cplusplus
+template <size_t size, typename T>
+constexpr bool is_member_aligned_to(const T& v) {
+    // This is not strictly constexpr, but works on GCC
+    return (reinterpret_cast<const uintptr_t>(&v) % size) == 0;
+}
+#endif


### PR DESCRIPTION
A clone of https://github.com/particle-iot/firmware-private/pull/381.

### Problem
Buffers being used by DMA or between KM0 and KM4 should be 32-byte aligned, and the length of it should be multiple of 32 bytes, otherwise, data in SRAM might be corrupted.

### References
N/A

Tested:

1. Flash new prebootloadder and bootloader agianst the branch in this PR
2. Flash old system firmware that is against the `develop` branch.
3. Verified sleep functionalities.
4. Verified bootloader updating using `particle flash --serial`

"Old prebootloader/bootloader + new system firmware" is broken, but this normally won't happen given that users wil go 
 through the safe mode healer to update system firmware.

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
