### PR TITLE
[tests] Fix listening mode tests on trackerM

### DIFF
--- a/user/tests/wiring/no_fixture/ble_provisioning.cpp
+++ b/user/tests/wiring/no_fixture/ble_provisioning.cpp
@@ -19,14 +19,9 @@
 #include "unit-test/unit-test.h"
 
 #if HAL_PLATFORM_BLE
-
+const system_tick_t WAIT_TIMEOUT = 15 * 60 * 1000;
 // Do not enter listening mode based on the flag
 test(LISTENING_00_DISABLE_LISTENING_MODE) {
-    // If Particle.disconnect() is not called here, the Network.listen() calls
-    // could potentially interfere with ncpClient and rendering undefined
-    // behavior for some of the following tests 
-    Particle.disconnect();
-    waitUntil(Particle.disconnected);
     System.enableFeature(FEATURE_DISABLE_LISTENING_MODE);
     Network.listen();
     SCOPE_GUARD({
@@ -51,6 +46,7 @@ test(LISTENING_01_ENABLE_LISTENING_MODE) {
     Network.listen(false);
     delay(1000); // Time for system thread to exit listening mode
     assertFalse(Network.listening());
+    waitFor(Particle.connected, WAIT_TIMEOUT);  // Wait for Particle connection to come back
 }
 
 // If the flag is enabled while device is in listening mode,
@@ -70,6 +66,7 @@ test(LISTENING_02_DISABLE_FLAG_WHILE_IN_LISTENING_MODE) {
     });
     delay(1500); // Time for system thread to process the flag
     assertFalse(Network.listening());
+    waitFor(Particle.connected, WAIT_TIMEOUT);  // Wait for Particle connection to come back
 }
 
 test(LISTENING_03_ENABLE_BLE_PROV_MODE_WHEN_FLAG_SET) {
@@ -102,7 +99,6 @@ test(LISTENING_04_ENABLE_BLE_PROV_MODE_WHEN_FLAG_CLEARED) {
 
 test(LISTENING_05_ENABLE_BLE_PROV_AFTER_LISTENING_MODE) {
     // 15 min gives the device time to go through a 10 min timeout & power cycle
-    const system_tick_t WAIT_TIMEOUT = 15 * 60 * 1000;
     SCOPE_GUARD({
         System.disableFeature(FEATURE_DISABLE_LISTENING_MODE);
     });

--- a/user/tests/wiring/no_fixture/ble_provisioning.cpp
+++ b/user/tests/wiring/no_fixture/ble_provisioning.cpp
@@ -22,6 +22,11 @@
 
 // Do not enter listening mode based on the flag
 test(LISTENING_00_DISABLE_LISTENING_MODE) {
+    // If Particle.disconnect() is not called here, the Network.listen() calls
+    // could potentially interfere with ncpClient and rendering undefined
+    // behavior for some of the following tests 
+    Particle.disconnect();
+    waitUntil(Particle.disconnected);
     System.enableFeature(FEATURE_DISABLE_LISTENING_MODE);
     Network.listen();
     SCOPE_GUARD({
@@ -59,6 +64,7 @@ test(LISTENING_02_DISABLE_FLAG_WHILE_IN_LISTENING_MODE) {
     delay(1000); // Time for system thread to enter listening mode
     assertTrue(Network.listening());
     System.enableFeature(FEATURE_DISABLE_LISTENING_MODE);
+    Particle.process();
     SCOPE_GUARD({
         System.disableFeature(FEATURE_DISABLE_LISTENING_MODE);
     });
@@ -112,6 +118,7 @@ test(LISTENING_05_ENABLE_BLE_PROV_AFTER_LISTENING_MODE) {
         assertTrue(Particle.connected());
     });
     System.enableFeature(FEATURE_DISABLE_LISTENING_MODE);
+    Particle.process();
     delay(1500); // Time for system thread to process the flag
     assertFalse(Network.listening());
     BLE.provisioningMode(true);

--- a/user/tests/wiring/no_fixture/ble_provisioning.cpp
+++ b/user/tests/wiring/no_fixture/ble_provisioning.cpp
@@ -19,6 +19,17 @@
 #include "unit-test/unit-test.h"
 
 #if HAL_PLATFORM_BLE
+
+const system_tick_t LISTENING_MODE_STATE_CHANGE_TIMEOUT = 30000;
+
+bool waitListening(bool state, system_tick_t timeout = LISTENING_MODE_STATE_CHANGE_TIMEOUT) {
+    if (state) {
+        return waitFor(Network.listening, timeout);
+    } else {
+        return waitForNot(Network.listening, timeout);
+    }
+}
+
 const system_tick_t WAIT_TIMEOUT = 15 * 60 * 1000;
 // Do not enter listening mode based on the flag
 test(LISTENING_00_DISABLE_LISTENING_MODE) {
@@ -27,10 +38,12 @@ test(LISTENING_00_DISABLE_LISTENING_MODE) {
     SCOPE_GUARD({
         System.disableFeature(FEATURE_DISABLE_LISTENING_MODE);
         Network.listen(false);
-        delay(1000);
     });
-    delay(1000); // Time for system thread to enter listening mode, if any
-    assertFalse(Network.listening());
+    // We should not enter listening mode, give LISTENING_MODE_STATE_CHANGE_TIMEOUT
+    // worst case scenario for this to NOT happen
+    assertFalse(waitListening(true));
+    // Check that we are still not listening mode
+    assertTrue(waitListening(false));
 }
 
 // Enter listening mode based on the flag
@@ -39,14 +52,11 @@ test(LISTENING_01_ENABLE_LISTENING_MODE) {
     Network.listen();
     SCOPE_GUARD({
         Network.listen(false);
-        delay(1000);
+        assertTrue(waitListening(false));
     });
-    delay(1000); // Time for system thread to enter listening mode
-    assertTrue(Network.listening());
+    assertTrue(waitListening(true));
     Network.listen(false);
-    delay(1000); // Time for system thread to exit listening mode
-    assertFalse(Network.listening());
-    waitFor(Particle.connected, WAIT_TIMEOUT);  // Wait for Particle connection to come back
+    assertTrue(waitListening(false));
 }
 
 // If the flag is enabled while device is in listening mode,
@@ -55,18 +65,15 @@ test(LISTENING_02_DISABLE_FLAG_WHILE_IN_LISTENING_MODE) {
     Network.listen();
     SCOPE_GUARD({
         Network.listen(false);
-        delay(1000);
+        assertTrue(waitListening(false));
     });
-    delay(1000); // Time for system thread to enter listening mode
-    assertTrue(Network.listening());
+    assertTrue(waitListening(true));
     System.enableFeature(FEATURE_DISABLE_LISTENING_MODE);
     Particle.process();
     SCOPE_GUARD({
         System.disableFeature(FEATURE_DISABLE_LISTENING_MODE);
     });
-    delay(1500); // Time for system thread to process the flag
-    assertFalse(Network.listening());
-    waitFor(Particle.connected, WAIT_TIMEOUT);  // Wait for Particle connection to come back
+    assertTrue(waitListening(false));
 }
 
 test(LISTENING_03_ENABLE_BLE_PROV_MODE_WHEN_FLAG_SET) {
@@ -103,11 +110,10 @@ test(LISTENING_05_ENABLE_BLE_PROV_AFTER_LISTENING_MODE) {
         System.disableFeature(FEATURE_DISABLE_LISTENING_MODE);
     });
     Network.listen();
-    delay(1000); // Time for system thread to enter listening mode
-    assertTrue(Network.listening());
+    assertTrue(waitListening(true));
     SCOPE_GUARD({
         Network.listen(false);
-        delay(1000);
+        assertTrue(waitListening(false));
         // Make sure we restore cloud connection after exiting this test because we entered listening mode
         Particle.connect();
         waitFor(Particle.connected, WAIT_TIMEOUT);
@@ -115,8 +121,7 @@ test(LISTENING_05_ENABLE_BLE_PROV_AFTER_LISTENING_MODE) {
     });
     System.enableFeature(FEATURE_DISABLE_LISTENING_MODE);
     Particle.process();
-    delay(1500); // Time for system thread to process the flag
-    assertFalse(Network.listening());
+    assertTrue(waitListening(false));
     BLE.provisioningMode(true);
     delay(100);
     assertTrue(BLE.getProvisioningStatus());


### PR DESCRIPTION
### Problem

Listening mode tests are unstable on trackerM with threading enabled.
1. Unable to process feature flag as expected
2. Radio is repeatedly turned off indefinitely

### Solution

1. Some of the tests depend on a certain feature flag being processed by Spark_Idle_Events(), hence calling Particle.process() unblocks the system thread as needed and processes the feature flag
3. Network.listen() calls could potentially interfere with the state of ncpClient() and renders undefined behavior and doesn't detect the cell radio being powered off, hence calling Particle.disconnect() at the beginning of the tests keeps the ncpClient() states as expected

### Steps to Test

Run `wiring/no_fixture` tests

### References

[SC-107222](https://app.shortcut.com/particle/story/107222/tracker-m-invoke-particle-connect-inside-listening-tests-cause-blocking-behavior-with-threading-enabled)

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
