### PR TITLE
[p2][photon2] Add VBAT_MEAS pin and charging indication pin for Photon2

### DIFF
--- a/hal/src/rtl872x/gpio_hal.cpp
+++ b/hal/src/rtl872x/gpio_hal.cpp
@@ -68,6 +68,10 @@ bool isCachePin(hal_pin_t pin) {
     return false;
 }
 
+bool isVbatMeasPin(hal_pin_t pin) {
+    return(pin == A6) ? true : false;
+}
+
 bool isCachePinSetToOutput(hal_pin_t pin) {
     hal_pin_info_t* pinInfo = hal_pin_map() + pin;
     if ((pinInfo->pin_mode == OUTPUT) ||
@@ -100,6 +104,7 @@ void hal_gpio_mode(hal_pin_t pin, PinMode mode) {
 
 int hal_gpio_configure(hal_pin_t pin, const hal_gpio_config_t* conf, void* reserved) {
     CHECK_TRUE(hal_pin_is_valid(pin), SYSTEM_ERROR_INVALID_ARGUMENT);
+    CHECK_FALSE(isVbatMeasPin(pin), SYSTEM_ERROR_NOT_SUPPORTED);
     CHECK_TRUE(conf, SYSTEM_ERROR_INVALID_ARGUMENT);
 
     hal_pin_info_t* pinInfo = hal_pin_map() + pin;
@@ -218,7 +223,7 @@ PinMode hal_gpio_get_mode(hal_pin_t pin) {
 }
 
 void hal_gpio_write(hal_pin_t pin, uint8_t value) {
-    if (!hal_pin_is_valid(pin)) {
+    if (!hal_pin_is_valid(pin) || isVbatMeasPin(pin)) {
         return;
     }
 
@@ -252,7 +257,7 @@ void hal_gpio_write(hal_pin_t pin, uint8_t value) {
 }
 
 int32_t hal_gpio_read(hal_pin_t pin) {
-    if (!hal_pin_is_valid(pin)) {
+    if (!hal_pin_is_valid(pin) || isVbatMeasPin(pin)) {
         return 0;
     }
 
@@ -304,7 +309,7 @@ uint32_t hal_gpio_pulse_in(hal_pin_t pin, uint16_t value) {
     const uint64_t THREE_SECONDS_IN_MICROSECONDS = 3000000;
     #define FAST_READ(pin) ((gpiobase->EXT_PORT[0] >> pin) & 1UL)
 
-    if (!hal_pin_is_valid(pin)) {
+    if (!hal_pin_is_valid(pin) || isVbatMeasPin(pin)) {
         return 0;
     }
 

--- a/hal/src/rtl872x/gpio_hal.cpp
+++ b/hal/src/rtl872x/gpio_hal.cpp
@@ -68,8 +68,9 @@ bool isCachePin(hal_pin_t pin) {
     return false;
 }
 
-bool isVbatMeasPin(hal_pin_t pin) {
-    return(pin == A6) ? true : false;
+bool isGpioPin(hal_pin_t pin) {
+    hal_pin_info_t* pinInfo = hal_pin_map() + pin;
+    return(pinInfo->gpio_port != RTL_PORT_NONE) ? true : false;
 }
 
 bool isCachePinSetToOutput(hal_pin_t pin) {
@@ -104,7 +105,7 @@ void hal_gpio_mode(hal_pin_t pin, PinMode mode) {
 
 int hal_gpio_configure(hal_pin_t pin, const hal_gpio_config_t* conf, void* reserved) {
     CHECK_TRUE(hal_pin_is_valid(pin), SYSTEM_ERROR_INVALID_ARGUMENT);
-    CHECK_FALSE(isVbatMeasPin(pin), SYSTEM_ERROR_NOT_SUPPORTED);
+    CHECK_TRUE(isGpioPin(pin), SYSTEM_ERROR_NOT_SUPPORTED);
     CHECK_TRUE(conf, SYSTEM_ERROR_INVALID_ARGUMENT);
 
     hal_pin_info_t* pinInfo = hal_pin_map() + pin;
@@ -223,7 +224,7 @@ PinMode hal_gpio_get_mode(hal_pin_t pin) {
 }
 
 void hal_gpio_write(hal_pin_t pin, uint8_t value) {
-    if (!hal_pin_is_valid(pin) || isVbatMeasPin(pin)) {
+    if (!hal_pin_is_valid(pin) || !isGpioPin(pin)) {
         return;
     }
 
@@ -257,7 +258,7 @@ void hal_gpio_write(hal_pin_t pin, uint8_t value) {
 }
 
 int32_t hal_gpio_read(hal_pin_t pin) {
-    if (!hal_pin_is_valid(pin) || isVbatMeasPin(pin)) {
+    if (!hal_pin_is_valid(pin) || !isGpioPin(pin)) {
         return 0;
     }
 
@@ -309,7 +310,7 @@ uint32_t hal_gpio_pulse_in(hal_pin_t pin, uint16_t value) {
     const uint64_t THREE_SECONDS_IN_MICROSECONDS = 3000000;
     #define FAST_READ(pin) ((gpiobase->EXT_PORT[0] >> pin) & 1UL)
 
-    if (!hal_pin_is_valid(pin) || isVbatMeasPin(pin)) {
+    if (!hal_pin_is_valid(pin) || !isGpioPin(pin)) {
         return 0;
     }
 

--- a/hal/src/tron/pinmap_defines.cpp
+++ b/hal/src/tron/pinmap_defines.cpp
@@ -45,11 +45,12 @@ static hal_pin_info_t pinmap[TOTAL_PINS] = {
 /* S6            - 21 */ { RTL_PORT_B, 31, PIN_MODE_NONE, PF_NONE, ADC_CHANNEL_NONE, PWM_INSTANCE_NONE, PWM_CHANNEL_NONE, 0},
 
 /* System space */
-/* RGBR          - 22 */ { RTL_PORT_A, 30, PIN_MODE_NONE, PF_NONE, ADC_CHANNEL_NONE, 0,                 1,                0},
-/* RGBG          - 23 */ { RTL_PORT_B, 23, PIN_MODE_NONE, PF_NONE, ADC_CHANNEL_NONE, 0,                 3,                0},
-/* RGBB          - 24 */ { RTL_PORT_B, 22, PIN_MODE_NONE, PF_NONE, ADC_CHANNEL_NONE, 0,                 2,                0},
-/* MODE BUTTON   - 25 */ { RTL_PORT_A, 4,  PIN_MODE_NONE, PF_NONE, ADC_CHANNEL_NONE, PWM_INSTANCE_NONE, PWM_CHANNEL_NONE, 0},
-/* ANTSW         - 26 */ { RTL_PORT_A, 2,  PIN_MODE_NONE, PF_NONE, ADC_CHANNEL_NONE, PWM_INSTANCE_NONE, PWM_CHANNEL_NONE, 0},
+/* RGBR          - 22 */ { RTL_PORT_A,    30, PIN_MODE_NONE, PF_NONE, ADC_CHANNEL_NONE, 0,                 1,                0},
+/* RGBG          - 23 */ { RTL_PORT_B,    23, PIN_MODE_NONE, PF_NONE, ADC_CHANNEL_NONE, 0,                 3,                0},
+/* RGBB          - 24 */ { RTL_PORT_B,    22, PIN_MODE_NONE, PF_NONE, ADC_CHANNEL_NONE, 0,                 2,                0},
+/* MODE BUTTON   - 25 */ { RTL_PORT_A,    4,  PIN_MODE_NONE, PF_NONE, ADC_CHANNEL_NONE, PWM_INSTANCE_NONE, PWM_CHANNEL_NONE, 0},
+/* ANTSW         - 26 */ { RTL_PORT_A,    2,  PIN_MODE_NONE, PF_NONE, ADC_CHANNEL_NONE, PWM_INSTANCE_NONE, PWM_CHANNEL_NONE, 0},
+/* VBAT_MEAS/A6  - 27 */ { RTL_PORT_NONE, 0,  PIN_MODE_NONE, PF_NONE, 7,                PWM_INSTANCE_NONE, PWM_CHANNEL_NONE, 0},
 };
 
 } // anonymous

--- a/hal/src/tron/pinmap_defines.h
+++ b/hal/src/tron/pinmap_defines.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#define TOTAL_PINS          27
+#define TOTAL_PINS          28
 #define TOTAL_ANALOG_PINS   6
 #define FIRST_ANALOG_PIN    11
 
@@ -60,6 +60,7 @@
 #define A3                  D0
 #define A4                  D1
 #define A5                  D14
+#define A6                  27  // VBAT_MEAS, only use it as analog pin
 
 // RGB and Button
 #define RGBR                22
@@ -99,3 +100,6 @@
 #define WKP                 D10
 
 #define ANTSW               26
+
+// Charge indicator pin for LightCycle only
+#define CHG                 S5

--- a/hal/src/tron/pinmap_defines.h
+++ b/hal/src/tron/pinmap_defines.h
@@ -60,7 +60,7 @@
 #define A3                  D0
 #define A4                  D1
 #define A5                  D14
-#define A6                  27  // VBAT_MEAS, only use it as analog pin
+#define A6                  27  // VBAT_MEAS on Photon2, when used as an analog pin
 
 // RGB and Button
 #define RGBR                22
@@ -101,5 +101,5 @@
 
 #define ANTSW               26
 
-// Charge indicator pin for LightCycle only
+// Read-only charge indicator pin for Photon2 
 #define CHG                 S5


### PR DESCRIPTION
### Problem

This PR is to add `VBAT_MEAS` and charging pin to P2 pinmap.

 - `VBAT_MEAS` is an ADC-dedicated pin, it can measure the input voltage with 5V tolerance,
 - Charging pin is only used on Lightcycle

### Solution

Add VBAT_MEAS as the A6 pin, note that the reference voltage is 5V instead of 3.3V

### Steps to Test

1. Re-compile and download bootloader/system-part1/user-app
2. Measure different voltage with A6 pin

### Example App

```c
#include "Particle.h"

SYSTEM_MODE(MANUAL);

Serial1LogHandler log(115200, LOG_LEVEL_ALL);

void setup() {
}

void loop() {
    int value = analogRead(A6);
    Log.info("A6 value: %d, volt: %f", value, value / 4096.0 * 5.0);

    int A0Value = analogRead(A0);
    Log.info("A0 Value: %d, volt: %f", A0Value, A0Value / 4096.0 * 3.3);
    delay(1000);
}
```

### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
