### PR TITLE
[rtl872x] usb: force SDK to pass recipient=interface requests by faking type=class

### DIFF
--- a/hal/src/rtl872x/usbd_driver.cpp
+++ b/hal/src/rtl872x/usbd_driver.cpp
@@ -104,10 +104,9 @@ int __wrap_usb_hal_read_packet(void* ptr, uint32_t size, void* unknown) {
     if (size == sizeof(sLastUsbSetupRequest)) {
         auto req = static_cast<SetupRequest*>(ptr);
         memcpy(&sLastUsbSetupRequest, req, sizeof(sLastUsbSetupRequest));
-        // FIXME: only handling MSFT WCID request here to avoid any issues
-        if (req->bRequest == 0xee && req->bmRequestType == 0xc1 && req->wIndex == 0x0005) {
+        if (req->bmRequestTypeRecipient == SetupRequest::RECIPIENT_INTERFACE) {
             // Patch recipient to be device instead of interface
-            req->bmRequestType = 0xc0;
+            req->bmRequestTypeType = SetupRequest::TYPE_CLASS;
             fixed = true;
             RtlUsbDriver::instance()->halReadPacketFixup(ptr);
         }


### PR DESCRIPTION
### Problem

After #2625 it seems that the Realtek SDK has new behavior again and doesn't pass even more interface requests to setup request callback.

### Solution

Fake/force it to pass those requests by patching in wrapper `__wrap_usb_hal_read_packet` with `bmRequestTypeType` = `SetupRequest::TYPE_CLASS`. This for some reasons makes the SDK deliver these requests to our setup request callback.

### Steps to Test

Build bootloader, go into DFU, test that `dfu-util -d 2b04:d020 -a 1 -s 3106:192 -U p2.der` works fine (involves SET_INTERFACE request).

### Example App

N/A

### References

- Fixes #2625 

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
