### PR TITLE
[hal] wifi: add generic 'world' country code as not every country code is exposed through API

### DIFF
--- a/hal/inc/wlan_hal.h
+++ b/hal/inc/wlan_hal.h
@@ -236,6 +236,7 @@ typedef enum wlan_country_code_t {
     WLAN_CC_GB = 0x4742,
     WLAN_CC_AU = 0x4155,
     WLAN_CC_KR = 0x4B52,
+    WLAN_CC_WORLD = 0xFFFE,
     WLAN_CC_MAX = 0xFFFF
 } wlan_country_code_t;
 #if PLATFORM_ID != PLATFORM_GCC

--- a/hal/network/ncp_client/realtek/rtl_ncp_client.cpp
+++ b/hal/network/ncp_client/realtek/rtl_ncp_client.cpp
@@ -99,6 +99,11 @@ void wifi_set_country_code(void) {
             channel_plan = 0x35;
             country_code_sdk = RTW_COUNTRY_AU;
             break;
+        case WLAN_CC_WORLD: {
+            channel_plan = 0x20;
+            country_code_sdk = RTW_COUNTRY_WORLD;
+            break;
+        }
     }
 
     SPARK_ASSERT(wifi_set_country(country_code_sdk) == RTW_SUCCESS);


### PR DESCRIPTION
### Problem

As title says. 2.4G channels 13-14 are not available by default and 14 is also not available in current country codes, same story with 5G. Even if only for testing allow explicitly allow all channels. The default is still US.

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
