### PR TITLE
[rtl872x] BLE scanning panic

### DIFF
--- a/hal/src/rtl872x/ble_hal.cpp
+++ b/hal/src/rtl872x/ble_hal.cpp
@@ -1629,9 +1629,12 @@ int BleGap::startScanning(hal_ble_on_scan_result_cb_t callback, void* context) {
                 HAL_Delay_Milliseconds(10);
             }
             if (isScanning_) {
-                stop();
-                init();
-                start();
+                int ret = stop();
+                SPARK_ASSERT(ret == SYSTEM_ERROR_NONE);
+                ret = init();
+                SPARK_ASSERT(ret == SYSTEM_ERROR_NONE);
+                ret = start();
+                SPARK_ASSERT(ret == SYSTEM_ERROR_NONE);
             }
             isScanning_ = false;
             clearPendingResult();

--- a/hal/src/rtl872x/ble_hal.cpp
+++ b/hal/src/rtl872x/ble_hal.cpp
@@ -1171,11 +1171,13 @@ int BleGap::stop() {
         if (isAdvertising_) {
             // This will also wait for advertisements to stop
             stopAdvertising();
+            isAdvertising_ = false;
         }
 
         if (isScanning_) {
             stopScanning();
             le_scan_stop(); // Just in case
+            isScanning_ = false;
         }
 
         // Prevent BLE stack from generating coexistence events, otherwise we may leak memory
@@ -1626,7 +1628,12 @@ int BleGap::startScanning(hal_ble_on_scan_result_cb_t callback, void* context) {
                 }
                 HAL_Delay_Milliseconds(10);
             }
-            SPARK_ASSERT(!isScanning_);
+            if (isScanning_) {
+                stop();
+                init();
+                start();
+            }
+            isScanning_ = false;
             clearPendingResult();
         }
     });


### PR DESCRIPTION
### Problem

BLE scanning may finally panic after running for a long time, bacause of corrupted BLE stack.

### Solution

Restart BLE stack, instead of panic.

### Steps to Test

`user/tests/app/ble/scanner` or `user/tests/app/ble/uart_central`

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
