### PR TITLE
Use OTP Feature flag to change ADC reference source

### DIFF
--- a/hal/src/nRF52840/adc_hal.cpp
+++ b/hal/src/nRF52840/adc_hal.cpp
@@ -141,6 +141,7 @@ void hal_adc_dma_init() {
 #endif // PLATFORM_ID == PLATFORM_BORON
 
     hal_device_hw_info hwInfo = {};
+    hwInfo.size = sizeof(hwInfo);
     hal_get_device_hw_info(&hwInfo, nullptr);
     if ((hwInfo.features & HW_FEATURE_FLAG_USE_INTERNAL_ADC_REFERENCE_BIT) == 0) {
         adcReference = HAL_ADC_REFERENCE_INTERNAL;

--- a/hal/src/nRF52840/adc_hal.cpp
+++ b/hal/src/nRF52840/adc_hal.cpp
@@ -38,6 +38,7 @@ static const nrfx_saadc_config_t saadcConfig = {
 
 static hal_adc_reference_t adcReference = HAL_ADC_REFERENCE_EXTERNAL;
 static constexpr uint32_t HAL_VERSION_BRN404X_V003 = 0x03;
+static constexpr uint32_t HW_FEATURE_FLAG_USE_INTERNAL_ADC_REFERENCE_BIT = (1<<15);
 
 static void analog_in_event_handler(nrfx_saadc_evt_t const *p_event) {
     (void) p_event;
@@ -138,7 +139,11 @@ void hal_adc_dma_init() {
         adcReference = HAL_ADC_REFERENCE_INTERNAL;
     }
 #else
-    (void)adcReference;
+    hal_device_hw_info hwInfo = {};
+    hal_get_device_hw_info(&hwInfo, nullptr);
+    if ((hwInfo.features & HW_FEATURE_FLAG_USE_INTERNAL_ADC_REFERENCE_BIT) == 0) {
+        adcReference = HAL_ADC_REFERENCE_INTERNAL;
+    }
 #endif // PLATFORM_ID == PLATFORM_BORON
 }
 

--- a/hal/src/nRF52840/adc_hal.cpp
+++ b/hal/src/nRF52840/adc_hal.cpp
@@ -138,13 +138,13 @@ void hal_adc_dma_init() {
     if (ret == SYSTEM_ERROR_NONE && hwVersion == HAL_VERSION_BRN404X_V003) {
         adcReference = HAL_ADC_REFERENCE_INTERNAL;
     }
-#else
+#endif // PLATFORM_ID == PLATFORM_BORON
+
     hal_device_hw_info hwInfo = {};
     hal_get_device_hw_info(&hwInfo, nullptr);
     if ((hwInfo.features & HW_FEATURE_FLAG_USE_INTERNAL_ADC_REFERENCE_BIT) == 0) {
         adcReference = HAL_ADC_REFERENCE_INTERNAL;
     }
-#endif // PLATFORM_ID == PLATFORM_BORON
 }
 
 /*


### PR DESCRIPTION
### Problem

There are potentially many different platforms that may end up using the richtek DCDC part with the excessive ripple voltage. For already shipped `BRN404X` platforms, the `HW_VERSION` OTP field can be used to identify them. For other SKUs, we need a different method.

### Solution

The `HW Feature Flags` bytes of HW INFO in OTP have bits available. However, the `tracker` platform [uses all but one of these bits](https://docs.google.com/document/d/1NWEVTn1BI07rdKzzvx_HsGqpiBn-hIN0Kc91B989_3c/edit#heading=h.35xkyity7v7y). We will use the last OTP feature flag bit to denote the presence of the RIchtek part, and thus the need to switch to the internal ADC reference voltage. 

### Steps to Test

1. Clear the OTP bit
2. Reboot, and the ADC should use the internal reference

### Example App

```
#define PARTICLE_USE_UNSTABLE_API
#include "storage_hal.h"

void burnOTP(){
    const uintptr_t HW_DATA_OTP_ADDRESS = 0x00000022;

    uint8_t hwFeatures[] = {0x00, 0x00};
    int r = hal_storage_read(HAL_STORAGE_ID_OTP, HW_DATA_OTP_ADDRESS, hwFeatures, 2);
    Log.info("Read result: %d / %x %x", r, hwFeatures[0], hwFeatures[1]);

    // Clear bit 15 of the HW Feature Flags bytes
    hwFeatures[1] &= 0x7F;
    r = hal_storage_write(HAL_STORAGE_ID_OTP, HW_DATA_OTP_ADDRESS, hwFeatures, 2);
    Log.info("Write result: %d", r);

    r = hal_storage_read(HAL_STORAGE_ID_OTP, HW_DATA_OTP_ADDRESS, hwFeatures, 2);
    Log.info("Read result after writing: %d / %x %x", r, hwFeatures[0], hwFeatures[1]);
}

void setup()
{
    // Init the ADC HAL to force reading of the OTP bits
    hal_adc_read(D0);
}

void loop()
{
    if (!Serial.available()) {
        return;
    }

    auto ch {Serial.read()};

    switch (ch) {
    case '1':
        burnOTP();
        break;
    default:
        Serial.printf("Invalid selection\r\n");
        break;
    }

    hal_device_hw_info hwInfo = {};
    hal_get_device_hw_info(&hwInfo, nullptr);
    Log.info("Feature Bits: %08x Top byte %02x Low Byte %02x", 
        hwInfo.features, 
        (hwInfo.features & 0x0000FF00) >> 8,
        hwInfo.features & 0x000000FF);
}
```

Burning the bit should show this
```
0000017308 [app] INFO: Feature Bits: 0000ebfe Top byte eb Low Byte fe
0000017308 [app] INFO: Read result: 2 / fe eb
0000017309 [app] INFO: Write result: 2
0000017309 [app] INFO: Read result after writing: 2 / fe 6b
0000022312 [app] INFO: Feature Bits: 00006bfe Top byte 6b Low Byte fe
```

After reboot, the ADC source will be internal. 

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
