### PR TITLE
[rtl872x] Implement WiFi.selectAntenna

### DIFF
--- a/hal/inc/radio_hal.h
+++ b/hal/inc/radio_hal.h
@@ -24,5 +24,4 @@ typedef enum radio_antenna_type {
     RADIO_ANT_DEFAULT = 0, ///< Default antenna (platform-specific).
     RADIO_ANT_INTERNAL = 1, ///< Internal antenna.
     RADIO_ANT_EXTERNAL = 2, ///< External antenna.
-    RADIO_ANT_UNKNOWN = 0xff
 } radio_antenna_type;

--- a/hal/inc/radio_hal.h
+++ b/hal/inc/radio_hal.h
@@ -23,5 +23,6 @@
 typedef enum radio_antenna_type {
     RADIO_ANT_DEFAULT = 0, ///< Default antenna (platform-specific).
     RADIO_ANT_INTERNAL = 1, ///< Internal antenna.
-    RADIO_ANT_EXTERNAL = 2 ///< External antenna.
+    RADIO_ANT_EXTERNAL = 2, ///< External antenna.
+    RADIO_ANT_UNKNOWN = 0xff
 } radio_antenna_type;

--- a/hal/network/ncp/wifi/wlan_hal.cpp
+++ b/hal/network/ncp/wifi/wlan_hal.cpp
@@ -289,10 +289,8 @@ void SPARK_WLAN_SmartConfigProcess() {
 void HAL_WLAN_notify_simple_config_done() {
 }
 
-static WLanSelectAntenna_TypeDef current_antenna = ANT_AUTO;
-
 int wlan_select_antenna(WLanSelectAntenna_TypeDef antenna) {
-    radio_antenna_type new_antenna = RADIO_ANT_UNKNOWN;
+    radio_antenna_type new_antenna;
 
     if (antenna == ANT_AUTO) {
         new_antenna = RADIO_ANT_DEFAULT;
@@ -300,19 +298,26 @@ int wlan_select_antenna(WLanSelectAntenna_TypeDef antenna) {
         new_antenna = RADIO_ANT_INTERNAL;
     } else if (antenna == ANT_EXTERNAL) {
         new_antenna = RADIO_ANT_EXTERNAL;
+    } else {
+        return SYSTEM_ERROR_NOT_SUPPORTED;    
     }
 
-    if (new_antenna != RADIO_ANT_UNKNOWN) {
-        CHECK(selectRadioAntenna(new_antenna));
-        current_antenna = antenna;
-        return 0;
-    }
-
-    return SYSTEM_ERROR_NOT_SUPPORTED;
+    CHECK(selectRadioAntenna(new_antenna));
+    return 0;
 }
 
 WLanSelectAntenna_TypeDef wlan_get_antenna(void* reserved) {
-    return current_antenna;
+    radio_antenna_type antenna;
+
+    if (getRadioAntenna(&antenna) || antenna == RADIO_ANT_DEFAULT) {
+        return ANT_AUTO;
+    } else if (antenna == RADIO_ANT_INTERNAL) {
+        return ANT_INTERNAL;
+    } else if (antenna == RADIO_ANT_EXTERNAL) {
+        return ANT_EXTERNAL;
+    } else {
+        return ANT_AUTO;
+    }
 }
 
 void wlan_connect_cancel(bool called_from_isr) {

--- a/hal/network/ncp/wifi/wlan_hal.cpp
+++ b/hal/network/ncp/wifi/wlan_hal.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "wlan_hal.h"
+#include "radio_common.h"
 
 #include "network/ncp/wifi/ncp.h"
 #include "network/ncp/wifi/wifi_network_manager.h"
@@ -288,15 +289,30 @@ void SPARK_WLAN_SmartConfigProcess() {
 void HAL_WLAN_notify_simple_config_done() {
 }
 
+static WLanSelectAntenna_TypeDef current_antenna = ANT_AUTO;
+
 int wlan_select_antenna(WLanSelectAntenna_TypeDef antenna) {
-    if (antenna != ANT_AUTO) {
-        return SYSTEM_ERROR_NOT_SUPPORTED;
+    radio_antenna_type new_antenna = RADIO_ANT_UNKNOWN;
+
+    if (antenna == ANT_AUTO) {
+        new_antenna = RADIO_ANT_DEFAULT;
+    } else if (antenna == ANT_INTERNAL) {
+        new_antenna = RADIO_ANT_INTERNAL;
+    } else if (antenna == ANT_EXTERNAL) {
+        new_antenna = RADIO_ANT_EXTERNAL;
     }
-    return 0;
+
+    if (new_antenna != RADIO_ANT_UNKNOWN) {
+        CHECK(selectRadioAntenna(new_antenna));
+        current_antenna = antenna;
+        return 0;
+    }
+
+    return SYSTEM_ERROR_NOT_SUPPORTED;
 }
 
 WLanSelectAntenna_TypeDef wlan_get_antenna(void* reserved) {
-    return ANT_AUTO;
+    return current_antenna;
 }
 
 void wlan_connect_cancel(bool called_from_isr) {

--- a/hal/src/nRF52840/radio_common.cpp
+++ b/hal/src/nRF52840/radio_common.cpp
@@ -110,7 +110,7 @@ int selectAntenna(radio_antenna_type antenna) {
 
 } // namespace
 
-int initRadioAntenna() {
+radio_antenna_type readRadioAntenna(){
     auto antenna = RADIO_ANT_DEFAULT;
     uint8_t dctAntenna = 0xff;
     if (dct_read_app_data_copy(DCT_RADIO_ANTENNA_OFFSET, &dctAntenna, DCT_RADIO_ANTENNA_SIZE) < 0) {
@@ -119,7 +119,11 @@ int initRadioAntenna() {
     } else if (dctAntenna == RADIO_ANT_INTERNAL || dctAntenna == RADIO_ANT_EXTERNAL) {
         antenna = (radio_antenna_type)dctAntenna;
     }
-    CHECK(selectAntenna(antenna));
+    return antenna;
+}
+
+int initRadioAntenna() {
+    CHECK(selectAntenna(readRadioAntenna()));
     return SYSTEM_ERROR_NONE;
 }
 
@@ -159,6 +163,14 @@ int selectRadioAntenna(radio_antenna_type antenna) {
         return SYSTEM_ERROR_UNKNOWN;
     }
     return SYSTEM_ERROR_NONE;
+}
+
+int getRadioAntenna(radio_antenna_type* antenna) {
+    if (!antenna) {
+        return SYSTEM_ERROR_INVALID_ARGUMENT;
+    }
+    *antenna = readRadioAntenna();
+    return 0;
 }
 
 } // namespace particle

--- a/hal/src/nRF52840/radio_common.h
+++ b/hal/src/nRF52840/radio_common.h
@@ -50,4 +50,12 @@ int enableRadioAntenna();
  */
 int selectRadioAntenna(radio_antenna_type antenna);
 
+/**
+ * Return the currently configured antenna type from DCT.
+ *
+ * @param antenna Currently configured Antenna type.
+ * @return 0 on success or a negative result code in case of an error.
+ */
+int getRadioAntenna(radio_antenna_type* antenna);
+
 } // particle

--- a/hal/src/rtl872x/radio_common.cpp
+++ b/hal/src/rtl872x/radio_common.cpp
@@ -122,4 +122,18 @@ int selectRadioAntenna(radio_antenna_type antenna) {
     return SYSTEM_ERROR_NONE;
 }
 
+int getRadioAntenna(radio_antenna_type * antenna) {
+    if (!antenna) {
+        return SYSTEM_ERROR_INVALID_ARGUMENT;
+    }
+    uint8_t dctAntenna = 0xff;
+    CHECK(dct_read_app_data_copy(DCT_RADIO_ANTENNA_OFFSET, &dctAntenna, sizeof(dctAntenna)));
+    if ((radio_antenna_type)dctAntenna <= RADIO_ANT_EXTERNAL) {
+        *antenna = (radio_antenna_type)dctAntenna;
+        return 0;
+    }
+
+    return SYSTEM_ERROR_INTERNAL;
+}
+
 } // namespace particle

--- a/hal/src/rtl872x/radio_common.cpp
+++ b/hal/src/rtl872x/radio_common.cpp
@@ -86,7 +86,7 @@ int selectAntenna(radio_antenna_type antenna) {
 
 } // namespace
 
-int initRadioAntenna() {
+radio_antenna_type readRadioAntenna(){
     auto antenna = RADIO_ANT_DEFAULT;
     uint8_t dctAntenna = 0xff;
     if (dct_read_app_data_copy(DCT_RADIO_ANTENNA_OFFSET, &dctAntenna, DCT_RADIO_ANTENNA_SIZE) < 0) {
@@ -95,7 +95,11 @@ int initRadioAntenna() {
     } else if (dctAntenna == RADIO_ANT_INTERNAL || dctAntenna == RADIO_ANT_EXTERNAL) {
         antenna = (radio_antenna_type)dctAntenna;
     }
-    CHECK(selectAntenna(antenna));
+    return antenna;
+}
+
+int initRadioAntenna() {
+    CHECK(selectAntenna(readRadioAntenna()));
     return SYSTEM_ERROR_NONE;
 }
 
@@ -122,18 +126,12 @@ int selectRadioAntenna(radio_antenna_type antenna) {
     return SYSTEM_ERROR_NONE;
 }
 
-int getRadioAntenna(radio_antenna_type * antenna) {
+int getRadioAntenna(radio_antenna_type* antenna) {
     if (!antenna) {
         return SYSTEM_ERROR_INVALID_ARGUMENT;
     }
-    uint8_t dctAntenna = 0xff;
-    CHECK(dct_read_app_data_copy(DCT_RADIO_ANTENNA_OFFSET, &dctAntenna, sizeof(dctAntenna)));
-    if ((radio_antenna_type)dctAntenna <= RADIO_ANT_EXTERNAL) {
-        *antenna = (radio_antenna_type)dctAntenna;
-        return 0;
-    }
-
-    return SYSTEM_ERROR_INTERNAL;
+    *antenna = readRadioAntenna();
+    return 0;
 }
 
 } // namespace particle

--- a/hal/src/rtl872x/radio_common.cpp
+++ b/hal/src/rtl872x/radio_common.cpp
@@ -67,14 +67,14 @@ int selectAntenna(radio_antenna_type antenna) {
 #if HAL_PLATFORM_RADIO_ANTENNA_INTERNAL
     case RADIO_ANT_INTERNAL: {
         CHECK(selectInternalAntenna());
-        LOG(TRACE, "Using internal BLE antenna");
+        LOG(TRACE, "Using internal antenna");
         break;
     }
 #endif
 #if HAL_PLATFORM_RADIO_ANTENNA_EXTERNAL
     case RADIO_ANT_EXTERNAL: {
         CHECK(selectExtenalAntenna());
-        LOG(TRACE, "Using external BLE antenna");
+        LOG(TRACE, "Using external antenna");
         break;
     }
 #endif

--- a/hal/src/rtl872x/radio_common.h
+++ b/hal/src/rtl872x/radio_common.h
@@ -56,6 +56,6 @@ int selectRadioAntenna(radio_antenna_type antenna);
  * @param antenna Currently configured Antenna type.
  * @return 0 on success or a negative result code in case of an error.
  */
-int getRadioAntenna(radio_antenna_type * antenna);
+int getRadioAntenna(radio_antenna_type* antenna);
 
 } // particle

--- a/hal/src/rtl872x/radio_common.h
+++ b/hal/src/rtl872x/radio_common.h
@@ -50,4 +50,12 @@ int enableRadioAntenna();
  */
 int selectRadioAntenna(radio_antenna_type antenna);
 
+/**
+ * Return the currently configured antenna type from DCT.
+ *
+ * @param antenna Currently configured Antenna type.
+ * @return 0 on success or a negative result code in case of an error.
+ */
+int getRadioAntenna(radio_antenna_type * antenna);
+
 } // particle


### PR DESCRIPTION
### Problem

`WiFi.selectAntenna()` is not implemented for P2

### Solution

On P2, BLE and WiFi share the same physical antenna, so use `selectAntenna()` from `radio_common.cpp`

### Steps to Test

Use test app below to verify antenna switches

### Example App

```c
#include "Particle.h"

SYSTEM_MODE(AUTOMATIC);
SYSTEM_THREAD(ENABLED);

SerialLogHandler logHandler(LOG_LEVEL_ERROR,
{
    { "app", LOG_LEVEL_ALL },
});

String anntena_names[] = {"Internal", "External", "", "Automatic"};

void setup() {
    
}
 
void loop() {
    if (!Serial.available()) {
        return;
    }

    while (Serial.available()) {
        char c = Serial.read();
        Log.info("Got %c", c);
        int result = 0;
        if (c == 'i') {
            result = WiFi.selectAntenna(ANT_INTERNAL);
        }
        else if (c == 'e') {
            result = WiFi.selectAntenna(ANT_EXTERNAL);
        }
        else if (c == 'a') {
            result = WiFi.selectAntenna(ANT_AUTO);
        }
        else if (c == 'n') {
            result = WiFi.selectAntenna(ANT_NONE);
        }

        String antenna_name = "";
        WLanSelectAntenna_TypeDef antenna = WiFi.getAntenna();
        if (antenna <= ANT_AUTO) {
            antenna_name = anntena_names[(int)antenna];
        }

        Log.info("WiFi.selectAntenna result: %d now using %s antenna", result, antenna_name.c_str());

        if (result == SYSTEM_ERROR_NONE) {
            WiFiAccessPoint aps[20];
            int found = WiFi.scan(aps, 20);
            for (int i=0; i<found; i++) {
                WiFiAccessPoint& ap = aps[i];
                Log.info("ssid=%s security=%d channel=%d rssi=%d", ap.ssid, (int)ap.security, (int)ap.channel, ap.rssi);
            }    
        }
    }
}
```

### Test output with no external antenna
```
0000012710 [app] INFO: Got n
0000012717 [app] INFO: WiFi.selectAntenna result: -120 now using Automatic antenna
0000017798 [app] INFO: Got i
0000017968 [app] INFO: WiFi.selectAntenna result: 0 now using Internal antenna
0000022089 [app] INFO: ssid=derp security=3 channel=9 rssi=-47
0000022105 [app] INFO: ssid=derp5 security=3 channel=153 rssi=-55
0000025071 [app] INFO: Got e
0000025238 [app] INFO: WiFi.selectAntenna result: 0 now using External antenna
0000029357 [app] INFO: ssid=derp5 security=3 channel=153 rssi=-70
0000029374 [app] INFO: ssid=derp security=3 channel=9 rssi=-88
0000033136 [app] INFO: Got a
0000033307 [app] INFO: WiFi.selectAntenna result: 0 now using Automatic antenna
0000037429 [app] INFO: ssid=derp security=3 channel=9 rssi=-47
0000037444 [app] INFO: ssid=derp5 security=3 channel=153 rssi=-55
```
Switching from Auto / Internal to external shows a drop in RSSI

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
