### PR TITLE
[rtl872x] usb: HID

### DIFF
--- a/hal/src/rtl872x/usb_hal.cpp
+++ b/hal/src/rtl872x/usb_hal.cpp
@@ -23,8 +23,14 @@
 #include "usbd_cdc.h"
 #include <mutex>
 #include "usb_settings.h"
+#include "usbd_hid.h"
 
 using namespace particle::usbd;
+
+CdcClassDriver& getCdcClassDriver() {
+    static CdcClassDriver cdc;
+    return cdc;
+}
 
 namespace {
 
@@ -32,11 +38,6 @@ namespace {
 static Device& getUsbDevice() {
     static Device dev;
     return dev;
-}
-
-static CdcClassDriver& getCdcClassDriver() {
-    static CdcClassDriver cdc;
-    return cdc;
 }
 
 #define LOBYTE(x)  ((uint8_t)(x & 0x00FF))
@@ -73,6 +74,7 @@ void HAL_USB_Init(void) {
 
         getUsbDevice().registerClass(ControlInterfaceClassDriver::instance());
         getUsbDevice().registerClass(&getCdcClassDriver());
+        getUsbDevice().registerClass(HidClassDriver::instance());
 
         ControlInterfaceClassDriver::instance()->enable(true);
         // Only enabled if HAL_USB_USART_Init() was called to configure buffers

--- a/hal/src/rtl872x/usb_hal_hid.cpp
+++ b/hal/src/rtl872x/usb_hal_hid.cpp
@@ -16,30 +16,51 @@
  */
 
 #include "usb_hal.h"
+#include "usbd_hid.h"
+#include "usbd_cdc.h"
+
+using namespace particle::usbd;
+
+extern CdcClassDriver& getCdcClassDriver();
 
 void HAL_USB_HID_Init(uint8_t reserved, void* reserved1) {
-    // TODO
+    if (HidClassDriver::instance()->isEnabled()) {
+        return;
+    }
 }
 
 void HAL_USB_HID_Begin(uint8_t reserved, void* reserved1) {
-    // TODO
+    if (!HidClassDriver::instance()->isEnabled()) {
+        HAL_USB_Detach();
+        HidClassDriver::instance()->enable(true);
+        getCdcClassDriver().useDummyIntEp(true);
+        HAL_USB_Init();
+        HAL_USB_Attach();
+    }
 }
 
 void HAL_USB_HID_End(uint8_t reserved) {
-    // TODO
+    if (HidClassDriver::instance()->isEnabled()) {
+        HAL_USB_Detach();
+        HidClassDriver::instance()->enable(false);
+        getCdcClassDriver().useDummyIntEp(false);
+        HAL_USB_Attach();
+    }
 }
 
 uint8_t HAL_USB_HID_Set_State(uint8_t id, uint8_t state, void* reserved) {
-    // TODO
+    if (HidClassDriver::instance()->isEnabled()) {
+        HAL_USB_Detach();
+        HidClassDriver::instance()->setDigitizerState(state);
+        HAL_USB_Attach();
+    }
     return 0;
 }
 
 void HAL_USB_HID_Send_Report(uint8_t reserved, void *pHIDReport, uint16_t reportSize, void* reserved1) {
-    // TODO
+    HidClassDriver::instance()->sendReport((const uint8_t*)pHIDReport, reportSize);
 }
 
-int32_t HAL_USB_HID_Status(uint8_t reserved, void* reserved1)
-{
-    // TODO
-    return 0;
+int32_t HAL_USB_HID_Status(uint8_t reserved, void* reserved1) {
+    return HidClassDriver::instance()->transferStatus();
 }

--- a/hal/src/rtl872x/usbd_cdc.h
+++ b/hal/src/rtl872x/usbd_cdc.h
@@ -92,6 +92,8 @@ public:
 
     bool buffersConfigured() const;
 
+    void useDummyIntEp(bool state);
+
 protected:
     void setOpenState(bool state);
 
@@ -139,6 +141,7 @@ private:
 #if !HAL_PLATFORM_USB_SOF
     os_timer_t txTimer_ = nullptr;
 #endif // !HAL_PLATFORM_USB_SOF
+    bool useDummyIntEp_ = false;
 };
 
 } } /* namespace particle::usbd */

--- a/hal/src/rtl872x/usbd_device.cpp
+++ b/hal/src/rtl872x/usbd_device.cpp
@@ -283,6 +283,7 @@ int Device::getDescriptor(DescriptorType type, uint8_t* buf, size_t len, Speed s
         appender.appendUInt8(0x40);
         appender.appendUInt8(0x01);
         appender.appendUInt8(0x00);
+        break;
     }
     }
     return SYSTEM_ERROR_INVALID_ARGUMENT;
