### PR TITLE
[rtl872x] enable factory reset feature

### DIFF
--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -648,7 +648,6 @@ int resetSettingsToFactoryDefaultsIfNeeded() {
     }
     SYSTEM_FLAG(NVMEM_SPARK_Reset_SysFlag) = 0x0000;
     Save_SystemFlags();
-#if HAL_PLATFORM_NRF52840
     LOG(WARN, "Resetting all settings to factory defaults");
 #if HAL_PLATFORM_WIFI
     // Clear WiFi credentials
@@ -670,7 +669,6 @@ int resetSettingsToFactoryDefaultsIfNeeded() {
     CHECK(dct_write_app_data(devPubKey.get(), DCT_ALT_DEVICE_PUBLIC_KEY_OFFSET, DCT_ALT_DEVICE_PUBLIC_KEY_SIZE));
     // Restore default server key and address
     ServerConfig::instance()->restoreDefaultSettings();
-#endif // HAL_PLATFORM_NRF52840
 #endif // !defined(SPARK_NO_PLATFORM) && HAL_PLATFORM_DCT
     return 0;
 }


### PR DESCRIPTION
### Problem

Factory reset through bootloader and long MODE button press until blinking WHITE is only available as of right now on nRF52840 platforms.

### Solution

Fix that, enable on P2 and Tracker M as well.

List of things that are reset:
1. Wifi configuration
2. Cellular configuration (SIM external/internal/APN etc)
3. Everything in DCT except for device keys
4. Power management settings

### TODO

1. ~Reset power management configuration?~ In DCT, already reset.
2. Reset system cache (NCP fw version, NCP MAC, ADC calibration offset)?
3. Reset OTA transfer state?

### Steps to Test

1. Flash system part out of this branch
5. Hold RESET and MODE, release RESET, continue holding until flashing WHITE (after MAGENTA and YELLOW)
6. Release MODE
7. Device should boot and lose its WiFi configuration, feature flags etc.

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
