### PR TITLE
[test] Add thresholds for trackerM for slo tests

### DIFF
--- a/user/tests/integration/slo/startup/startup-slos.spec.js
+++ b/user/tests/integration/slo/startup/startup-slos.spec.js
@@ -19,6 +19,10 @@ const THRESHOLDS = {
         targetAppFlashSize: 21 * 1024, // 21KB
         targetFreeRam: 3 * 1024 * 1024 // 3MB
     },
+    trackerm: {
+        targetAppFlashSize: 21 * 1024, // 21KB
+        targetFreeRam: 3 * 1024 * 1024 // 3MB
+    },
     // See rational on this magic number: https://app.clubhouse.io/particle/story/72460/build-device-os-test-runner-integration-test-that-validates-the-minimum-flash-space-and-connects-quickly-slo#activity-72937
     default: {
         targetAppFlashSize: 18105,


### PR DESCRIPTION
### Description

As title says

### Steps to Test

Run device-os-test runner for slo/startup tests.

```
  Device startup service level objectives (SLOs)
    trackerm
    Target device: 0a10aced202194944a001be0 (keerthy-trackerm-ff-05)
    Flashing application: startup.bin
    Getting device tests
      systemThread=enabled
        Initializing device test suite
        Running device test: slo_startup_stats
        Device test passed
        Waiting cloud event: startup_stats
startupStats JSON { free_mem: 3334304, app_flash_size: 20480 }
actual_free_mem=3334304 target_free_mem=3145728 platform=trackerm
actual_app_flash_size=20480 target_app_flash_size=21504 platform=trackerm
        ✓ slo startup stats (112.5s)
    Resetting device


  1 passing (2m)
```

### References

[SC-110519](https://app.shortcut.com/particle/story/110519/trackerm-tests-exceeds-flash-size-and-free-mem-for-on-device-tests)

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
