### PR TITLE
Fix GCC platform on some versions of GCC; Fix wiring/api tests for P2; Fix building of wiring/api tests on CI

### DIFF
--- a/ci/enumerate_build_matrix.sh
+++ b/ci/enumerate_build_matrix.sh
@@ -48,10 +48,14 @@ MAKE=runmake
 # "" means execute execute the $MAKE command without that var specified
 DEBUG_BUILD=( y n )
 PLATFORM=( argon boron asom bsom b5som esomx p2 )
-PLATFORM_BOOTLOADER=( argon boron asom bsom b5som tracker esomx p2 )
-PLATFORM_PREBOOTLOADER=( p2 )
-APP=( "" tinker product_id_and_version)
-TEST=( wiring/api wiring/no_fixture wiring/no_fixture_long_running )
+# All modules are now built by reease scripts instead, skip
+# Only building applications and tests here
+# PLATFORM_BOOTLOADER=( argon boron asom bsom b5som tracker esomx p2 )
+# PLATFORM_PREBOOTLOADER=( p2 )
+PLATFORM_BOOTLOADER=()
+PLATFORM_PREBOOTLOADER=()
+APP=( "" product_id_and_version )
+TEST=( wiring/api )
 
 MODULAR_PLATFORM=( argon boron asom bsom b5som tracker esomx p2 )
 

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -30,8 +30,9 @@ if [ -n "$CI_BUILD_RELEASE" ]; then
     if [ -z "$BUILD_PLATFORM" ]; then
         cd /firmware/build
         checkFailures
-        exit $?
+        # exit $?
     fi
+    export BUILD_PLATFORM=$BUILD_PLATFORM_ORIGINAL
 fi
 
 $DEVICE_OS_ROOT/ci/enumerate_build_matrix.sh

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -x
+
 # ensure we are in the root
 cd "$( dirname "${BASH_SOURCE[0]}" )/.."
 
@@ -27,6 +30,7 @@ if [ -n "$CI_BUILD_RELEASE" ]; then
     echo "BUILD_PLATFORM=${BUILD_PLATFORM}"
     ./ci/ci_release.sh
     RET=$?
+    echo "ci/ci_release.sh ret=${RET}"
     if [ -z "$BUILD_PLATFORM" ]; then
         cd /firmware/build
         checkFailures

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -x
-
 # ensure we are in the root
 cd "$( dirname "${BASH_SOURCE[0]}" )/.."
 

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -31,12 +31,14 @@ if [ -n "$CI_BUILD_RELEASE" ]; then
     ./ci/ci_release.sh
     RET=$?
     echo "ci/ci_release.sh ret=${RET}"
-    if [ -z "$BUILD_PLATFORM" ]; then
-        cd /firmware/build
-        checkFailures
-        # exit $?
+    cd /firmware/build
+    checkFailures
+    RET=$?
+    if [ $RET -ne 0 ]; then
+        exit $RET
     fi
     export BUILD_PLATFORM=$BUILD_PLATFORM_ORIGINAL
 fi
 
+cd $DEVICE_OS_ROOT
 $DEVICE_OS_ROOT/ci/enumerate_build_matrix.sh

--- a/hal/src/gcc/device_config.cpp
+++ b/hal/src/gcc/device_config.cpp
@@ -39,15 +39,6 @@ namespace po = boost::program_options;
 
 DeviceConfig deviceConfig;
 
-namespace {
-
-const char* CMD_HELP = "help";
-const char* CMD_VERSION = "version";
-
-// These are still supported by the Cloud
-const int PHOTON_PLATFORM_ID = 6;
-const int P1_PLATFORM_ID = 8;
-
 std::istream& operator>>(std::istream& in, ProtocolFactory& pf)
 {
     std::string value;
@@ -60,6 +51,16 @@ std::istream& operator>>(std::istream& in, ProtocolFactory& pf)
         throw boost::program_options::invalid_option_value(value);
     return in;
 }
+
+namespace {
+
+const char* CMD_HELP = "help";
+const char* CMD_VERSION = "version";
+
+// These are still supported by the Cloud
+const int PHOTON_PLATFORM_ID = 6;
+const int P1_PLATFORM_ID = 8;
+
 
 class ConfigParser
 {

--- a/test/unit_tests/services/dcd.cpp
+++ b/test/unit_tests/services/dcd.cpp
@@ -75,7 +75,7 @@ SCENARIO("RAMRlashStore provides pointer to data", "[ramflash]")
 
     REQUIRE(data1 != nullptr);
     REQUIRE(data2 != nullptr);
-    REQUIRE(long(data1+100) == long(data2));
+    REQUIRE((uintptr_t)(data1+100) == (uintptr_t)(data2));
 }
 
 SCENARIO("RAMFlashStore is initially random", "[ramflash]")

--- a/user/tests/wiring/api/wiring.cpp
+++ b/user/tests/wiring/api/wiring.cpp
@@ -174,6 +174,10 @@ test(api_rgb) {
     API_COMPILE(RGB.mirrorTo(A1, A0, A7, false));
     API_COMPILE(RGB.mirrorTo(A1, A0, A7, true, true));
 #endif // PLATFORM_ID == PLATFORM_ARGON || PLATFORM_ID == PLATFORM_BORON
+#elif HAL_PLATFORM_RTL872X
+    API_COMPILE(RGB.mirrorTo(A2, A4, A5));
+    API_COMPILE(RGB.mirrorTo(A2, A4, A5, false));
+    API_COMPILE(RGB.mirrorTo(A2, A4, A5, true, true));
 #else
     #error "Unsupported platform"
 #endif

--- a/wiring/src/user.cpp
+++ b/wiring/src/user.cpp
@@ -67,12 +67,6 @@ void serialEvent() __attribute__((weak));
 void serialEvent1() __attribute__((weak));
 void usbSerialEvent1() __attribute__((weak));
 
-#if PLATFORM_ID == PLATFORM_GCC
-// gcc doesn't allow weak functions to not exist, so they must be defined.
-__attribute__((weak)) void serialEvent() {}
-__attribute__((weak)) void serialEvent1() {}
-#endif // PLATFORM_ID == PLATFORM_GCC
-
 #if Wiring_Serial2
 void serialEvent2() __attribute__((weak));
 #endif
@@ -107,19 +101,19 @@ void serialEventRun()
         serialEvent1();
 
 #if Wiring_Serial2
-    if (serialEventRun2) serialEventRun2();
+    if (serialEvent2) serialEventRun2();
 #endif
 
 #if Wiring_Serial3
-    if (serialEventRun3) serialEventRun3();
+    if (serialEvent3) serialEventRun3();
 #endif
 
 #if Wiring_Serial4
-    if (serialEventRun4) serialEventRun4();
+    if (serialEvent4) serialEventRun4();
 #endif
 
 #if Wiring_Serial5
-    if (serialEventRun5) serialEventRun5();
+    if (serialEvent5) serialEventRun5();
 #endif
 
 #if Wiring_USBSerial1


### PR DESCRIPTION
### Description

As title says:

1. Fixes builds of GCC platform under some versions of GCC
2. Fixes building of `wiring/api` tests on CI
3. Fixes `wiring/api` tests for P2
4. Clean up weak `serialEvent` stuff and make sure unused serialEvent references are optimized out

### Steps to Test

Wait for CI build.

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
