### PR TITLE
[tests] [esomx] disable RGB pwm channel(s) when running pwm tests

### DIFF
--- a/hal/src/boron/pinmap_hal.c
+++ b/hal/src/boron/pinmap_hal.c
@@ -125,7 +125,7 @@ const uint8_t NRF_PIN_LOOKUP_TABLE[48] = {
 
 #if PLATFORM_ID == PLATFORM_ESOMX
 
-// H/W v0.02
+// H/W v0.02 and H/W v0.03
 static Hal_Pin_Info s_pin_map[TOTAL_PINS] = {
 /* User space */
 /* D0            - 00 */ { NRF_PORT_1,    1,           PIN_MODE_NONE, PF_NONE, ADC_CHANNEL_NONE, 1,                 0,                8, EXTI_CHANNEL_NONE, 0},

--- a/user/tests/wiring/no_fixture/gpio.cpp
+++ b/user/tests/wiring/no_fixture/gpio.cpp
@@ -175,11 +175,7 @@ test(GPIO_07_pulseIn_TimesOutAfter3Seconds) {
 }
 
 test(GPIO_08_DigitalReadWorksMixedWithAnalogRead) {
-#if PLATFORM_ID == PLATFORM_ESOMX
-    pin_t pin = A3;
-#else 
     pin_t pin = A0;
-#endif
 
     pinMode(pin, INPUT_PULLUP);
     assertEqual(hal_gpio_get_mode(pin), INPUT_PULLUP);

--- a/user/tests/wiring/no_fixture_long_running/pwm.cpp
+++ b/user/tests/wiring/no_fixture_long_running/pwm.cpp
@@ -47,14 +47,14 @@ static hal_pin_t pin = pwm_pins[0].pin;
 
 template <typename F> void for_all_pwm_pins(F callback)
 {
-    // RGB.control(true);
+    RGB.control(true);
     for (uint8_t i = 0; i<arraySize(pwm_pins); i++)
     {
         callback(pwm_pins[i].pin, pwm_pins[i].name);
         // Make sure to disable PWM pins
         pinMode(pwm_pins[i].pin, INPUT);
     }
-    // RGB.control(false);
+    RGB.control(false);
 }
 
 test(PWM_01_NoAnalogWriteWhenPinModeIsNotSetToOutput) {


### PR DESCRIPTION
## `NOTE: This PR should also be backported to 4.x`

### Problem

`wiring/no_fixture_long_running` PWM tests are failing on esomx platform, specifically PWM tests with pin `C5`.
`C5` shares a PWM channel with the RGB LEDs (channel 0). When running the PWM long running tests, the RGB led would interfere with the tests, causing them to fail.

### Solution
Disabling the RGB LED during the PWM tests allows them to execute without the LED system interfering.

**`NOTE:` this change does affect all PWM tests on all platforms, not just esomx**

I tested this PR with `esomx`, `p2` and `boron` platforms and all passed.

### Steps to Test

Run `wiring/no_fixture_long_running` tests

### Example App
Run `wiring/no_fixture_long_running` tests


### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
