### PR TITLE
[rtl872x] fix incorrect I2C read timeout

### DIFF
--- a/hal/src/rtl872x/i2c_hal.cpp
+++ b/hal/src/rtl872x/i2c_hal.cpp
@@ -346,7 +346,7 @@ public:
                 I2C_ClearAllINT(i2cDev_);
                 goto ret;
             }
-            if (waitStop && !WAIT_TIMED(transConfig_.timeout_ms, !stopDetected())) {
+            if (waitStop && !WAIT_TIMED(config->timeout_ms, !stopDetected())) {
                 reset();
                 return SYSTEM_ERROR_I2C_STOP_TIMEOUT;
             }


### PR DESCRIPTION
### Problem
I2C read timeout is not correct.

### Solution
Use the timeout specified in the given parameter in read request API.

### Steps to Test
See the following test app.

### Example App
I2C master:
```c
#include "Particle.h"

SYSTEM_MODE(SEMI_AUTOMATIC);

void setup() {
  Serial.begin(115200);  // start serial for output
  waitFor(Serial.isConnected, 10000);

  Wire.begin();        // join i2c bus (address optional for master)
}

void loop() {
  char c {};
  unsigned int numCharsReceived {};

  Wire.requestFrom(8, 1);    // request 1 byte from slave device #8

  while (Wire.available()) { // slave may send less than requested
    c = Wire.read(); // receive a byte as character
    numCharsReceived++;
  }

  Serial.printlnf("Character received = %c,  NumCharsReceived = %u", c, numCharsReceived);

  delay(1000);
}
```

I2C slave:
```c
#include "Particle.h"

SYSTEM_MODE(SEMI_AUTOMATIC);

void requestEvent();
bool received {false};

void setup() {
  Serial.begin(115200);
  waitFor(Serial.isConnected, 10000);

  // Wire.stretchClock(true);
  Wire.begin(8);                // join i2c bus with address #8
  Wire.onRequest(requestEvent); // register event
}

void loop() {
  if (received) {
    received = false;
    Serial.println("Sent something");
  }
}

// function that executes whenever data is requested by master
// this function is registered as an event, see setup()
void requestEvent() {
  received = true;
  Wire.write("s"); // respond with message of 1 byte
}
```

### References
N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
