### PR TITLE
feature/sc-77462/project-commands

### DIFF
--- a/ci/test-build-tasks.ps1
+++ b/ci/test-build-tasks.ps1
@@ -28,7 +28,7 @@ $ErrorActionPreference = "Stop"
 $deviceOSSource = "source:${deviceOSPath}"
 $tinkerPath = "$($deviceOSPath)\user\applications\tinker\"
 $platforms = @()
-$tasks = @()
+$taskPairs = @()
 
 if ($platformList){
 	$platforms = $platformList.split(' ')
@@ -41,9 +41,9 @@ if ($platformList){
 }
 
 if ($taksList){
-	$tasks = $taksList.split(' ')
+	$taskPairs = $taksList.split(' ')
 } else {
-	$tasks = @(
+	$taskPairs = @(
 		'compile:user'
 		'clean:user'
 		'compile:all'
@@ -56,7 +56,7 @@ if ($taksList){
 echo ":::: Using prtcl $(prtcl version)"
 echo ":::: Using Device OS at $($deviceOSPath)"
 echo ":::: Targeting platforms: $($platforms)"
-echo ":::: Running tasks: $($tasks)"
+echo ":::: Running tasks: $($taskPairs)"
 
 # install toolchain and run specified tasks
 run prtcl toolchain:install $deviceOSSource --quiet
@@ -65,8 +65,9 @@ foreach ($platform in $platforms){
 	echo ":::: Testing build tasks for $($platform)"
 	echo ""
 
-	foreach ($task in $tasks){
-		run prtcl $task $deviceOSSource $platform $tinkerPath --quiet
+	foreach ($taskPair in $taskPairs){
+		$subcmd, $task = $taskPair.Split(":");
+		run prtcl project:$subcmd $tinkerPath --toolchain $deviceOSSource --platform $platform --task $task --quiet
 
 		if ($LASTEXITCODE -ne 0){
 			throw "Failure! Exit code is $LASTEXITCODE"

--- a/ci/test-build-tasks.sh
+++ b/ci/test-build-tasks.sh
@@ -10,7 +10,7 @@ hasCmd(){
 if [ $# -lt 1 ]; then
 	echo ":::: Error: Missing script arguments!"
 	echo ":::: Fix: \`deviceOSPath\` is required - e.g. \`~/path/to/device-os\`"
-	echo ":::: Usage: <script> <deviceOSPath> [<platform>] [<tasks>]"
+	echo ":::: Usage: <script> <deviceOSPath> [<platform>] [<taskpairs>]"
 	exit 1
 fi
 
@@ -45,9 +45,9 @@ else
 fi
 
 if [ $# -gt 2 ]; then
-	declare -a tasks=($3)
+	declare -a taskpairs=($3)
 else
-	tasks=(
+	taskpairs=(
 		'compile:user'
 		'clean:user'
 		'compile:all'
@@ -60,7 +60,7 @@ fi
 echo ":::: Using prtcl $(prtcl version)"
 echo ":::: Using Device OS at: ${deviceOSPath}"
 echo ":::: Targeting platforms: ${platforms[@]}"
-echo ":::: Running tasks: ${tasks[@]}"
+echo ":::: Running task pairs: ${taskpairs[@]}"
 
 # install toolchain and run specified tasks
 prtcl toolchain:install ${deviceOSSource} --quiet
@@ -69,8 +69,10 @@ for platform in "${platforms[@]}"; do
 	echo ":::: Testing build tasks for ${platform}"
 	echo
 
-	for task in "${tasks[@]}"; do
-		prtcl ${task} ${deviceOSSource} ${platform} ${tinkerPath} --quiet
+	for taskpair in "${taskpairs[@]}"; do
+		subcmd=$(echo $taskpair | cut -d ':' -f1)
+		task=$(echo $taskpair | cut -d ':' -f2)
+		prtcl project:$subcmd ${tinkerPath} --toolchain ${deviceOSSource} --platform ${platform} --task $task --quiet
 	done
 done
 


### PR DESCRIPTION
### Problem

The `prtcl` CLI now includes support for `project`-related build commands. The current `compile`, `flash`, and `clean` commands will be deprecated and removed

### Solution

Move the `test-build-system` CI workflow over to the new `project:compile` and `project:clean` commands 

### Steps to Test

1. Using macOS...
2. Install the `prtcl` CLI ([instructions](https://github.com/particle-iot/cli/tree/main/packages/cli#macos-via-brew))
3. Run the CI test script:
    * `cd /path/to/device-os`
    * `./ci/test-build-tasks.sh ./`
4. Using linux (Ubuntu)...
5. Install the `prtcl` CLI ([instructions](https://github.com/particle-iot/cli/tree/main/packages/cli#ubuntu--debian-via-apt))
6. Run the CI test script:
    * `cd /path/to/device-os`
    * `./ci/test-build-tasks.sh ./` 
7. Using Windows + Powershell...
8. Install the `prtcl` CLI ([instructions](https://github.com/particle-iot/cli/tree/main/packages/cli#windows))
9. Run the CI test script:
    * `cd C:\\path\to\device-os`
    * `.\ci\test-build-tasks.ps1 .\` 
10. Observe the [latest CI run in CircleCI](https://app.circleci.com/pipelines/github/particle-iot/device-os/1343/workflows/21095020-a1ec-4818-9495-e648b920d4ed)

**outcome**

Scripts should run properly - exiting on error and otherwise reporting success. CI configuration changes should make sense and do what you expect.


### References

https://app.shortcut.com/particle/story/77462

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [x] Added documentation
- [x] Added to CHANGELOG.md after merging (add links to docs and issues)
