### PR TITLE
[p2] fixes INTERRUPTS_01_isisr_willpreempt_servicedirqn test

### DIFF
--- a/hal/inc/interrupts_hal.h
+++ b/hal/inc/interrupts_hal.h
@@ -111,12 +111,6 @@ int hal_interrupt_set_direct_handler(IRQn_Type irqn, hal_interrupt_direct_handle
 
 #ifdef USE_STDPERIPH_DRIVER
 
-    #if defined(STM32F10X_MD) || defined(STM32F10X_HD)
-        #include "stm32f10x.h"
-    #elif defined(STM32F2XX)
-        #include "stm32f2xx.h"
-    #endif // defined(STM32F10X_MD) || defined(STM32F10X_HD)
-
     #ifdef nRF52840
         #include <nrf52840.h>
     #endif /* nRF52840 */

--- a/user/tests/wiring/no_fixture/interrupts.cpp
+++ b/user/tests/wiring/no_fixture/interrupts.cpp
@@ -47,4 +47,11 @@ test(INTERRUPTS_01_isisr_willpreempt_servicedirqn)
 	assertFalse(hal_interrupt_will_preempt(SysTick_IRQn, SysTick_IRQn));
 	assertTrue(hal_interrupt_will_preempt(NonMaskableInt_IRQn, SysTick_IRQn));
 	assertFalse(hal_interrupt_will_preempt(SysTick_IRQn, NonMaskableInt_IRQn));
+
+#if HAL_PLATFORM_RTL872X
+	// Using arbitrary interrupt
+	assertTrue(attachInterruptDirect(I2C0_IRQ, []() {return;}));
+	assertFalse(attachInterruptDirect(I2C0_IRQ, []() {return;}));
+	assertTrue(detachInterruptDirect(I2C0_IRQ));
+#endif
 }


### PR DESCRIPTION
### Problem

`INTERRUPTS_01_isisr_willpreempt_servicedirqn` test fails on P2 due to unimplemented HAL

### Solution

Use an array to backup any overridden ISR handlers. When override is removed, restore the backup.

There are other parts of the HAL that are still unimplemented, namely `HAL_Core_Restore_Interrupt()` and the `link_interrupt_vectors_location` RAM table in general during `HAL_Core_Config()`.

This PR is still a WIP to facilitate discussion on how to approach these problems. 

### Steps to Test

Run `wiring/no_fixture`, specifically `INTERRUPTS_01_isisr_willpreempt_servicedirqn`

### Example App

Run `wiring/no_fixture`

### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
