### PR TITLE
[nRF52] UART sleep/wakeup

### DIFF
--- a/hal/src/nRF52840/sleep_hal.cpp
+++ b/hal/src/nRF52840/sleep_hal.cpp
@@ -578,6 +578,8 @@ static uint32_t configUsartWakeupSource(const hal_wakeup_source_base_t* wakeupSo
             // nrf_uarte_int_disable(NRF_UARTE0, NRF_UARTE_INT_RXDRDY_MASK);
             // nrf_uarte_event_clear(NRF_UARTE0, NRF_UARTE_EVENT_RXDRDY);
             if (!nrf_uarte_int_enable_check(NRF_UARTE0, NRF_UARTE_INT_RXDRDY_MASK)) {
+                // We're safe to clear the event if application didn't enable the RXDRDY interrupt
+                nrf_uarte_event_clear(NRF_UARTE0, NRF_UARTE_EVENT_RXDRDY);
                 nrf_uarte_int_enable(NRF_UARTE0, NRF_UARTE_INT_RXDRDY_MASK);
             }
             NVIC_EnableIRQ(UARTE0_UART0_IRQn);
@@ -599,6 +601,8 @@ static bool configNetworkWakeupSource(const hal_wakeup_source_base_t* wakeupSour
                 // nrf_uarte_int_disable(NRF_UARTE1, NRF_UARTE_INT_RXDRDY_MASK);
                 // nrf_uarte_event_clear(NRF_UARTE1, NRF_UARTE_EVENT_RXDRDY);
                 if (!nrf_uarte_int_enable_check(NRF_UARTE1, NRF_UARTE_INT_RXDRDY_MASK)) {
+                    // We're safe to clear the event if application didn't enable the RXDRDY interrupt
+                    nrf_uarte_event_clear(NRF_UARTE1, NRF_UARTE_EVENT_RXDRDY);
                     nrf_uarte_int_enable(NRF_UARTE1, NRF_UARTE_INT_RXDRDY_MASK);
                 } else {
                     ret = true;


### PR DESCRIPTION
### Problem

Device wakes up immediately if uart is confirgured as wakeup source and the uart has received data before sleep.

### Solution

Clear the RXDRDY event accordingly before enabling the RXDRDY interrupt in sleep HAL.

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
