### PR TITLE
[rtl872x] ble: start BLE stack/event dispatching before a connection attempt

### DIFF
--- a/hal/src/rtl872x/ble_hal.cpp
+++ b/hal/src/rtl872x/ble_hal.cpp
@@ -1802,6 +1802,10 @@ int BleGap::connect(const hal_ble_conn_cfg_t* config, hal_ble_conn_handle_t* con
     CHECK_TRUE(connections_.size() < BLE_MAX_LINK_COUNT, SYSTEM_ERROR_LIMIT_EXCEEDED);
     CHECK_TRUE(config, SYSTEM_ERROR_INVALID_ARGUMENT);
     CHECK_TRUE(connHandle, SYSTEM_ERROR_INVALID_ARGUMENT);
+
+    // Make sure that event dispatching is started
+    CHECK(start());
+
     // Stop scanning first to give the scanning semaphore if possible.
     CHECK(stopScanning());
     SCOPE_GUARD ({


### PR DESCRIPTION
### Problem

`BLE.connect()` causes an assertion failure waiting for connection events from the stack.

### Solution

Start BLE stack/event dispatching before a connection attempt.

### Steps to Test

See app below.

### Example App

```c++
void setup() {
    uint8_t addr[] = {0,1,2,3,4,5};
    Log.info("try connect");
    BLE.on();
    BLE.connect(BleAddress(addr));
}

void loop() {

}
```

### References

- [SC116668]

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
