### PR TITLE
rtl872x: sleep improvements

### DIFF
--- a/hal/network/lwip/cellular/pppncpnetif.cpp
+++ b/hal/network/lwip/cellular/pppncpnetif.cpp
@@ -166,8 +166,8 @@ void PppNcpNetif::loop(void* arg) {
     PppNcpNetif* self = static_cast<PppNcpNetif*>(arg);
     unsigned int timeout = 100;
     while(!self->exit_) {
-        self->celMan_->ncpClient()->enable(); // Make sure the client is enabled
         os_semaphore_take(self->netifSemaphore_, timeout, false);
+        self->celMan_->ncpClient()->enable(); // Make sure the client is enabled
 
         // We shouldn't be enforcing state on boot!
         if (self->lastNetifEvent_ != NetifEvent::None) {

--- a/hal/src/rtl872x/sleep_hal.cpp
+++ b/hal/src/rtl872x/sleep_hal.cpp
@@ -102,7 +102,7 @@ public:
                            hal_ble_gap_is_connected(nullptr, nullptr);
         hal_ble_stack_deinit(nullptr);
         // The delay is essential to make sure the resources are successfully freed.
-        DelayMs(1500);
+        DelayMs(2000);
 
         HAL_USB_Detach();
 

--- a/hal/src/rtl872x/sleep_hal.cpp
+++ b/hal/src/rtl872x/sleep_hal.cpp
@@ -51,6 +51,7 @@ extern "C" {
 #include "dct.h"
 #include "dct_hal.h"
 #include "align_util.h"
+#include "delay_hal.h"
 
 using namespace particle;
 
@@ -102,7 +103,7 @@ public:
                            hal_ble_gap_is_connected(nullptr, nullptr);
         hal_ble_stack_deinit(nullptr);
         // The delay is essential to make sure the resources are successfully freed.
-        DelayMs(2000);
+        HAL_Delay_Milliseconds(2000);
 
         HAL_USB_Detach();
 

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -80,15 +80,10 @@ network_status_t system_sleep_network_suspend(network_interface_index index) {
             }
         }
 #endif
-#if HAL_PLATFORM_RTL872X
-        // P2 doesn't need to turn off the modem manually
-        system_notify_event(network_status, network_status_off);
-#else
         network_off(index, 0, 0, NULL);
         LOG(TRACE, "Waiting interface %d to be off...", (int)index);
         // There might be up to 30s delay to turn off the modem for particular platforms.
         network_wait_off(index, 120000/*ms*/, nullptr);
-#endif
     } else {
         LOG(TRACE, "Interface %d is off already", (int)index);
     }


### PR DESCRIPTION
### Problem

1. P2 may consume high current after entered sleep mode
2. Trackerm doesn't turn off cellular modme after entered sleep mode

### Solution

1. Avoid deead loop in uart hal driver
2. Delay more time before entering sleep state to make sure that resources being occupied by BLE stack are completely leased.
3. Generalize system sleep sequence to turn off modem by NCP client 

### Steps to Test

Build and run the attached example app.

### Example App

```c
 #include "Particle.h"

SYSTEM_MODE(SEMI_AUTOMATIC);

auto& SerialDev {Serial1};

Serial1LogHandler logger(115200, LOG_LEVEL_ALL);

static void print_menu()
{
    SerialDev.printf("Enter option:\r\n");
    SerialDev.printf("1. Enter sleep mode\r\n");
}

static void print_sleep_result(const SystemSleepResult& result) {
    switch (result.wakeupReason()) {
        case SystemSleepWakeupReason::BY_GPIO:
            SerialDev.println("Wakeup by GPIO");
            break;
        case SystemSleepWakeupReason::BY_RTC:
            SerialDev.println("Wakeup by RTC");
            break;
        case SystemSleepWakeupReason::BY_LPCOMP:
            SerialDev.println("Wakeup by LP comp");
            break;
        case SystemSleepWakeupReason::BY_USART:
            SerialDev.println("Wakeup by serial");
            break;
        case SystemSleepWakeupReason::BY_CAN:
            SerialDev.println("Wakeup by CAN");
            break;
        case SystemSleepWakeupReason::BY_BLE:
            SerialDev.println("Wakeup by BLE");
            break;
        case SystemSleepWakeupReason::BY_NETWORK:
            SerialDev.println("Wakeup by network");
            break;
        case SystemSleepWakeupReason::UNKNOWN:
        default:
            SerialDev.println("Wakeup by unknown reason");
            break;
    }
}

// Adapted from TrackerSleep
static void enter_ultra_low_power()
{
    SystemSleepConfiguration config;

    constexpr auto led_cycle_duration_ms {5000};
    constexpr auto led_cycle_period_ms {250};
    // blink RGB to signal entering shipping mode
    RGB.control(true);
    RGB.brightness(255);
    for(int i=0;
        i < (led_cycle_duration_ms / led_cycle_period_ms);
        i++)
    {
        // cycle between primary colors
        RGB.color(((uint32_t) 0xFF) << ((i % 3) * 8));
        HAL_Delay_Milliseconds(led_cycle_period_ms);
    }

    config.mode(SystemSleepMode::ULTRA_LOW_POWER)
          .gpio(WKP, FALLING)
          .duration(10s);
    SystemSleepResult ret = System.sleep(config);
    if (ret.error() != SYSTEM_ERROR_NONE) {
        print_sleep_result(ret);
    }

    RGB.control(false);
}

// setup() runs once, when the device is first turned on.
void setup() {
    pinMode(GNSS_PWR_EN, OUTPUT);
    digitalWrite(GNSS_PWR_EN, HIGH);
    pinMode(GNSS_GEOFENCE, OUTPUT);
    digitalWrite(GNSS_GEOFENCE, HIGH);
    pinMode(GNSS_RST, OUTPUT);
    digitalWrite(GNSS_RST, HIGH);

    Cellular.off();

    SerialDev.begin(115200);
    print_menu();

    delay(10s);

    pinMode(BGPWR, OUTPUT);
    digitalWrite(BGPWR, LOW);

    enter_ultra_low_power();
}

// loop() runs over and over again, as quickly as it can execute.
void loop() {
    if (!SerialDev.available()) {
        return;
    }

    auto ch {SerialDev.read()};

    switch (ch) {
    case '1':
        SerialDev.printf("Entering sleep (ultra low power) mode...\r\n");
        enter_ultra_low_power();
        break;
    default:
        SerialDev.printf("Invalid selection\r\n");
        break;
    }

    print_menu();
}
```

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
