### PR TITLE
[ci] branch pattern changes for test-build-system

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -422,13 +422,16 @@ workflows:
             pattern: "^master$"
             value: << pipeline.git.branch >>
         - matches:
-            pattern: "^develop$"
+            pattern: "^develop.*"
             value: << pipeline.git.branch >>
         - matches:
             pattern: "^test/v.*"
             value: << pipeline.git.branch >>
         - matches:
             pattern: "^release/.*"
+            value: << pipeline.git.branch >>
+        - matches:
+            pattern: ".*test-build-system.*"
             value: << pipeline.git.branch >>
     jobs:
       - setup-workspace:


### PR DESCRIPTION
### Problem

- If you want to push changes to fix test-build-system, currently you have to modify the branch pattern to do so.  There should be some pattern we can use for PRs that allows us to test changes in the PR before they are merged... without having to think about changing the pattern.  Suggest anything matching `*test-build-system*`.
- Also doesn't include `develop-*.x` branches

### Solution

- Modify/Add required patterns

### Steps to Test

- CircleCI should run the `test-build-system` workflow when a branch contains `test-build-system`
- CircleCI should run the `test-build-system` workflow when a branch is merged to `develop-4.x`

### References

[sc-107219](https://app.shortcut.com/particle/story/107219/add-a-branch-pattern-to-workbench-test-build-system-circleci-script-workflow-to-assist-fixing-changing-the-test-build-system)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
