### PR TITLE
[tinker] Fix tinker build for non-p2 platforms

### DIFF
--- a/user/applications/tinker/application.cpp
+++ b/user/applications/tinker/application.cpp
@@ -18,7 +18,7 @@
 /* Includes ------------------------------------------------------------------*/
 #include "application.h"
 #include <cctype>
-#if HAL_PLATFORM_RTL872X && ENABLE_FQC_FUNCTIONALITY
+#if HAL_PLATFORM_RTL872X && defined(ENABLE_FQC_FUNCTIONALITY)
 #include "request_handler.h"
 #include "src/burnin_test.h"
 #endif
@@ -128,7 +128,7 @@ void setup()
     Particle.function("analogread", tinkerAnalogRead);
     Particle.function("analogwrite", tinkerAnalogWrite);
 
-#if HAL_PLATFORM_RTL872X && ENABLE_FQC_FUNCTIONALITY
+#if HAL_PLATFORM_RTL872X && defined(ENABLE_FQC_FUNCTIONALITY)
     BurninTest::instance()->setup();
 #endif
 }
@@ -138,7 +138,7 @@ void loop()
 {
     //This will run in a loop
 
-#if HAL_PLATFORM_RTL872X && ENABLE_FQC_FUNCTIONALITY
+#if HAL_PLATFORM_RTL872X && defined(ENABLE_FQC_FUNCTIONALITY)
     BurninTest::instance()->loop();
 #endif
 }
@@ -260,7 +260,7 @@ int tinkerAnalogWrite(String command)
     return -1;
 }
 
-#if HAL_PLATFORM_RTL872X && ENABLE_FQC_FUNCTIONALITY
+#if HAL_PLATFORM_RTL872X && defined(ENABLE_FQC_FUNCTIONALITY)
 // Tinker app specific USB requests. For P2 these are FQC commands
 void ctrl_request_custom_handler(ctrl_request* req) {
     particle::RequestHandler::instance()->process(req);


### PR DESCRIPTION
### Problem

Deprecating tinker-fqc broke tinker for non p2 platforms

### Solution

Only build FQC functionality for p2 platforms

### Steps to Test
build tinker / run CI 

### Example App
tinker

### References

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
