### PR TITLE
[rtl872x] Allow KM4 SDK Bootloader images to boot

### DIFF
--- a/bootloader/prebootloader/src/rtl872x/part1/rtl_support.c
+++ b/bootloader/prebootloader/src/rtl872x/part1/rtl_support.c
@@ -345,6 +345,8 @@ void rtlLowLevelInit() {
         BKUP_Set(BKUP_REG0, BIT_SW_SIM_RSVD);
     }
 
+    BKUP_Write(BKUP_REG7, (uint32_t)&flash_init_para);
+
     // Copy-paste from app_start()
 
     SystemCoreClockUpdate();


### PR DESCRIPTION
### Problem

We want to allow Particle built prebootloader binaries to boot Realtek SDK based KM4 bootloader binaries. This is broken in the current Device OS.

### Solution

The RTK SDK KM4 based bootloaders expect a `FLASH_InitTypeDef flash_init_para` structure to be present in `BKUP_REG7` at boot. We had this originally, but since our bootloader does not need this, it was removed.
It doesnt appear that anything internal to DVOS uses `BKUP_REG7`, so this change should be safe

### Steps to Test

1. Build `prebootloader-part1` from this branch, flash to p2
1. Flash SDK KM4 Bootloader + APP images
1. Verify the KM4 bootloader + KM4 APP runs

### Example App
Ask scott for KM4 SDK Bootloader binary

### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
