### PR TITLE
[test] mailbox support and support for resets within tests

### DIFF
--- a/user/tests/integration/application/src/request_handler.h
+++ b/user/tests/integration/application/src/request_handler.h
@@ -47,6 +47,7 @@ private:
     int getStatus(Request* req);
     int getLog(Request* req);
     int reset(Request* req);
+    int readMailbox(Request* req);
 };
 
 } // namespace particle

--- a/user/tests/integration/runner/mailbox/mailbox.cpp
+++ b/user/tests/integration/runner/mailbox/mailbox.cpp
@@ -42,3 +42,20 @@ test(03_mailbox) {
     assertEqual(0, pushMailboxMsg(data2, 10000));
     assertEqual(0, pushMailboxBuffer(data3, sizeof(data3) - 1));
 }
+
+test(04_mailbox_reset_postponed) {
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
+    // We've waited up to 10 seconds for test runner to understand that we are going to reset
+    auto t = new Thread("test", [](void* param) -> os_thread_return_t {
+        delay(5000);
+        System.reset();
+    }, nullptr);
+    // This will leak, but that's fine
+    assertTrue(t);
+}
+
+test(05_mailbox) {
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::DATA).data(data1, sizeof(data1) - 1)));
+    assertEqual(0, pushMailboxMsg(data2, 10000));
+    assertEqual(0, pushMailboxBuffer(data3, sizeof(data3) - 1));
+}

--- a/user/tests/integration/runner/mailbox/mailbox.cpp
+++ b/user/tests/integration/runner/mailbox/mailbox.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "application.h"
+#include "test.h"
+
+namespace {
+constexpr char data1[] = "test";
+constexpr char data2[] = "deadbeef";
+constexpr char data3[] = "\x00\x01\x02\x03";
+} // anonymous
+
+test(01_mailbox) {
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::DATA).data(data1, sizeof(data1) - 1)));
+    assertEqual(0, pushMailboxMsg(data2, 10000));
+    assertEqual(0, pushMailboxBuffer(data3, sizeof(data3) - 1));
+}
+
+
+test(02_mailbox_reset) {
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
+    // We've waited up to 10 seconds for test runner to understand that we are going to reset
+    System.reset();
+}
+
+test(03_mailbox) {
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::DATA).data(data1, sizeof(data1) - 1)));
+    assertEqual(0, pushMailboxMsg(data2, 10000));
+    assertEqual(0, pushMailboxBuffer(data3, sizeof(data3) - 1));
+}

--- a/user/tests/integration/runner/mailbox/mailbox.spec.js
+++ b/user/tests/integration/runner/mailbox/mailbox.spec.js
@@ -1,0 +1,35 @@
+suite('Test runner mailbox');
+
+platform('gen3');
+systemThread('enabled');
+
+let device = null;
+
+before(function() {
+    device = this.particle.devices[0];
+    device.on('mailbox', (msg) => {
+        console.log('mailbox msg', msg);
+    });
+});
+
+test('01_mailbox', async function () {
+    expect(device.mailBox).to.eql([
+        {t: 2, d: 'test'},
+        {t: 2, d: 'deadbeef'},
+        {t: 2, d: '\u0000\u0001\u0002\u0003'}
+    ]);
+});
+
+test('02_mailbox_reset', async function () {
+    expect(device.mailBox).to.eql([
+        {t: 1} // RESET_PENDING
+    ]);
+});
+
+test('03_mailbox', async function () {
+    expect(device.mailBox).to.eql([
+        {t: 2, d: 'test'},
+        {t: 2, d: 'deadbeef'},
+        {t: 2, d: '\u0000\u0001\u0002\u0003'}
+    ]);
+});

