### PR TITLE
Turn off cell modem on Tracker M sleep

### DIFF
--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -81,13 +81,17 @@ network_status_t system_sleep_network_suspend(network_interface_index index) {
         }
 #endif
 #if HAL_PLATFORM_RTL872X
-        // P2 doesn't need to turn off the modem manually
-        system_notify_event(network_status, network_status_off);
-#else
+        if (index == NETWORK_INTERFACE_WIFI_STA) {
+            // P2 doesn't need to turn off the modem manually
+            system_notify_event(network_status, network_status_off);
+        } else {
+#endif
         network_off(index, 0, 0, NULL);
         LOG(TRACE, "Waiting interface %d to be off...", (int)index);
         // There might be up to 30s delay to turn off the modem for particular platforms.
         network_wait_off(index, 120000/*ms*/, nullptr);
+#if HAL_PLATFORM_RTL872X
+        }
 #endif
     } else {
         LOG(TRACE, "Interface %d is off already", (int)index);


### PR DESCRIPTION
### Description

`system_sleep_network_suspend` is effectively a no-op on P2 platforms, but this should only apply to the WiFi interface. 

### Steps to Test

Manual testing that calling `System.sleep` will automatically turn off the cell modem on Tracker M proto boards.

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
