### PR TITLE
[wiring][gen3] Allow gen3 to select internal ADC reference source

### DIFF
--- a/hal/inc/adc_hal.h
+++ b/hal/inc/adc_hal.h
@@ -26,6 +26,12 @@ typedef enum hal_adc_state_t {
     HAL_ADC_STATE_SUSPENDED
 } hal_adc_state_t;
 
+typedef enum hal_adc_reference_t {
+    HAL_ADC_REFERENCE_DEFAULT = 0,
+    HAL_ADC_REFERENCE_INTERNAL = 1,
+    HAL_ADC_REFERENCE_VCC = 2
+} hal_adc_reference_t;
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -35,7 +41,7 @@ int32_t hal_adc_read(hal_pin_t pin);
 void hal_adc_dma_init();
 int hal_adc_calibrate(uint32_t reserved, void* reserved1);
 int hal_adc_sleep(bool sleep, void* reserved);
-
+int hal_adc_set_reference(uint32_t reference, void* reserved);
 
 #include "adc_hal_compat.h"
 

--- a/hal/inc/adc_hal.h
+++ b/hal/inc/adc_hal.h
@@ -42,6 +42,7 @@ void hal_adc_dma_init();
 int hal_adc_calibrate(uint32_t reserved, void* reserved1);
 int hal_adc_sleep(bool sleep, void* reserved);
 int hal_adc_set_reference(uint32_t reference, void* reserved);
+int hal_adc_get_reference(void* reserved);
 
 #include "adc_hal_compat.h"
 

--- a/hal/inc/hal_dynalib_gpio.h
+++ b/hal/inc/hal_dynalib_gpio.h
@@ -90,6 +90,7 @@ DYNALIB_FN(37, hal_gpio, hal_adc_sleep, int(bool, void*))
 DYNALIB_FN(38, hal_gpio, hal_pwm_sleep, int(bool, void*))
 DYNALIB_FN(39, hal_gpio, hal_gpio_configure, int(hal_pin_t, const hal_gpio_config_t*, void*))
 DYNALIB_FN(40, hal_gpio, hal_adc_calibrate, int(uint32_t, void*))
+DYNALIB_FN(41, hal_gpio, hal_adc_set_reference, int(uint32_t, void*))
 
 DYNALIB_END(hal_gpio)
 

--- a/hal/inc/hal_dynalib_gpio.h
+++ b/hal/inc/hal_dynalib_gpio.h
@@ -91,6 +91,7 @@ DYNALIB_FN(38, hal_gpio, hal_pwm_sleep, int(bool, void*))
 DYNALIB_FN(39, hal_gpio, hal_gpio_configure, int(hal_pin_t, const hal_gpio_config_t*, void*))
 DYNALIB_FN(40, hal_gpio, hal_adc_calibrate, int(uint32_t, void*))
 DYNALIB_FN(41, hal_gpio, hal_adc_set_reference, int(uint32_t, void*))
+DYNALIB_FN(42, hal_gpio, hal_adc_get_reference, int(void*))
 
 DYNALIB_END(hal_gpio)
 

--- a/hal/src/nRF52840/adc_hal.cpp
+++ b/hal/src/nRF52840/adc_hal.cpp
@@ -22,11 +22,6 @@
 #include "check.h"
 #include "deviceid_hal.h"
 
