### PR TITLE
[rtl872x] Dont enable usart RX/TX pullups

### DIFF
--- a/hal/src/rtl872x/usart_hal.cpp
+++ b/hal/src/rtl872x/usart_hal.cpp
@@ -193,8 +193,8 @@ public:
             Pinmux_Config(hal_pin_to_rtl_pin(txPin_), PINMUX_FUNCTION_UART);
             Pinmux_Config(hal_pin_to_rtl_pin(rxPin_), PINMUX_FUNCTION_UART);
         }
-        PAD_PullCtrl(hal_pin_to_rtl_pin(txPin_), GPIO_PuPd_UP);
-        PAD_PullCtrl(hal_pin_to_rtl_pin(rxPin_), GPIO_PuPd_UP);
+        PAD_PullCtrl(hal_pin_to_rtl_pin(txPin_), GPIO_PuPd_NOPULL);
+        PAD_PullCtrl(hal_pin_to_rtl_pin(rxPin_), GPIO_PuPd_NOPULL);
         // Configure CTS/RTS pins
         if (ctsPin_ != PIN_INVALID) {
             Pinmux_Config(hal_pin_to_rtl_pin(ctsPin_), PINMUX_FUNCTION_UART_RTSCTS);


### PR DESCRIPTION
### Problem

P2 USARTs enable software pullups on TX/RX pins, which is unnecessary.

### Solution

Dont enable pullups by default

### Steps to Test

Run any serial logging app, confirm communication works fine

### Example App

```c
#include "Particle.h"

SYSTEM_MODE(AUTOMATIC);
SYSTEM_THREAD(ENABLED);

SerialLogHandler logHandler(LOG_LEVEL_ALL);

void setup() {
    Serial3.begin(115200, SERIAL_8N1 | SERIAL_FLOW_CONTROL_RTS_CTS);
    Serial3.write("Application started");
}
 
void loop() {
    if (!Serial3.available()) {
        return;
    }

    while (Serial3.available()) {
    	char c = Serial3.read();
    	Log.info("got char %c", c);
    	Serial3.write(c);
    }
}

```

### References

[Community post here](https://community.particle.io/t/p2-module-tmc2209-driver-tx-rx-pullup-issue-possibly-preventing-bidirectional-comms/64194/1)

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
