### PR TITLE
Fix inconsistent BLE state issue.

### DIFF
--- a/user/tests/app/ble/uart_central/application.cpp
+++ b/user/tests/app/ble/uart_central/application.cpp
@@ -57,7 +57,7 @@ void loop() {
     }
     else {
         delay(3000);
-        size_t count = BLE.scan(results, SCAN_RESULT_COUNT);
+        ssize_t count = BLE.scan(results, SCAN_RESULT_COUNT);
         if (count > 0) {
             for (uint8_t i = 0; i < count; i++) {
                 BleUuid foundServiceUUID;

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -2776,7 +2776,7 @@ void BleLocalDevice::onPairingEvent(const BleOnPairingEventStdFunction& callback
 
 int BleLocalDevice::disconnect() const {
     WiringBleLock lk;
-    for (auto& p : impl()->peers()) {
+    for (auto p : impl()->peers()) {
         hal_ble_conn_info_t connInfo = {};
         connInfo.version = BLE_API_VERSION;
         connInfo.size = sizeof(hal_ble_conn_info_t);
@@ -2801,7 +2801,9 @@ int BleLocalDevice::disconnectAll() const {
     WiringBleLock lk;
     // DO NOT use auto&, otherwise, any operation using BlePeerDevice::impl() after the peer device
     // being removed from the peers() vector may not be guaranteed. See BlePeerDevice::disconnect().
-    for (auto p : impl()->peers()) {
+    auto& peers = impl()->peers();
+    while (peers.size() > 0) {
+        auto p = peers[0];
         lk.unlock();
         p.disconnect();
         lk.lock();


### PR DESCRIPTION
### Problem
1. It may be failed to stop BLE advertising
2. BLE scanning may timeout most of time
3. BLE scanning may cause buffer overflow
4. BLE disconnection might be failed
5. It may be failed to establish a new BLE connection

### Solution
Fixed

### Example App
Peripheral:
```c
#include "Particle.h"

SerialLogHandler logHandler(LOG_LEVEL_ALL);
SYSTEM_MODE(MANUAL);
SYSTEM_THREAD(ENABLED);

const BleUuid serviceUuid("6E400001-B5A3-F393-E0A9-E50E24DCCA9E");
const BleUuid rxUuid("6E400002-B5A3-F393-E0A9-E50E24DCCA9E");
const BleUuid txUuid("6E400003-B5A3-F393-E0A9-E50E24DCCA9E");
BleCharacteristic peerTxCharacteristic;

void onDataReceived(const uint8_t* data, size_t len, const BlePeerDevice& peer, void* context) {
    Log.info("CBack: Data Received with len=%d and data=%s", len, data);
    for (size_t ii = 0; ii < len; ii++) {
        Serial.write(data[ii]);
        Log.info("0x%x",data[ii]);
    }
}

void setup() {
    Log.info("Setup: BLE Scan test setup()");
    Serial.begin();
    BLE.on();

    BLE.setScanPhy(BlePhy::BLE_PHYS_AUTO);
    BLE.setPairingIoCaps(BlePairingIoCaps::NONE);
    BLE.setPairingAlgorithm(BlePairingAlgorithm::LESC_ONLY);

    peerTxCharacteristic.onDataReceived(onDataReceived, &peerTxCharacteristic);

    Log.info("Setup: System version: %s", (const char*)System.version());
    String myID = System.deviceID();
    Log.info("Setup: Device ID=%s", myID.c_str());
}

void loop() {
    // Start as peripheral
    static bool peripheral_statrted = false;
    if (!peripheral_statrted) {
        Log.info("Loop: Peripheral Started with name - P2-Periph");
        BleAdvertisingData data;
        data.appendLocalName("P2-Periph");
        BLE.advertise(&data);
        peripheral_statrted = 1;
    }
}
```

Central:
```c
#include "Particle.h"

Serial1LogHandler logHandler(115200, LOG_LEVEL_ALL);
SYSTEM_MODE(MANUAL);
SYSTEM_THREAD(ENABLED);

BlePeerDevice peer;
const size_t SCAN_RESULT_COUNT = 20;
BleScanResult scanResults[SCAN_RESULT_COUNT];

const unsigned long SCAN_PERIOD_MS = 2000;
unsigned long lastScan = 0;

// Timer to handle central/peripheral roles
#define BLE_TIMER       15000
#define BLE_PERIPHERAL  0
#define BLE_CENTRAL     1

void ble_timer_handler();
void ble_central();

static bool ble_mode              = BLE_PERIPHERAL;
static bool state_change_started  = false;
Timer ble_timer(BLE_TIMER, ble_timer_handler);

void ble_timer_handler() {
    Log.info("Timer: BLE timer expired, role =%d", ble_mode);
    ble_mode = !ble_mode;
    Log.info("Timer: New role                =%d", ble_mode);
    state_change_started = false;
}

void setup() {
    Log.info("Setup: BLE Scan test setup()");
    BLE.on();

	BLE.setScanPhy(BlePhy::BLE_PHYS_AUTO);
    BLE.setPairingIoCaps(BlePairingIoCaps::NONE);
    BLE.setPairingAlgorithm(BlePairingAlgorithm::LESC_ONLY);

    Log.info("Setup: System version: %s", (const char*)System.version());
    String myID = System.deviceID();
    Log.info("Setup: Device ID=%s", myID.c_str());

    // Start timer which switches the roles flag
    ble_timer.start();
}

void loop() {
    // Start as peripheral
    if (ble_mode == BLE_PERIPHERAL) {
        if (!state_change_started) {
            Log.info("Loop: Device is working as BLE_PERIPHERAL-P2-C_P\n");
            BLE.stopScanning();
            BleAdvertisingData data;
            data.appendLocalName("P2-C_P");
            BLE.advertise(&data);
            state_change_started = true;
        }
  } else {
        if (!state_change_started) {
            Log.info("Loop: Device as BLE_CENTRAL\n");
            BLE.stopAdvertising();
            BLE.disconnectAll();
            state_change_started = true;
        }
        ble_central();
    }
}

void ble_central() {
    if (BLE.connected()) {
        // if (BLE.isPaired(peer) == true) {
            //Pairing needed to start the session/s
        //     Log.info("Central: BLE peer is in paired state");
        // } else {
            // int pairingStatus = BLE.startPairing(peer);
            // if (pairingStatus == SYSTEM_ERROR_NONE) {
            //     Log.info("Central: BLE peer paired :)");  
            // }
        // }
    } else {
        if (millis() - lastScan >= SCAN_PERIOD_MS) {
            Log.info("Central: NOT CONNECTED");
            lastScan      = millis();
            ssize_t count  = BLE.scan(scanResults, SCAN_RESULT_COUNT);
            if (count > 0) {
                Log.info("Central: %d devices found", count);
                for (int ii = 0; ii < count; ii++) {
                    String name = scanResults[ii].advertisingData().deviceName();
                    if ((name.length()) && (strncmp(name.c_str(),"P2-Periph", 9) == 0)) {
                        Log.info("Central: Found the peripheral, connecting to %s", name.c_str());
                        peer = BLE.connect(scanResults[ii].address());
                        if (peer.connected()) {
                            Log.info("Central: Peer connected :)");
                        } else {
                            Log.info("Central: Peer NOT connected :(");
                        }
                    }
                } // for loop
            } // scan count
        } // scan spacing
    }
}
```

### References

N/A

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
