### PR TITLE
Disable direct logging in listening mode

### DIFF
--- a/wiring/inc/spark_wiring_logging.h
+++ b/wiring/inc/spark_wiring_logging.h
@@ -702,23 +702,12 @@ inline Print* spark::StreamLogHandler::stream() const {
     return stream_;
 }
 
-inline void spark::StreamLogHandler::write(const char *data, size_t size) {
-    stream_->write((const uint8_t*)data, size);
-}
-
 inline void spark::StreamLogHandler::write(const char *str) {
     write(str, strlen(str));
 }
 
 inline void spark::StreamLogHandler::write(char c) {
     write(&c, 1);
-}
-
-inline void spark::StreamLogHandler::printf(const char *fmt, ...) {
-    va_list args;
-    va_start(args, fmt);
-    stream_->vprintf(false, fmt, args);
-    va_end(args);
 }
 
 // spark::JSONStreamLogHandler

--- a/wiring/src/spark_wiring_logging.cpp
+++ b/wiring/src/spark_wiring_logging.cpp
@@ -475,6 +475,11 @@ int spark::detail::LogFilter::nodeIndex(const Vector<Node> &nodes, const char *n
 
 // spark::StreamLogHandler
 void spark::StreamLogHandler::logMessage(const char *msg, LogLevel level, const char *category, const LogAttributes &attr) {
+#if PLATFORM_ID != PLATFORM_GCC && !defined(LOG_IN_LISTENING_MODE)
+    if (stream_ == &Serial && Network.listening()) {
+        return; // Do not mix logging and serial console output
+    }
+#endif
     const char *s = nullptr;
     // Timestamp
     if (attr.has_time) {
@@ -537,7 +542,6 @@ void spark::StreamLogHandler::logMessage(const char *msg, LogLevel level, const 
 }
 
 void spark::StreamLogHandler::write(const char *data, size_t size) {
-    // TODO: Move this check to a base class (see also JSONStreamLogHandler::logMessage())
 #if PLATFORM_ID != PLATFORM_GCC && !defined(LOG_IN_LISTENING_MODE)
     if (stream_ == &Serial && Network.listening()) {
         return; // Do not mix logging and serial console output
@@ -567,12 +571,11 @@ void spark::StreamLogHandler::printf(const char *fmt, ...) {
 
 // spark::JSONStreamLogHandler
 void spark::JSONStreamLogHandler::logMessage(const char *msg, LogLevel level, const char *category, const LogAttributes &attr) {
-    // TODO: Move this check to a base class (see also StreamLogHandler::write())
 #if PLATFORM_ID != PLATFORM_GCC && !defined(LOG_IN_LISTENING_MODE)
     if (this->stream() == &Serial && Network.listening()) {
         return; // Do not mix logging and serial console output
     }
-#endif // PLATFORM_ID != PLATFORM_GCC
+#endif
     JSONStreamWriter json(*this->stream());
     json.beginObject();
     // Level

--- a/wiring/src/spark_wiring_logging.cpp
+++ b/wiring/src/spark_wiring_logging.cpp
@@ -34,6 +34,9 @@
 // Uncomment to enable logging in interrupt handlers
 // #define LOG_FROM_ISR
 
+// Uncomment to enable logging to the USB serial while in listening mode
+// #define LOG_IN_LISTENING_MODE
+
 #if defined(LOG_FROM_ISR) && PLATFORM_ID != PLATFORM_GCC
 // When compiled with LOG_FROM_ISR defined use ATOMIC_BLOCK
 #define LOG_WITH_LOCK(x) ATOMIC_BLOCK()
@@ -472,12 +475,6 @@ int spark::detail::LogFilter::nodeIndex(const Vector<Node> &nodes, const char *n
 
 // spark::StreamLogHandler
 void spark::StreamLogHandler::logMessage(const char *msg, LogLevel level, const char *category, const LogAttributes &attr) {
-    // TODO: Move this check to a base class (see also JSONStreamLogHandler::logMessage())
-#if PLATFORM_ID != PLATFORM_GCC
-    if (stream_ == &Serial && Network.listening()) {
-        return; // Do not mix logging and serial console output
-    }
-#endif // PLATFORM_ID != PLATFORM_GCC
     const char *s = nullptr;
     // Timestamp
     if (attr.has_time) {
@@ -539,10 +536,39 @@ void spark::StreamLogHandler::logMessage(const char *msg, LogLevel level, const 
     write("\r\n", 2);
 }
 
+void spark::StreamLogHandler::write(const char *data, size_t size) {
+    // TODO: Move this check to a base class (see also JSONStreamLogHandler::logMessage())
+#if PLATFORM_ID != PLATFORM_GCC && !defined(LOG_IN_LISTENING_MODE)
+    if (stream_ == &Serial && Network.listening()) {
+        return; // Do not mix logging and serial console output
+    }
+#endif
+    stream_->write((const uint8_t*)data, size);
+}
+
+void spark::StreamLogHandler::printf(const char *fmt, ...) {
+    char buf[32];
+    va_list args;
+    va_start(args, fmt);
+    int n = vsnprintf(buf, sizeof(buf), fmt, args);
+    va_end(args);
+    if ((size_t)n >= sizeof(buf)) {
+        char buf[n + 1]; // Use a larger buffer
+        va_start(args, fmt);
+        n = vsnprintf(buf, sizeof(buf), fmt, args);
+        va_end(args);
+        if (n > 0) {
+            write(buf, n);
+        }
+    } else if (n > 0) {
+        write(buf, n);
+    }
+}
+
 // spark::JSONStreamLogHandler
 void spark::JSONStreamLogHandler::logMessage(const char *msg, LogLevel level, const char *category, const LogAttributes &attr) {
-    // TODO: Move this check to a base class (see also StreamLogHandler::logMessage())
-#if PLATFORM_ID != PLATFORM_GCC
+    // TODO: Move this check to a base class (see also StreamLogHandler::write())
+#if PLATFORM_ID != PLATFORM_GCC && !defined(LOG_IN_LISTENING_MODE)
     if (this->stream() == &Serial && Network.listening()) {
         return; // Do not mix logging and serial console output
     }


### PR DESCRIPTION
### Problem

Device OS disables logging to the USB serial when the device is in listening mode in order to prevent mixing up the serial console and logging output. However, it turns out that messages logged via `LOG_PRINT()` and other macros for direct logging still get through and may garble the serial console output. This PR fixes that by disabling direct logging in listening mode.
