### PR TITLE
[tests] integration: bump binary-version-reader and device-constants dependency for P2-related module manipulationfixes

### DIFF
--- a/user/tests/integration/package-lock.json
+++ b/user/tests/integration/package-lock.json
@@ -26,9 +26,9 @@
       }
     },
     "@particle/device-constants": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-1.3.0.tgz",
-      "integrity": "sha512-OI7K5yEsN8R/ommsM0IiFfQSEN0NhPFelQGLKIQ+yNXUVvEsZOW18QdZirLreKIheIrqsZOhuqppDp0orykL6g=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-2.1.0.tgz",
+      "integrity": "sha512-fxXZTO1UJilppCL+1Mu0Wozxm+xXzrfoAkMkNxeCShHgYbgZ/oosCjaVae6Mv21B/Yy0qBRrE/HIASresEYl0g=="
     },
     "aggregate-error": {
       "version": "3.1.0",
@@ -50,9 +50,9 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "binary-version-reader": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/binary-version-reader/-/binary-version-reader-1.1.2.tgz",
-      "integrity": "sha512-C004qSxo7hUBNufccaOijzj0LCBKod32AT+cYUVGbV6fIfUq2nSlIWZMd/gnJqHKEEuo2dgFTayPwp6kRWt4ag==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/binary-version-reader/-/binary-version-reader-1.3.0.tgz",
+      "integrity": "sha512-D7WlGiZSzmQTLpL1QqOWdv2stZg+BngaHC5AvaMqmZkJ9Nql7F7txz1BiC50ilxwvGNOnq+kPeh00Bn5P1k/Pw==",
       "requires": {
         "buffer-crc32": "^0.2.5",
         "when": "^3.7.3",
@@ -79,7 +79,7 @@
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="
     },
     "clean-stack": {
       "version": "2.2.0",
@@ -373,7 +373,7 @@
     "when": {
       "version": "3.7.8",
       "resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz",
-      "integrity": "sha1-xxMLan6gRpPoQs3J56Hyqjmjn4I="
+      "integrity": "sha512-5cZ7mecD3eYcMiCH4wtRPA5iFJZ50BJYDfckI5RRpQiktMiYTcn0ccLTZOvcbBume+1304fQztxeNzNS9Gvrnw=="
     },
     "wrappy": {
       "version": "1.0.2",

--- a/user/tests/integration/package.json
+++ b/user/tests/integration/package.json
@@ -2,8 +2,8 @@
   "description": "Device OS Integration Tests",
   "private": true,
   "dependencies": {
-    "@particle/device-constants": "^1.3.0",
-    "binary-version-reader": "^1.1.2",
+    "@particle/device-constants": "^2.1.0",
+    "binary-version-reader": "^1.3.0",
     "tempy": "^1.0.1"
   }
 }


### PR DESCRIPTION
### Desciption

See https://github.com/particle-iot/binary-version-reader/pull/54

### Steps to Test

When running locally make sure to `npm install` inside `user/tests/integration` folder first.

Run `ota/multiple_ota_no_reset` on all platforms, they should pass on P2 and Tracker M (there is another issue on Tracker M though currently related to this).

### Example App

N/A

### References

- https://github.com/particle-iot/binary-version-reader/pull/54

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
