### PR TITLE
fix overflow error in HAL_Delay_Microseconds

### DIFF
--- a/hal/src/rtl872x/delay_hal.cpp
+++ b/hal/src/rtl872x/delay_hal.cpp
@@ -34,21 +34,9 @@ void HAL_Delay_Milliseconds(uint32_t nTime)
 
 void HAL_Delay_Microseconds(uint32_t uSec)
 {
-    system_tick_t start_micros = HAL_Timer_Get_Micro_Seconds();
-    system_tick_t current_micros = start_micros;
-    system_tick_t end_micros = start_micros + uSec;
+    const system_tick_t start_micros = HAL_Timer_Get_Micro_Seconds();
 
-    // Handle case where micros rolls over
-    if (end_micros < start_micros) {
-        while(1) {
-            current_micros = HAL_Timer_Get_Micro_Seconds();
-            if (current_micros < start_micros) {
-                break;
-            }
-        }
-    }
-
-    while (current_micros < end_micros) {
-        current_micros = HAL_Timer_Get_Micro_Seconds();
+    while (HAL_Timer_Get_Micro_Seconds() - start_micros < uSec) {
+        HAL_Notify_WDT();
     }
 }

--- a/hal/src/rtl872x/delay_hal.cpp
+++ b/hal/src/rtl872x/delay_hal.cpp
@@ -37,6 +37,5 @@ void HAL_Delay_Microseconds(uint32_t uSec)
     const system_tick_t start_micros = HAL_Timer_Get_Micro_Seconds();
 
     while (HAL_Timer_Get_Micro_Seconds() - start_micros < uSec) {
-        HAL_Notify_WDT();
     }
 }


### PR DESCRIPTION
### Problem

`HAL_Delay_Microseconds` on the P2 has this main loop:

```
    system_tick_t start_micros = HAL_Timer_Get_Micro_Seconds();
    system_tick_t current_micros = start_micros;
    system_tick_t end_micros = start_micros + uSec;

    ...

    while (current_micros < end_micros) {
        current_micros = HAL_Timer_Get_Micro_Seconds();
    }
```

If `end_micros` is close to `UINT_MAX` then it is possible that updating `current_micros` can wrap the counter and reset it to a low value, extending the wait by > 71 minutes. The closer `end_micros` is to precisely `UINT_MAX`, the less likely the loop will ever terminate.

### Solution

Check if we've waited long enough by using unsigned difference instead of comparing to `end_micros`. Watchdog isn't implemented yet but is expected later and makes this mirror the nRF code.

### Steps to Test

`wiring/no_fixture` runs without errors.
Run publish in Tracker Edge with sleep enabled to test the startup delay call.

### References

https://app.shortcut.com/particle/story/113600/overflow-in-p2-hal-delay-microseconds-causes-hangs-in-tracker-edge

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
