### PR TITLE
rtl872x: set RXD sample delay for SPI0@50MHz

### DIFF
--- a/hal/src/rtl872x/spi_hal.cpp
+++ b/hal/src/rtl872x/spi_hal.cpp
@@ -322,6 +322,13 @@ public:
             u32 rtlClockDivider = 256;
             clockDivToRtlClockDiv(config_.clockDiv, &rtlClockDivider);
             SSI_SetBaudDiv(SPI_DEV_TABLE[rtlSpiIndex_].SPIx, rtlClockDivider);
+
+            // Set sample delay for SPI0@50MHz
+            if (rtlClockDivider == 2 && SPI_DEV_TABLE[rtlSpiIndex_].SPIx == SPI0_DEV) {
+                SSI_SetSampleDelay(SPI_DEV_TABLE[rtlSpiIndex_].SPIx, 0x1);
+            } else {
+                SSI_SetSampleDelay(SPI_DEV_TABLE[rtlSpiIndex_].SPIx, 0x0);
+            }
         }
 
         // Set bit order


### PR DESCRIPTION
### Problem

For the external flash read/write test, SPI0 and SPI1 passed test at 25MHz. SPI0 failed to communicate with the flash at the highest speed 50MHz.

Writting the regular data `0x55 0x55 0x55 ...` to the flash, which is 01010101 waveform on the oscilloscope, we read back the data `0xaa 0xaa ... 0xaa 0x1a 0xaa...`, this anomaly seems to have a pattern, the data appears to have shifted by one bit.

### Solution

The data corruption issue can be fixed by setting the sample delay to one clock cycle.

Please refer to < UM0400 Ameba-D User Manual > 25.2.3.1.1 RXD Sample Delay

![Screenshot 2023-08-01 at 14 11 36](https://github.com/particle-iot/device-os/assets/7424522/734435d7-2663-4ba2-bfc7-646eb1a22d16)

![Screenshot 2023-08-01 at 14 11 41](https://github.com/particle-iot/device-os/assets/7424522/3ff57f42-511a-429e-bf83-938c552cd681)


### References

[CH119867]

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
