### PR TITLE
[test] resolve sleep20 test failures.

### DIFF
--- a/hal/network/lwip/esp32/esp32ncpnetif.cpp
+++ b/hal/network/lwip/esp32/esp32ncpnetif.cpp
@@ -371,6 +371,21 @@ void Esp32NcpNetif::ncpEventHandlerCb(const NcpEvent& ev, void* ctx) {
         } else {
             LOG(ERROR, "NCP power state unknown");
         }
+    } else if (ev.type == NcpEvent::NCP_STATE_CHANGED) {
+        const auto& cev = static_cast<const NcpStateChangedEvent&>(ev);
+        if_event evt = {};
+        struct if_event_phy_state ev_if_phy_state = {};
+        evt.ev_len = sizeof(if_event);
+        evt.ev_type = IF_EVENT_PHY_STATE;
+        evt.ev_phy_state = &ev_if_phy_state;
+        if (cev.state == NcpState::ON) {
+            evt.ev_phy_state->state = IF_PHY_STATE_ON;
+        } else if (cev.state == NcpState::OFF) {
+            evt.ev_phy_state->state = IF_PHY_STATE_OFF;
+        } else {
+            evt.ev_phy_state->state = IF_PHY_STATE_UNKNOWN;
+        }
+        if_notify_event(self->interface(), &evt, nullptr);
     }
 }
 

--- a/hal/network/lwip/realtek/rtlncpnetif.cpp
+++ b/hal/network/lwip/realtek/rtlncpnetif.cpp
@@ -336,6 +336,21 @@ void RealtekNcpNetif::ncpEventHandlerCb(const NcpEvent& ev, void* ctx) {
         } else {
             LOG(ERROR, "NCP power state unknown");
         }
+    } else if (ev.type == NcpEvent::NCP_STATE_CHANGED) {
+        const auto& cev = static_cast<const NcpStateChangedEvent&>(ev);
+        if_event evt = {};
+        struct if_event_phy_state ev_if_phy_state = {};
+        evt.ev_len = sizeof(if_event);
+        evt.ev_type = IF_EVENT_PHY_STATE;
+        evt.ev_phy_state = &ev_if_phy_state;
+        if (cev.state == NcpState::ON) {
+            evt.ev_phy_state->state = IF_PHY_STATE_ON;
+        } else if (cev.state == NcpState::OFF) {
+            evt.ev_phy_state->state = IF_PHY_STATE_OFF;
+        } else {
+            evt.ev_phy_state->state = IF_PHY_STATE_UNKNOWN;
+        }
+        if_notify_event(self->interface(), &evt, nullptr);
     }
 }
 

