### PR TITLE
Ensure task yield and system thread pump in system_delay_pump

### DIFF
--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -556,8 +556,10 @@ void system_delay_pump(unsigned long ms, bool force_no_background_loop=false)
                 delay = (std::numeric_limits<system_tick_t>::max() - start_micros) + end_micros;
             }
 
-            HAL_Delay_Microseconds(delay);
-            return;
+            for (uint32_t i = 0; i < delay; i++) {
+                HAL_Delay_Microseconds(1);
+            }
+            break;
         }
         else
         {

--- a/user/tests/wiring/no_fixture/time.cpp
+++ b/user/tests/wiring/no_fixture/time.cpp
@@ -290,7 +290,7 @@ test(TIME_17_RtcAlarmFiresCorrectly) {
     }, (void*)&alarmFired, nullptr);
     assertEqual(r, 0);
     while (!alarmFired && (millis() - ms) <= 6000) {
-        HAL_Delay_Milliseconds(10);
+        delay(1);
     }
     assertLessOrEqual(millis() - ms, 6000);
     hal_rtc_cancel_alarm();
@@ -307,7 +307,7 @@ test(TIME_17_RtcAlarmFiresCorrectly) {
     }, (void*)&alarmFired, nullptr);
     assertEqual(r, 0);
     while (!alarmFired && (millis() - ms) <= 6000) {
-        HAL_Delay_Milliseconds(10);
+        delay(1);
     }
     assertLessOrEqual(millis() - ms, 6000);
     hal_rtc_cancel_alarm();


### PR DESCRIPTION
### Problem

Calling `delay(1)` from a user application in a tight loop does not allow the RTOS application task to yield and does not pump the system thread. Attempting to delay down to the microsecond resolution is also problematic.

### Solution

Always delay at least 1 ms, ignore microsecond resolution, and explicitly call `spark_process` no matter what during each call. 

### Steps to Test

`no_fixture` test `TIME_17_RtcAlarmFiresCorrectly` on Tracker was the original test that failed

### Example App

Run `no_fixture` and test `TIME_17_RtcAlarmFiresCorrectly`

### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
