### PR TITLE
[rtl8721x] Fix HAL defines in the main dynalib pointers table

### DIFF
--- a/modules/shared/rtl872x/inc/system-part1/module_system_part1.inc
+++ b/modules/shared/rtl872x/inc/system-part1/module_system_part1.inc
@@ -78,9 +78,9 @@ extern "C" __attribute__((externally_visible)) const void* const system_part1_mo
     DYNALIB_TABLE_NAME(hal_netdb),
     DYNALIB_TABLE_NAME(hal_ifapi),
     DYNALIB_TABLE_NAME(hal_resolvapi)
-#if HAL_PLATFORM_WIFI && HAL_PLATFORM_WIFI_COMPAT
+#if HAL_PLATFORM_WIFI
     , DYNALIB_TABLE_NAME(hal_wlan)
-#endif // HAL_PLATFORM_WIFI && HAL_PLATFORM_WIFI_COMPAT
+#endif // HAL_PLATFORM_WIFI
 #if HAL_PLATFORM_BLE
     , DYNALIB_TABLE_NAME(hal_ble)
 #endif // HAL_PLATFORM_BLE


### PR DESCRIPTION
### Problem

Missing dynalib tables in the .inc file causing problems to access `cellular_signal` function from `cellular_hal` table

### Solution

Fix the relevant #defines according to the platforms in the .inc file that holds the main table of dynalib pointers

### Steps to Test

Run `slo/connect_time` tests 

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
