### PR TITLE
Remove manual wakeup. Hibernate + watchdog on platforms that support it

### DIFF
--- a/user/tests/wiring/watchdog/watchdog.cpp
+++ b/user/tests/wiring/watchdog/watchdog.cpp
@@ -73,17 +73,19 @@ test(WATCHDOG_02_default_2) {
     checkState(WatchdogState::DISABLED);
 }
 
+#if HAL_PLATFORM_RTL872X || (PLATFORM_ID == PLATFORM_TRACKER)
 test(WATCHDOG_03_stopped_in_hibernate_mode_1) {
     startWatchdog(WatchdogConfiguration().timeout(5s));
     // Notify about a pending reset
     assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
-    System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::HIBERNATE).gpio(WKP, FALLING));
+    System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::HIBERNATE).duration(10s));
 }
 
 test(WATCHDOG_03_stopped_in_hibernate_mode_2) {
     assertTrue(System.resetReason() == RESET_REASON_POWER_MANAGEMENT);
     checkState(WatchdogState::DISABLED);
 }
+#endif
 
 test(WATCHDOG_04_continue_running_after_waking_up_from_none_hibernate_mode_1) {
     startWatchdog(WatchdogConfiguration().timeout(5s).capabilities(WatchdogCap::RESET)); // SLEEP_RUNNING is cleared


### PR DESCRIPTION
### Problem

Watchdog test 3 requires manual triggering of WKP pin to pass. This isnt feasible on HIL with automated tests. 

### Solution

Change test to duration based hibernation with watchdog enabled. Only run tests on platforms that support this: RTL872X platforms + Tracker

### Steps to Test

run `wiring/watchdog` tests

### Example App

`wiring/watchdog`

### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
