### PR TITLE
[rtl872x] Support IO wakeup sources through IO expander.

### DIFF
--- a/bootloader/prebootloader/src/rtl872x/part1/sleep_handler.cpp
+++ b/bootloader/prebootloader/src/rtl872x/part1/sleep_handler.cpp
@@ -126,7 +126,6 @@ void onSleepRequestReceived(km0_km4_ipc_msg_t* msg, void* context) {
 
 void configureSleepWakeupSource(const hal_sleep_config_t* config) {
     sleepDuration = 0;
-    hal_pin_info_t* halPinMap = hal_pin_map();
 
 #if HAL_PLATFORM_IO_EXTENSION && HAL_PLATFORM_MCP23S17
     bool ioExpanderIntConfigured = false;
@@ -145,6 +144,7 @@ void configureSleepWakeupSource(const hal_sleep_config_t* config) {
             uint32_t rtlPin;
             InterruptMode mode;
 #if HAL_PLATFORM_IO_EXTENSION && HAL_PLATFORM_MCP23S17
+            const hal_pin_info_t* halPinMap = hal_pin_map();
             if (halPinMap[gpioWakeup->pin].type == HAL_PIN_TYPE_MCU)
 #endif
             {

--- a/hal/src/rtl872x/interrupts_hal.cpp
+++ b/hal/src/rtl872x/interrupts_hal.cpp
@@ -306,6 +306,8 @@ void hal_interrupt_restore(void) {
             GPIO_INTMode(rtlPin, ENABLE, trigger, polarity, GPIO_INT_DEBOUNCE_ENABLE);
             GPIO_INTConfig(rtlPin, ENABLE);
             interruptsConfig[i].state = INT_STATE_ENABLED;
+        } else {
+            interruptsConfig[i].state = INT_STATE_DISABLED;
         }
     }
 }


### PR DESCRIPTION
As the title describes.

### Example App

```c
void setup() {
  /* A minimal example app is super helpful 
   * for testing new features and fixes. 
   * A link to a Docs PR is even better!
   */
}

void loop() {

}
```

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
