### PR TITLE
[p2] Simplify burn in LED blink, work around System.millis() reset

### DIFF
--- a/user/applications/tinker/src/burnin_test.cpp
+++ b/user/applications/tinker/src/burnin_test.cpp
@@ -188,7 +188,7 @@ static void blinkLed(int blink_time, int red, int green, int blue) {
 
 // Blink LED / signal uptime / failure state
 void BurninTest::ledLoop(void * arg) {
-	uint32_t total_runtime_millis = 0;
+	system_tick_t total_runtime_millis = 0;
 	int blinks_this_period = 0;
 
     while (true) {

--- a/user/applications/tinker/src/burnin_test.h
+++ b/user/applications/tinker/src/burnin_test.h
@@ -33,11 +33,8 @@ private:
 	static void ledLoop(void * arg);
     os_thread_t led_thread_ = nullptr;
 
-	static const uint32_t BLINK_PERIOD_MILLIS = 500;
-	static const uint32_t BLINK_PERIOD_STATUS_REPORT_MILLIS =  (10 * 2 * BLINK_PERIOD_MILLIS);
-	uint64_t start_time_millis_;
-	uint64_t next_blink_millis_;
-	uint64_t next_status_report_millis_;
+	static const uint32_t BLINK_PERIOD_MILLIS = 1000;
+	static const uint32_t BLINK_COUNT_PER_CYCLE = 10;
 
 	typedef bool (BurninTest::*burnin_test_function)();
 	Vector<burnin_test_function> tests_;


### PR DESCRIPTION
### Problem

The P2 burn in process is supposed to indicate how long it has run by blinking the LED every 1s. An alternating green/blue pattern indicates the tests are still running and passing.
 
For burn in hours X:
x >= 72h : 6 green blinks 4 blue
72h > x >= 48h : 7 green blinks 3 blue 
48h > x >= 24h : 8 green blinks, 2 blue
x < 24h : 9 green blinks, 1 blue

The current LED blink logic is convoluted, and relies on the `System.millis()` value monotonically increasing. Unfortunately there is also a bug right now where it resets sometimes, which causes the LED logic to break and stop blinking all together. 

### Solution

Simplify LED blink logic. Just use `delay()` since LED loop has its own thread. No need to rely on `System.millis()`

### Steps to Test

Build tinker, run burnin

### Example App

Tinker

### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
