### PR TITLE
RTL872x: Implement APIs to set/get BLE address

### DIFF
--- a/hal/inc/deviceid_hal.h
+++ b/hal/inc/deviceid_hal.h
@@ -96,6 +96,11 @@ int hal_get_device_hw_version(uint32_t* revision, void* reserved);
  */
 int hal_get_device_hw_model(uint32_t* model, uint32_t* variant, void* reserved);
 
+/**
+ * Get the device's BLE MAC address.
+ */
+int hal_get_ble_mac_address(uint8_t* dest, size_t destLen, void* reserved);
+
 #include "deviceid_hal_compat.h"
 
 #ifdef	__cplusplus

--- a/hal/inc/deviceid_hal.h
+++ b/hal/inc/deviceid_hal.h
@@ -96,12 +96,9 @@ int hal_get_device_hw_version(uint32_t* revision, void* reserved);
  */
 int hal_get_device_hw_model(uint32_t* model, uint32_t* variant, void* reserved);
 
-/**
- * Get the device's BLE MAC address.
- */
-int hal_get_ble_mac_address(uint8_t* dest, size_t destLen, void* reserved);
-
 #include "deviceid_hal_compat.h"
+
+#include "deviceid_hal_impl.h"
 
 #ifdef	__cplusplus
 }

--- a/hal/src/gcc/deviceid_hal_impl.h
+++ b/hal/src/gcc/deviceid_hal_impl.h
@@ -17,27 +17,4 @@
 
 #pragma once
 
-#define HAL_DEVICE_MAC_ADDR_SIZE        6
-
-#define HAL_DEVICE_MAC_WIFI_STA         0
-#define HAL_DEVICE_MAC_BLE              1
-#define HAL_DEVICE_MAC_WIFI_AP          2
-#define HAL_DEVICE_MAC_ETHERNET         3
-
-#define isSupportedMacType(type)        ((type) == HAL_DEVICE_MAC_WIFI_STA || \
-                                         (type) == HAL_DEVICE_MAC_BLE || \
-                                         (type) == HAL_DEVICE_MAC_WIFI_AP || \
-                                         (type) == HAL_DEVICE_MAC_ETHERNET)
-
-#ifdef	__cplusplus
-extern "C" {
-#endif
-
-/**
- * Get the device's BLE MAC address.
- */
-int hal_get_mac_address(uint8_t type, uint8_t* dest, size_t destLen, void* reserved);
-
-#ifdef	__cplusplus
-}
-#endif
+// placeholder

--- a/hal/src/nRF52840/deviceid_hal_impl.h
+++ b/hal/src/nRF52840/deviceid_hal_impl.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// placeholder

--- a/hal/src/newhal/deviceid_hal_impl.h
+++ b/hal/src/newhal/deviceid_hal_impl.h
@@ -17,27 +17,4 @@
 
 #pragma once
 
-#define HAL_DEVICE_MAC_ADDR_SIZE        6
-
-#define HAL_DEVICE_MAC_WIFI_STA         0
-#define HAL_DEVICE_MAC_BLE              1
-#define HAL_DEVICE_MAC_WIFI_AP          2
-#define HAL_DEVICE_MAC_ETHERNET         3
-
-#define isSupportedMacType(type)        ((type) == HAL_DEVICE_MAC_WIFI_STA || \
-                                         (type) == HAL_DEVICE_MAC_BLE || \
-                                         (type) == HAL_DEVICE_MAC_WIFI_AP || \
-                                         (type) == HAL_DEVICE_MAC_ETHERNET)
-
-#ifdef	__cplusplus
-extern "C" {
-#endif
-
-/**
- * Get the device's BLE MAC address.
- */
-int hal_get_mac_address(uint8_t type, uint8_t* dest, size_t destLen, void* reserved);
-
-#ifdef	__cplusplus
-}
-#endif
+// placeholder

