### PR TITLE
Ensure thread07 test executes as intended

### DIFF
--- a/system/inc/active_object.h
+++ b/system/inc/active_object.h
@@ -420,9 +420,9 @@ public:
         run();
     }
 
-    void process()
+    bool process()
     {
-        ActiveObjectQueue::process();
+        return ActiveObjectQueue::process();
     }
 };
 

--- a/system/inc/system_cloud.h
+++ b/system/inc/system_cloud.h
@@ -289,7 +289,7 @@ bool spark_sync_time_pending(void* reserved);
 system_tick_t spark_sync_time_last(time32_t* tm32, time_t* tm);
 
 
-void spark_process(void);
+bool spark_process(void);
 bool spark_cloud_flag_connected(void);
 
 /**

--- a/system/inc/system_dynalib_cloud.h
+++ b/system/inc/system_dynalib_cloud.h
@@ -37,7 +37,7 @@ DYNALIB_BEGIN(system_cloud)
 
 DYNALIB_FN(0, system_cloud, spark_variable, bool(const char*, const void*, Spark_Data_TypeDef, spark_variable_t*))
 DYNALIB_FN(1, system_cloud, spark_function, bool(const char*, p_user_function_int_str_t, void*))
-DYNALIB_FN(2, system_cloud, spark_process, void(void))
+DYNALIB_FN(2, system_cloud, spark_process, bool(void))
 DYNALIB_FN(3, system_cloud, spark_cloud_flag_connect, void(void))
 DYNALIB_FN(4, system_cloud, spark_cloud_flag_disconnect, void(void))
 DYNALIB_FN(5, system_cloud, spark_cloud_flag_connected, bool(void))

--- a/system/src/system_cloud.cpp
+++ b/system/src/system_cloud.cpp
@@ -257,13 +257,13 @@ int spark_cloud_disconnect(const spark_cloud_disconnect_options* options, void* 
     return 0;
 }
 
-void spark_process(void)
+bool spark_process(void)
 {
 	// application thread will pump application messages
 #if PLATFORM_THREADING
     if (APPLICATION_THREAD_CURRENT()) {
         if (system_thread_get_state(NULL)) {
-            ApplicationThread.process();
+            return ApplicationThread.process();
         } else {
             Spark_Idle_Events(true);
         }
@@ -272,6 +272,7 @@ void spark_process(void)
     // run the background processing loop, and specifically also pump cloud events
     Spark_Idle_Events(true);
 #endif // PLATFORM_THREADING
+    return false;
 }
 
 String spark_deviceID(void)

--- a/user/tests/wiring/no_fixture/ble_provisioning.cpp
+++ b/user/tests/wiring/no_fixture/ble_provisioning.cpp
@@ -69,7 +69,7 @@ test(LISTENING_02_DISABLE_FLAG_WHILE_IN_LISTENING_MODE) {
     });
     assertTrue(waitListening(true));
     System.enableFeature(FEATURE_DISABLE_LISTENING_MODE);
-    Particle.process();
+    while (Particle.process());
     SCOPE_GUARD({
         System.disableFeature(FEATURE_DISABLE_LISTENING_MODE);
     });
@@ -120,7 +120,7 @@ test(LISTENING_05_ENABLE_BLE_PROV_AFTER_LISTENING_MODE) {
         assertTrue(Particle.connected());
     });
     System.enableFeature(FEATURE_DISABLE_LISTENING_MODE);
-    Particle.process();
+    while (Particle.process());
     assertTrue(waitListening(false));
     BLE.provisioningMode(true);
     delay(100);

--- a/user/tests/wiring/no_fixture/tcp.cpp
+++ b/user/tests/wiring/no_fixture/tcp.cpp
@@ -14,6 +14,9 @@ const auto TCP_RETRY_ATTEMPTS = 10;
 
 test(TCP_01_tcp_client_failed_connect_invalid_ip)
 {
+    Particle.connect();
+    waitFor(Particle.connected,HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME);
+
     TCPClient client;
     assertFalse(client.connect(IPAddress(0,0,0,0), 567));
     assertFalse(client.connected());
@@ -22,6 +25,9 @@ test(TCP_01_tcp_client_failed_connect_invalid_ip)
 
 test(TCP_02_tcp_client_failed_connect_invalid_fqdn)
 {
+    Particle.connect();
+    waitFor(Particle.connected,HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME);
+
     TCPClient client;
     assertFalse(client.connect("does.not.exist", 567));
     assertFalse(client.connected());
@@ -30,6 +36,9 @@ test(TCP_02_tcp_client_failed_connect_invalid_fqdn)
 
 test(TCP_03_tcp_client_success_connect_valid_ip)
 {
+    Particle.connect();
+    waitFor(Particle.connected,HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME);
+
     IPAddress ip;
     for (int i = 0; i < TCP_RETRY_ATTEMPTS; i++) {
         ip = Network.resolve("www.httpbin.org");
@@ -57,6 +66,9 @@ test(TCP_03_tcp_client_success_connect_valid_ip)
 
 test(TCP_04_tcp_client_success_connect_valid_fqdn)
 {
+    Particle.connect();
+    waitFor(Particle.connected,HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME);
+
     TCPClient client;
     int r = 0;
     for (int i = 0; i < TCP_RETRY_ATTEMPTS; i++) {

--- a/user/tests/wiring/no_fixture/thread.cpp
+++ b/user/tests/wiring/no_fixture/thread.cpp
@@ -205,10 +205,7 @@ test(THREAD_07_particle_process_behavior_when_threading_enabled)
     assertEqual((int)test_val_fn1, 0);
     // The increment task that was added to the Application Queue via invoke_async is not guaranteed to be the first and only item in the Application Thread Queue
     // Call process() repeatedly in order to ensure that all potential messages in the queue are consumed, including the increment function
-    bool processed = false;
-    do {
-        processed = Particle.process();
-    } while (processed);
+    while (Particle.process());
 
     assertEqual((int)test_val_fn1, 1);
     // Unblock system thread

--- a/user/tests/wiring/no_fixture/thread.cpp
+++ b/user/tests/wiring/no_fixture/thread.cpp
@@ -203,7 +203,11 @@ test(THREAD_07_particle_process_behavior_when_threading_enabled)
     assertTrue(Particle.connected());
 
     assertEqual((int)test_val_fn1, 0);
-    Particle.process();
+    for (int i = 0; i < 20; i++) {
+        // The increment task that was added to the Application Queue via invoke_async is not guarenteed to be the first and only item in the Application Thread Queue
+        // Call process() repeatedly in order to ensure that all potential messages in the queue are consumed, including the increment function
+        Particle.process();    
+    }
     assertEqual((int)test_val_fn1, 1);
     // Unblock system thread
     test_val = 0;

--- a/user/tests/wiring/no_fixture/thread.cpp
+++ b/user/tests/wiring/no_fixture/thread.cpp
@@ -203,11 +203,13 @@ test(THREAD_07_particle_process_behavior_when_threading_enabled)
     assertTrue(Particle.connected());
 
     assertEqual((int)test_val_fn1, 0);
-    for (int i = 0; i < 20; i++) {
-        // The increment task that was added to the Application Queue via invoke_async is not guarenteed to be the first and only item in the Application Thread Queue
-        // Call process() repeatedly in order to ensure that all potential messages in the queue are consumed, including the increment function
-        Particle.process();    
-    }
+    // The increment task that was added to the Application Queue via invoke_async is not guaranteed to be the first and only item in the Application Thread Queue
+    // Call process() repeatedly in order to ensure that all potential messages in the queue are consumed, including the increment function
+    bool processed = false;
+    do {
+        processed = Particle.process();
+    } while (processed);
+
     assertEqual((int)test_val_fn1, 1);
     // Unblock system thread
     test_val = 0;

--- a/user/tests/wiring/no_fixture/time.cpp
+++ b/user/tests/wiring/no_fixture/time.cpp
@@ -265,7 +265,7 @@ test(TIME_16_TimeChangedEvent) {
     waitFor(Particle.syncTimeDone, 120000);
     // If wiring/no_fixture was built with USE_THREADING=y, we need to process application queue here
     // in order to ensure that event handler has been called by the time we check s_time_changed_reason
-    Particle.process();
+    while (Particle.process());
     assertMore(Particle.timeSyncedLast(), syncedLastMillis);
     assertEqual(s_time_changed_reason, (int)time_changed_sync);
 }

--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -369,9 +369,9 @@ public:
         spark_cloud_flag_connect();
     }
     static void disconnect(const CloudDisconnectOptions& options = CloudDisconnectOptions());
-    static void process(void) {
-    		application_checkin();
-    		spark_process();
+    static bool process(void) {
+            application_checkin();
+            return spark_process();
     }
     static String deviceID(void) { return SystemClass::deviceID(); }
 


### PR DESCRIPTION
### Problem

Test `THREAD_07_particle_process_behavior_when_threading_enabled` fails in most cases with current `develop`. The problem is that when an Async task is inserted into the application thread queue, we only call `Particle.process()` once to execute the task. This works fine unless there are other work items in the queue ahead of that task. 

### Solution

For now, we will simply exhaust the queue by calling `Particle.process()` repeatedly. See discussion [here](https://s.slack.com/archives/CS0T32ZKK/p1676072611430139?thread_ts=1676047385.672259&cid=CS0T32ZKK)
Longer term we need to investigate if all queue items should be consumed when explicitly calling `Particle.process()` outside of the normal system idle loop.  

### Steps to Test

Run test runner test `THREAD_07_particle_process_behavior_when_threading_enabled`

### Example App

`THREAD_07_particle_process_behavior_when_threading_enabled`

### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
