### PR TITLE
[p2] attachInterrupt() should not configure input pullup/pulldown/nopull

### DIFF
--- a/user/tests/app/input_pinmode/input_pinmode.cpp
+++ b/user/tests/app/input_pinmode/input_pinmode.cpp
@@ -1,0 +1,122 @@
+#include "Particle.h"
+SYSTEM_MODE(SEMI_AUTOMATIC);
+SerialLogHandler logHandler(LOG_LEVEL_ALL);
+bool switch_test = false;
+int count = 0;
+int error = 0;
+int test_errors = 0;
+int state = 1;
+int COUNT_MULTIPLIER = 1;
+system_tick_t lastState = 0;
+const system_tick_t TIME_FOR_5_PULSES = (20 * 5);
+InterruptMode intType = CHANGE;
+//
+// We will set most pins to INPUT_x modes, but only test the first 7
+// since PM_INT takes up one of the 8, and after that RISING and CHANGE pending interrupt tests will fail.
+//
+#if (PLATFORM_ID == PLATFORM_P2)
+    const int PIN_MAX = D6; // TEST: D0 ~ D6 (however all will work on P2)
+#elif (PLATFORM_ID == PLATFORM_ARGON) || (PLATFORM_ID == PLATFORM_BORON)
+    const int PIN_MAX = D6; // TEST: D0 ~ D6
+#elif (PLATFORM_ID == PLATFORM_B5SOM)
+    const int PIN_MAX = D6;// TEST: D0 ~ D6
+#elif (PLATFORM_ID == PLATFORM_BSOM)
+    const int PIN_MAX = D6; // TEST: D0 ~ D6 (SDA, SCL, RTS, CTS, PWM0, PWM1, PWM2)
+#elif (PLATFORM_ID == PLATFORM_ESOMX)
+    const int PIN_MAX = D9; // TEST: D0, D1, D2, D5, D8, D9
+#elif (PLATFORM_ID == PLATFORM_TRACKER)
+    const int PIN_MAX = D6; // TEST: D0 ~ D3 (D4,D6 will error like shared PORT event interrupts do)
+#else
+    #error "Platform not supported!"
+#endif
+
+// required for B SoM / B5SoM
+#if defined(HAL_PLATFORM_POWER_MANAGEMENT_OPTIONAL) && HAL_PLATFORM_POWER_MANAGEMENT_OPTIONAL
+// Disable runtime PMIC / FuelGauge detection so we can test D0/D1 (SDA/SCL)
+STARTUP(System.disable(SYSTEM_FLAG_PM_DETECTION));
+#endif // defined(HAL_PLATFORM_POWER_MANAGEMENT_OPTIONAL) && HAL_PLATFORM_POWER_MANAGEMENT_OPTIONAL
+
+pin_t PULSE_PIN = A5; // A randomly higher up pin that's available on all platforms (and won't be in the test as an interrupt pin)
+
+void button_handler(system_event_t event, int clicks) {
+    if (event == button_final_click) {
+        if (clicks >= 1) {
+            switch_test = true;
+        }
+    }
+}
+
+static void attach_interrupt_handler() {
+    count++;
+}
+
+void teardownTest() {
+    for (int i = 0; i <= PIN_MAX; i++) {
+        if (i >= D7) continue;
+#if (PLATFORM_ID == PLATFORM_ESOMX && SYSTEM_VERSION <= SYSTEM_VERSION_BETA(4,0,0,1))
+        if (i == D3 || i == D3 || i == D6 || i == D7 || i == D22 || i == D23) continue; // these don't exist
+#endif
+        detachInterrupt(i);
+    }
+}
+
+void setupTest(InterruptMode type) {
+    static int pinModeType = 0;
+    Log.info("CHECK (%s) WITH (%s)", type == RISING ? "RISING" : type == FALLING ? "FALLING" : "CHANGE",
+            pinModeType == 0 ? "INPUT" : pinModeType == 1 ? "INPUT_PULLUP" : "INPUT_PULLDOWN");
+    digitalWriteFast(A5, HIGH);
+    delayMicroseconds(10);
+    digitalWriteFast(A5, LOW);
+    for (int i = 0; i <= PIN_MAX; i++) {
+        if (pinModeType == 0) {
+            pinMode(i, INPUT);
+        } else if (pinModeType == 1) {
+            pinMode(i, INPUT_PULLUP);
+        } else {
+            pinMode(i, INPUT_PULLDOWN);
+        }
+    }
+    if (type == CHANGE) {
+        pinModeType++;
+        pinModeType = pinModeType % 2;
+    }
+    digitalWriteFast(A5, HIGH);
+    delayMicroseconds(10);
+    digitalWriteFast(A5, LOW);
+    for (int i = 0; i <= PIN_MAX; i++) {
+        if (i >= D7) continue;
+#if (PLATFORM_ID == PLATFORM_ESOMX && SYSTEM_VERSION <= SYSTEM_VERSION_BETA(4,0,0,1))
+        if (i == D3 || i == D3 || i == D6 || i == D7 || i == D22 || i == D23) continue; // these don't exist
+#endif
+        attachInterrupt(i, attach_interrupt_handler, type);
+    }
+    digitalWriteFast(A5, HIGH);
+    delayMicroseconds(10);
+    digitalWriteFast(A5, LOW);
+}
+
+void setup() {
+    waitFor(Serial.isConnected, 10000);
+    delay(200);
+    Log.info("Attach a scope to A5, and test input D0 ~ D6 one at a time.");
+    Log.info("Check that test input mode only changes between the first two pulses on A5,");
+    Log.info("and not the second and third. Press the MODE button to cycle through all 9");
+    Log.info("configurations (INPUT/INPUT_PULLUP/INPUT_PULLDOWN) with (RISING/FALLING/CHANGE).");
+    pinMode(A5, OUTPUT);
+    System.on(button_final_click, button_handler);
+}
+
+void loop() {
+    if (switch_test) {
+        switch_test = false;
+        if (intType == CHANGE) {
+            intType = RISING;
+        } else if (intType == RISING) {
+            intType = FALLING;
+        } else if (intType == FALLING) {
+            intType = CHANGE;
+        }
+        teardownTest();
+        setupTest(intType);
+    }
+}