--- a/hal/src/rtl872x/ble_hal.cpp
+++ b/hal/src/rtl872x/ble_hal.cpp
@@ -160,8 +160,14 @@ bool addressEqual(const hal_ble_addr_t& srcAddr, const hal_ble_addr_t& destAddr)
 
 hal_ble_addr_t chipDefaultPublicAddress() {
     hal_ble_addr_t localAddr = {};
-    hal_get_ble_mac_address(localAddr.addr, BLE_SIG_ADDR_LEN, nullptr);
-    localAddr.addr_type = BLE_SIG_ADDR_TYPE_PUBLIC;
+    uint8_t mac[BLE_SIG_ADDR_LEN] = {};
+    if (hal_get_mac_address(HAL_DEVICE_MAC_BLE, mac, BLE_SIG_ADDR_LEN, nullptr) == BLE_SIG_ADDR_LEN) {
+        // As per BLE spec, we store BLE data in little-endian
+        for (uint8_t i = 0, j = BLE_SIG_ADDR_LEN - 1; i < BLE_SIG_ADDR_LEN; i++, j--) {
+            localAddr.addr[i] = mac[j];
+        }
+        localAddr.addr_type = BLE_SIG_ADDR_TYPE_PUBLIC;
+    }
     return localAddr;
 }
 

--- a/hal/src/rtl872x/ble_hal_impl.h
+++ b/hal/src/rtl872x/ble_hal_impl.h
@@ -133,6 +133,8 @@ typedef uint16_t hal_ble_attr_handle_t;
 typedef uint16_t hal_ble_conn_handle_t;
 
 
+int hal_get_ble_mac_address(uint8_t* dest, size_t destLen, void* reserved);
+
 #endif //HAL_PLATFORM_BLE
 
 

--- a/hal/src/rtl872x/ble_hal_impl.h
+++ b/hal/src/rtl872x/ble_hal_impl.h
@@ -133,8 +133,6 @@ typedef uint16_t hal_ble_attr_handle_t;
 typedef uint16_t hal_ble_conn_handle_t;
 
 
-int hal_get_ble_mac_address(uint8_t* dest, size_t destLen, void* reserved);
-
 #endif //HAL_PLATFORM_BLE
 
 

