### PR TITLE
[test] turn off NCP before testing wiring/watchdog

### DIFF
--- a/user/tests/wiring/watchdog/watchdog.cpp
+++ b/user/tests/wiring/watchdog/watchdog.cpp
@@ -33,6 +33,29 @@ static void checkState(WatchdogState state) {
     assertTrue(info.state() == state);
 }
 
+test(WATCHDOG_00_setup_disconnect_power_off_ncp) {
+    // Ensure NCP is already off for test timing to work properly.
+    // sleep STOP mode can "pause" the WDT countdown, but if the NCP is on
+    // when sleep API's are called, extra time will be need to disconnect
+    // and power off before sleeping.
+    Particle.disconnect();
+    waitFor(Particle.disconnected, 60000);
+    assertTrue(Particle.disconnected());
+#if Wiring_Cellular
+    Cellular.disconnect();
+    waitForNot(Cellular.ready, 60000);
+    Cellular.off();
+    waitFor(Cellular.isOff, 120000);
+    assertTrue(Cellular.isOff());
+#elif Wiring_WiFi
+    WiFi.disconnect();
+    waitForNot(WiFi.ready, 60000);
+    WiFi.off();
+    waitFor(WiFi.isOff, 120000);
+    assertTrue(WiFi.isOff());
+#endif
+}
+
 test(WATCHDOG_01_capabilities) {
     WatchdogInfo info;
     assertEqual(0, Watchdog.getInfo(info));

--- a/user/tests/wiring/watchdog/watchdog.spec.js
+++ b/user/tests/wiring/watchdog/watchdog.spec.js
@@ -1,3 +1,4 @@
 suite('Watchdog');
 
 platform('gen3');
+timeout(5 * 60 * 1000);


### PR DESCRIPTION
### Problem

- `TEST=wiring/watchdog` failing for cellular devices due to WDT firing too soon

### Solution

- Add a setup phase to WDT tests that turns off the NCP, to ensure sleep will enter in a timely manner for WDT tests.
