### PR TITLE
[rtl872x] RTC is not remained after waking up from hibernate mode.

### DIFF
--- a/hal/src/rtl872x/core_hal.c
+++ b/hal/src/rtl872x/core_hal.c
@@ -416,9 +416,10 @@ void HAL_Core_Setup(void) {
     // and global constructors have executed, but interrupt HAL can only be accessed after both of those things happened.
     hal_button_init(HAL_BUTTON1, HAL_BUTTON_MODE_EXTI);
 
-    hal_rtc_init();
-
     hal_backup_ram_init();
+
+    // Note: the rtc module has retained data, so hal_backup_ram_init() should be called first.
+    hal_rtc_init();
 
 #if !defined(MODULAR_FIRMWARE) || !MODULAR_FIRMWARE
     module_user_init_hook();


### PR DESCRIPTION
### Problem

RTC is always reset after waking up from hibernate mode.

### Solution

Do not initialize the RTC if device wakes up from hibernate mode.

### Steps to Test

See the following test app.

### Example App

```c
#include "application.h"

SYSTEM_MODE(MANUAL);

Serial1LogHandler l(115200, LOG_LEVEL_ALL);

static time32_t year, month, day, weekday, hour, minute, second;

void updateTime() {
    year = Time.year();
    month = Time.month();
    day = Time.day();
    weekday = Time.weekday();
    hour = Time.hour();
    minute = Time.minute();
    second = Time.second();
}

STARTUP(updateTime());

void setup() {
    Log.info("%d-%d-%d, %d:%d:%d, %d, test: %ld", year, month, day, hour, minute, second, weekday);

    delay(5s);

    updateTime();
    Log.info("%d-%d-%d, %d:%d:%d, %d, test: %ld", year, month, day, hour, minute, second, weekday);

    System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::HIBERNATE).duration(10s));
}
```

Sample output:
```
#0000000617 [system] INFO: Device 0a10aced202194944a04072c started
0000000619 [system] TRACE: Last reset reason: 30 (data: 0x00)
0000000625 [hal] TRACE: Using internal antenna
0000000647 [hal] INFO: rltk_wlan_set_netif_info: 0, 94:94:4a:04:07:2c
0000000850 [hal] INFO: WiFi on
0000001085 [net.lwip_rltk] INFO: promisc_deinit TODO
0000001087 [hal] INFO: WiFi off
0000001698 [system.nm] INFO: State changed: NONE -> DISABLED
0000001700 [system.nm] TRACE: Interface 4 power state: 1
0000001727 [comm] INFO: channel inited
0000001728 [app] INFO: 2000-1-1, 0:2:11, 7
0000006731 [app] INFO: 2000-1-1, 0:2:17, 7
0000006732 [system.sleep] TRACE: Entering system_sleep_ext()
0000006736 [system.sleep] TRACE: Interface 4 is off already
0000006742 [system.sleep] TRACE: Interface 3 is off already

#0000000614 [system] INFO: Device 0a10aced202194944a04072c started
0000000616 [system] TRACE: Last reset reason: 30 (data: 0x00)
0000000622 [hal] TRACE: Using internal antenna
0000000643 [hal] INFO: rltk_wlan_set_netif_info: 0, 94:94:4a:04:07:2c
0000000847 [hal] INFO: WiFi on
0000001081 [net.lwip_rltk] INFO: promisc_deinit TODO
0000001083 [hal] INFO: WiFi off
0000001694 [system.nm] INFO: State changed: NONE -> DISABLED
0000001696 [system.nm] TRACE: Interface 4 power state: 1
0000001723 [comm] INFO: channel inited
0000001724 [app] INFO: 2000-1-1, 0:2:30, 7
0000006727 [app] INFO: 2000-1-1, 0:2:36, 7
0000006728 [system.sleep] TRACE: Entering system_sleep_ext()
0000006732 [system.sleep] TRACE: Interface 4 is off already
0000006738 [system.sleep] TRACE: Interface 3 is off already
```

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