@@ -315,7 +316,7 @@ int Device::getRawString(const char* data, size_t len, uint8_t* buf, size_t bufl
         return 0;
     }
 
-    if (buflen < (len + 2) * 2) {
+    if (buflen < (len + 2)) {
         return SYSTEM_ERROR_TOO_LARGE;
     }
 

--- a/hal/src/rtl872x/usbd_driver.h
+++ b/hal/src/rtl872x/usbd_driver.h
@@ -79,6 +79,7 @@ private:
     static uint8_t setConfigCb(usb_dev_t* dev, uint8_t config);
     static uint8_t clearConfigCb(usb_dev_t* dev, uint8_t config);
     static uint8_t setupCb(usb_dev_t* dev, usb_setup_req_t* req);
+    static uint8_t getClassDescriptorCb(usb_dev_t* dev, usb_setup_req_t* req);
     static uint8_t sofCb(usb_dev_t* dev);
     static uint8_t suspendCb(usb_dev_t* dev);
     static uint8_t resumeCb(usb_dev_t* dev);
@@ -100,7 +101,7 @@ private:
     // TODO: Validate whether these are required to be present at all times
     // or can be allocated on stack temporarily.
     usbd_config_t usbdCfg_ = {
-        .max_ep_num = USBD_MAX_ENDPOINTS - 1,
+        .max_ep_num = USBD_MAX_ENDPOINTS,
         .rx_fifo_size = USBD_MAX_RX_FIFO_SIZE,
         .nptx_fifo_size = USBD_MAX_NPTX_FIFO_SIZE,
         .ptx_fifo_size = USBD_MAX_PTX_FIFO_SIZE,
@@ -115,7 +116,7 @@ private:
         .set_config = &setConfigCb,
         .clear_config = &clearConfigCb,
         .setup = &setupCb,
-        .get_class_descriptor = nullptr,
+        .get_class_descriptor = &getClassDescriptorCb,
         .clear_feature = nullptr,
         .sof = nullptr, // This is not delivered
         .suspend = &suspendCb,

--- a/hal/src/rtl872x/usbd_hid.cpp
+++ b/hal/src/rtl872x/usbd_hid.cpp
@@ -1,0 +1,379 @@
+/*
+ * Copyright (c) 2023 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "logging.h"
+#include "usbd_hid.h"
+#include <cstring>
+#include <algorithm>
+#include "usbd_wcid.h"
+#include "appender.h"
+#include "check.h"
+#include "scope_guard.h"
+#include "endian_util.h"
+#include <algorithm>
+#include <mutex>
+#include "service_debug.h"
+
+using namespace particle::usbd;
+
+namespace {
+
+const char DEFAULT_NAME[] = HAL_PLATFORM_USB_PRODUCT_STRING " " "HID Mouse / Keyboard";
+
+uint8_t __attribute__((aligned(4))) DEFAULT_HID_DESCRIPTOR[] = {
+    0x05, 0x01,                    // USAGE_PAGE (Generic Desktop)
+    0x09, 0x02,                    // USAGE (Mouse)
+    0xa1, 0x01,                    // COLLECTION (Application)
+    0x85, 0x01,                    //   REPORT_ID (1)
+    0x09, 0x01,                    //   USAGE (Pointer)
+    0xa1, 0x00,                    //   COLLECTION (Physical)
+    0x05, 0x09,                    //     USAGE_PAGE (Button)
+    0x19, 0x01,                    //     USAGE_MINIMUM (Button 1)
+    0x29, 0x03,                    //     USAGE_MAXIMUM (Button 3)
+    0x15, 0x00,                    //     LOGICAL_MINIMUM (0)
+    0x25, 0x01,                    //     LOGICAL_MAXIMUM (1)
+    0x95, 0x03,                    //     REPORT_COUNT (3)
+    0x75, 0x01,                    //     REPORT_SIZE (1)
+    0x81, 0x02,                    //     INPUT (Data,Var,Abs)
+    0x95, 0x01,                    //     REPORT_COUNT (1)
+    0x75, 0x05,                    //     REPORT_SIZE (5)
+    0x81, 0x03,                    //     INPUT (Cnst,Var,Abs)
+    0x05, 0x01,                    //     USAGE_PAGE (Generic Desktop)
+    0x09, 0x30,                    //     USAGE (X)
+    0x09, 0x31,                    //     USAGE (Y)
+    // 0x36, 0x01, 0x80,              //     PHYSICAL_MINIMUM (-32767)
+    // 0x46, 0xff, 0x7f,              //     PHYSICAL_MAXIMUM (32767)
+    0x16, 0x01, 0x80,              //     LOGICAL_MINIMUM (-32767)
+    0x26, 0xff, 0x7f,              //     LOGICAL_MAXIMUM (32767)
+    // 0x15, 0x81,                    //     LOGICAL_MINIMUM (-127)
+    // 0x25, 0x7f,                    //     LOGICAL_MAXIMUM (127)
+    0x75, 0x10,                    //     REPORT_SIZE (16)
+    0x95, 0x02,                    //     REPORT_COUNT (2)
+    0x81, 0x06,                    //     INPUT (Data,Var,Rel)
+    0x09, 0x38,                    //     USAGE (WHEEL)
+    0x15, 0x81,                    //     LOGICAL_MINIMUM (-127)
+    0x25, 0x7f,                    //     LOGICAL_MAXIMUM (127)
+    0x75, 0x08,                    //     REPORT_SIZE (8)
+    0x95, 0x01,                    //     REPORT_COUNT (1)
+    0x81, 0x06,                    //     INPUT (Data,Var,Rel)
+    0xc0,                          //   END_COLLECTION
+    0xc0,                          // END_COLLECTION
+    0x05, 0x01,                    // USAGE_PAGE (Generic Desktop)
+    0x09, 0x06,                    // USAGE (Keyboard)
+    0xa1, 0x01,                    // COLLECTION (Application)
+    0x85, 0x02,                    //   REPORT_ID (2)
+    0x05, 0x07,                    //   USAGE_PAGE (Keyboard)
+    0x19, 0xe0,                    //   USAGE_MINIMUM (Keyboard LeftControl)
+    0x29, 0xe7,                    //   USAGE_MAXIMUM (Keyboard Right GUI)
+    0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
+    0x25, 0x01,                    //   LOGICAL_MAXIMUM (1)
+    0x75, 0x01,                    //   REPORT_SIZE (1)
+    0x95, 0x08,                    //   REPORT_COUNT (8)
+    0x81, 0x02,                    //   INPUT (Data,Var,Abs)
+    0x95, 0x01,                    //   REPORT_COUNT (1)
+    0x75, 0x08,                    //   REPORT_SIZE (8)
+    0x81, 0x01,                    //   INPUT (Cnst,Ary,Abs)
+    // We don't use OUT endpoint to receive LED reports from host
+    // 0x95, 0x05,                    //   REPORT_COUNT (5)
+    // 0x75, 0x01,                    //   REPORT_SIZE (1)
+    // 0x05, 0x08,                    //   USAGE_PAGE (LEDs)
+    // 0x19, 0x01,                    //   USAGE_MINIMUM (Num Lock)
+    // 0x29, 0x05,                    //   USAGE_MAXIMUM (Kana)
+    // 0x91, 0x02,                    //   OUTPUT (Data,Var,Abs)
+    // 0x95, 0x01,                    //   REPORT_COUNT (1)
+    // 0x75, 0x03,                    //   REPORT_SIZE (3)
+    // 0x91, 0x01,                    //   OUTPUT (Cnst,Ary,Abs)
+    0x95, 0x06,                    //   REPORT_COUNT (6)
+    0x75, 0x08,                    //   REPORT_SIZE (8)
+    0x15, 0x00,                    //   LOGICAL_MINIMUM (0)
+    0x25, 0xdd,                    //   LOGICAL_MAXIMUM (221)
+    0x05, 0x07,                    //   USAGE_PAGE (Keyboard)
+    0x19, 0x00,                    //   USAGE_MINIMUM (Reserved (no event indicated))
+    0x29, 0xdd,                    //   USAGE_MAXIMUM (Keypad Hexadecimal)
+    0x81, 0x00,                    //   INPUT (Data,Ary,Abs)
+    0xc0,                          // END_COLLECTION
+    0x05, 0x0d,                    // USAGE_PAGE (Digitizer)
+    0x09, 0x02,                    // USAGE (Pen)
+    0xa1, 0x01,                    // COLLECTION (Application)
+    0x85, 0x03,                    //   REPORT_ID (3)
+    0x09, 0x20,                    //   USAGE (Stylus)
+    0xa1, 0x00,                    //   COLLECTION (Physical)
+    0x09, 0x42,                    //     USAGE (Tip Switch)
+    0x09, 0x32,                    //     USAGE (In Rnage)
+    0x15, 0x00,                    //     LOGICAL_MINIMUM (0)
+    0x25, 0x01,                    //     LOGICAL_MAXIMUM (1)
+    0x75, 0x01,                    //     REPORT_SIZE (1)
+    0x95, 0x02,                    //     REPORT_COUNT (2)
+    0x81, 0x02,                    //     INPUT (Data,Var,Abs)
+    0x75, 0x01,                    //     REPORT_SIZE (1)
+    0x95, 0x06,                    //     REPORT_COUNT (6)
+    0x81, 0x01,                    //     INPUT (Cnst,Ary,Abs)
+    0x05, 0x01,                    //     USAGE_PAGE (Generic Desktop)
+    0x09, 0x01,                    //     USAGE (Pointer)
+    0xa1, 0x00,                    //     COLLECTION (Physical)
+    0x09, 0x30,                    //       USAGE (X)
+    0x09, 0x31,                    //       USAGE (Y)
+    0x16, 0x00, 0x00,              //       LOGICAL_MINIMUM (0)
+    0x26, 0xff, 0x7f,              //       LOGICAL_MAXIMUM (32767)
+    0x36, 0x00, 0x00,              //       PHYSICAL_MINIMUM (0)
+    0x46, 0xff, 0x7f,              //       PHYSICAL_MAXIMUM (32767)
+    0x65, 0x00,                    //       UNIT (None)
+    0x75, 0x10,                    //       REPORT_SIZE (16)
+    0x95, 0x02,                    //       REPORT_COUNT (2)
+    0x81, 0x02,                    //       INPUT (Data,Var,Abs)
+    0xc0,                          //     END_COLLECTION
+    0xc0,                          //   END_COLLECTION
+    0xc0                           // END_COLLECTION
+};
+
+const size_t DEFAULT_HID_DESCRIPTOR_DIGITIZER_LEN = 65;
+
+} // anonymous
+
+HidClassDriver::HidClassDriver()
+        : ClassDriver() {
+}
+
+HidClassDriver::~HidClassDriver() {
+    setName(nullptr);
+}
+
+HidClassDriver* HidClassDriver::instance() {
+    static HidClassDriver hid;
+    return &hid;
+}
+
+int HidClassDriver::init(unsigned cfgIdx) {
+    // deinit(cfgIdx);
+    CHECK_TRUE(epIn_ != ENDPOINT_INVALID, SYSTEM_ERROR_INVALID_STATE);
+
+    CHECK(dev_->openEndpoint(epIn_, EndpointType::INTERRUPT, hid::MAX_DATA_PACKET_SIZE));
+
+    return 0;
+}
+
+int HidClassDriver::deinit(unsigned cfgIdx) {
+    if (isConfigured()) {
+        if (txState_) {
+            dev_->flushEndpoint(epIn_);
+        }
+    }
+
+    dev_->closeEndpoint(epIn_);
+
+    epIn_ = ENDPOINT_INVALID;
+    txState_ = false;
+
+    altSetting_ = 0;
+    protocol_ = 0;
+    idleState_ = 0;
+    return 0;
+}
+
+void HidClassDriver::setName(const char* name) {
+    if (name_) {
+        free(name_);
+        name_ = nullptr;
+    }
+    if (name) {
+        // Ignore allocation failures, we'll just default to DEFAULT_NAME
+        name_ = strdup(name);
+    }
+}
+
+int HidClassDriver::setup(SetupRequest* req) {
+    if (req->bmRequestTypeType != SetupRequest::TYPE_CLASS && req->bmRequestTypeType != SetupRequest::TYPE_STANDARD) {
+        return SYSTEM_ERROR_INVALID_ARGUMENT;
+    }
+    if (req->wIndex != interfaceBase_) {
+        return SYSTEM_ERROR_INVALID_ARGUMENT;
+    }
+
+    // Class or standard request
+    if (req->bmRequestTypeType == SetupRequest::TYPE_CLASS) {
+        if (req->bmRequestTypeDirection /* Device to host */) {
+            return handleInSetupRequest(req);
+        } else {
+            return handleOutSetupRequest(req);
+        }
+    } else {
+        // Standard
+        switch (req->bRequest) {
+        case SetupRequest::REQUEST_GET_DESCRIPTOR: {
+            if ((req->wValue >> 8) == hid::DESCRIPTOR_HID_REPORT) {
+                return dev_->setupReply(req, DEFAULT_HID_DESCRIPTOR, reportDescriptorLen());
+            }
+            break;
+        }
+        case SetupRequest::REQUEST_GET_INTERFACE: {
+            return dev_->setupReply(req, &altSetting_, sizeof(altSetting_));
+        }
+        case SetupRequest::REQUEST_SET_INTERFACE: {
+            if (req->wValue == 0) {
+                return dev_->setupReply(req, nullptr, 0);
+            }
+            break;
+        }
+        }
+    }
+    return SYSTEM_ERROR_INVALID_ARGUMENT;
+}
+
+int HidClassDriver::handleInSetupRequest(SetupRequest* req) {
+    switch (req->bRequest) {
+    case hid::GET_PROTOCOL: {
+        return dev_->setupReply(req, (const uint8_t*)&protocol_, sizeof(protocol_));
+    }
+    case hid::GET_IDLE: {
+        return dev_->setupReply(req, (const uint8_t*)&idleState_, sizeof(idleState_));
+    }
+    default: {
+    }
+    }
+    return SYSTEM_ERROR_INVALID_ARGUMENT;
+}
+
+int HidClassDriver::handleOutSetupRequest(SetupRequest* req) {
+    switch (req->bRequest) {
+    case hid::SET_PROTOCOL: {
+        protocol_ = (uint8_t)req->wValue;
+        return 0;
+    }
+    case hid::SET_IDLE: {
+        idleState_ = (uint8_t)req->wValue;
+        return 0;
+    }
+    default: {
+    }
+    }
+    return SYSTEM_ERROR_INVALID_ARGUMENT;
+}
+
+int HidClassDriver::dataIn(unsigned ep, particle::usbd::EndpointEvent ev, size_t len) {
+    if (ep != epIn_) {
+        return SYSTEM_ERROR_UNKNOWN;
+    }
+
+    if (!txState_) {
+        return 0;
+    }
+
+    txState_ = false;
+
+    return 0;
+}
+
+int HidClassDriver::dataOut(unsigned ep, particle::usbd::EndpointEvent ev, size_t len) {
+    return 0;
+}
+
+int HidClassDriver::startOfFrame() {
+    return 0;
+}
+
+int HidClassDriver::getConfigurationDescriptor(uint8_t* buf, size_t length, Speed speed, unsigned index) {
+    BufferAppender appender(buf, length);
+ 
+    // No need for interface association descriptor, as only one interface is used
+    
+    // Interface Descriptor
+    appender.appendUInt8(0x09);   // bLength: Interface Descriptor size
+    appender.appendUInt8(DESCRIPTOR_INTERFACE);  // bDescriptorType: Interface
+    appender.appendUInt8(interfaceBase_);   // bInterfaceNumber: Number of Interface
+    appender.appendUInt8(0x00);   // bAlternateSetting: Alternate setting
+    appender.appendUInt8(0x01);   // bNumEndpoints: 1, we are out of endpoints
+    appender.appendUInt8(0x03);   // bInterfaceClass: HID
+    appender.appendUInt8(0x00);   // bInterfaceSubClass: 0 = BOOT
+    appender.appendUInt8(0x00);   // bInterfaceProtocol: 0 = none
+    appender.appendUInt8(stringBase_);   // iInterface (using same string as iFunction in IAD)
+
+    // Joystick Mouse HID
+    appender.appendUInt8(0x09); // bLength: HID descriptor size
+    appender.appendUInt8(0x21); // bDescriptorType: HID
+    appender.appendUInt8(0x11); // bcdHID: HID Class Spec release number
+    appender.appendUInt8(0x01); //
+    appender.appendUInt8(0x00); // bCountryCode: Hardware target country
+    appender.appendUInt8(0x01); // bNumDescriptors: Number of HID class descriptors to follow
+    appender.appendUInt8(0x22); // bDescriptorType: HID
+    appender.appendUInt16LE(reportDescriptorLen()); // wItemLength: Total length of Report descriptor
+
+    uint8_t epIn = CHECK(getNextAvailableEndpoint(ENDPOINT_IN));
+    // Endpoint descriptor (IN)
+    appender.appendUInt8(0x07); // bLength: Endpoint Descriptor size
+    appender.appendUInt8(DESCRIPTOR_ENDPOINT); // bDescriptorType
+    appender.appendUInt8(epIn); // bEndpointAddress: Endpoint Address (IN)
+    appender.appendUInt8(0x03); // bmAttributes: Interrupt endpoint
+    appender.appendUInt16LE(hid::MAX_DATA_PACKET_SIZE); // wMaxPacketSize
+    appender.appendUInt8(0x01); // bInterval: Polling Interval (10 ms)
+
+    epIn_ = epIn;
+
+    return appender.dataSize();
+}
+
+int HidClassDriver::getString(unsigned id, uint16_t langId, uint8_t* buf, size_t length) {
+    if (id == stringBase_) {
+        if (name_) {
+            return dev_->getUnicodeString(name_, strlen(name_), buf, length);
+        }
+        return dev_->getUnicodeString(DEFAULT_NAME, sizeof(DEFAULT_NAME) - 1, buf, length);
+    }
+    return SYSTEM_ERROR_NOT_FOUND;
+}
+
+int HidClassDriver::getNumInterfaces() const {
+    return 1;
+}
+
+int HidClassDriver::getNumStrings() const {
+    return 1;
+}
+
+int HidClassDriver::sendReport(const uint8_t* report, size_t size) {
+    CHECK_TRUE(isConfigured(), SYSTEM_ERROR_INVALID_STATE);
+    CHECK_TRUE(report && size, SYSTEM_ERROR_INVALID_ARGUMENT);
+
+    if (txState_) {
+        return SYSTEM_ERROR_BUSY;
+    }
+
+    if (size > hid::MAX_DATA_PACKET_SIZE) {
+        return SYSTEM_ERROR_TOO_LARGE;
+    }
+
+    txState_ = true;
+
+    memcpy(buffer_, report, size);
+    return dev_->transferIn(epIn_, buffer_, size);
+}
+
+int HidClassDriver::setDigitizerState(bool state) {
+    digitizerState_ = state;
+    return 0;
+}
+
+int HidClassDriver::transferStatus() const {
+    return txState_ && isConfigured();
+}
+
+size_t HidClassDriver::reportDescriptorLen() const {
+    size_t len = sizeof(DEFAULT_HID_DESCRIPTOR);
+    if (!digitizerState_) {
+        len -= DEFAULT_HID_DESCRIPTOR_DIGITIZER_LEN;
+    }
+    return len;
+}

