### PR TITLE
[rtl872x] Revert BOD reset

### DIFF
--- a/bootloader/prebootloader/src/rtl872x/part1/rtl_support.c
+++ b/bootloader/prebootloader/src/rtl872x/part1/rtl_support.c
@@ -316,9 +316,11 @@ void rtlLowLevelInit() {
     InterruptRegister((IRQ_FUN)bodIrqHandler, BOR2_IRQ_LP, 0, 0);
     InterruptEn(BOR2_IRQ_LP, 0);
     BOR_ThresholdSet(BOR_TH_LOW7, BOR_TH_HIGH7);
-    BOR_ModeSet(BOR_INTR, ENABLE);
-    // XXX: Does this work? Enable BOD reset as well
-    BOR_ModeSet(BOR_RESET, ENABLE);
+    // BOR_ModeSet(BOR_INTR, ENABLE);
+    // // XXX: Does this work? Enable BOD reset as well
+    // BOR_ModeSet(BOR_RESET, ENABLE);
+    BOR_ModeSet(BOR_INTR, DISABLE);
+    BOR_ModeSet(BOR_RESET, DISABLE);
 
     boot_ram_function_enable();
 


### PR DESCRIPTION
### Problem

We enabled brown out detection on all p2 platforms in device os `5.2.0`. This may be causing problems with P2 platform specifically since it does not have an external reset IC like photon 2 / msom

### Solution

Disable brown out reset + interrupt while we investigate the issue

### Steps to Test

[See slack](https://s.slack.com/archives/C05BMP0GVE1)

### Example App

### References

[sc-120473](https://app.shortcut.com/particle/story/120473/p2-bor-causes-lockup-issue)


---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
