### PR TITLE
minor fix to ensure PS only mode is only applied to R510 at this time

### DIFF
--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -1097,17 +1097,19 @@ int SaraNcpClient::selectNetworkProf(ModemState& state) {
         CHECK(checkNetConfForImsi());
     }
 
-    // AT+CEMODE? query can take up to 24 seconds to poll without CellularFunctionality::MINIMUM first, and we don't
-    // want to be dropping to CellularFunctionality::MINIMUM every boot / connection.
-    // Check cached value to see if we need to change CEMODE=0 (PS_ONLY).
-    CellularOperationMode cemode = CellularOperationMode::NONE;
-    getOperationModeCached(cemode); // We're not checking the result because it will return SYSTEM_ERROR_NOT_FOUND the first time through
-    if (cemode != CellularOperationMode::PS_ONLY) {
-        CHECK_PARSER_OK(setModuleFunctionality(CellularFunctionality::MINIMUM, true /* check */));
-        CHECK_PARSER_OK(setOperationMode(CellularOperationMode::PS_ONLY, true /* check */, true /* save */));
-        CHECK(modemSoftReset()); // reset the SIM
-        CHECK(waitAtResponseFromPowerOn(state));
-        // NOTE: may need to be in minimum functionality for setting umnoprof, let configureApn() set it back to full
+    if (ncpId() == PLATFORM_NCP_SARA_R510) {
+        // AT+CEMODE? query can take up to 24 seconds to poll without CellularFunctionality::MINIMUM first, and we don't
+        // want to be dropping to CellularFunctionality::MINIMUM every boot / connection.
+        // Check cached value to see if we need to change CEMODE=0 (PS_ONLY).
+        CellularOperationMode cemode = CellularOperationMode::NONE;
+        getOperationModeCached(cemode); // We're not checking the result because it will return SYSTEM_ERROR_NOT_FOUND the first time through
+        if (cemode != CellularOperationMode::PS_ONLY) {
+            CHECK_PARSER_OK(setModuleFunctionality(CellularFunctionality::MINIMUM, true /* check */));
+            CHECK_PARSER_OK(setOperationMode(CellularOperationMode::PS_ONLY, true /* check */, true /* save */));
+            CHECK(modemSoftReset()); // reset the SIM
+            CHECK(waitAtResponseFromPowerOn(state));
+            // NOTE: may need to be in minimum functionality for setting umnoprof, let configureApn() set it back to full
+        }
     }
 
     bool reset = false;


### PR DESCRIPTION
### Problem

R410 was failing the `slo/connect_time` tests due to PS only mode not being saved for R410 devices.

### Solution

Guard against running PS only mode code for any device other than R510 for now to preserve system cache settings for those devices, in case we decide to enable this for them in the future.

### Steps to Test

Run integration tests `slo/connect_time` for R410 based devices.

### References

#2639 

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
