### PR TITLE
[rtl872x] fixes pinResetFast clearing too many pins and improves speed

### DIFF
--- a/user/tests/wiring/no_fixture/fastpin.cpp
+++ b/user/tests/wiring/no_fixture/fastpin.cpp
@@ -1,69 +1,86 @@
-
 #include "application.h"
 #include "unit-test/unit-test.h"
 
-
-
 test(FASTPIN_01_MaxDuration_PinSet) {
-    // Attempt pinSetFast and pinResetFast numerous times and check speed.
+    // Attempt pinSetFast numerous times and check speed.
 
 #if HAL_PLATFORM_GEN == 3
-    // expected max ticks of pinSetFast / pinResetFast on Gen3
-    const uint32_t MAX_DURATION_PINSET_TICKS = 70;
+#if PLATFORM_ID == PLATFORM_ESOMX
+    const pin_t pin = D5;
+#else
+    const pin_t pin = D7;
+#endif // PLATFORM_ID == PLATFORM_ESOMX
+
+#if HAL_PLATFORM_RTL872X
+    const uint32_t MAX_DURATION_PINSET_NS = 3050; // 1% higher than measured (includes for() loop overhead)
+#else
+    const uint32_t MAX_DURATION_PINSET_NS = 1030; // 1% higher than measured (includes for() loop overhead)
+#endif // HAL_PLATFORM_RTL872X
 #else
 #error "No gpio fastpin timing benchmark yet measured for this platform"
-#endif
+#endif // HAL_PLATFORM_GEN == 3
+
+    SCOPE_GUARD ({
+        pinMode(pin, INPUT);
+    });
 
     const uint32_t NUM_ITERATIONS = 100;
     uint32_t start, finish;
+    pinMode(pin, OUTPUT);
 
     ATOMIC_BLOCK()  {
-        start = System.ticks();
+        start = HAL_Timer_Get_Micro_Seconds() * 1000;
         for (uint32_t i = 0; i < NUM_ITERATIONS; i++) {
-        #if PLATFORM_ID == PLATFORM_ESOMX
-            pinSetFast(D5);
-        #else
-            pinSetFast(D7);
-        #endif
-            //pinResetFast(D7);
+            pinSetFast(pin);
+            // pinResetFast(pin);
         }
-        finish = System.ticks();
+        finish = HAL_Timer_Get_Micro_Seconds() * 1000;
     }
     uint32_t duration = finish - start;
-//    Serial.print("Set duration:");
-//    Serial.println(duration);
-    assertLessOrEqual(duration, NUM_ITERATIONS*MAX_DURATION_PINSET_TICKS);
+    uint32_t expected = NUM_ITERATIONS * MAX_DURATION_PINSET_NS;
+    // Serial.printlnf("pinSetFast total duration: %lu vs. expected duration: %lu", duration, expected);
+    assertNotEqual(duration, 0);
+    assertLessOrEqual(duration, expected);
 }
 
 test(FASTPIN_02_MaxDuration_PinReset) {
     // Attempt pinResetFast numerous times and check speed.
 
 #if HAL_PLATFORM_GEN == 3
-    // expected max ticks of pinResetFast on Gen3
-    const uint32_t MAX_DURATION_PINRESET_TICKS = 70;
+#if PLATFORM_ID == PLATFORM_ESOMX
+    const pin_t pin = D5;
+#else
+    const pin_t pin = D7;
+#endif // PLATFORM_ID == PLATFORM_ESOMX
+
+#if HAL_PLATFORM_RTL872X
+    const uint32_t MAX_DURATION_PINRESET_NS = 3000; // 1% higher than measured (includes for() loop overhead)
+#else
+    const uint32_t MAX_DURATION_PINRESET_NS = 1030; // 1% higher than measured (includes for() loop overhead)
+#endif // HAL_PLATFORM_RTL872X
 #else
 #error "No gpio fastpin timing benchmark yet measured for this platform"
-#endif
+#endif // HAL_PLATFORM_GEN == 3
+
+    SCOPE_GUARD ({
+        pinMode(pin, INPUT);
+    });
 
     const uint32_t NUM_ITERATIONS = 100;
     uint32_t start, finish;
+    pinMode(pin, OUTPUT);
 
     ATOMIC_BLOCK()  {
-        start = System.ticks();
+        start = HAL_Timer_Get_Micro_Seconds() * 1000;
         for (uint32_t i = 0; i < NUM_ITERATIONS; i++) {
-        #if PLATFORM_ID == PLATFORM_ESOMX
-            pinResetFast(D5);
-        #else
-            pinResetFast(D7);
-        #endif
+            // pinSetFast(pin);
+            pinResetFast(pin);
         }
-        finish = System.ticks();
+        finish = HAL_Timer_Get_Micro_Seconds() * 1000;
     }
     uint32_t duration = finish - start;
-//    Serial.print("Reset duration:");
-//    Serial.println(duration);
-    assertLessOrEqual(duration, NUM_ITERATIONS*MAX_DURATION_PINRESET_TICKS);
+    uint32_t expected = NUM_ITERATIONS * MAX_DURATION_PINRESET_NS;
+    // Serial.printlnf("pinResetFast total duration: %lu vs. expected duration: %lu", duration, expected);
+    assertNotEqual(duration, 0);
+    assertLessOrEqual(duration, expected);
 }
-
-
-

