### PR TITLE
rtl872x: Dcache fixes for exflash HAL

### DIFF
--- a/hal/src/rtl872x/linker.ld
+++ b/hal/src/rtl872x/linker.ld
@@ -142,6 +142,8 @@ SECTIONS
         *(.image2.ram.data*)
         *(.image2.net.ram.data*)
         . = ALIGN(4);
+        *(.boot.ipc_data)
+        *(.ram.sleep*)
         /* This is used by the startup in order to initialize the .data secion */
         link_global_data_end = .;
     } > SRAM AT> APP_FLASH
@@ -163,6 +165,10 @@ SECTIONS
         . = ALIGN(4);
         /* This is used by the startup in order to initialize the .bss secion */
         link_bss_location = .;
+
+        /* Coalesces FreeRTOS symbols into a single location for some tooling */
+        INCLUDE linker_freertos_task_symbols.ld
+        
         *(.bss*)
         *(.image2.ram.bss*)
         *(.image2.net.ram.bss*)


### PR DESCRIPTION
### Problem
The read data from external flash might be incorrect. This issue cannot be reliably reproduced, but once it encountered, the issue persists on every wakup from hibernate mode, and the RGB will give several blinks while it is restoring the server key and address.

### Solution
Clean the Dcache after reading data from external flash.

### Test App
```
#include "application.h"

SYSTEM_MODE(MANUAL);

Serial1LogHandler l(115200, LOG_LEVEL_ALL);

void setup() {
    delay(5s);
    System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::HIBERNATE).duration(3s));
}

void loop() {
}
```

### References
N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
