### PR TITLE
[rtl872x] hal: uart may deadlock on initialization.

### DIFF
--- a/hal/src/rtl872x/usart_hal.cpp
+++ b/hal/src/rtl872x/usart_hal.cpp
@@ -69,13 +69,17 @@ public:
     public:
         AtomicBlock(Usart* instance)
                 : uart_(instance) {
+            enabled_ = NVIC_GetEnableIRQ(uart_->uartTable_[uart_->index_].IrqNum);
             NVIC_DisableIRQ(uart_->uartTable_[uart_->index_].IrqNum);
         }
         ~AtomicBlock() {
-            NVIC_EnableIRQ(uart_->uartTable_[uart_->index_].IrqNum);
+            if (enabled_) {
+                NVIC_EnableIRQ(uart_->uartTable_[uart_->index_].IrqNum);
+            }
         }
     private:
         Usart* uart_;
+        bool enabled_;
     };
 
     class RxLock {


### PR DESCRIPTION
### Problem

 If the device on the other end of the UART bus is transmitting while doing `Serial1.begin()`, the P2 freezes.

### Solution

Conditionally enable NVIC IRQ in `AtomicBlock`

### Steps to Test

Get two P2s, build and flash the following example app accordingly.

### Example App

```c
#include "application.h"

SYSTEM_THREAD(ENABLED);
SYSTEM_MODE(MANUAL);

#if 1
void setup() {
    Serial.begin(9600);
    WITH_LOCK(Serial) {
        Serial.printf("\n%s - Hello", (const char*)Time.timeStr());
    }
    Serial1.begin(9600, SERIAL_8N1);
}

void loop() {
    Serial1.printlnf("Tick: %ld", millis());
    delay(1s);
}

#else // The other end of UART

void setup() {
    Serial1.begin(9600, SERIAL_8N1);
}

void loop() {
    Serial1.printlnf("Tick: %ld", millis());
    delay(10);
}

#endif
```

### References

https://community.particle.io/t/serial1-causing-solid-led-on-p2/64269/7

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
