### PR TITLE
chore/sc-107395/v4.x-bundleignore

### DIFF
--- a/.bundleignore
+++ b/.bundleignore
@@ -1,14 +1,17 @@
 **/.git
+**/*.zip
 /ci
 /docs
 /misc
-/scripts
+/test
 /build/target
+/third_party/ambd_sdk/ambd_sdk/doc
+/third_party/ambd_sdk/ambd_sdk/tools
+/third_party/ambd_sdk/ambd_sdk/component/common/example/
 /third_party/nrf5_sdk/nrf5_sdk/examples
 /third_party/nrf5_sdk/nrf5_sdk/components/802_15_4
 /third_party/nrf5_sdk/nrf5_sdk/components/toolchain/cmsis/dsp
 /third_party/freertos/freertos/FreeRTOS/Demo
+/third_party/freertos/freertos/FreeRTOS-Plus
 /user/applications/tinker/target
-/.workbench/manifest.json
-/.workbench/intellisense/asom.json
 


### PR DESCRIPTION
### Problem

The `.bundleignore ` file can be tuned and standardized between `v4.x` and `v5.x` lines

### Solution

Pull over `.bundleignore ` updates from https://github.com/particle-iot/device-os/pull/2475

### Steps to Test

see docs: [1](https://github.com/particle-iot/cli#development:~:text=How%20to%20exclude%20files%20and%20directories%20from%20toolchain%20dependency%20bundles), [2](https://github.com/particle-iot/cli#development:~:text=How%20to%20create%20a%20new%20Device%20OS%20toolchain%20dependency%20bundle)


### References

https://app.shortcut.com/particle/story/107395
https://github.com/particle-iot/device-os/pull/2475
https://github.com/particle-iot/device-os/pull/2326
https://github.com/particle-iot/cli/pull/44

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [x] Added to CHANGELOG.md after merging (add links to docs and issues)
