### PR TITLE
[test] fixes race condition with wiring/no_fixture TIME_17

### DIFF
--- a/user/tests/wiring/no_fixture/time.cpp
+++ b/user/tests/wiring/no_fixture/time.cpp
@@ -27,6 +27,7 @@
 #include "unit-test/unit-test.h"
 #include "rtc_hal.h"
 #include "simple_ntp_client.h"
+#include "scope_guard.h"
 
 test(TIME_01_NowReturnsCorrectUnixTime) {
     // when
@@ -270,11 +271,12 @@ test(TIME_16_TimeChangedEvent) {
 }
 
 test(TIME_17_RtcAlarmFiresCorrectly) {
-    if (Particle.syncTimePending()) {
-        waitFor(Particle.syncTimeDone, 60000);
-        assertTrue(Particle.syncTimeDone());
-        assertTrue(Time.isValid());
-    }
+    SCOPE_GUARD ({
+            Particle.connect();
+            waitFor(Particle.connected, 60000);
+        });
+    Particle.disconnect();
+    waitFor(Particle.disconnected, 60000);
 
     // Absolute time
     struct timeval now;
@@ -288,7 +290,7 @@ test(TIME_17_RtcAlarmFiresCorrectly) {
     }, (void*)&alarmFired, nullptr);
     assertEqual(r, 0);
     while (!alarmFired && (millis() - ms) <= 6000) {
-        delay(1);
+        HAL_Delay_Milliseconds(10);
     }
     assertLessOrEqual(millis() - ms, 6000);
     hal_rtc_cancel_alarm();
@@ -305,7 +307,7 @@ test(TIME_17_RtcAlarmFiresCorrectly) {
     }, (void*)&alarmFired, nullptr);
     assertEqual(r, 0);
     while (!alarmFired && (millis() - ms) <= 6000) {
-        delay(1);
+        HAL_Delay_Milliseconds(10);
     }
     assertLessOrEqual(millis() - ms, 6000);
     hal_rtc_cancel_alarm();
@@ -313,11 +315,12 @@ test(TIME_17_RtcAlarmFiresCorrectly) {
 }
 
 test(TIME_18_RtcAlarmReturnsAnErrorWhenTimeInThePast) {
-    if (Particle.syncTimePending()) {
-        waitFor(Particle.syncTimeDone, 60000);
-        assertTrue(Particle.syncTimeDone());
-        assertTrue(Time.isValid());
-    }
+    SCOPE_GUARD ({
+            Particle.connect();
+            waitFor(Particle.connected, 60000);
+        });
+    Particle.disconnect();
+    waitFor(Particle.disconnected, 60000);
 
     // Absolute time
     struct timeval now;


### PR DESCRIPTION
### Problem

TIME_17 was failing, presumably due to a race condition with time sync arriving late

### Solution

Run TIME_17 offline and use the RTC as-is (it might have sync'd time, it might not... doesn't matter for the test)

### Steps to Test

- Run `TEST=wiring/no_fixture` (TIME*) tests

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