-typedef enum hal_adc_reference_t {
-    HAL_ADC_REFERENCE_EXTERNAL,
-    HAL_ADC_REFERENCE_INTERNAL
-} hal_adc_reference_t;
-
 static volatile hal_adc_state_t adcState = HAL_ADC_STATE_DISABLED;
 
 static const nrfx_saadc_config_t saadcConfig = {
@@ -36,7 +31,7 @@ static const nrfx_saadc_config_t saadcConfig = {
     .low_power_mode     = false
 };
 
-static hal_adc_reference_t adcReference = HAL_ADC_REFERENCE_EXTERNAL;
+static hal_adc_reference_t adcReference = HAL_ADC_REFERENCE_VCC;
 static constexpr uint32_t HAL_VERSION_BRN404X_V003 = 0x03;
 static constexpr uint32_t HW_FEATURE_FLAG_USE_INTERNAL_ADC_REFERENCE_BIT = (1<<15);
 
@@ -177,3 +172,20 @@ int hal_adc_sleep(bool sleep, void* reserved) {
 int hal_adc_calibrate(uint32_t reserved, void* reserved1) {
     return SYSTEM_ERROR_NOT_SUPPORTED;
 }
+
+int hal_adc_set_reference(uint32_t reference, void* reserved) {
+    switch (reference) {
+        case HAL_ADC_REFERENCE_DEFAULT:
+        case HAL_ADC_REFERENCE_VCC:
+            adcReference = HAL_ADC_REFERENCE_VCC;
+            break;
+        case HAL_ADC_REFERENCE_INTERNAL:
+            adcReference = HAL_ADC_REFERENCE_INTERNAL;
+            break;
+        default: 
+            return SYSTEM_ERROR_INVALID_ARGUMENT;
+    }
+
+    return SYSTEM_ERROR_NONE;
+}
+

--- a/hal/src/nRF52840/adc_hal.cpp
+++ b/hal/src/nRF52840/adc_hal.cpp
@@ -39,6 +39,27 @@ static void analog_in_event_handler(nrfx_saadc_evt_t const *p_event) {
     (void) p_event;
 }
 
+static hal_adc_reference_t hal_adc_get_default_reference(void) {
+    hal_adc_reference_t defaultSource = HAL_ADC_REFERENCE_VCC;
+
+#if PLATFORM_ID == PLATFORM_BORON
+    uint32_t hwVersion = 0xFF;
+    auto ret = hal_get_device_hw_version(&hwVersion, nullptr);
+    if (ret == SYSTEM_ERROR_NONE && hwVersion == HAL_VERSION_BRN404X_V003) {
+        defaultSource = HAL_ADC_REFERENCE_INTERNAL;
+    }
+#endif // PLATFORM_ID == PLATFORM_BORON
+
+    hal_device_hw_info hwInfo = {};
+    hwInfo.size = sizeof(hwInfo);
+    hal_get_device_hw_info(&hwInfo, nullptr);
+    if ((hwInfo.features & HW_FEATURE_FLAG_USE_INTERNAL_ADC_REFERENCE_BIT) == 0) {
+        defaultSource = HAL_ADC_REFERENCE_INTERNAL;
+    }
+
+    return defaultSource;
+}
+
 void hal_adc_set_sample_time(uint8_t sample_time) {
     // deprecated
 }
@@ -127,20 +148,7 @@ void hal_adc_dma_init() {
     uint32_t err_code = nrfx_saadc_init(&saadcConfig, analog_in_event_handler);
     SPARK_ASSERT(err_code == NRF_SUCCESS);
 
-#if PLATFORM_ID == PLATFORM_BORON
-    uint32_t hwVersion = 0xFF;
-    auto ret = hal_get_device_hw_version(&hwVersion, nullptr);
-    if (ret == SYSTEM_ERROR_NONE && hwVersion == HAL_VERSION_BRN404X_V003) {
-        adcReference = HAL_ADC_REFERENCE_INTERNAL;
-    }
-#endif // PLATFORM_ID == PLATFORM_BORON
-
-    hal_device_hw_info hwInfo = {};
-    hwInfo.size = sizeof(hwInfo);
-    hal_get_device_hw_info(&hwInfo, nullptr);
-    if ((hwInfo.features & HW_FEATURE_FLAG_USE_INTERNAL_ADC_REFERENCE_BIT) == 0) {
-        adcReference = HAL_ADC_REFERENCE_INTERNAL;
-    }
+    adcReference = hal_adc_get_default_reference();
 }
 
 /*
@@ -174,13 +182,14 @@ int hal_adc_calibrate(uint32_t reserved, void* reserved1) {
 }
 
 int hal_adc_set_reference(uint32_t reference, void* reserved) {
+
     switch (reference) {
-        case HAL_ADC_REFERENCE_DEFAULT:
         case HAL_ADC_REFERENCE_VCC:
-            adcReference = HAL_ADC_REFERENCE_VCC;
-            break;
         case HAL_ADC_REFERENCE_INTERNAL:
-            adcReference = HAL_ADC_REFERENCE_INTERNAL;
+            adcReference = (hal_adc_reference_t)reference;
+            break;    
+        case HAL_ADC_REFERENCE_DEFAULT:
+            adcReference = hal_adc_get_default_reference();
             break;
         default: 
             return SYSTEM_ERROR_INVALID_ARGUMENT;
@@ -189,3 +198,6 @@ int hal_adc_set_reference(uint32_t reference, void* reserved) {
     return SYSTEM_ERROR_NONE;
 }
 
+int hal_adc_get_reference(void* reserved) {
+    return (int)adcReference;
+}

--- a/hal/src/rtl872x/adc_hal.cpp
+++ b/hal/src/rtl872x/adc_hal.cpp
@@ -298,6 +298,6 @@ int hal_adc_set_reference(uint32_t reference, void* reserved) {
     return SYSTEM_ERROR_NOT_SUPPORTED;
 }
 
-int hal_adc_get_reference(uint32_t reference, void* reserved) {
+int hal_adc_get_reference(void* reserved) {
     return (int)HAL_ADC_REFERENCE_DEFAULT;
 }

--- a/hal/src/rtl872x/adc_hal.cpp
+++ b/hal/src/rtl872x/adc_hal.cpp
@@ -293,3 +293,7 @@ int hal_adc_sleep(bool sleep, void* reserved) {
 int hal_adc_calibrate(uint32_t reserved, void* reserved1) {
     return Adc::instance().calibration();
 }
+
+int hal_adc_set_reference(uint32_t reference, void* reserved) {
+    return SYSTEM_ERROR_NOT_SUPPORTED;
+}

--- a/hal/src/rtl872x/adc_hal.cpp
+++ b/hal/src/rtl872x/adc_hal.cpp
@@ -297,3 +297,7 @@ int hal_adc_calibrate(uint32_t reserved, void* reserved1) {
 int hal_adc_set_reference(uint32_t reference, void* reserved) {
     return SYSTEM_ERROR_NOT_SUPPORTED;
 }
+
+int hal_adc_get_reference(uint32_t reference, void* reserved) {
+    return (int)HAL_ADC_REFERENCE_DEFAULT;
+}

--- a/hal/src/rtl872x/adc_hal.cpp
+++ b/hal/src/rtl872x/adc_hal.cpp
@@ -299,5 +299,5 @@ int hal_adc_set_reference(uint32_t reference, void* reserved) {
 }
 
 int hal_adc_get_reference(void* reserved) {
-    return (int)HAL_ADC_REFERENCE_DEFAULT;
+    return (int)HAL_ADC_REFERENCE_INTERNAL;
 }

--- a/user/tests/wiring/api/wiring.cpp
+++ b/user/tests/wiring/api/wiring.cpp
@@ -38,6 +38,14 @@ test(api_wiring_analogWrite) {
   API_COMPILE(analogWrite(D0, 50, 10000));
 }
 
+test(api_wiring_analogSetReference) {
+  API_COMPILE(analogSetReference(AdcReference::INTERNAL));
+}
+
+test(api_wiring_analogGetReference) {
+  API_COMPILE(analogGetReference());
+}
+
 test(api_wiring_wire_setSpeed)
 {
     API_COMPILE(Wire.setSpeed(CLOCK_SPEED_100KHZ));

--- a/wiring/inc/spark_wiring.h
+++ b/wiring/inc/spark_wiring.h
@@ -74,6 +74,12 @@ enum class DriveStrength: uint8_t {
     STANDARD   = HAL_GPIO_DRIVE_STANDARD
 };
 
+enum class AdcReference {
+    DEFAULT   = HAL_ADC_REFERENCE_DEFAULT,
+    INTERNAL  = HAL_ADC_REFERENCE_INTERNAL,
+    VCC       = HAL_ADC_REFERENCE_VCC
+};
+
 /*
 * GPIO
 */
@@ -103,6 +109,7 @@ uint8_t analogWriteResolution(hal_pin_t pin, uint8_t value);
 uint8_t analogWriteResolution(hal_pin_t pin);
 uint32_t analogWriteMaxFrequency(hal_pin_t pin);
 void setDACBufferred(hal_pin_t pin, uint8_t state);
+int analogSetReference(AdcReference reference);
 
 int map(int value, int fromStart, int fromEnd, int toStart, int toEnd);
 double map(double value, double fromStart, double fromEnd, double toStart, double toEnd);

--- a/wiring/inc/spark_wiring.h
+++ b/wiring/inc/spark_wiring.h
@@ -110,6 +110,7 @@ uint8_t analogWriteResolution(hal_pin_t pin);
 uint32_t analogWriteMaxFrequency(hal_pin_t pin);
 void setDACBufferred(hal_pin_t pin, uint8_t state);
 int analogSetReference(AdcReference reference);
+AdcReference analogGetReference(void);
 
 int map(int value, int fromStart, int fromEnd, int toStart, int toEnd);
 double map(double value, double fromStart, double fromEnd, double toStart, double toEnd);

--- a/wiring_globals/src/spark_wiring_gpio.cpp
+++ b/wiring_globals/src/spark_wiring_gpio.cpp
@@ -376,5 +376,13 @@ void setDACBufferred(hal_pin_t pin, uint8_t state) {
 }
 
 int analogSetReference(AdcReference reference) {
-  return hal_adc_set_reference((uint32_t)reference, nullptr);
+  return hal_adc_set_reference(particle::to_underlying(reference), nullptr);
+}
+
+AdcReference analogGetReference(void) {
+  int result = hal_adc_get_reference(nullptr);
+  if (result >= SYSTEM_ERROR_NONE) {
+    return static_cast<AdcReference>(result);
+  } 
+  return AdcReference::DEFAULT;
 }

--- a/wiring_globals/src/spark_wiring_gpio.cpp
+++ b/wiring_globals/src/spark_wiring_gpio.cpp
@@ -374,3 +374,7 @@ uint32_t pulseIn(hal_pin_t pin, uint16_t value) {
 void setDACBufferred(hal_pin_t pin, uint8_t state) {
   HAL_DAC_Enable_Buffer(pin, state);
 }
+
+int analogSetReference(AdcReference reference) {
+  return hal_adc_set_reference((uint32_t)reference, nullptr);
+}


### PR DESCRIPTION
### Problem
Customer wishes to change ADC reference source from the default external VCC source to the internal voltage reference because it has greater accuracy on their particular design. 

### Solution

Add Wiring API to change the source at runtime. Setting is not persistent

### Steps to Test

I used a boron to test ADC reading on pin A5 with 2v from a bench supply. 

### Example App

```c
void setup() {
  /* A minimal example app is super helpful 
   * for testing new features and fixes. 
   * A link to a Docs PR is even better!
   */
}

void loop() {
    static uint8_t i = 0;
    int analogPin = A5;
    int value = 0;
    String source;

    // Set ADC reference source
    if (i++ % 2) {
        analogSetReference(AdcReference::INTERNAL);
    } else {
        analogSetReference(AdcReference::VCC);
    }

    source = (analogGetReference() == AdcReference::INTERNAL ? "INTERNAL" : "VCC     ");

    // Read ADC
    value = analogRead(analogPin);
    Log("ADC Source: %s ADC Value: %d", source.c_str(), value);
    
    delay(2000);
}
```
Sample output comparing the two sources:
```
0000444524 [app] INFO: ADC Source: VCC      ADC Value: 2574
0000446525 [app] INFO: ADC Source: internal ADC Value: 2594
0000448526 [app] INFO: ADC Source: VCC      ADC Value: 2569
0000450527 [app] INFO: ADC Source: internal ADC Value: 2592
0000452528 [app] INFO: ADC Source: VCC      ADC Value: 2582
0000454529 [app] INFO: ADC Source: internal ADC Value: 2586
0000456530 [app] INFO: ADC Source: VCC      ADC Value: 2583
```


### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