--- a/hal/src/rtl872x/deviceid_hal.cpp
+++ b/hal/src/rtl872x/deviceid_hal.cpp
@@ -99,17 +99,17 @@ int HAL_Get_Device_Identifier(const char** name, char* buf, size_t buflen, unsig
 }
 
 int hal_get_mac_address(uint8_t type, uint8_t* dest, size_t destLen, void* reserved) {
-    CHECK_TRUE(dest && destLen >= MAC_ADDR_SIZE, SYSTEM_ERROR_INVALID_ARGUMENT);
+    CHECK_TRUE(dest && destLen >= HAL_DEVICE_MAC_ADDR_SIZE, SYSTEM_ERROR_INVALID_ARGUMENT);
     CHECK_TRUE(isSupportedMacType(type), SYSTEM_ERROR_INVALID_ARGUMENT);
-    uint8_t mac[MAC_ADDR_SIZE] = {};
+    uint8_t mac[HAL_DEVICE_MAC_ADDR_SIZE] = {};
     if (type == HAL_DEVICE_MAC_BLE) {
-        CHECK(readLogicalEfuse(BLE_MAC_OFFSET, mac, MAC_ADDR_SIZE));
+        CHECK(readLogicalEfuse(BLE_MAC_OFFSET, mac, HAL_DEVICE_MAC_ADDR_SIZE));
     } else {
-        CHECK(readLogicalEfuse(WIFI_MAC_OFFSET, mac, MAC_ADDR_SIZE));
+        CHECK(readLogicalEfuse(WIFI_MAC_OFFSET, mac, HAL_DEVICE_MAC_ADDR_SIZE));
         // Derive the final MAC address
         mac[5] += type;
     }
-    return MAC_ADDR_SIZE;
+    return HAL_DEVICE_MAC_ADDR_SIZE;
 }
 
 int hal_get_device_serial_number(char* str, size_t size, void* reserved) {
@@ -124,7 +124,7 @@ int hal_get_device_serial_number(char* str, size_t size, void* reserved) {
     CHECK(readLogicalEfuse(SERIAL_NUMBER_OFFSET, (uint8_t*)fullSerialNumber, SERIAL_NUMBER_FRONT_PART_SIZE));
 
     // generate hex string from non-OUI MAC bytes
-    uint8_t wifiMacRandomBytes[MAC_ADDR_SIZE - WIFI_OUID_SIZE] = {};
+    uint8_t wifiMacRandomBytes[HAL_DEVICE_MAC_ADDR_SIZE - WIFI_OUID_SIZE] = {};
     CHECK(readLogicalEfuse(WIFI_MAC_OFFSET + WIFI_OUID_SIZE, wifiMacRandomBytes, sizeof(wifiMacRandomBytes)));
     bytes2hexbuf(wifiMacRandomBytes, sizeof(wifiMacRandomBytes), &fullSerialNumber[SERIAL_NUMBER_FRONT_PART_SIZE]);
 

--- a/hal/src/rtl872x/deviceid_hal.cpp
+++ b/hal/src/rtl872x/deviceid_hal.cpp
@@ -43,6 +43,7 @@ using namespace particle;
 #define EFUSE_SUCCESS           1
 #define EFUSE_FAILURE           0
 
+#define BLE_MAC_OFFSET          0x190
 #define WIFI_MAC_OFFSET         0x11A
 #define MOBILE_SECRET_OFFSET    0x160
 #define SERIAL_NUMBER_OFFSET    0x16F
@@ -50,6 +51,7 @@ using namespace particle;
 #define HARDWARE_MODEL_OFFSET   0x17B
 
 #define WIFI_MAC_SIZE                   6
+#define BLE_MAC_SIZE                    6
 #define SERIAL_NUMBER_FRONT_PART_SIZE   9
 #define HARDWARE_DATA_SIZE              4
 #define HARDWARE_MODEL_SIZE             4
@@ -84,13 +86,6 @@ int readLogicalEfuse(uint32_t offset, uint8_t* buf, size_t size) {
     return SYSTEM_ERROR_NONE;
 };
 
-// big-endian
-int readBaseMacAddress(uint8_t* dest, size_t destLen) {
-    // The parameters should have been checked
-    CHECK(readLogicalEfuse(WIFI_MAC_OFFSET, dest, destLen));
-    return WIFI_MAC_SIZE;
-}
-
 } // Anonymous
 
 unsigned hal_get_device_id(uint8_t* dest, unsigned destLen) {
@@ -113,16 +108,15 @@ int HAL_Get_Device_Identifier(const char** name, char* buf, size_t buflen, unsig
 }
 
 int hal_get_ble_mac_address(uint8_t* dest, size_t destLen, void* reserved) {
-    CHECK_TRUE(dest && destLen >= WIFI_MAC_SIZE, SYSTEM_ERROR_INVALID_ARGUMENT);
-    uint8_t mac[WIFI_MAC_SIZE] = {};
-    destLen = WIFI_MAC_SIZE;
-    CHECK(readBaseMacAddress(mac, WIFI_MAC_SIZE));
+    CHECK_TRUE(dest && destLen >= BLE_MAC_SIZE, SYSTEM_ERROR_INVALID_ARGUMENT);
+    uint8_t mac[BLE_MAC_SIZE] = {};
+    destLen = BLE_MAC_SIZE;
+    CHECK(readLogicalEfuse(BLE_MAC_OFFSET, mac, BLE_MAC_SIZE));
     // As per BLE spec, we store BLE data in little-endian
-    for (uint8_t i = 0, j = WIFI_MAC_SIZE - 1; i < WIFI_MAC_SIZE; i++, j--) {
+    for (uint8_t i = 0, j = BLE_MAC_SIZE - 1; i < BLE_MAC_SIZE; i++, j--) {
         dest[i] = mac[j];
     }
-    dest[0] += BLE_MAC_DELTA;
-    return WIFI_MAC_SIZE;
+    return BLE_MAC_SIZE;
 }
 
 

--- a/hal/src/rtl872x/deviceid_hal_impl.h
+++ b/hal/src/rtl872x/deviceid_hal_impl.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define MAC_ADDR_SIZE                   6
+
+#define HAL_DEVICE_MAC_WIFI_STA         0
+#define HAL_DEVICE_MAC_BLE              1
+#define HAL_DEVICE_MAC_WIFI_AP          2
+#define HAL_DEVICE_MAC_ETHERNET         3
+
+#define isSupportedMacType(type)        ((type) == HAL_DEVICE_MAC_WIFI_STA || \
+                                         (type) == HAL_DEVICE_MAC_BLE || \
+                                         (type) == HAL_DEVICE_MAC_WIFI_AP || \
+                                         (type) == HAL_DEVICE_MAC_ETHERNET)
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+/**
+ * Get the device's BLE MAC address.
+ */
+int hal_get_mac_address(uint8_t type, uint8_t* dest, size_t destLen, void* reserved);
+
+#ifdef	__cplusplus
+}
+#endif

--- a/hal/src/trackerm/network/network.cpp
+++ b/hal/src/trackerm/network/network.cpp
@@ -154,8 +154,8 @@ int if_init_platform(void*) {
     reserve_netif_index();
 
     /* en2 - Ethernet FeatherWing (optional) */
-    uint8_t mac[MAC_ADDR_SIZE] = {};
-    CHECK(hal_get_mac_address(HAL_DEVICE_MAC_ETHERNET, mac, MAC_ADDR_SIZE, nullptr));
+    uint8_t mac[HAL_DEVICE_MAC_ADDR_SIZE] = {};
+    CHECK(hal_get_mac_address(HAL_DEVICE_MAC_ETHERNET, mac, HAL_DEVICE_MAC_ADDR_SIZE, nullptr));
 
     if (HAL_Feature_Get(FEATURE_ETHERNET_DETECTION)) {
         en2 = new WizNetif(HAL_SPI_INTERFACE1, D5, D3, D4, mac);

--- a/hal/src/trackerm/network/network.cpp
+++ b/hal/src/trackerm/network/network.cpp
@@ -154,10 +154,8 @@ int if_init_platform(void*) {
     reserve_netif_index();
 
     /* en2 - Ethernet FeatherWing (optional) */
-    uint8_t deviceId[HAL_DEVICE_ID_SIZE] = {};
-    hal_get_device_id(deviceId, sizeof(deviceId));
-    uint8_t* mac = deviceId + HAL_DEVICE_ID_SIZE - 6;
-    mac[5] += 3;
+    uint8_t mac[MAC_ADDR_SIZE] = {};
+    CHECK(hal_get_mac_address(HAL_DEVICE_MAC_ETHERNET, mac, MAC_ADDR_SIZE, nullptr));
 
     if (HAL_Feature_Get(FEATURE_ETHERNET_DETECTION)) {
         en2 = new WizNetif(HAL_SPI_INTERFACE1, D5, D3, D4, mac);

--- a/hal/src/tron/network/network.cpp
+++ b/hal/src/tron/network/network.cpp
@@ -107,10 +107,8 @@ int if_init_platform(void*) {
     reserve_netif_index();
 
     /* en2 - Ethernet FeatherWing (optional) */
-    uint8_t deviceId[HAL_DEVICE_ID_SIZE] = {};
-    hal_get_device_id(deviceId, sizeof(deviceId));
-    uint8_t* mac = deviceId + HAL_DEVICE_ID_SIZE - 6;
-    mac[5] += 3;
+    uint8_t mac[HAL_DEVICE_MAC_ADDR_SIZE] = {};
+    CHECK(hal_get_mac_address(HAL_DEVICE_MAC_ETHERNET, mac, HAL_DEVICE_MAC_ADDR_SIZE, nullptr));
 
     if (HAL_Feature_Get(FEATURE_ETHERNET_DETECTION)) {
         en2 = new WizNetif(HAL_SPI_INTERFACE1, D5, D3, D4, mac);


### PR DESCRIPTION
As the title describes.

### Example App

```c
void setup() {
    BLE.on();
    BLE.advertise();
    // BLE.setAddress("D3:12:34:56:78:AB");
    delay(3000);
    auto foo = BLE.address();
    Log.info(foo.toString());
}
```

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
