### PR TITLE
[p2] WiFi bugfixes

### DIFF
--- a/hal/network/ncp_client/realtek/rtl_ncp_client.cpp
+++ b/hal/network/ncp_client/realtek/rtl_ncp_client.cpp
@@ -129,7 +129,9 @@ int rtlSecurityToWifiSecurity(rtw_security_t rtlSec) {
     }
     case RTW_SECURITY_WPA2_AES_PSK:
     case RTW_SECURITY_WPA2_TKIP_PSK:
-    case RTW_SECURITY_WPA2_MIXED_PSK: {
+    case RTW_SECURITY_WPA2_MIXED_PSK:
+    // FIXME:
+    case RTW_SECURITY_WPA2_WPA3_MIXED: {
         return (int)WifiSecurity::WPA2_PSK;
     }
     case RTW_SECURITY_WPA_WPA2_TKIP_PSK:
@@ -320,6 +322,9 @@ int RealtekNcpClient::connect(const char* ssid, const MacAddress& bssid, WifiSec
 }
 
 int RealtekNcpClient::getNetworkInfo(WifiNetworkInfo* info) {
+    const NcpClientLock lock(this);
+    CHECK_TRUE(connState_ == NcpConnectionState::CONNECTED, SYSTEM_ERROR_INVALID_STATE);
+
     int rtlError = 0;
     // LOG(INFO, "RNCP getNetworkInfo");
 


### PR DESCRIPTION
### Description

- Adds support for WPA2/WPA3 mixed APs
- Fixes race condition in `RealtekNcpClient::getNetworkInfo()` when calling into Realtek SDK without a lock with network threads potentially doing the same. This occasionally causes a crash.

### Steps to Test

N/A

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
