### PR TITLE
allow ethernet detection on P2

### DIFF
--- a/hal/src/rtl872x/hal_platform_rtl8721x_config.h
+++ b/hal/src/rtl872x/hal_platform_rtl8721x_config.h
@@ -50,7 +50,8 @@
 
 #define HAL_PLATFORM_IFAPI (1)
 
-// #define HAL_PLATFORM_ETHERNET (1)
+// Allow detection of ethernet on SPI 
+#define HAL_PLATFORM_ETHERNET (1)
 
 #define HAL_PLATFORM_I2C2 (1)
 


### PR DESCRIPTION
<details>
  <summary>Allow P2 to use our legacy ethernet detection</summary>


</details>

### Problem

Ethernet detection was disabled on P2 until now

### Solution

Simply enable our legacy ethernet detection on the traditional SPI port

### Steps to Test

Which unit/integration/application tests are applicable to this code change? (At minimum a test of some kind should be provided)

### Example App

```c


#include "Particle.h"

SYSTEM_THREAD(ENABLED);
SYSTEM_MODE(SEMI_AUTOMATIC);

SerialLogHandler logHandler(115200, LOG_LEVEL_INFO);

void setup() {
    System.enableFeature(FEATURE_RESET_INFO);
    int reason = System.resetReason();
    delay(4000);//wait for usb serial to start
    Log.info("setup start after reset: %d", reason);

    // as a test, clear wifi credentials and force ethernet connection
    Log.info("clear wifi creds...");
    WiFi.clearCredentials();

    if (System.featureEnabled(FEATURE_ETHERNET_DETECTION)) {
    	Log.info("FEATURE_ETHERNET_DETECTION enabled");
    }
    else {
      Log.info("enable ethernet...");
      System.enableFeature(FEATURE_ETHERNET_DETECTION);
    }

    Log.info("checking ethernet...");
    if (Ethernet.isOn()) {
        Log.info("Ethernet on");
        uint8_t mac_addr_buf[8] = {};
        uint8_t* mac_addr = Ethernet.macAddress(mac_addr_buf);
        if (nullptr != mac_addr) {
          Log.info("Ethernet mac: %02x %02x %02x %02x %02x %02x ",
              mac_addr[0], mac_addr[1], mac_addr[2], mac_addr[3], mac_addr[4], mac_addr[5] );
        }
        Log.info("Ethernet.ready: %d", Ethernet.ready());
    }
}



void loop() {
    const uint32_t pub_wait_millis = (30 * 1000); // 30 seconds
    static uint64_t last_pub_time = 0;
    uint64_t cur_time = System.millis();
    char buf[128] = {};


    if (!Particle.connected()) {
        Log.info("Particle connect...");
        Particle.connect();
        waitFor(Particle.connected, 30000);
        if (!Particle.connected()) {
            Log.error("Could not connect!");
            return;
        }
    }
    else {
        system_tick_t delta = (uint32_t)(cur_time - last_pub_time);
        if (delta >= pub_wait_millis) {
            uint32_t high_count = (uint32_t)(cur_time >> 32);
            uint32_t low_count = (uint32_t)(cur_time & 0xFFFFFFFF);
            Log.info("publishing at: %lu %lu", high_count, low_count);
            sprintf(buf,"{ \"h\": %lu, \"l\": %lu }", high_count, low_count);
            Particle.publish("blob", buf, PRIVATE | WITH_ACK);
            last_pub_time = cur_time;
        }
        else {
            delay(1000); // just idle
        }
    }
  
}

```

### References


---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
