### PR TITLE
[TrackerM] Collect cellular properties with system info

### DIFF
--- a/hal/src/trackerm/ota_flash_hal.cpp
+++ b/hal/src/trackerm/ota_flash_hal.cpp
@@ -19,8 +19,20 @@
 #include "ota_flash_hal_impl.h"
 #include "platform_ncp.h"
 #include "platform_radio_stack.h"
+#include "cellular_hal.h"
 
 void HAL_OTA_Add_System_Info(hal_system_info_t* info, bool create, void* reserved)
 {
-    add_system_properties(info, create, 0);
+    const int additional = 3;
+    int count = add_system_properties(info, create, additional);
+    if (create) {
+        info->key_value_count = count + additional;
+
+        CellularDevice device = {};
+        device.size = sizeof(device);
+        cellular_device_info(&device, NULL);
+        set_key_value(info->key_values+count, "imei", device.imei);
+        set_key_value(info->key_values+count+1, "iccid", device.iccid);
+        set_key_value(info->key_values+count+2, "cellfw", device.radiofw);
+    }
 }


### PR DESCRIPTION
### Problem

Currently running `particle serial identify` on TrackerM doesn't provide cellular info
```
 $ particle serial identify

Your device id is 0a10aced202194944a001be0
Your system firmware version is 5.1.0
```

### Solution

Collect cellular info as a part of system info collection similar to other cellular platforms

### Steps to Test

Run `particle serial identify` on trackerM
```
$ particle serial identify

Your device id is 0a10aced202194944a001d40
Your IMEI is 862464063731082
Your ICCID is 89883070000013773179
Your system firmware version is 5.1.0
```

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
