### PR TITLE
Apply new usb stack and patch to fix the USB issue on Windows

### DIFF
--- a/bootloader/src/rtl872x/osdep_service.cpp
+++ b/bootloader/src/rtl872x/osdep_service.cpp
@@ -30,7 +30,7 @@ particle::StaticRecursiveCriticalSectionLock sCsLock;
 thread_func_t sFunc = nullptr;
 void *sCtx = nullptr;
 
-const size_t RTW_USBD_TASK_MAIN_LOOP_SEMAPHORE_OFFSET = 364;
+const size_t RTW_USBD_TASK_MAIN_LOOP_SEMAPHORE_OFFSET = 400;
 const uint32_t RTW_USBD_TASK_MAIN_LOOP_PERIOD_MS = 1;
 
 class AtomicCountingSemaphore {

--- a/hal/src/rtl872x/usbd_driver.cpp
+++ b/hal/src/rtl872x/usbd_driver.cpp
@@ -78,8 +78,10 @@ uint8_t endpointTypeToRtl(EndpointType type) {
     return 0;
 }
 
-const size_t RTL_USB_DEV_PCD_OFFSET = 0xd8;
-const size_t RTL_USB_PCD_SPINLOCK_OFFSET = 0x15c;
+// FIXME: it should be fine to directly use rtlDev_->pcd or &usbd_pcd, but for now keeping things as-is to keep
+// changes to a minimum
+const size_t RTL_USB_DEV_PCD_OFFSET = offsetof(usb_dev_t, pcd);
+const size_t RTL_USB_PCD_SPINLOCK_OFFSET = 0x180;
 
 } // anonymous
 

--- a/hal/src/rtl872x/usbd_driver.cpp
+++ b/hal/src/rtl872x/usbd_driver.cpp
@@ -45,15 +45,15 @@ namespace {
 
 SetupRequest sLastUsbSetupRequest = {};
 
-Speed rtlSpeedToDriver(usbd_speed_type_t speed) {
+Speed rtlSpeedToDriver(usb_speed_type_t speed) {
     switch (speed) {
-    case USBD_SPEED_HIGH: {
+    case USB_SPEED_HIGH: {
         return Speed::HIGH;
     }
-    case USBD_SPEED_LOW: {
+    case USB_SPEED_LOW: {
         return Speed::LOW;
     }
-    case USBD_SPEED_FULL:
+    case USB_SPEED_FULL:
     default: {
         return Speed::FULL;
     }
@@ -310,7 +310,7 @@ unsigned RtlUsbDriver::updateEndpointMask(unsigned mask) const {
     return mask;
 }
 
-uint8_t* RtlUsbDriver::getDescriptorCb(usb_setup_req_t *req, usbd_speed_type_t speed, uint16_t* len) {
+uint8_t* RtlUsbDriver::getDescriptorCb(usb_setup_req_t *req, usb_speed_type_t speed, uint16_t* len) {
     auto self = instance();
     std::lock_guard<RtlUsbDriver> lk(*self);
 

--- a/hal/src/rtl872x/usbd_driver.h
+++ b/hal/src/rtl872x/usbd_driver.h
@@ -75,7 +75,7 @@ private:
     RtlUsbDriver();
     virtual ~RtlUsbDriver();
 
-    static uint8_t* getDescriptorCb(usb_setup_req_t *req, usbd_speed_type_t speed, uint16_t* len);
+    static uint8_t* getDescriptorCb(usb_setup_req_t *req, usb_speed_type_t speed, uint16_t* len);
     static uint8_t setConfigCb(usb_dev_t* dev, uint8_t config);
     static uint8_t clearConfigCb(usb_dev_t* dev, uint8_t config);
     static uint8_t setupCb(usb_dev_t* dev, usb_setup_req_t* req);
@@ -104,8 +104,7 @@ private:
         .rx_fifo_size = USBD_MAX_RX_FIFO_SIZE,
         .nptx_fifo_size = USBD_MAX_NPTX_FIFO_SIZE,
         .ptx_fifo_size = USBD_MAX_PTX_FIFO_SIZE,
-        .intr_use_ptx_fifo = 1, // ?
-        .speed = USBD_SPEED_FULL,
+        .speed = USB_SPEED_FULL,
         .dma_enable = 0, // ?
         .self_powered = 1,
         .isr_priority = RTL_USBD_ISR_PRIORITY,
@@ -116,6 +115,8 @@ private:
         .set_config = &setConfigCb,
         .clear_config = &clearConfigCb,
         .setup = &setupCb,
+        .get_class_descriptor = nullptr,
+        .clear_feature = nullptr,
         .sof = nullptr, // This is not delivered
         .suspend = &suspendCb,
         .resume = &resumeCb,


### PR DESCRIPTION
## TODO

```
const size_t RTW_USBD_TASK_MAIN_LOOP_SEMAPHORE_OFFSET = 364;
const size_t RTL_USB_DEV_PCD_OFFSET = 0xd8;
const size_t RTL_USB_PCD_SPINLOCK_OFFSET = 0x15c;
```

Most likely at the very least the above definitions need to be adjusted due to internal USB stack struct changes.

### Problem

We found the USB request Get Line Coding couldn't get a response on the AMD Windows PC, the symptom could be that we can't open the com port on a serial tool software on the AMD Windows PC.

By enabling the low level USB log in `hw_config.c`
```
ConfigDebugClose = 0;
DBG_ERR_MSG_ON(MODULE_USB_OTG);
DBG_WARN_MSG_ON(MODULE_USB_OTG);
DBG_INFO_MSG_ON(MODULE_USB_OTG);
ConfigDebug[LEVEL_TRACE] |= BIT(MODULE_USB_OTG);
```

we can see the last log when P2 got stuck, that is a race condition to access TxFIFO between EP3 and EP0.
```
[MODULE_USB_OTG-LEVEL_TRACE]:NPTxFEmp: token received for EP3 when TxFIFO is not ready
```
 
### Solution

Realtek helped to release a new patch and USB stack for us to fix this issue.

### TODO

This patch not only fixes the USB issue, but also provides some new APIs and callbacks. If necessary, we can further improve the USB driver.

```
u8(*get_class_descriptor)(usb_dev_t *dev, usb_setup_req_t  *req);
u8(*clear_feature)(usb_dev_t *dev, usb_setup_req_t  *req);

u8 usbd_ep_set_stall(usb_dev_t *dev, u8 ep_addr);
u8 usbd_ep_clear_stall(usb_dev_t *dev, u8 ep_addr);
u8 usbd_ep_is_stall(usb_dev_t *dev, u8 ep_addr);
u8 usbd_ep0_set_stall(usb_dev_t *dev);

/* API for debug */
void usbd_config_debug(u8 enable);
void usbd_dump_registers(void);
```

### Steps to Test

1. Checkout this branch, compile firmware for P2
2. Install a serial tool software and try to open/close the com port
<img width="592" alt="Screen Shot 2023-01-05 at 17 58 57" src="https://user-images.githubusercontent.com/7424522/210753367-c4034a39-d3e2-4048-a821-93fcb430912f.png">

### References

[CH109872]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
