### PR TITLE
[rtl872x] add cellular hal into dynalib for supporting platforms

### DIFF
--- a/modules/shared/rtl872x/inc/system-part1/module_system_part1.inc
+++ b/modules/shared/rtl872x/inc/system-part1/module_system_part1.inc
@@ -42,6 +42,9 @@ DYNALIB_TABLE_EXTERN(hal_ble);
 #endif // HAL_PLATFORM_BLE
 DYNALIB_TABLE_EXTERN(hal_posix_syscall);
 DYNALIB_TABLE_EXTERN(hal_storage);
+#if HAL_PLATFORM_CELLULAR
+DYNALIB_TABLE_EXTERN(hal_cellular);
+#endif // HAL_PLATFORM_CELLULAR
 
 // strange that this is needed given that the entire block is scoped extern "C"
 // without it, the section name doesn't match *.system_part2_module as expected in the linker script
@@ -82,7 +85,10 @@ extern "C" __attribute__((externally_visible)) const void* const system_part1_mo
     , DYNALIB_TABLE_NAME(hal_ble)
 #endif // HAL_PLATFORM_BLE
     , DYNALIB_TABLE_NAME(hal_posix_syscall),
-    DYNALIB_TABLE_NAME(hal_storage)
+    DYNALIB_TABLE_NAME(hal_storage),
+#if HAL_PLATFORM_CELLULAR
+    DYNALIB_TABLE_NAME(hal_cellular)
+#endif // HAL_PLATFORM_CELLULAR
 };
 
 #include "system_part1_loader.c"


### PR DESCRIPTION
### Problem

Missing cellular hal calls in dynalib which is causing issues when the user module calls `hal_storage` related tables

### Solution

Add missing cellular hal into dynalib for supporting platforms

### Steps to Test

### Example App

Run user `ota/multiple_ota_no_reset` integration tests

### References

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
