### PR TITLE
[rtl872x] hal: I2C may fail to read/write from/to slave device.

### DIFF
--- a/hal/src/rtl872x/i2c_hal.cpp
+++ b/hal/src/rtl872x/i2c_hal.cpp
@@ -302,6 +302,10 @@ public:
         rxBuffer_.reset();
         uint32_t quantity = std::min((size_t)config->quantity, rxBuffer_.size());
 
+        // Dirty-hack: It may not generate the start signal when communicating with certain type of slave device.
+        I2C_Cmd(i2cDev_, DISABLE);
+        I2C_Cmd(i2cDev_, ENABLE);
+
         setAddress(config->address);
 
         for (uint32_t i = 0; i < quantity; i++) {
@@ -378,6 +382,10 @@ public:
         if (i2cInitStruct_.I2CMaster != I2C_MASTER_MODE) {
             return SYSTEM_ERROR_INVALID_STATE;
         }
+
+        // Dirty-hack: It may not generate the start signal when communicating with certain type of slave device.
+        I2C_Cmd(i2cDev_, DISABLE);
+        I2C_Cmd(i2cDev_, ENABLE);
 
         setAddress(transConfig_.address);
 

--- a/hal/src/rtl872x/i2c_hal.cpp
+++ b/hal/src/rtl872x/i2c_hal.cpp
@@ -534,7 +534,7 @@ private:
 
     bool masterRestarted() {
         return (i2cDev_->IC_RAW_INTR_STAT & BIT_IC_INTR_STAT_R_START_DET) &&
-                !(i2cDev_->IC_RAW_INTR_STAT & BIT_IC_INTR_STAT_R_STOP_DET);
+                !(i2cDev_->IC_RAW_INTR_STAT & BIT_IC_INTR_STAT_R_STOP_DET) &&
                 (i2cDev_->IC_RAW_INTR_STAT & BIT_IC_INTR_STAT_R_ACTIVITY);
     }
 


### PR DESCRIPTION
### Problem

1. RTL872x-based platforms acting as I2C master may failed to communicate with certain type of slave device.
2. RTL872x-based platforms acting as I2C slave may failed to communicate with I2C master.

### Solution

1. Re-enabled I2C before performing the I2C transmission.
2. Fix I2C slave race conditions.

### Example App

```c
#include "Particle.h"

SYSTEM_MODE(MANUAL)

SerialLogHandler l(115200, LOG_LEVEL_ALL);

uint8_t i2cAddr = 0x3C; // SSD1306

void setup() {
    Log.info("Application started");

    Wire.begin();

    uint8_t test[2] = {0x55, 0xaa};

    bool stop = true;
    for (uint8_t i = 0; i < 4; i++) {
        Wire.beginTransmission(i2cAddr);
        Wire.write(test, sizeof(test)); 
        int ret = Wire.endTransmission(stop);
        if (ret != 0) {
            Log.info("TX FAILED");
            while (1);
        }
        if (i < 2) {
            Wire.beginTransmission(i2cAddr);
            Wire.write(test, sizeof(test));
            int ret = Wire.endTransmission(true);
            if (ret != 0) {
                Log.info("TX -> TX FAILED, stop: %d", stop);
                while (1);
            }
        } else {
            int cnt = Wire.requestFrom(i2cAddr, sizeof(test), true);
            if (cnt != sizeof(test)) {
                Log.info("TX -> RX FAILED, stop: %d", stop);
                while (1);
            }
        }
        stop = !stop;
    }

    stop = true;
    for (uint8_t i = 0; i < 4; i++) {
        int cnt = Wire.requestFrom(i2cAddr, sizeof(test), stop);
        if (cnt != sizeof(test)) {
            Log.info("RX FAILED");
            while (1);
        }
        if (i < 2) {
            Wire.beginTransmission(i2cAddr);
            Wire.write(test, sizeof(test));
            int ret = Wire.endTransmission(true);
            if (ret != 0) {
                Log.info("RX -> TX FAILED");
                while (1);
            }
        } else {
            int cnt = Wire.requestFrom(i2cAddr, sizeof(test), true);
            if (cnt != sizeof(test)) {
                Log.info("RX -> RX FAILED");
                while (1);
            }
        }
        stop = !stop;
    }

    Log.info("Test done");

    delay(1s);
    System.reset();
}
 
void loop() {

}
```

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
