### PR TITLE
chore/sc-101315/test-build-system-tune-windows-timeouts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,7 +353,7 @@ commands:
     steps:
       - run:
           name: "Test Local Compilation Tasks"
-          no_output_timeout: "20m"
+          no_output_timeout: "30m"
           command: pwsh ci/test-build-tasks.ps1 $home\project "<< parameters.platform >>" "<< parameters.tasks >>"
           environment:
             PRTCL_DISABLE_AUTOUPDATE: "1"


### PR DESCRIPTION
### Problem

We're seeing more frequent timeouts in the `test-build-system` CI workflow's `windows` jobs (examples: [1](https://app.circleci.com/pipelines/github/particle-iot/device-os/1358/workflows/f8a19c12-5dfd-4fea-8a0d-26af9432ae8a/jobs/29032?invite=true#step-104-24), [2](https://app.circleci.com/pipelines/github/particle-iot/device-os/1348/workflows/66c649f3-afc2-4bf7-ba20-fdaa67a2a019/jobs/28818?invite=true#step-104-24), [3](https://app.circleci.com/pipelines/github/particle-iot/device-os/1328/workflows/6e71ca44-6c15-4ca5-a54c-90781376f322/jobs/28337?invite=true#step-104-22), [4](https://app.circleci.com/pipelines/github/particle-iot/device-os/1386/workflows/e9ed71f8-e530-4bd3-b278-56ace2961b56/jobs/30209?invite=true#step-104-24)) 

### Solution

Increase the timeout threshold for `windows` jobs from `20m` to `30m`

### Steps to Test

1. Review the [updated CI/CD step / command timeout](https://github.com/particle-iot/device-os/blob/chore/sc-101315/test-build-system-tune-windows-timeouts/.circleci/config.yml#L356)
5. Observe the [latest CI run in CircleCI](https://app.circleci.com/pipelines/github/particle-iot/device-os/1362/workflows/9eb5da07-fe44-4c95-b8ee-c46e39009cc7)

**outcome**

CI workflow should pass, changes should be appropriate

### References

https://app.shortcut.com/particle/story/101315/device-os-test-build-system-ci-workflow-occasionally-errors
https://app.circleci.com/pipelines/github/particle-iot/device-os?filter=all
https://github.com/particle-iot/device-os/pull/2455
https://github.com/particle-iot/device-os/pull/2444
https://github.com/particle-iot/device-os/pull/2434
https://github.com/particle-iot/device-os/pull/2418

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