--- a/user/tests/wiring/no_fixture/interrupts.cpp
+++ b/user/tests/wiring/no_fixture/interrupts.cpp
@@ -1,6 +1,7 @@
 
 #include "application.h"
 #include "unit-test/unit-test.h"
+#include "scope_guard.h"
 
 // TODO for HAL_PLATFORM_NRF52840
 // TestHandler is currently unused but leaving in for refernece
@@ -32,6 +33,12 @@ public:
 	static int count;
 };
 
+int count = 0;
+
+static void attach_interrupt_handler() {
+    count++;
+}
+
 } // namespace
 
 test(INTERRUPTS_01_isisr_willpreempt_servicedirqn)
@@ -54,4 +61,50 @@ test(INTERRUPTS_01_isisr_willpreempt_servicedirqn)
 	assertFalse(attachInterruptDirect(I2C0_IRQ, []() {return;}));
 	assertTrue(detachInterruptDirect(I2C0_IRQ));
 #endif
+}
+
+test(INTERRUPTS_02_attachintterupt_does_not_affect_pullup_pulldown_nopull)
+{
+#if PLATFORM_ID == PLATFORM_ESOMX
+	const pin_t START_PIN = D0;
+    const pin_t END_PIN = D2;
+#else
+    // Every other platform has D2 ~ D3 available.
+    const pin_t START_PIN = D2;
+    const pin_t END_PIN = D3;
+#endif // PLATFORM_ID == PLATFORM_ESOMX
+    SCOPE_GUARD ({
+            for (int i = START_PIN; i <= END_PIN; i++) {
+                detachInterrupt(i);
+            }
+        });
+    for (int i = START_PIN; i <= END_PIN; i++) {
+        pinMode(i, INPUT_PULLUP);
+    }
+    for (int i = START_PIN; i <= END_PIN; i++) {
+        attachInterrupt(i, attach_interrupt_handler, RISING); // used to set PULLDOWN before sc-107554
+        delay(100);
+        assertTrue(digitalRead(i) == HIGH); // INPUT_PULLUP should still be set
+    }
+    for (int i = START_PIN; i <= END_PIN; i++) {
+        detachInterrupt(i);
+    }
+
+    for (int i = START_PIN; i <= END_PIN; i++) {
+        pinMode(i, INPUT_PULLDOWN);
+    }
+    for (int i = START_PIN; i <= END_PIN; i++) {
+        attachInterrupt(i, attach_interrupt_handler, FALLING); // used to set PULLUP before sc-107554
+        delay(100);
+        assertTrue(digitalRead(i) == LOW); // INPUT_PULLDOWN should still be set
+    }
+    for (int i = START_PIN; i <= END_PIN; i++) {
+        detachInterrupt(i);
+    }
+    for (int i = START_PIN; i <= END_PIN; i++) {
+        attachInterrupt(i, attach_interrupt_handler, CHANGE); // used to set PULLUP before sc-107554
+        delay(100);
+        assertTrue(digitalRead(i) == LOW); // INPUT_PULLDOWN should still be set
+    }
+    // SCOPE_GUARD will detachInterrupt's
 }


### PR DESCRIPTION
### Problem

From [Docs on attachInterrupt](https://docs.particle.io/reference/device-os/api/interrupts/attachinterrupt/):

> NOTE: pinMode() MUST be called prior to calling attachInterrupt() to set the desired mode for the interrupt pin (INPUT, INPUT_PULLUP or INPUT_PULLDOWN).

P2 implementation currently does not respect this and modifies the pin pull up based on the InterruptMode type (RISING/FALLING/CHANGE).

### Solution

- The Realtek routines that modify pullup/pulldown resistors are `GPIO_Init()` and `GPIO_INTMode()`.  Since these are compiled libraries, we have to reimplement them without the calls to `PAD_PullCtrl()` for use only in `hal_interrupt_attach()`
- I moved the placement/timing of `GPIO_Init_HAL()` based on guidance from Realtek examples and documentation.

### Steps to Test

- Run `TEST=wiring/no_fixture` (INTERRUPTS* - automated test)
- Run `TEST=app/interrupts` (follow logging prompts - manual test)
- Run `TEST=app/input_pinmode` (follow logging prompts - manual test)
```
Attach a scope to A5, and test input D0 ~ D6 one at a time.
Check that test input mode only changes between the first two pulses on A5,
and not the second and third. Press the MODE button to cycle through all 9
configurations (INPUT/INPUT_PULLUP/INPUT_PULLDOWN) with (RISING/FALLING/CHANGE).
```

### References

- [sc-107554](https://app.shortcut.com/particle/story/107554/p2-attachinterrupt-api-should-not-add-pull-up-down-resistors)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
