### PR TITLE
Fix no_fixture_i2c for esomx,boron,bsom platforms

### DIFF
--- a/user/tests/wiring/no_fixture_i2c/i2c.cpp
+++ b/user/tests/wiring/no_fixture_i2c/i2c.cpp
@@ -131,9 +131,7 @@ test(I2C_02_test_acquire_wire1_buffer) {
 test(I2C_03_long_read_rtc)
 {
     // Test > 32 byte reads by reading from AM18x5 RTC peripheral
-    Wire1.begin();
-
-    // Read full register range
+    // Read beyond full register range
     const uint8_t REGISTER_RANGE = 64;
     uint8_t longReadBuffer[REGISTER_RANGE] = {};
     uint8_t readLength = REGISTER_RANGE; 
@@ -147,6 +145,8 @@ test(I2C_03_long_read_rtc)
     hal_i2c_interface_t wireInterface = HAL_PLATFORM_EXTERNAL_RTC_I2C;
     uint8_t rtcAddress = HAL_PLATFORM_EXTERNAL_RTC_I2C_ADDR;
     uint8_t rtcRegister = 0x00;
+
+    hal_i2c_begin(wireInterface, I2C_MODE_MASTER, 0x00, NULL);
 
     hal_i2c_lock(wireInterface, nullptr);
     SCOPE_GUARD({

--- a/user/tests/wiring/no_fixture_i2c/i2c.cpp
+++ b/user/tests/wiring/no_fixture_i2c/i2c.cpp
@@ -57,7 +57,11 @@ hal_i2c_config_t acquireWire1Buffer()
 test(I2C_00_hal_init_default_buffer)
 {
     // Initializing the HAL with a null config is allowed and should allocate system defaults
-    assertEqual(hal_i2c_init(HAL_I2C_INTERFACE1, nullptr), (int)SYSTEM_ERROR_NONE);
+    if (!hal_i2c_is_enabled(HAL_I2C_INTERFACE1, nullptr)) {
+        assertEqual(hal_i2c_init(HAL_I2C_INTERFACE1, nullptr), (int)SYSTEM_ERROR_NONE);    
+    } else {
+        assertEqual(hal_i2c_init(HAL_I2C_INTERFACE1, nullptr), (int)SYSTEM_ERROR_INVALID_ARGUMENT);    
+    }
 
 #if (PLATFORM_ID == PLATFORM_TRACKER) || (PLATFORM_ID == PLATFORM_TRACKERM)
     // Tracker platforms should have buffers at least 512 bytes large, allocated by the system on startup
@@ -166,8 +170,11 @@ test(I2C_05_long_read_pmic)
     Wire1.begin();
 #endif
 
-    // Read full register range
-    const uint8_t REGISTER_RANGE = 64;
+    // Turn on PMIC
+    PMIC().begin();
+
+    // Read beyond full register range
+    const uint8_t REGISTER_RANGE = 34;
     uint8_t longReadBuffer[REGISTER_RANGE] = {};
     uint8_t readLength = REGISTER_RANGE; 
 


### PR DESCRIPTION
### Problem

`no_fixture_i2c` tests were only validated against `p2` and `tracker` platforms. Unfortunately other platforms fail the tests.

### Solution

`boron`: For some reason, the PMIC on boron NAKs bytes after 34 reads, where the same part on tracker will allow 64 byte reads.
`bsom`: The BSOM initializes the PMIC on boot, so the `Wire` interface is already initialized when attempting to init with a null buffer

### Steps to Test

`device-os-test --test-dir ~/develop/device-os/user/tests/integration --device-os-dir ~/develop/device-os run bsom wiring/no_fixture_i2c -v `

### Example App

`no_fixture_i2c`

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
