### PR TITLE
[photon2] Update FQC test with photon 2 pinout

### DIFF
--- a/hal/src/rtl872x/deviceid_hal_impl.h
+++ b/hal/src/rtl872x/deviceid_hal_impl.h
@@ -46,6 +46,8 @@
 #define WIFI_OUID_SIZE                  3
 #define DEVICE_ID_PREFIX_SIZE           6
 
+#define MODEL_VARIANT_PHOTON_2 1
+
 #ifdef	__cplusplus
 extern "C" {
 #endif

--- a/hal/src/rtl872x/deviceid_hal_impl.h
+++ b/hal/src/rtl872x/deviceid_hal_impl.h
@@ -46,8 +46,6 @@
 #define WIFI_OUID_SIZE                  3
 #define DEVICE_ID_PREFIX_SIZE           6
 
-#define MODEL_VARIANT_PHOTON_2 1
-
 #ifdef	__cplusplus
 extern "C" {
 #endif

--- a/hal/src/tron/hal_platform_config.h
+++ b/hal/src/tron/hal_platform_config.h
@@ -36,3 +36,6 @@
 #endif // defined(MODULE_FUNCTION) && MODULE_FUNCTION != 2 // MOD_FUNC_BOOTLOADER
 
 #define PRODUCT_SERIES "Pseries"
+
+#define PLATFORM_P2_MODEL_BARE_SOM_DEFAULT (0xffff)
+#define PLATFORM_P2_PHOTON_2               (0x0001)

--- a/user/applications/tinker/src/fqc_test.cpp
+++ b/user/applications/tinker/src/fqc_test.cpp
@@ -266,7 +266,7 @@ bool FqcTest::bleScan(JSONValue req) {
 static Vector<uint16_t> p2_gpio_test_pins = { A5, S6, WKP, S4, D0, D1, S0, S1, S2, A1, S3, D2, D4, D5, D3, A0, A2, S5 };
 static Vector<uint16_t> photon2_gpio_test_pins = {A0, D10, A1, D7, A2, D6, A5, D5, S4, D4, S3, D3, SCK, D2, MOSI, D1, MISO, D0 };
 
-static Vector<uint16_t> gpio_test_pins;
+static Vector<uint16_t> gpio_test_pins = {};
 
 static bool assertAllPinsLow(uint16_t exceptPinA, uint16_t exceptPinB, uint16_t * errorPin) {
     for(auto pin : gpio_test_pins) {
@@ -336,8 +336,11 @@ bool FqcTest::ioTest(JSONValue req) {
     // Pick which set of pins to use based on hardware variant
     uint32_t model, variant;
     hal_get_device_hw_model(&model, &variant, nullptr);
-    Log.info("Hardware Model: 0x%x Variant: 0x%x", model, variant);
+    Log.info("Hardware Model: %lu Variant: %lu", model, variant);
+
+    #if PLATFORM_ID == PLATFORM_P2
     gpio_test_pins = variant == PLATFORM_P2_PHOTON_2 ? photon2_gpio_test_pins : p2_gpio_test_pins;
+    #endif
 
     for(int i = 0; i < gpio_test_pins.size(); i+=2){
         pinA = gpio_test_pins[i];

--- a/user/applications/tinker/src/fqc_test.cpp
+++ b/user/applications/tinker/src/fqc_test.cpp
@@ -336,7 +336,7 @@ bool FqcTest::ioTest(JSONValue req) {
     // Pick which set of pins to use based on hardware variant
     uint32_t model, variant;
     hal_get_device_hw_model(&model, &variant, nullptr);
-    gpio_test_pins = variant == MODEL_VARIANT_PHOTON_2 ? photon2_gpio_test_pins : p2_gpio_test_pins;
+    gpio_test_pins = variant == PLATFORM_P2_PHOTON_2 ? photon2_gpio_test_pins : p2_gpio_test_pins;
 
     for(int i = 0; i < gpio_test_pins.size(); i+=2){
         pinA = gpio_test_pins[i];

--- a/user/applications/tinker/src/fqc_test.cpp
+++ b/user/applications/tinker/src/fqc_test.cpp
@@ -264,7 +264,7 @@ bool FqcTest::bleScan(JSONValue req) {
 // - S4 (PA0) + WKP/D10 (PA15)
 // - A5 (PB4) + S6 (PB31)
 static Vector<uint16_t> p2_gpio_test_pins = { A5, S6, WKP, S4, D0, D1, S0, S1, S2, A1, S3, D2, D4, D5, D3, A0, A2, S5 };
-static Vector<uint16_t> photon2_gpio_test_pins = {A0, A1, A2, A5, S4, S3, S2, S0, S1, D0, D1, D2, D3, D4, D5, D10 };
+static Vector<uint16_t> photon2_gpio_test_pins = {A0, D10, A1, D7, A2, D6, A5, D5, S4, D4, S3, D3, SCK, D2, MOSI, D1, MISO, D0 };
 
 static Vector<uint16_t> gpio_test_pins;
 
@@ -336,6 +336,7 @@ bool FqcTest::ioTest(JSONValue req) {
     // Pick which set of pins to use based on hardware variant
     uint32_t model, variant;
     hal_get_device_hw_model(&model, &variant, nullptr);
+    Log.info("Hardware Model: 0x%x Variant: 0x%x", model, variant);
     gpio_test_pins = variant == PLATFORM_P2_PHOTON_2 ? photon2_gpio_test_pins : p2_gpio_test_pins;
 
     for(int i = 0; i < gpio_test_pins.size(); i+=2){


### PR DESCRIPTION
### Problem

Photon 2 devices are going into production. The feather pinout of the Photon 2 differs from the bare P2 module. The FQC test will need to be updated to test the feather pins

### Solution

Update the GPIO pin mapping to reflect which pins are available and adjacent on the feather pins

### Steps to Test

Run FQC tests with photon 2 (NOTE: Current pre DVT photon 2 boards do not have the efuse model variant settings programed, so they will not be detected as Photon 2s. In order to test FQC, you will have to make local modifications to tinker to use the photon 2 pins, then jumper those pins together). 

### Example App
Use Tinker

### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
