### PR TITLE
[rtl872x] Fix millis() rollover

### DIFF
--- a/hal/src/rtl872x/timer_hal.cpp
+++ b/hal/src/rtl872x/timer_hal.cpp
@@ -66,7 +66,7 @@ namespace {
 constexpr int TIMER_INDEX = 4;                              // Use TIM4
 constexpr int TIMER_PRESCALAR = 39;                         // Input clock = 40MHz_XTAL / (39 + 1) = 1MHz
 constexpr int TIMER_COUNTER_US_THRESHOLD = 1;               // 1us = 1tick
-constexpr int US_PER_OVERFLOW = 65536;                      // 65536us
+constexpr uint64_t US_PER_OVERFLOW = 65536;                 // 65536us
 constexpr int TIMER_IRQ_PRIORITY = 0;                       // Default priority in the close-source timer driver per FAE
 constexpr IRQn_Type TIMER_IRQ[] = {
     TIMER0_IRQ,
@@ -183,7 +183,7 @@ public:
     uint64_t getTime() {
 #ifndef HAL_TIMER_USE_SYSTIMER_ONLY
         auto state = getOverflowCounterWithTick();
-        return usSystemTimeMicrosBase_ + state.overflowCounter * US_PER_OVERFLOW + ticksToTime(state.curTimerTicks);
+        return usSystemTimeMicrosBase_ + state.overflowCounter * (uint64_t)US_PER_OVERFLOW + ticksToTime(state.curTimerTicks);
 #else
         return sysTimerUs();
 #endif // HAL_TIMER_USE_SYSTIMER_ONLY


### PR DESCRIPTION
### Problem

`HAL_Timer_Get_Milli_Seconds()` / `HAL_Timer_Get_Micro_Seconds()` Eventually reset after ~1 hour of execution. This results in `millis()` rolling over to zero. 

### Solution

It appears that the problem is due to integer promotion (in this case, demotion?) when calculating elapsed micro seconds:
```
constexpr int US_PER_OVERFLOW = 65536;                 // 65536us
...
return usSystemTimeMicrosBase_ + state.overflowCounter * US_PER_OVERFLOW + ticksToTime(state.curTimerTicks);
```

Making `US_PER_OVERFLOW` a uint64_t seems to solve the problem.

### Steps to Test

Modify `timer_hal.cpp` `init()` and `start()` functions to start the `overflowCounter_` at a value close to 65536
```
        overflowCounter_ = 65000;
```

Run the app and observe the uptime millis incrementing beyond `0004294659`

### Example App

tinker or any app with timestamp logging

### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
