### PR TITLE
[TrackerM] Prevent connection over wifi when configured in SCAN_ONLY mode

### DIFF
--- a/system/src/system_network_manager.cpp
+++ b/system/src/system_network_manager.cpp
@@ -725,10 +725,14 @@ bool NetworkManager::haveLowerLayerConfiguration(if_t iface) const {
     if_get_name(iface, name);
 #if HAL_PLATFORM_WIFI && HAL_PLATFORM_NCP
     if (!strncmp(name, "wl", 2)) {
+#if HAL_PLATFORM_WIFI_SCAN_ONLY
+        return false;
+#else
         auto wifiMan = wifiNetworkManager();
         return wifiMan->hasNetworkConfig();
+#endif // HAL_PLATFORM_WIFI_SCAN_ONLY
     }
-#endif // HAL_PLATFORM_WIFI
+#endif // HAL_PLATFORM_WIFI && HAL_PLATFORM_NCP
 
     return true;
 }


### PR DESCRIPTION
### Problem

TrackerM attempts to connect over wifi as well (as cellular), with wifi running in scan-only mode. This is seen only when wifi credentials are provided on the device.

### Solution

Skip interfaces that are not supported for connection

### Steps to Test

### Example App

Since wifi credentials are not able to configured by default with `HAL_PLATFORM_WIFI_SCAN_ONLY` mode, this flag needs to be disabled first to configure the credentials for testing
1. Configure wifi credentials on trackerM using the following process
    1. Disable `HAL_PLATFORM_WIFI_SCAN_ONLY` flag [here for trackerM](https://github.com/particle-iot/device-os/blob/develop/hal/src/trackerm/hal_platform_config.h#L18)
    2. This facilitates configuring wifi credentials on the device. Use `particle serial wifi --file credentials.json` or similar approach
2. Flash tinker with this branch and ensure that connection is not attempted over wifi and is established over cellular

### References



---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
