### PR TITLE
Use the internal ADC reference on BRN404X

### DIFF
--- a/hal/inc/adc_hal.h
+++ b/hal/inc/adc_hal.h
@@ -26,11 +26,6 @@ typedef enum hal_adc_state_t {
     HAL_ADC_STATE_SUSPENDED
 } hal_adc_state_t;
 
-typedef enum hal_adc_reference_t {
-    HAL_ADC_REFERENCE_EXTERNAL,
-    HAL_ADC_REFERENCE_INTERNAL
-} hal_adc_reference_t;
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/hal/inc/adc_hal.h
+++ b/hal/inc/adc_hal.h
@@ -26,6 +26,11 @@ typedef enum hal_adc_state_t {
     HAL_ADC_STATE_SUSPENDED
 } hal_adc_state_t;
 
+typedef enum hal_adc_reference_t {
+    HAL_ADC_REFERENCE_EXTERNAL,
+    HAL_ADC_REFERENCE_INTERNAL
+} hal_adc_reference_t;
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/hal/src/nRF52840/adc_hal.cpp
+++ b/hal/src/nRF52840/adc_hal.cpp
@@ -22,6 +22,11 @@
 #include "check.h"
 #include "deviceid_hal.h"
 
+typedef enum hal_adc_reference_t {
+    HAL_ADC_REFERENCE_EXTERNAL,
+    HAL_ADC_REFERENCE_INTERNAL
+} hal_adc_reference_t;
+
 static volatile hal_adc_state_t adcState = HAL_ADC_STATE_DISABLED;
 
 static const nrfx_saadc_config_t saadcConfig = {
@@ -108,7 +113,7 @@ int32_t hal_adc_read(uint16_t pin) {
         nrfx_saadc_channel_uninit(PIN_MAP[pin].adc_channel);
         if (adcReference == HAL_ADC_REFERENCE_INTERNAL) {
             // With the internal reference (0.6V) and GAIN1_6, the 12bit ADC range is 0~4095 -> 0V~3.6V, need a conversion
-            adcValue = (int16_t)(adcValue * 3.6 / 3.3);
+            adcValue = (int16_t)(adcValue * 3600 / 3300);
         }
         return (uint16_t) adcValue;
     }


### PR DESCRIPTION
### Problem

There are a number of supply secure products that use a new DCDC part from Richtek called the RT5760. A quality issue was discovered where 10% of the components have a large output voltage ripple. 

### Solution

We can workaround this by switching the ADC to the internal NRF reference voltage. 

### Steps to Test

1. Pick a defective BRN404X
2. Download the example app
3. Measure the GND/3V3 and random voltage, and observe the VPP(peak-to-peak) value

Here is a log for the test results between internal reference and external reference.
```
0000323583 [app] INFO: avg: 1654.8, max: 1646.8, min: 1629.1, vpp: 17.7
0000324590 [app] INFO: avg: 1654.8, max: 1646.0, min: 1629.9, vpp: 16.1
0000325597 [app] INFO: avg: 1654.8, max: 1646.0, min: 1629.9, vpp: 16.1
0000326606 [app] INFO: avg: 1654.4, max: 1650.0, min: 1629.1, vpp: 20.9
0000327612 [app] INFO: avg: 1654.7, max: 1647.6, min: 1626.6, vpp: 20.9
0000328619 [app] INFO: avg: 1654.7, max: 1646.8, min: 1631.5, vpp: 15.3
0000329626 [app] INFO: avg: 1654.9, max: 1645.2, min: 1630.7, vpp: 14.5


0000025497 [app] INFO: avg: 1617.1, max: 1654.0, min: 1557.3, vpp: 96.7
0000026504 [app] INFO: avg: 1621.9, max: 1651.6, min: 1559.0, vpp: 92.7
0000027511 [app] INFO: avg: 1621.7, max: 1653.2, min: 1554.1, vpp: 99.1
0000028517 [app] INFO: avg: 1621.8, max: 1654.0, min: 1547.7, vpp: 106.3
0000029524 [app] INFO: avg: 1619.0, max: 1657.3, min: 1554.1, vpp: 103.1
0000030531 [app] INFO: avg: 1621.7, max: 1657.3, min: 1554.1, vpp: 103.1
0000031537 [app] INFO: avg: 1629.0, max: 1653.2, min: 1559.0, vpp: 94.3
```

### Example App

```c
void setup() {

}

void loop() {
    int avg = 0;
    int max = 0;
    int min = 0;
    int val = 0;
    avg = max = min = analogRead(A0);
    for (int i = 0; i < 100; i++) {
        val = analogRead(A0);
        avg += val;
        max = (max < val) ? val : max;
        min = (min > val) ? val : min;
        delay(10);
    }
    Log.info("avg: %.1f, max: %.1f, min: %.1f, vpp: %.1f", avg/100.0/4096.0*3300, max/4096.0*3300, min/4096.0*3300, max/4096.0*3300 - min/4096.0*3300);
}
```

### References

[CH112569]
[CH112519]

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