--- a/hal/src/rtl872x/usbd_hid.cpp
+++ b/hal/src/rtl872x/usbd_hid.cpp
@@ -241,8 +241,6 @@ int HidClassDriver::handleInSetupRequest(SetupRequest* req) {
     case hid::GET_IDLE: {
         return dev_->setupReply(req, (const uint8_t*)&idleState_, sizeof(idleState_));
     }
-    default: {
-    }
     }
     return SYSTEM_ERROR_INVALID_ARGUMENT;
 }
@@ -256,8 +254,6 @@ int HidClassDriver::handleOutSetupRequest(SetupRequest* req) {
     case hid::SET_IDLE: {
         idleState_ = (uint8_t)req->wValue;
         return 0;
-    }
-    default: {
     }
     }
     return SYSTEM_ERROR_INVALID_ARGUMENT;
@@ -278,7 +274,7 @@ int HidClassDriver::dataIn(unsigned ep, particle::usbd::EndpointEvent ev, size_t
 }
 
 int HidClassDriver::dataOut(unsigned ep, particle::usbd::EndpointEvent ev, size_t len) {
-    return 0;
+    return SYSTEM_ERROR_NOT_SUPPORTED;
 }
 
 int HidClassDriver::startOfFrame() {
@@ -286,6 +282,7 @@ int HidClassDriver::startOfFrame() {
 }
 
 int HidClassDriver::getConfigurationDescriptor(uint8_t* buf, size_t length, Speed speed, unsigned index) {
+    CHECK_TRUE(buf && length, SYSTEM_ERROR_INVALID_ARGUMENT);
     BufferAppender appender(buf, length);
  
     // No need for interface association descriptor, as only one interface is used

--- a/hal/src/rtl872x/usbd_hid.h
+++ b/hal/src/rtl872x/usbd_hid.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2023 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "usbd_device.h"
+#include "usbd_wcid.h"
+#include "hal_platform.h"
+#include "usb_hal.h"
+#include <functional>
+
+namespace particle { namespace usbd {
+
+namespace hid {
+
+enum Request {
+    SET_PROTOCOL = 0x0B,
+    GET_PROTOCOL = 0x03,
+    SET_IDLE = 0x0A,
+    GET_IDLE = 0x02,
+    SET_REPORT = 0x09,
+    GET_REPORT = 0x01,
+    INVALID_REQUEST = 0xff
+};
+
+enum DescriptorType {
+    DESCRIPTOR_HID = 0x21,
+    DESCRIPTOR_HID_REPORT = 0x22
+};
+
+const size_t MAX_DATA_PACKET_SIZE = 64;
+
+} /* namespace hid */
+
+class HidClassDriver : public particle::usbd::ClassDriver {
+public:
+    static HidClassDriver* instance();
+    ~HidClassDriver();
+
+    virtual int init(unsigned cfgIdx) override;
+    virtual int deinit(unsigned cfgIdx) override;
+    virtual int setup(particle::usbd::SetupRequest* req) override;
+    virtual int startOfFrame() override;
+    virtual int dataIn(unsigned ep, particle::usbd::EndpointEvent ev, size_t len) override;
+    virtual int dataOut(unsigned ep, particle::usbd::EndpointEvent ev, size_t len) override;
+    virtual int getConfigurationDescriptor(uint8_t* buf, size_t length, Speed speed = Speed::FULL, unsigned index = 0) override;
+    virtual int getString(unsigned id, uint16_t langId, uint8_t* buf, size_t length) override;
+
+    virtual int getNumInterfaces() const override;
+    virtual int getNumStrings() const override;
+
+    void setName(const char* name);
+
+    int sendReport(const uint8_t* report, size_t size);
+    int transferStatus() const;
+    int setDigitizerState(bool state);
+
+private:
+    int handleInSetupRequest(SetupRequest *req);
+    int handleOutSetupRequest(SetupRequest *req);
+    size_t reportDescriptorLen() const;
+
+protected:
+    HidClassDriver();
+
+private:
+    char* name_ = nullptr;
+    uint8_t epIn_ = ENDPOINT_INVALID;
+
+    volatile bool txState_ = false;
+
+    __attribute__((aligned(4))) uint8_t buffer_[hid::MAX_DATA_PACKET_SIZE] = {};
+
+    uint8_t altSetting_ = 0;
+    uint8_t protocol_ = 0;
+    uint8_t idleState_ = 0;
+    bool digitizerState_ = true;
+};
+
+} } /* namespace particle::usbd */
+

--- a/user/tests/wiring/usbhid2/usbhid.py
+++ b/user/tests/wiring/usbhid2/usbhid.py
@@ -310,6 +310,7 @@ class SerialConnection:
         if port is not None:
             self.s = serial.Serial(port, timeout=0, writeTimeout=0.5)
         self.state = False
+        self.buffer = b''
 
     def start(self):
         if self.s is not None:
@@ -353,11 +354,17 @@ class SerialConnection:
     def handle(self):
         l = b''
         if self.s is not None:
-            l = self.s.readline()
+            l = self.s.read()
         if l == b'':
             return None
+        if l == b'\n':
+            l = self.buffer
+            self.buffer = b''
+        else:
+            self.buffer += l
+            return None
         l = l.strip()
-        print(l.decode('utf-8'))
+        print('line='+l.decode('utf-8'))
         if l == b'Running tests':
             self.state = True
         elif l.startswith(b'Test summary:'):

--- a/wiring/inc/spark_wiring_platform.h
+++ b/wiring/inc/spark_wiring_platform.h
@@ -149,11 +149,11 @@
 #endif
 
 #ifndef Wiring_Keyboard
-#define Wiring_Keyboard 0
+#define Wiring_Keyboard (HAL_PLATFORM_USB_HID)
 #endif // Wiring_Keyboard
 
 #ifndef Wiring_Mouse
-#define Wiring_Mouse 0
+#define Wiring_Mouse (HAL_PLATFORM_USB_HID)
 #endif // Wiring_Mouse
 
 #if HAL_PLATFORM_MESH_DEPRECATED

--- a/wiring/inc/spark_wiring_usbkeyboard.h
+++ b/wiring/inc/spark_wiring_usbkeyboard.h
@@ -26,9 +26,9 @@
 #ifndef __SPARK_WIRING_USBKEYBOARD_H
 #define __SPARK_WIRING_USBKEYBOARD_H
 
-#include "usb_config_hal.h"
+#include "spark_wiring_platform.h"
 
-#ifdef SPARK_USB_KEYBOARD
+#if Wiring_Keyboard
 #include "spark_wiring.h"
 #include "spark_wiring_usbkeyboard_scancode.h"
 

--- a/wiring/inc/spark_wiring_usbmouse.h
+++ b/wiring/inc/spark_wiring_usbmouse.h
@@ -26,9 +26,9 @@
 #ifndef __SPARK_WIRING_USBMOUSE_H
 #define __SPARK_WIRING_USBMOUSE_H
 
-#include "usb_config_hal.h"
+#include "spark_wiring_platform.h"
 
-#ifdef SPARK_USB_MOUSE
+#if Wiring_Mouse
 #include "spark_wiring.h"
 #include <array>
 

--- a/wiring/src/spark_wiring_usbkeyboard.cpp
+++ b/wiring/src/spark_wiring_usbkeyboard.cpp
@@ -23,10 +23,8 @@
   ******************************************************************************
  */
 
-#include "usb_hal.h"
-
-#ifdef SPARK_USB_KEYBOARD
 #include "spark_wiring_usbkeyboard.h"
+#if Wiring_Keyboard
 
 #define SHIFT_MOD 0x80
 

--- a/wiring/src/spark_wiring_usbmouse.cpp
+++ b/wiring/src/spark_wiring_usbmouse.cpp
@@ -23,10 +23,10 @@
   ******************************************************************************
  */
 
-#include "usb_hal.h"
-
-#ifdef SPARK_USB_MOUSE
 #include "spark_wiring_usbmouse.h"
+
+#if Wiring_Mouse
+
 #include <cmath>
 
 //


### PR DESCRIPTION
### Description

USB HID (Mouse / Keyboard) support for P2 / Photon 2.

Same APIs as previously on Photon / P1 / Electron:
https://docs.particle.io/reference/device-os/api/keyboard/keyboard/
https://docs.particle.io/reference/device-os/api/mouse/mouse/

### Caveats

1. `Mouse.moveTo()` might not be moving the cursor (at least on Linux). Might need to come up with a different digitizer descriptor. Wayland uses multiple pointers, so standard pointer doesn't move. Might be the same nowadays on Windows/OSX.
2. We are out of USB endpoints to run CDC + HID at the same time. When both are enabled we are again using a hack from Electron times where one of the CDC endpoints is in fact invalid. This works fine on Linux, double check Windows / OSX behavior, but should probably behave fine as well, as again we've done the same thing with Electron.
