### PR TITLE
A workaround to fix the AMD USB issue

### DIFF
--- a/hal/src/rtl872x/usbd_driver.cpp
+++ b/hal/src/rtl872x/usbd_driver.cpp
@@ -263,8 +263,10 @@ int RtlUsbDriver::setupReply(SetupRequest* r, const uint8_t* data, size_t size) 
             // some common cases of returning not a lot of data generated on stack
             memcpy(tempBuffer_, data, size);
             CHECK_RTL_USB_TO_SYSTEM(usbd_ep0_transmit(rtlDev_, tempBuffer_, size));
+            HAL_Delay_Milliseconds(2);
         } else {
             CHECK_RTL_USB_TO_SYSTEM(usbd_ep0_transmit(rtlDev_, (uint8_t*)data, size));
+            HAL_Delay_Milliseconds(2);
         }
     } else if (data == nullptr && size == 0) {
         // FIXME: doesn't work

--- a/hal/src/rtl872x/usbd_driver.cpp
+++ b/hal/src/rtl872x/usbd_driver.cpp
@@ -263,10 +263,14 @@ int RtlUsbDriver::setupReply(SetupRequest* r, const uint8_t* data, size_t size) 
             // some common cases of returning not a lot of data generated on stack
             memcpy(tempBuffer_, data, size);
             CHECK_RTL_USB_TO_SYSTEM(usbd_ep0_transmit(rtlDev_, tempBuffer_, size));
+#if MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
             HAL_Delay_Milliseconds(2);
+#endif // MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
         } else {
             CHECK_RTL_USB_TO_SYSTEM(usbd_ep0_transmit(rtlDev_, (uint8_t*)data, size));
+#if MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
             HAL_Delay_Milliseconds(2);
+#endif // MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
         }
     } else if (data == nullptr && size == 0) {
         // FIXME: doesn't work


### PR DESCRIPTION
### Problem

We found the USB request `Get Line Coding` couldn't get a response on the AMD Windows PC, the symptom could be that we can't open the com port on a serial tool software on the AMD Windows PC.

### Solution

This is a workaround, not an ideal solution, create this PR for further discussion.

A straightforward fix is to add a bit of delay after `usbd_ep0_transmit()`, then the response of `Get Line Coding` can be sent. The transmit operation seems to be blocked. 

The FAE said `usbd_ep0_transmit()` only enables `NPTXFEM` interrupt, the real transfer is finished in the USB thread `usbd_isr_...` for which we configured its priority to `RTL_USBD_ISR_PRIORITY=7`.

But the callstack shows `usbd_ep0_transmit()` is called in `setupCb()` which has already been running in the USB thread.
![Screen Shot 2023-01-04 at 13 58 01](https://user-images.githubusercontent.com/7424522/210752176-05de934f-6191-4308-9684-0195c6f48060.png)


### Steps to Test

1. Checkout this branch, compile firmware for P2
2. Install a serial tool software and try to open/close the com port
<img width="592" alt="Screen Shot 2023-01-05 at 17 58 57" src="https://user-images.githubusercontent.com/7424522/210753367-c4034a39-d3e2-4048-a821-93fcb430912f.png">


### References

[CH109872]

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
