### PR TITLE
[Quectel] Account for "eMTC" type while obtaining signal values

### DIFF
--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -695,7 +695,9 @@ int QuectelNcpClient::getSignalQuality(CellularSignalQuality* qual) {
         {"TDSCDMA", CellularAccessTechnology::UTRAN},
         {"LTE", CellularAccessTechnology::LTE},
         {"CAT-M1", CellularAccessTechnology::LTE_CAT_M1},
-        {"CAT-NB1", CellularAccessTechnology::LTE_NB_IOT}
+        {"eMTC", CellularAccessTechnology::LTE_CAT_M1},
+        {"CAT-NB1", CellularAccessTechnology::LTE_NB_IOT},
+        {"NBIoT", CellularAccessTechnology::LTE_NB_IOT},
     };
 
     int vals[5] = {};

--- a/user/tests/integration/slo/connect_time/connect_time.cpp
+++ b/user/tests/integration/slo/connect_time/connect_time.cpp
@@ -55,6 +55,15 @@ inline auto& network() {
 #endif
 }
 
+#if Wiring_Cellular
+bool isQuectelRadio(int radioType) {
+    return (radioType == DEV_QUECTEL_BG96 || radioType == DEV_QUECTEL_EG91_E ||
+            radioType == DEV_QUECTEL_EG91_NA || radioType == DEV_QUECTEL_EG91_EX ||
+            radioType == DEV_QUECTEL_BG95_M1 || radioType == DEV_QUECTEL_EG91_NAX ||
+            radioType == DEV_QUECTEL_BG77 || radioType == DEV_QUECTEL_BG95_MF);
+}
+#endif
+
 const char* ratToString(hal_net_access_tech_t rat) {
     switch (rat) {
     case NET_ACCESS_TECHNOLOGY_WIFI:
@@ -191,7 +200,7 @@ bool testCloudConnectTimeFromColdBoot() {
             Test::out->println("Failed to retreive cellular_device_info!");
             return false;
         }
-        if (devInfo.dev == DEV_QUECTEL_BG96 || devInfo.dev == DEV_QUECTEL_EG91_NA) {
+        if (isQuectelRadio(devInfo.dev)) {
             delay(6000);
         }
         signal = network().RSSI();


### PR DESCRIPTION
### Problem

Signal values on certain Cat-M1 radios are invalid. Example: BG95-M1 / TrackerM

### Solution

Account for `eMTC` type/sysmode while collecting signal values from QCSQ. Added minor correction around NBIoT wording.

### Steps to Test

Run test-runner for `slo/connect_time` tests on trackerM or any module with BG95-M1 radio
Results should have valid signal values collected as below.
```
stats:
{ cold:
   { cloud_connect: [ 15233, 14841, 17527, 17399, 15229, 14993, 15228, 18301 ],
     network_connect: [ 5670, 5550, 5514, 5610, 5535, 5533, 5814, 5614 ],
     cloud_full_handshake: [ 8373, 8109, 10831, 10599, 8504, 8274, 8231, 11497 ],
     signal:
      { rat:
         [ 'LTE M1', 'LTE M1', 'LTE M1', 'LTE M1', 'LTE M1', 'LTE M1', 'LTE M1', 'LTE M1' ],
        sig_perc: [ 67.5, 72.5, 72.5, 80, 80, 65, 75, 75 ],
        qual_perc: [ 100, 87.5, 100, 87.5, 100, 87.5, 100, 87.5 ],
        sig: [ -88, -86, -86, -82, -82, -89, -85, -85 ],
        qual: [ -6, -7, -6, -7, -6, -7, -6, -7 ] } },
  warm:
   { cloud_connect: [ 4521, 4617, 10020, 4642, 4441, 4580, 4514, 4673 ],
     network_connect: [ 1195, 1195, 1195, 1197, 1195, 1195, 1195, 1195 ],
     cloud_session_resume: [ 2136, 2239, 7634, 2255, 2055, 2195, 2129, 2288 ],
     signal:
      { rat:
         [ 'LTE M1', 'LTE M1', 'LTE M1', 'LTE M1', 'LTE M1', 'LTE M1', 'LTE M1', 'LTE M1' ],
        sig_perc: [ 76.7, 72.5, 75, 75, 78.3, 75, 72.5, 75 ],
        qual_perc: [ 87.5, 87.5, 87.5, 87.5, 75, 87.5, 75, 87.5 ],
        sig: [ -84, -86, -85, -85, -83, -85, -86, -85 ],
        qual: [ -7, -7, -7, -7, -8, -7, -8, -7 ] } } }
cloud_connect_time_from_cold_boot: 17399
cloud_connect_time_from_warm_boot: 4642
        ✓ publish_and_validate_stats
    Resetting device


  17 passing (6m)


```

### References

[SC-110518](https://app.shortcut.com/particle/story/110518/trackerm-does-not-report-signal-str-qual-in-connection-time-tests)

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
