### PR TITLE
[rtl872x] usb: make sure CDC line coding struct is packed

### DIFF
--- a/hal/src/rtl872x/usbd_cdc.h
+++ b/hal/src/rtl872x/usbd_cdc.h
@@ -31,12 +31,14 @@ namespace particle { namespace usbd {
 
 namespace cdc {
 
+#pragma pack(push, 1)
 struct LineCoding {
     uint32_t dwDTERate;
     uint8_t bCharFormat;
     uint8_t bParityType;
     uint8_t bDataBits;
 };
+#pragma pack(pop)
 
 enum Request {
     SET_LINE_CODING = 0x20,


### PR DESCRIPTION
### Problem

USB linecoding struct is supposed to be 7 bytes only, due to default packing configuration compiler aligns it to 8 bytes currently, which causes SET_LINE_CODING requests to fail.

### Example App

N/A

### References

- [SC109872]

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