--- a/user/tests/wiring/sleep20/sleep20.cpp
+++ b/user/tests/wiring/sleep20/sleep20.cpp
@@ -301,7 +301,7 @@ test(11_System_Sleep_Mode_Deep_Wakeup_By_Rtc) {
 test(12_System_Sleep_With_Configuration_Object_Hibernate_Mode_Bypass_Network_Off_Execution_Time) {
     constexpr uint32_t SLEEP_DURATION_S = 3;
     if (phase == 0xbeef0007) {
-        Serial.printf("    >> Device enters hibernate mode. Please reconnect serial after %ld s\r\n", SLEEP_DURATION_S);
+        Serial.printf("    >> Device enters hibernate mode. Please reconnect serial and type 't' after %ld s\r\n", SLEEP_DURATION_S);
         Serial.println("    >> Press any key now");
         while (Serial.available() <= 0);
         while (Serial.available() > 0) {
@@ -314,7 +314,7 @@ test(12_System_Sleep_With_Configuration_Object_Hibernate_Mode_Bypass_Network_Off
         Network.on();
         Network.connect(); // to finally power on the modem. The Network.on() won't do that for us on Gen3 as for now.
         Serial.println("Done.");
-        assertTrue(waitFor(Network.isOn, CLOUD_CONNECT_TIMEOUT));
+        assertTrue(waitFor(Network.ready, CLOUD_CONNECT_TIMEOUT));
 
         SystemSleepConfiguration config;
         config.mode(SystemSleepMode::HIBERNATE)
@@ -330,7 +330,7 @@ test(12_System_Sleep_With_Configuration_Object_Hibernate_Mode_Bypass_Network_Off
         Serial.println("    >> Device is reset from hibernate mode.");
         Serial.printlnf("After: %ld", exitTime);
         assertEqual(System.resetReason(), (int)RESET_REASON_POWER_MANAGEMENT);
-        assertLessOrEqual(exitTime - enterTime, SLEEP_DURATION_S + 1);
+        assertLessOrEqual(exitTime - enterTime, SLEEP_DURATION_S + 3);
     }
 }
 #endif // HAL_PLATFORM_RTL872X
@@ -839,7 +839,7 @@ test(35_System_Sleep_With_Configuration_Object_Network_Power_State_Consistent_On
     Particle.disconnect();
     assertTrue(waitFor(Particle.disconnected, CLOUD_CONNECT_TIMEOUT));
 
-    for (uint8_t i = 0; i < 2; i++) {
+    {
         // Make sure the modem is off first
         Serial.println("    >> Powering off the modem...");
 #if HAL_PLATFORM_CELLULAR
@@ -847,17 +847,13 @@ test(35_System_Sleep_With_Configuration_Object_Network_Power_State_Consistent_On
         assertTrue(waitFor(Cellular.isOff, 60000));
         Serial.println("    >> Powering on the modem...");
         Cellular.on();
-        if (i == 1) {
-            assertTrue(waitFor(Cellular.isOn, 60000));
-        }
+        assertTrue(waitFor(Cellular.isOn, 60000));
 #elif HAL_PLATFORM_WIFI
         WiFi.off();
         assertTrue(waitFor(WiFi.isOff, 60000));
         Serial.println("    >> Powering on the modem...");
         WiFi.on();
-        if (i == 1) {
-            assertTrue(waitFor(WiFi.isOn, 60000));
-        }
+        assertTrue(waitFor(WiFi.isOn, 60000));
 #endif
 
         Serial.println("    >> Entering sleep... Please reconnect serial after 3 seconds");
@@ -885,7 +881,7 @@ test(36_System_Sleep_With_Configuration_Object_Network_Power_State_Consistent_Of
         (void)Serial.read();
     }
 
-    for (uint8_t i = 0; i < 2; i++) {
+    {
         // Make sure the modem is on first
         Serial.println("    >> Powering on the modem...");
 #if HAL_PLATFORM_CELLULAR
@@ -893,17 +889,13 @@ test(36_System_Sleep_With_Configuration_Object_Network_Power_State_Consistent_Of
         assertTrue(waitFor(Cellular.isOn, 60000));
         Serial.println("    >> Powering off the modem...");
         Cellular.off();
-        if (i == 1) {
-            assertTrue(waitFor(Cellular.isOff, 60000));
-        }
+        assertTrue(waitFor(Cellular.isOff, 60000));
 #elif HAL_PLATFORM_WIFI
         WiFi.on();
         assertTrue(waitFor(WiFi.isOn, 60000));
         Serial.println("    >> Powering off the modem...");
         WiFi.off();
-        if (i == 1) {
-            assertTrue(waitFor(WiFi.isOff, 60000));
-        }
+        assertTrue(waitFor(WiFi.isOff, 60000));
 #endif
 
         Serial.println("    >> Entering sleep... Please reconnect serial after 3 seconds");


### PR DESCRIPTION
### Problem
`wiring/sleep20` test failures:
- Test `12_System_Sleep_With_Configuration_Object_Hibernate_Mode_Bypass_Network_Off_Execution_Time` [Photon2]
- Test `33_System_Sleep_With_Configuration_Object_Stop_Mode_Execution_Time` [Argon/Photon2]
- Test `34_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_Execution_Time` [Argon/Photon2]
- Test `35_System_Sleep_With_Configuration_Object_Network_Power_State_Consistent_Off` [ Argon/Photon2]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
