### PR TITLE
[wiring] ApplicationWatchdog: fixes potential 2x timeout required  to fire

### DIFF
--- a/user/tests/wiring/no_fixture/thread.cpp
+++ b/user/tests/wiring/no_fixture/thread.cpp
@@ -262,8 +262,8 @@ test(APPLICATION_WATCHDOG_01_fires_timeout)
 {
 	s_ram_free_before = System.freeMemory();
 	timeout_called = 0;
-	ApplicationWatchdog wd(5, timeout);
-	HAL_Delay_Milliseconds(10);
+	ApplicationWatchdog wd(50, timeout);
+	HAL_Delay_Milliseconds(60);
 
 	assertEqual((int)timeout_called, 1);
 	waitForComplete(wd);

--- a/user/tests/wiring/no_fixture/thread.cpp
+++ b/user/tests/wiring/no_fixture/thread.cpp
@@ -289,10 +289,10 @@ test(APPLICATION_WATCHDOG_02_doesnt_fire_when_app_checks_in)
 		waitForComplete(wd);
 		uint32_t endTime = millis();
 		assertEqual((int)timeout_called, 1);
-		const auto expected = t * 3; // should be t*3
-		const auto margin = expected / 50; // 2%
-		assertMoreOrEqual(endTime - startTime, expected - margin);
-		assertLessOrEqual(endTime - startTime, expected + margin);
+		const auto expectedLow = t * 3; // should be t*3
+		const auto expectedHigh = t * 4;
+		assertMoreOrEqual(endTime - startTime, expectedLow - (expectedLow / 50)); // -2%
+		assertLessOrEqual(endTime - startTime, expectedHigh + (expectedHigh / 50)); // +2%
 		// LOG_DEBUG(INFO, "E %d",endTime-startTime);
 	}
 }

--- a/user/tests/wiring/no_fixture/thread.cpp
+++ b/user/tests/wiring/no_fixture/thread.cpp
@@ -254,7 +254,7 @@ void timeout()
 void waitForComplete(ApplicationWatchdog& wd)
 {
 	while (!wd.isComplete()) {
-		HAL_Delay_Milliseconds(10);
+		HAL_Delay_Milliseconds(0);
 	}
 }
 
@@ -285,14 +285,11 @@ test(APPLICATION_WATCHDOG_02_doesnt_fire_when_app_checks_in)
 			application_checkin();
 			os_thread_yield();
 		}
-		// now force a timeout
-		// Worst case scenario it may take two application watchdog loop iterations
-		HAL_Delay_Milliseconds(t * 2);
 		// LOG_DEBUG(INFO, "TIME: %d, R %d:%s", millis()-startTime, x, timeout_called?"pass":"fail");
-		assertEqual((int)timeout_called, 1);
 		waitForComplete(wd);
 		uint32_t endTime = millis();
-		const auto expected = t * 4; // should be t*4
+		assertEqual((int)timeout_called, 1);
+		const auto expected = t * 3; // should be t*3
 		const auto margin = expected / 50; // 2%
 		assertMoreOrEqual(endTime - startTime, expected - margin);
 		assertLessOrEqual(endTime - startTime, expected + margin);

--- a/wiring/inc/spark_wiring_thread.h
+++ b/wiring/inc/spark_wiring_thread.h
@@ -196,6 +196,10 @@ public:
         return isValid() && os_thread_is_current(d_->handle);
     }
 
+    bool isRunning() const {
+        return isValid() && d_->started && !d_->exited;
+    }
+
     Thread& operator=(Thread&& thread)
     {
         d_ = std::move(thread.d_);

--- a/wiring_globals/src/spark_wiring_watchdog.cpp
+++ b/wiring_globals/src/spark_wiring_watchdog.cpp
@@ -17,7 +17,7 @@ void ApplicationWatchdog::loop()
 	auto wakeupTimestamp = last_checkin + timeout;
 	auto now = current_time();
 	if (wakeupTimestamp > now) {
-		HAL_Delay_Milliseconds(wakeupTimestamp - now);
+		HAL_Delay_Milliseconds(wakeupTimestamp - now + 1);
 	}
 
 	while (true) {


### PR DESCRIPTION
### Problem

See [SC](https://app.shortcut.com/particle/story/109275/application-watchdog-running-for-double-time)

This is a bug/problematic behavior in ApplicationWatchdog: https://github.com/particle-iot/device-os/blob/develop/wiring/inc/spark_wiring_watchdog.h#L52
https://github.com/particle-iot/device-os/blob/develop/wiring_globals/src/spark_wiring_watchdog.cpp#L22

`checkin()` gets called after `ApplicationWatchdog` thread has been started and the thread went to sleep. This updates `last_checkin` and upon wake-up in 10 minutes in this case the condition `now - last_checkin` will not be `>= timeout`, requiring another sleep cycle.

### Solution

Update `last_checkin` first, use `last_checkin` + `timeout` as initial timeout in watchdog thread.

### Steps to Test

- `wiring/no_fixture` `APPLICATION*`

### Example App

See SC

### References

- [SC109275]

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