--- a/user/tests/integration/slo/application_max_size/application_max_size.cpp
+++ b/user/tests/integration/slo/application_max_size/application_max_size.cpp
@@ -21,7 +21,7 @@
 namespace {
 
 #if HAL_PLATFORM_NRF52840
-constexpr size_t FLASH_FILL_SIZE = 240 * 1024; // 240KB
+constexpr size_t FLASH_FILL_SIZE = 239 * 1024; // 239KB
 #elif HAL_PLATFORM_RTL872X
 constexpr size_t FLASH_FILL_SIZE = 1945 * 1024; // 1.9MB
 #else

--- a/user/tests/integration/slo/connect_time/connect_time.cpp
+++ b/user/tests/integration/slo/connect_time/connect_time.cpp
@@ -171,13 +171,13 @@ bool testCloudConnectTimeFromColdBoot() {
     network().on(); // Make sure the network interface is turned on, so we can turn it off more easily.
     waitFor(network().isOn, TEST_MAX_TIMEOUT - std::min(millis() - t0, TEST_MAX_TIMEOUT));
     if (!network().isOn()) {
-        Test::out->println("Failed to power on the network interface!");
+        TestRunner::instance()->pushMailboxMsg("Failed to power on the network interface!");
         return false;
     }
     network().off(); // Make sure the network interface is turned off
     waitFor(network().isOff, TEST_MAX_TIMEOUT - std::min(millis() - t0, TEST_MAX_TIMEOUT)); // Do not exceed max test time
     if (!network().isOff()) {
-        Test::out->println("Failed to power off the network interface!");
+        TestRunner::instance()->pushMailboxMsg("Failed to power off the network interface!");
         return false;
     }
     Particle.disconnect(CloudDisconnectOptions().clearSession(true)); // Clear the session data
@@ -185,7 +185,7 @@ bool testCloudConnectTimeFromColdBoot() {
     network().connect();
     waitFor(network().ready, TEST_MAX_TIMEOUT - std::min(millis() - t0, TEST_MAX_TIMEOUT)); // Do not exceed max test time
     if (!network().ready()) {
-        Test::out->println("Failed to connect to cellular!");
+        TestRunner::instance()->pushMailboxMsg("Failed to connect to cellular!");
         return false;
     }
     const auto t2 = millis();
@@ -197,7 +197,7 @@ bool testCloudConnectTimeFromColdBoot() {
         CellularDevice devInfo = {};
         devInfo.size = sizeof(devInfo);
         if (cellular_device_info(&devInfo, nullptr)) {
-            Test::out->println("Failed to retreive cellular_device_info!");
+            TestRunner::instance()->pushMailboxMsg("Failed to retreive cellular_device_info!");
             return false;
         }
         if (isQuectelRadio(devInfo.dev)) {
@@ -210,7 +210,7 @@ bool testCloudConnectTimeFromColdBoot() {
     Particle.connect();
     waitFor(Particle.connected, TEST_MAX_TIMEOUT - std::min(millis() - t0, TEST_MAX_TIMEOUT)); // Do not exceed max test time
     if (!Particle.connected()) {
-        Test::out->println("Failed to connect to cloud!");
+        TestRunner::instance()->pushMailboxMsg("Failed to connect to cloud!");
         return false;
     }
     const auto t4 = millis();
@@ -238,14 +238,14 @@ bool testCloudConnectTimeFromWarmBoot() {
     stats.cloudConnectTimeFromWarmBoot[n] = TEST_MAX_TIMEOUT;
 
     if (network().ready()) {
-        Test::out->println("Network connected already!");
+        TestRunner::instance()->pushMailboxMsg("Network connected already!");
         return false;
     }
     const auto t1 = millis();
     network().connect();
     waitFor(network().ready, TEST_MAX_TIMEOUT - std::min(millis() - t0, TEST_MAX_TIMEOUT));
     if (!network().ready()) {
-        Test::out->println("Failed to connect to cellular!");
+        TestRunner::instance()->pushMailboxMsg("Failed to connect to cellular!");
         return false;
     }
     const auto t2 = millis();
@@ -255,7 +255,7 @@ bool testCloudConnectTimeFromWarmBoot() {
     Particle.connect();
     waitFor(Particle.connected, TEST_MAX_TIMEOUT - std::min(millis() - t0, TEST_MAX_TIMEOUT));
     if (!Particle.connected()) {
-        Test::out->println("Failed to connect to cloud!");
+        TestRunner::instance()->pushMailboxMsg("Failed to connect to cloud!");
         return false;
     }
     const auto t4 = millis();
@@ -350,8 +350,5 @@ test(publish_and_validate_stats) {
     serializeStatsAsJson(buf.get(), n);
     buf[n] = '\0';
     const auto runner = TestRunner::instance();
-    if (runner->logSize() < n) {
-        runner->logSize(n);
-    }
-    out->print(buf.get());
+    assertEqual(0, runner->pushMailboxBuffer(buf.get(), n, 10000));
 }

--- a/user/tests/integration/slo/connect_time/connect_time.spec.js
+++ b/user/tests/integration/slo/connect_time/connect_time.spec.js
@@ -44,10 +44,8 @@ function percentile(values, p) {
 	return values[i];
 }
 
-// FIXME: this is a hack, there should be a native way to send some data back from the device
 async function fetchLog() {
-	const rep = await device._request({ c: 'L' }); // Get log
-	return rep.data.trim();
+	return device.mailBox;
 }
 
 before(function() {
@@ -55,12 +53,15 @@ before(function() {
 });
 
 // TODO: The test runner doesn't support resetting the device in a loop from within a test
+// FIXME: it does now, the tests need to be fixed
 for (let i = 1; i <= CONNECT_COUNT; ++i) {
 	test(`cloud_connect_time_from_cold_boot_${i.toString().padStart(2, '0')}`, async () => {
 		// dump any failure logs from this test
 		let testLog = await fetchLog();
 		if (testLog.length) {
-			console.log(testLog);
+			for (let msg of testLog) {
+				console.log(msg.d);
+			}
 		}
 		await device.reset(); // Reset the device before running the next test
 	});
@@ -71,7 +72,9 @@ for (let i = 1; i <= CONNECT_COUNT; ++i) {
 		// dump any failure logs from this test
 		let testLog = await fetchLog();
 		if (testLog.length) {
-			console.log(testLog);
+			for (let msg of testLog) {
+				console.log(msg.d);
+			}
 		}
 		await device.reset();
 	});
@@ -79,7 +82,7 @@ for (let i = 1; i <= CONNECT_COUNT; ++i) {
 
 test('publish_and_validate_stats', async function() {
 	let stats = await fetchLog();
-	stats = JSON.parse(stats);
+	stats = JSON.parse(stats[0].d);
 	console.log('stats:');
 	console.dir(stats, { depth: null, colors: true, compact: true, maxArrayLength: 100 });
 	// Cold boot

--- a/user/tests/wiring/no_fixture/system.cpp
+++ b/user/tests/wiring/no_fixture/system.cpp
@@ -487,3 +487,8 @@ test(SYSTEM_10_system_ticks_delay) {
     assertLessOrEqual(duration, expected_high);
     assertMoreOrEqual(duration, expected_low);
 }
+
+test(SYSTEM_11_system_reset) {
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
+    System.reset();
+}


### PR DESCRIPTION
### Problem

Currently there is no sane way of writing automated tests using our test framework that:
1. Generate messages during the test that the JS side can act upon
2. Notify device-os-test-runner about on-device tests triggering a reset/detach

### Solution

Add a device->host mailbox interface to send either specific notifications (e.g. device is going to reset) or generic data e.g. statistics from SLO tests.

NOTE: requires https://github.com/particle-iot/device-os-test-runner/pull/21

### Steps to Test

- runner/mailbox
- slo/connect_time
- wiring/no_fixture: system reset test

### Example App

See runner/mailbox test.

### References



---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
