### PR TITLE
[tests/trackerm] Add workaround for TrackerM ota tests

### DIFF
--- a/user/tests/integration/ota/multiple_ota_no_reset/multiple_ota_no_reset.cpp
+++ b/user/tests/integration/ota/multiple_ota_no_reset/multiple_ota_no_reset.cpp
@@ -84,6 +84,11 @@ test(02_flash_binaries) {
 }
 
 test(03_fix_ota_binary_and_reset) {
+    // FIXME: Add workaround for TrackerM units that fail to communicate with QSPI flash chip
+    // with an active cellular connection
+#if PLATFORM_ID == PLATFORM_TRACKERM
+    delay(500);
+#endif
     // The original issue (https://github.com/particle-iot/device-os/pull/2346) can't be reproduced
     // easily by flashing application binaries. As a workaround, we're restoring the correct platform
     // ID in the binary that is currently stored in the OTA section so that the bootloader can apply


### PR DESCRIPTION
### Description

Add delay workaround for TrackerM units that fail to communicate with QSPI flash chip with an active cellular connection.
This workaround is added to run tests for trackerM 5.1.0 release (fix in progress)


### Steps to Test

Run `ota/multiple_ota_no_reset` tests

### References

!TODO

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
