### PR TITLE
[rtl872x] adds Tracker M in release.sh for prebootloader build

### DIFF
--- a/build/release.sh
+++ b/build/release.sh
@@ -399,7 +399,7 @@ eval $MAKE_COMMAND
 release_binary "bootloader" "bootloader" "$SUFFIX" "$DEBUG_BUILD" "$USE_SWD_JTAG"
 
 # Prebootloader
-if [ $PLATFORM_ID -eq 32 ]; then
+if [ $PLATFORM_ID -eq 28 ] || [ $PLATFORM_ID -eq 32 ]; then
 cd ../bootloader/prebootloader
 
 COMPILE_LTO="n"

--- a/ci/enumerate_build_matrix.sh
+++ b/ci/enumerate_build_matrix.sh
@@ -48,10 +48,10 @@ MAKE=runmake
 # "" means execute execute the $MAKE command without that var specified
 DEBUG_BUILD=( y n )
 PLATFORM=( argon boron asom bsom b5som esomx p2 trackerm )
-# All modules are now built by reease scripts instead, skip
+# All modules are now built by release scripts instead, skip
 # Only building applications and tests here
 # PLATFORM_BOOTLOADER=( argon boron asom bsom b5som tracker esomx p2 )
-# PLATFORM_PREBOOTLOADER=( p2 )
+# PLATFORM_PREBOOTLOADER=( p2 trackerm )
 PLATFORM_BOOTLOADER=()
 PLATFORM_PREBOOTLOADER=()
 APP=( "" product_id_and_version )


### PR DESCRIPTION
### Problem

Tracker M prebootloader binaries are not included in the combined-binaries zip file.

### Solution

Add Tracker M to release.sh for the prebootloader build.

### Steps to Test

- Build in CircleCI
- Check combined-binaries workflow artifacts for correct files in zip

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