--- a/wiring/inc/fast_pin.h
+++ b/wiring/inc/fast_pin.h
@@ -68,21 +68,9 @@ inline void pinSetFast(hal_pin_t _pin) __attribute__((always_inline));
 inline void pinResetFast(hal_pin_t _pin) __attribute__((always_inline));
 inline int32_t pinReadFast(hal_pin_t _pin) __attribute__((always_inline));
 
-inline void pinConfigure(hal_pin_info_t _pin){
-    int padMuxIndex = (32 * _pin.gpio_port) + _pin.gpio_pin;
-    uint32_t Temp = PINMUX->PADCTR[padMuxIndex];
-
-    Temp &= ~PAD_BIT_MASK_FUNCTION_ID;
-    Temp |= (PINMUX_FUNCTION_GPIO & PAD_BIT_MASK_FUNCTION_ID); 
-    Temp &= ~PAD_BIT_SHUT_DWON;
-     
-    PINMUX->PADCTR[padMuxIndex] = Temp; 
-}
-
 inline void pinSetFast(hal_pin_t _pin)
 {
     hal_pin_info_t pin_info = fastPinGetPinmap()[_pin];
-    pinConfigure(pin_info);
 
     GPIO_TypeDef* gpiobase = ((pin_info.gpio_port == RTL_PORT_A) ? GPIOA_BASE : GPIOB_BASE);
     if (pin_info.pin_mode == OUTPUT_OPEN_DRAIN || pin_info.pin_mode == OUTPUT_OPEN_DRAIN_PULLUP) {
@@ -96,18 +84,16 @@ inline void pinSetFast(hal_pin_t _pin)
 inline void pinResetFast(hal_pin_t _pin)
 {
     hal_pin_info_t pin_info = fastPinGetPinmap()[_pin];
-    pinConfigure(pin_info);
 
     GPIO_TypeDef* gpiobase = ((pin_info.gpio_port == RTL_PORT_A) ? GPIOA_BASE : GPIOB_BASE);
-    gpiobase->PORT[0].DR &= (0 << pin_info.gpio_pin);
+    gpiobase->PORT[0].DR &= ~(1 << pin_info.gpio_pin);
     gpiobase->PORT[0].DDR |= (1 << pin_info.gpio_pin);
 }
 
 inline int32_t pinReadFast(hal_pin_t _pin)
 {
     hal_pin_info_t pin_info = fastPinGetPinmap()[_pin];
-    pinConfigure(pin_info);
-    
+
     GPIO_TypeDef* gpiobase = ((pin_info.gpio_port == RTL_PORT_A) ? GPIOA_BASE : GPIOB_BASE);
     return ((gpiobase->EXT_PORT[0] >> pin_info.gpio_pin) & 1UL);
 }


### PR DESCRIPTION
### Problem

- pinResetFast() clears too many pins due to masking error on rtl872x platform
- pinSetFast/pinResetFast/pinReadFast/digitalWriteFast API's are slow

### Solution

- Fixes bit masking for pinResetFast()
- Improves speed for fastPin APIs by removing checks
  - OUTPUT_OPEN_DRAIN_PULLUP - 2.8us HIGH, 1.9us LOW
  - OUTPUT - 2.9us HIGH, 3.2us LOW

For additional speed improvement, you may control GPIO's directly and avoid extra support for OPEN_DRAIN* pinMode's. 
 With this you can achieve OUTPUT - 1.5us HIGH, 1.8us LOW at best.  Going further and precalculating everything up front you can achieve 1.5us HIGH and LOW.  Unfortunately there's no way to increase bit-bang speed of GPIO's for rtl872x further. We will look into DMA control examples/API's for specific software-driven protocols if there is interest.

### Steps to Test

- run `TEST=wiring/no_fixture` tests

### Typical FastPin Example App (2.9us HIGH / 3.2us LOW)

```c
#include "Particle.h"
SYSTEM_THREAD(ENABLED)
SYSTEM_MODE(SEMI_AUTOMATIC)

void setup() {
    pinMode(A0, OUTPUT);
    // pinMode(A0, OUTPUT_OPEN_DRAIN_PULLUP);

    while (1) {
        ATOMIC_BLOCK() {
            // OUTPUT_OPEN_DRAIN_PULLUP - 2.8us HIGH, 1.9us LOW
            // OUTPUT - 2.9us HIGH, 3.2us LOW
            pinSetFast(A0);
            pinResetFast(A0);
        }
    }
}
```

### Best Case Direct Control Example App (1.5us HIGH / 1.5us LOW)

```c
#include "Particle.h"
SYSTEM_THREAD(ENABLED)
SYSTEM_MODE(SEMI_AUTOMATIC)

hal_pin_info_t pin_info = hal_pin_map()[A0];
uint32_t pinMask = 1 << (((pin_info.gpio_port << 5) | pin_info.gpio_pin) & 0x1f);
uint32_t pinMaskSet = 0;
uint32_t pinMaskReset = 0;
uint32_t portBase = (uint32_t)GPIOB_BASE;
uint32_t portOffset = 0x0;
uint32_t tempReg = 0;
volatile uint32_t* PORT_DR = (volatile uint32_t*)(portBase + portOffset);

void setup() {
    pinMode(A0, OUTPUT);

    tempReg = *PORT_DR;
    pinMaskSet = tempReg | pinMask;
    pinMaskReset = tempReg & ~pinMask;

    while (1) {
        ATOMIC_BLOCK() {
            *PORT_DR = pinMaskSet;
            *PORT_DR = pinMaskReset;
        }
    }
}
```

### References

- sc109756

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] (N/A) Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
