### PR TITLE
Device OS v5.0.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,29 @@
+## 5.0.0-alpha.2
+
+> ## :warning: Please note this is an internal release, do not use on production devices!
+
+### FEATURES
+- [p2] Allow setting WiFi country code and channel plan [#2485](https://github.com/particle-iot/device-os/pull/2485) [#2473](https://github.com/particle-iot/device-os/pull/2473)
+
+### ENHANCEMENTS
+- [p2][wifi] Add more complete WiFi network configuration information for P2 [#2474](https://github.com/particle-iot/device-os/pull/2474)
+- [p2][photon2] Add VBAT_MEAS pin and charging indication pin for Photon2 [#2482](https://github.com/particle-iot/device-os/pull/2482)
+- [ethernet][p2] Allow ethernet detection on P2 [#2478](https://github.com/particle-iot/device-os/pull/2478)
+
+### BUGFIXES
+- [p2] usart: flush DMA FIFO data when required [#2477](https://github.com/particle-iot/device-os/pull/2477)
+
+### INTERNAL
+- [p2] deprecate tinker-fqc app [#2479](https://github.com/particle-iot/device-os/pull/2479) [#2480](https://github.com/particle-iot/device-os/pull/2480) [#2481](https://github.com/particle-iot/device-os/pull/2481)
+- Update devtools .bundleignore for P2 SDK files [#2475](https://github.com/particle-iot/device-os/pull/2475)
+- Fix GCC platform on some versions of GCC; Fix wiring/api tests for P2; Fix building of wiring/api tests on CI [#2483](https://github.com/particle-iot/device-os/pull/2483)
+- [p2] Fix DCache alignment [#2476](https://github.com/particle-iot/device-os/pull/2476) 
+- [p2] fixes INTERRUPTS_01_isisr_willpreempt_servicedirqn test [#2486](https://github.com/particle-iot/device-os/pull/2486)
+- Remove redundant toolchain overrides [#2489](https://github.com/particle-iot/device-os/pull/2489)
+
 ## 5.0.0-alpha.1
 
-> ## :warning: Please note this is in internal release, do not use on production devices!
+> ## :warning: Please note this is an internal release, do not use on production devices!
 
 ### FEATURES
 - P2 Support [#2466](https://github.com/particle-iot/device-os/pull/2466)
@@ -22,7 +45,7 @@
 
 ## 4.0.0-alpha.2
 
-> ## :warning: Please note this is in internal release, do not use on production devices!
+> ## :warning: Please note this is an internal release, do not use on production devices!
 
 ### FEATURES
 - [esomx] Adds support for new platform esomx [#2443](https://github.com/particle-iot/device-os/pull/2443) [#2459](https://github.com/particle-iot/device-os/pull/2459)
@@ -39,7 +62,7 @@
 
 ## 4.0.0-alpha.1
 
-> ## :warning: Please note this is in internal release, do not use on production devices!
+> ## :warning: Please note this is an internal release, do not use on production devices!
 
 ### DEPRECATION
 

--- a/build/release.sh
+++ b/build/release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -o errexit -o pipefail -o noclobber -o nounset
 
-VERSION=${VERSION:="5.0.0-alpha.1"}
+VERSION=${VERSION:="5.0.0-alpha.2"}
 
 function display_help ()
 {

--- a/build/version.mk
+++ b/build/version.mk
@@ -1,7 +1,7 @@
-VERSION_STRING = 5.0.0-alpha.1
+VERSION_STRING = 5.0.0-alpha.2
 
 # PRODUCT_FIRMWARE_VERSION reported by default
 # FIXME: Unclear if this is used, PRODUCT_FIRMWARE_VERSION defaults to 65535 every release
-VERSION = 5000
+VERSION = 5001
 
 CFLAGS += -DSYSTEM_VERSION_STRING=$(VERSION_STRING)

--- a/modules/shared/system_module_version.mk
+++ b/modules/shared/system_module_version.mk
@@ -1,6 +1,6 @@
 # Skip to next 100 every v0.x.0 release (e.g. 108 for v0.6.2 to 200 for v0.7.0-rc.1)
 # Bump by 1 for every prerelease or release with the same v0.x.* base.
-COMMON_MODULE_VERSION ?= 5000
+COMMON_MODULE_VERSION ?= 5001
 SYSTEM_PART1_MODULE_VERSION ?= $(COMMON_MODULE_VERSION)
 
 RELEASE_080_MODULE_VERSION_BASE ?= 300

--- a/system/inc/system_version.h
+++ b/system/inc/system_version.h
@@ -191,7 +191,8 @@ extern "C" {
 #define SYSTEM_VERSION_v400ALPHA1   SYSTEM_VERSION_ALPHA(4, 0, 0, 1)
 #define SYSTEM_VERSION_v400ALPHA2   SYSTEM_VERSION_ALPHA(4, 0, 0, 2)
 #define SYSTEM_VERSION_v500ALPHA1   SYSTEM_VERSION_ALPHA(5, 0, 0, 1)
-#define SYSTEM_VERSION SYSTEM_VERSION_v500ALPHA1
+#define SYSTEM_VERSION_v500ALPHA2   SYSTEM_VERSION_ALPHA(5, 0, 0, 2)
+#define SYSTEM_VERSION SYSTEM_VERSION_v500ALPHA2
 
 /**
  * Previously we would set the least significant byte to 0 for the final release, but to make
@@ -347,6 +348,7 @@ extern "C" {
 #define SYSTEM_VERSION_400ALPHA1
 #define SYSTEM_VERSION_400ALPHA2
 #define SYSTEM_VERSION_500ALPHA1
+#define SYSTEM_VERSION_500ALPHA2
 
 typedef struct __attribute__((packed)) SystemVersionInfo
 {

--- a/system/system-versions.md
+++ b/system/system-versions.md
@@ -166,6 +166,7 @@
 | 1100 | 4000 | 4.0.0-alpha.1 |      Argon, Boron, B SoM, B5 SoM, Tracker |
 | 1101 | 4001 | 4.0.0-alpha.2 |      Argon, Boron, B SoM, B5 SoM, Tracker, E Som X |
 | 2000 | 5000 | 5.0.0-alpha.1 |      Argon, Boron, B SoM, B5 SoM, Tracker, E Som X, P2 | 
+| 2000 | 5001 | 5.0.0-alpha.2 |      Argon, Boron, B SoM, B5 SoM, Tracker, E Som X, P2 | 
 
 [1] For 0.8.0-rc.1, The v101 bootloader was also released in the Github releases as v200. Thus the next released bootloader in the 0.8.x line should be v201. As of 4/5/2018: 22 device had v200 bootloaders.
 


### PR DESCRIPTION
## 5.0.0-alpha.2

> ## :warning: Please note this is an internal release, do not use on production devices!

### FEATURES
- [p2] Allow setting WiFi country code and channel plan [#2485](https://github.com/particle-iot/device-os/pull/2485) [#2473](https://github.com/particle-iot/device-os/pull/2473)

### ENHANCEMENTS
- [p2][wifi] Add more complete WiFi network configuration information for P2 [#2474](https://github.com/particle-iot/device-os/pull/2474)
- [p2][photon2] Add VBAT_MEAS pin and charging indication pin for Photon2 [#2482](https://github.com/particle-iot/device-os/pull/2482)
- [ethernet][p2] Allow ethernet detection on P2 [#2478](https://github.com/particle-iot/device-os/pull/2478)

### BUGFIXES
- [p2] usart: flush DMA FIFO data when required [#2477](https://github.com/particle-iot/device-os/pull/2477)

### INTERNAL
- [p2] deprecate tinker-fqc app [#2479](https://github.com/particle-iot/device-os/pull/2479) [#2480](https://github.com/particle-iot/device-os/pull/2480) [#2481](https://github.com/particle-iot/device-os/pull/2481)
- Update devtools .bundleignore for P2 SDK files [#2475](https://github.com/particle-iot/device-os/pull/2475)
- Fix GCC platform on some versions of GCC; Fix wiring/api tests for P2; Fix building of wiring/api tests on CI [#2483](https://github.com/particle-iot/device-os/pull/2483)
- [p2] Fix DCache alignment [#2476](https://github.com/particle-iot/device-os/pull/2476) 
- [p2] fixes INTERRUPTS_01_isisr_willpreempt_servicedirqn test [#2486](https://github.com/particle-iot/device-os/pull/2486)
- Remove redundant toolchain overrides [#2489](https://github.com/particle-iot/device-os/pull/2489)