### PR TITLE
[services] device tree stubs

### DIFF
--- a/services/inc/devicetree_stubs.h
+++ b/services/inc/devicetree_stubs.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include <stdint.h>
+#include <unistd.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+int devicetree_init(const void*, uint32_t, void*);
+
+int devicetree_overlay_apply(const void*, uint32_t, void*);
+
+int devicetree_string_dictionary_register(const void*, size_t, uint32_t, void*);
+
+int devicetree_tree_lock(void*);
+
+int devicetree_tree_get(void*, uint32_t, void*);
+
+const char* devicetree_string_dictionary_lookup(uint32_t, void*);
+
+uint32_t devicetree_hash_string(const char*, size_t);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus

--- a/services/inc/services_dynalib.h
+++ b/services/inc/services_dynalib.h
@@ -27,6 +27,7 @@
 
 #ifdef DYNALIB_EXPORT
 #include "nanopb_misc.h"
+#include "devicetree_stubs.h"
 #include <stdint.h>
 #ifdef PB_WITHOUT_64BIT
 #define pb_int64_t int32_t
@@ -88,6 +89,13 @@ DYNALIB_FN(41, services, clear_system_error_message, void())
 DYNALIB_FN(42, services, get_system_error_message, const char*(int))
 DYNALIB_FN(43, services, jsmn_parse, int(jsmn_parser*, const char*, size_t, jsmntok_t*, unsigned int, void*))
 DYNALIB_FN(44, services, panic_set_hook, void(const PanicHook, void*))
+DYNALIB_FN(45, services, devicetree_init, int(const void*, uint32_t, void*))
+DYNALIB_FN(46, services, devicetree_overlay_apply, int(const void*, uint32_t, void*))
+DYNALIB_FN(47, services, devicetree_string_dictionary_register, int(const void*, size_t, uint32_t, void*))
+DYNALIB_FN(48, services, devicetree_tree_lock, int(void*))
+DYNALIB_FN(49, services, devicetree_tree_get, int(void*, uint32_t, void*))
+DYNALIB_FN(50, services, devicetree_string_dictionary_lookup, const char*(uint32_t, void*))
+DYNALIB_FN(51, services, devicetree_hash_string, uint32_t(const char*, size_t))
 
 DYNALIB_END(services)
 

--- a/services/src/devicetree_stubs.cpp
+++ b/services/src/devicetree_stubs.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "devicetree_stubs.h"
+#include "system_error.h"
+
+int devicetree_init(const void*, uint32_t, void*) {
+    return SYSTEM_ERROR_NOT_SUPPORTED;
+}
+
+int devicetree_overlay_apply(const void*, uint32_t, void*) {
+    return SYSTEM_ERROR_NOT_SUPPORTED;
+}
+
+int devicetree_string_dictionary_register(const void*, size_t, uint32_t, void*) {
+    return SYSTEM_ERROR_NOT_SUPPORTED;
+}
+
+int devicetree_tree_lock(void*) {
+    return SYSTEM_ERROR_NOT_SUPPORTED;
+}
+
+int devicetree_tree_get(void*, uint32_t, void*) {
+    return SYSTEM_ERROR_NOT_SUPPORTED;
+}
+
+const char* devicetree_string_dictionary_lookup(uint32_t, void*) {
+    return nullptr;
+}
+
+uint32_t devicetree_hash_string(const char*, size_t) {
+    return 0;
+}


### PR DESCRIPTION
Reserve functions in services dynalib for device tree support and for now just return `SYSTEM_ERROR_NOT_SUPPORTED` or other defaults where possible.