### PR TITLE
chore/sc-98414/remove-redundant-toolchain-overrides

### DIFF
--- a/.workbench/manifest.json
+++ b/.workbench/manifest.json
@@ -9,43 +9,5 @@
             "scripts": "buildscripts@1.11.0",
             "debuggers": "openocd@0.11.0-particle.4"
         }
-    ],
-    "scripts": {
-        "windows": {
-            "x64": [
-                {
-                    "name": "buildscripts",
-                    "version": "1.11.0",
-                    "main": ".",
-                    "url": "https://binaries.particle.io/buildscripts/windows/x64/v1.11.0.tar.gz",
-                    "sha256": "941b864f276f0c45253233b7ad8a65868daae9690abb2258c231858a29312c42"
-                }
-            ],
-            "x86": []
-        },
-        "darwin": {
-            "x64": [
-                {
-                    "name": "buildscripts",
-                    "version": "1.11.0",
-                    "main": ".",
-                    "url": "https://binaries.particle.io/buildscripts/darwin/x64/v1.11.0.tar.gz",
-                    "sha256": "941b864f276f0c45253233b7ad8a65868daae9690abb2258c231858a29312c42"
-                }
-            ],
-            "x86": []
-        },
-        "linux": {
-            "x64": [
-                {
-                    "name": "buildscripts",
-                    "version": "1.11.0",
-                    "main": ".",
-                    "url": "https://binaries.particle.io/buildscripts/linux/x64/v1.11.0.tar.gz",
-                    "sha256": "941b864f276f0c45253233b7ad8a65868daae9690abb2258c231858a29312c42"
-                }
-            ],
-            "x86": []
-        }
-    }
+    ]
 }


### PR DESCRIPTION
### Problem

Now that it has been published, the `buildscripts@1.11.0` toolchain dependency overrides are redundant. 

### Solution

Remove the `buildscripts@1.11.0` toolchain dependency overrides

### Steps to Test

1. Pull down this branch (`git pull && git checkout chore/sc-98414/remove-redundant-toolchain-overrides`)
2. Follow the [installation instructions](https://github.com/particle-iot/cli/tree/main/packages/cli#installation) for CLI-vNext (aka "Delorean")
3. Verify the `device@source` toolchain uses the `buildscripts@1.11.0` dependency: `prtcl toolchain:view source:/path/to/device-os-repo` (consult `--help` if you need)
4. Verify that you are able to install the toolchain: `prtcl toolchain:install source:/path/to/device-os-repo`


### References

https://app.shortcut.com/particle/story/98414/workbench-support-to-debug-modular-firmware
https://github.com/particle-iot/device-os/pull/2465
https://github.com/particle-iot/cli/pull/137

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [x] Added to CHANGELOG.md after merging (add links to docs and issues)
