### PR TITLE
HAL wiring api calls to access exflash read/write functions

### DIFF
--- a/hal/inc/storage_hal.h
+++ b/hal/inc/storage_hal.h
@@ -28,6 +28,7 @@ typedef enum hal_storage_id {
     HAL_STORAGE_ID_INVALID = 0,
     HAL_STORAGE_ID_INTERNAL_FLASH = 1,
     HAL_STORAGE_ID_EXTERNAL_FLASH = 2,
+    HAL_STORAGE_ID_OTP = 3,
     HAL_STORAGE_ID_MAX = 0x7fffffff
 } hal_storage_id;
 

--- a/hal/src/nRF52840/storage_hal.cpp
+++ b/hal/src/nRF52840/storage_hal.cpp
@@ -30,6 +30,9 @@ int hal_storage_read(hal_storage_id id, uintptr_t addr, uint8_t* buf, size_t siz
     } else if (id == HAL_STORAGE_ID_EXTERNAL_FLASH) {
         CHECK_TRUE(hal_exflash_read(addr, buf, size) >= 0, SYSTEM_ERROR_FLASH_IO);
         return size;
+    } else if (id == HAL_STORAGE_ID_OTP) {
+        CHECK_TRUE(hal_exflash_read_special(HAL_EXFLASH_SPECIAL_SECTOR_OTP, addr, buf, size) >= 0, SYSTEM_ERROR_FLASH_IO);
+        return size;
     }
 
     return SYSTEM_ERROR_NOT_FOUND;
@@ -41,6 +44,9 @@ int hal_storage_write(hal_storage_id id, uintptr_t addr, const uint8_t* buf, siz
         return size;
     } else if (id == HAL_STORAGE_ID_EXTERNAL_FLASH) {
         CHECK_TRUE(hal_exflash_write(addr, buf, size) >= 0, SYSTEM_ERROR_FLASH_IO);
+        return size;
+    } else if (id == HAL_STORAGE_ID_OTP) {
+        CHECK_TRUE(hal_exflash_write_special(HAL_EXFLASH_SPECIAL_SECTOR_OTP, addr, buf, size) >= 0, SYSTEM_ERROR_FLASH_IO);
         return size;
     }
 

--- a/hal/src/rtl872x/storage_hal.cpp
+++ b/hal/src/rtl872x/storage_hal.cpp
@@ -30,6 +30,9 @@ int hal_storage_read(hal_storage_id id, uintptr_t addr, uint8_t* buf, size_t siz
     } else if (id == HAL_STORAGE_ID_EXTERNAL_FLASH) {
         CHECK_TRUE(hal_exflash_read(addr, buf, size) >= 0, SYSTEM_ERROR_FLASH_IO);
         return size;
+    } else if (id == HAL_STORAGE_ID_OTP) {
+        CHECK_TRUE(hal_exflash_read_special(HAL_EXFLASH_SPECIAL_SECTOR_OTP, addr, buf, size) >= 0, SYSTEM_ERROR_FLASH_IO);
+        return size;
     }
 
     return SYSTEM_ERROR_NOT_FOUND;
@@ -41,6 +44,9 @@ int hal_storage_write(hal_storage_id id, uintptr_t addr, const uint8_t* buf, siz
         return size;
     } else if (id == HAL_STORAGE_ID_EXTERNAL_FLASH) {
         CHECK_TRUE(hal_exflash_write(addr, buf, size) >= 0, SYSTEM_ERROR_FLASH_IO);
+        return size;
+    } else if (id == HAL_STORAGE_ID_OTP) {
+        CHECK_TRUE(hal_exflash_write_special(HAL_EXFLASH_SPECIAL_SECTOR_OTP, addr, buf, size) >= 0, SYSTEM_ERROR_FLASH_IO);
         return size;
     }
 


### PR DESCRIPTION
### Description

Adds hal wiring API calls to access OTP

### Solution

Make the relevant functions available over wiring protected by `PARTICLE_USE_UNSTABLE_API`

### Steps to Test

### Example App
```c
#define PARTICLE_USE_UNSTABLE_API
#include "exflash_hal.h"

#include "Particle.h"

void setup() {
    uint8_t ncpId = 0;
    int r = hal_storage_read(HAL_STORAGE_ID_OTP, NCP_ID_OTP_ADDRESS, &ncpId, sizeof(ncpId));
    Log.info("Read result: %d / %u == %x", r, ncpId, ncpId);

    ncpId = 0x67;
    r = hal_storage_write(HAL_STORAGE_ID_OTP, NCP_ID_OTP_ADDRESS, &ncpId, sizeof(ncpId));
    Log.info("Write result: %d", r);

    r = hal_storage_read(HAL_STORAGE_ID_OTP, NCP_ID_OTP_ADDRESS, &ncpId, sizeof(ncpId));
    Log.info("Read result after writing: %d / %u == %x", r, ncpId, ncpId);
}

void loop() {
}

Result on P2:
0000002148 [app] INFO: Read result: 1 / 255 == ff
0000002154 [app] INFO: Write result: 1
0000002157 [app] INFO: Read result after writing: 1 / 103 == 67
```

### References

[SC-108936](https://app.shortcut.com/particle/story/108936/spec-way-to-re-provision-p2-device-with-new-provisioning-data)

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
