### PR TITLE
Fix i2c hal deadlock

### DIFF
--- a/hal/src/nRF52840/i2c_hal.cpp
+++ b/hal/src/nRF52840/i2c_hal.cpp
@@ -315,9 +315,9 @@ int hal_i2c_init(hal_i2c_interface_t i2c, const hal_i2c_config_t* config) {
         os_mutex_recursive_create(&i2cMap[i2c].mutex);
     } 
 
-    // Capture the mutex and re-enable threading
-    I2cLock lk(i2c);
+    // Re-enable threading and capture the mutex
     os_thread_scheduling(true, nullptr);
+    I2cLock lk(i2c);
 
     if (i2cMap[i2c].configured) {
         // Configured, but new buffers are invalid

--- a/hal/src/rtl872x/i2c_hal.cpp
+++ b/hal/src/rtl872x/i2c_hal.cpp
@@ -91,16 +91,18 @@ public:
         if (!mutex_) {
             os_mutex_recursive_create(&mutex_);
         }
-        lock();
         os_thread_scheduling(true, nullptr);
+        lock();
         if (isConfigured()) {
             // Configured, but new buffers are invalid
             if (!isConfigValid(conf)){
+                unlock();
                 return SYSTEM_ERROR_INVALID_ARGUMENT;
             }
             // Configured, but new buffers are smaller
             if (conf->rx_buffer_size <= rxBuffer_.size() ||
                conf->tx_buffer_size <= txBuffer_.size()) {    
+               unlock();
                return SYSTEM_ERROR_NOT_ENOUGH_DATA;
             } 
             CHECK(deInit());


### PR DESCRIPTION
### Problem

James reported a trackerm device that would not breathe cyan when running on battery power. The device appeared deadlocked. After investigation, the deadlock was traced to the i2c HAL mutex. The power management thread held the I2C mutex and the user application thread was blocked waiting on it. However, the scheduler was disabled so the power management thread could never execute and release the lock, resulting in a deadlock. 

### Solution

Re-enable scheduling when acquiring the i2c hal lock in order to allow any other tasks using it to execute and release their lock

### Steps to Test

Running any user app that uses the PMIC/Fuel gauge should work on trackerm hardware

### Example App

```c
void setup() {
  /* A minimal example app is super helpful 
   * for testing new features and fixes. 
   * A link to a Docs PR is even better!
   */
}

void loop() {
    FuelGauge fuel;
    Log.info( "voltage=%.2f", fuel.getVCell() );
    delay(5000);
}
```

### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
