### PR TITLE
[rtl872x] linker: stop relying on .dynalib + .psram_text being contiguous and properly and similarly aligned within LMA and VMA, just copy them separately

### DIFF
--- a/bootloader/src/rtl872x/linker.ld
+++ b/bootloader/src/rtl872x/linker.ld
@@ -251,6 +251,10 @@ PROVIDE (link_psram_code_flash_start = 0);
 PROVIDE (link_psram_code_start = link_psram_code_flash_start);
 PROVIDE (link_psram_code_end = link_psram_code_start);
 
+PROVIDE (link_dynalib_flash_start = 0);
+PROVIDE (link_dynalib_start = link_dynalib_flash_start);
+PROVIDE (link_dynalib_end = link_dynalib_start);
+
 /* Heap location */
 link_heap_location     = link_bss_end;
 link_heap_location_end = platform_ram_size - platform_backup_ram_all_size;

--- a/build/arm/startup/startup_rtl872x.S
+++ b/build/arm/startup/startup_rtl872x.S
@@ -149,6 +149,21 @@ Reset_Handler:
     bgt .L_loop4
 
 .L_loop4_done:
+/* Load dynalib into PSRAM */
+    ldr r1, =link_dynalib_flash_start
+    ldr r2, =link_dynalib_start
+    ldr r3, =link_dynalib_end
+
+    subs r3, r2
+    ble .L_loop5_done
+
+.L_loop5:
+    subs r3, #4
+    ldr r0, [r1,r3]
+    str r0, [r2,r3]
+    bgt .L_loop5
+
+.L_loop5_done:
     ldr r0, =Jump_To_Psram
     blx r0
 

--- a/hal/src/rtl872x/linker.ld
+++ b/hal/src/rtl872x/linker.ld
@@ -242,4 +242,8 @@ link_secure_stack_size     = platform_monolithic_firmware_secure_stack_size;
 link_secure_stack_location = platform_monolithic_firmware_secure_stack_start;
 link_secure_stack_end      = platform_monolithic_firmware_secure_stack_end;
 
+PROVIDE (link_dynalib_flash_start = 0);
+PROVIDE (link_dynalib_start = link_dynalib_flash_start);
+PROVIDE (link_dynalib_end = link_dynalib_start);
+
 INCLUDE linker_rtl872x_rom_ns.ld

--- a/modules/shared/rtl872x/inc/user_part_export.c
+++ b/modules/shared/rtl872x/inc/user_part_export.c
@@ -26,6 +26,11 @@ extern uintptr_t link_psram_code_start;
 extern uintptr_t link_psram_code_end;
 #define link_psram_code_size ((uintptr_t)&link_psram_code_end - (uintptr_t)&link_psram_code_start)
 
+extern uintptr_t link_dynalib_flash_start;
+extern uintptr_t link_dynalib_start;
+extern uintptr_t link_dynalib_end;
+#define link_dynalib_size ((uintptr_t)&link_dynalib_end - (uintptr_t)&link_dynalib_start)
+
 
 /**
  * Array of C++ static constructors.
@@ -49,6 +54,12 @@ __attribute__((section(".xip.text"))) void* module_user_pre_init() {
 
     // Initialize .bss
     _memset(&link_bss_location, 0, link_bss_size );
+
+    // Copy .dynalib
+    if ( (&link_dynalib_start != &link_dynalib_flash_start) && (link_dynalib_size != 0))
+    {
+        _memcpy(&link_dynalib_start, &link_dynalib_flash_start, link_dynalib_size);
+    }
 
     // Copy .psram_text
     if ( (&link_psram_code_start != &link_psram_code_flash_start) && (link_psram_code_size != 0))

--- a/modules/shared/rtl872x/linker_system_part1_common.ld
+++ b/modules/shared/rtl872x/linker_system_part1_common.ld
@@ -28,25 +28,20 @@ SECTIONS
     INCLUDE linker_build_id.ld
 
     /* Dynalib table */
-    .dynalib :
+    .dynalib : ALIGN(8)
     {
-        link_psram_code_flash_start = LOADADDR( .dynalib );
         link_dynalib_flash_start = LOADADDR( .dynalib );
-        . = ALIGN(4);
-        link_psram_code_start = .;
+
         link_dynalib_start = . ;
         KEEP (*(*.system_part1_module))
+        . = ALIGN(4);
         link_dynalib_end = . ;
-
-        /* WARN: the load address must increase as well due to alignement of virtual address,
-         * otherwise, the length of code to be copied to PSRAM is incorrect! */
-        FILL (0xff)
-        . = ALIGN(16);
     } > PSRAM AT> APP_FLASH
 
-    .psram_text :
+    .psram_text : ALIGN(4)
     {
-        . = ALIGN(4);
+        link_psram_code_flash_start = LOADADDR( .psram_text );
+        link_psram_code_start = .;
 
         /* Code */
         *(.flashtext) /* Realtek specific */

--- a/modules/shared/rtl872x/linker_user_part_common.ld
+++ b/modules/shared/rtl872x/linker_user_part_common.ld
@@ -25,18 +25,18 @@ SECTIONS
     /* Dynalib table. It has to be 8-bytes aligned, otherwise, the dynalib behave weirdly */
     .dynalib : ALIGN(8)
     {
-        link_psram_code_flash_start = LOADADDR( .dynalib );
         link_dynalib_flash_start = LOADADDR( .dynalib );
-        
-        link_psram_code_start = .;
+
         link_dynalib_start = .;
         KEEP (*(*.user_part_module))
+        . = ALIGN(4);
         link_dynalib_end = . ;
     } > PSRAM AT> APP_FLASH
 
-    .psram_text :
+    .psram_text : ALIGN(4)
     {
-        . = ALIGN(4);
+        link_psram_code_flash_start = LOADADDR( .psram_text );
+        link_psram_code_start = .;
 
         /* Code */
         *(.flashtext) /* Realtek specific */


### PR DESCRIPTION
### Problem

Some user apps break expectations of `.dynalib` + `.psram_text` being contiguous and similarly aligned in LMA (flash) and VMA (PSRAM). 

### Solution

We've had a number of issues with LD over the years especially during compiler version upgrades, so instead of relying on a workaround that exists in system-part1 right now, simply copy `.dynalib` and `.psram_text` separately.

### Steps to Test

Build system-part1 and the app below, both should run correctly.

[You_re_Muted__inferencing.zip](https://github.com/particle-iot/device-os/files/11826024/You_re_Muted__inferencing.zip)


### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
