### PR TITLE
System setup and BLE threading improvements

### DIFF
--- a/system/inc/system_setup.h
+++ b/system/inc/system_setup.h
@@ -92,6 +92,8 @@ protected:
     virtual void cleanup();
 
 private:
+    void read_line_gracefully(char *dst, int max_len);
+    
     USBSerial serial;
 };
 

--- a/system/inc/system_setup.h
+++ b/system/inc/system_setup.h
@@ -92,8 +92,6 @@ protected:
     virtual void cleanup();
 
 private:
-    void read_line_gracefully(char *dst, int max_len);
-    
     USBSerial serial;
 };
 

--- a/system/src/ble_provisioning_mode_handler.cpp
+++ b/system/src/ble_provisioning_mode_handler.cpp
@@ -344,6 +344,8 @@ int BleProvisioningModeHandler::exit() {
     // Do not allow other thread to modify the BLE configurations until this function exits.
     BleLock lk;
 
+    hal_ble_cancel_callback_on_adv_events(onBleAdvEvents, this, nullptr);
+
     SCOPE_GUARD ({
         preAdvData_.clear();
         preSrData_.clear();
@@ -359,7 +361,6 @@ int BleProvisioningModeHandler::exit() {
             LOG(ERROR, "Failed to restore user configuration.");
         }
     }
-    hal_ble_cancel_callback_on_adv_events(onBleAdvEvents, this, nullptr);
 
     exited_ = true;
     return SYSTEM_ERROR_NONE;

--- a/wiring/inc/spark_wiring.h
+++ b/wiring/inc/spark_wiring.h
@@ -89,7 +89,7 @@ int pinSetDriveStrength(hal_pin_t pin, DriveStrength drive);
 void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t val);
 uint8_t shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder);
 
-void serialReadLine(Stream *serialObj, char *dst, int max_len, system_tick_t timeout);
+bool serialReadLine(Stream *serialObj, char *dst, int max_len, system_tick_t timeout, int* read_len = nullptr);
 
 uint32_t pulseIn(hal_pin_t pin, uint16_t value);
 

--- a/wiring/inc/spark_wiring.h
+++ b/wiring/inc/spark_wiring.h
@@ -89,7 +89,7 @@ int pinSetDriveStrength(hal_pin_t pin, DriveStrength drive);
 void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t val);
 uint8_t shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder);
 
-bool serialReadLine(Stream *serialObj, char *dst, int max_len, system_tick_t timeout, int* read_len = nullptr);
+void serialReadLine(Stream *serialObj, char *dst, int max_len, system_tick_t timeout, void(*idle_cb)(int count) = nullptr);
 
 uint32_t pulseIn(hal_pin_t pin, uint16_t value);
 

--- a/wiring/src/spark_wiring_stream.cpp
+++ b/wiring/src/spark_wiring_stream.cpp
@@ -279,17 +279,21 @@ String Stream::readStringUntil(char terminator)
   return ret;
 }
 
-void serialReadLine(Stream *serialObj, char *dst, int max_len, system_tick_t timeout)
+bool serialReadLine(Stream *serialObj, char *dst, int max_len, system_tick_t timeout, int* read_len)
 {
     char c = 0, i = 0;
     system_tick_t last_millis = millis();
+    *read_len = 0;
 
     while (1)
     {
         if((timeout > 0) && ((millis()-last_millis) > timeout))
         {
             //Abort after a specified timeout
-            break;
+            if (read_len) {
+                *read_len = i;
+            }
+            return false;
         }
 
         if (0 < serialObj->available())
@@ -299,7 +303,10 @@ void serialReadLine(Stream *serialObj, char *dst, int max_len, system_tick_t tim
             if (i == max_len || c == '\r' || c == '\n')
             {
                 *dst = '\0';
-                break;
+                if (read_len) {
+                    *read_len = i;
+                }
+                return true;
             }
 
             if (c == 8 || c == 127)


### PR DESCRIPTION
## NOTE: this PR targets #2581 as it depends on it, make sure to retarget

### Problem

1. System events are blocked due to blocking function `serialReadLine()` when device resides in system setup mode
2. P2-specific:
     1) we may destroy the BLE adv timer in its handler
     2) We may try exiting the BLE events thread relying on a BLE event queue when it is the current thread, which may cause deadlock.
     3) BLE adv state may not set reliably

### Solution
1. Refactor `SystemSetupConsole::read_line/read_multiline`
2. P2-specific: marshall BLE commands to a dedicated thread to make sure ADV states are reliably transitted

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
