### PR TITLE
rtl872x: overshoot issue

### DIFF
--- a/hal/inc/gpio_hal.h
+++ b/hal/inc/gpio_hal.h
@@ -73,6 +73,8 @@ PinMode hal_gpio_get_mode(hal_pin_t pin);
 void hal_gpio_write(hal_pin_t pin, uint8_t value);
 int32_t hal_gpio_read(hal_pin_t pin);
 uint32_t hal_gpio_pulse_in(hal_pin_t pin, uint16_t value);
+hal_gpio_drive_t hal_gpio_get_drive_strength(hal_pin_t pin);
+int hal_gpio_configure_drive_strength(hal_pin_t pin, hal_gpio_drive_t drive);
 
 #include "gpio_hal_compat.h"
 

--- a/hal/inc/gpio_hal.h
+++ b/hal/inc/gpio_hal.h
@@ -73,7 +73,7 @@ PinMode hal_gpio_get_mode(hal_pin_t pin);
 void hal_gpio_write(hal_pin_t pin, uint8_t value);
 int32_t hal_gpio_read(hal_pin_t pin);
 uint32_t hal_gpio_pulse_in(hal_pin_t pin, uint16_t value);
-hal_gpio_drive_t hal_gpio_get_drive_strength(hal_pin_t pin);
+int hal_gpio_get_drive_strength(hal_pin_t pin, hal_gpio_drive_t* drive);
 int hal_gpio_configure_drive_strength(hal_pin_t pin, hal_gpio_drive_t drive);
 
 #include "gpio_hal_compat.h"

--- a/hal/inc/gpio_hal.h
+++ b/hal/inc/gpio_hal.h
@@ -74,7 +74,7 @@ void hal_gpio_write(hal_pin_t pin, uint8_t value);
 int32_t hal_gpio_read(hal_pin_t pin);
 uint32_t hal_gpio_pulse_in(hal_pin_t pin, uint16_t value);
 int hal_gpio_get_drive_strength(hal_pin_t pin, hal_gpio_drive_t* drive);
-int hal_gpio_configure_drive_strength(hal_pin_t pin, hal_gpio_drive_t drive);
+int hal_gpio_set_drive_strength(hal_pin_t pin, hal_gpio_drive_t drive);
 
 #include "gpio_hal_compat.h"
 

--- a/hal/src/rtl872x/gpio_hal.cpp
+++ b/hal/src/rtl872x/gpio_hal.cpp
@@ -110,6 +110,7 @@ void hal_gpio_mode(hal_pin_t pin, PinMode mode) {
     conf.size = sizeof(conf);
     conf.version = HAL_GPIO_VERSION;
     conf.mode = mode;
+    conf.drive_strength = HAL_GPIO_DRIVE_DEFAULT;
     hal_gpio_configure(pin, &conf, nullptr);
 }
 
@@ -159,7 +160,7 @@ int hal_gpio_configure(hal_pin_t pin, const hal_gpio_config_t* conf, void* reser
         }
 
         Pinmux_Config(hal_pin_to_rtl_pin(pin), PINMUX_FUNCTION_GPIO);
-        hal_gpio_set_drive_strength(pin, HAL_GPIO_DRIVE_DEFAULT);
+        hal_gpio_set_drive_strength(pin, static_cast<hal_gpio_drive_t>(conf->drive_strength));
 
         // Pre-set the output value if requested to avoid a glitch
         if (conf->set_value && (mode == OUTPUT || mode == OUTPUT_OPEN_DRAIN || mode == OUTPUT_OPEN_DRAIN_PULLUP)) {

--- a/hal/src/rtl872x/gpio_hal.cpp
+++ b/hal/src/rtl872x/gpio_hal.cpp
@@ -433,3 +433,65 @@ uint32_t hal_gpio_pulse_in(hal_pin_t pin, uint16_t value) {
 
     return (hal_timer_micros(nullptr) - pulse_start);
 }
+
+hal_gpio_drive_t hal_gpio_get_drive_strength(hal_pin_t pin) {
+    uint32_t rtlPin = hal_pin_to_rtl_pin(pin);
+
+    /* get PADCTR */
+    uint32_t drvStrength = PINMUX->PADCTR[rtlPin];
+
+    /* get Pin_Num drvStrength contrl */
+    drvStrength &= PAD_BIT_MASK_DRIVING_STRENGTH << PAD_BIT_SHIFT_DRIVING_STRENGTH;
+    drvStrength >>= PAD_BIT_SHIFT_DRIVING_STRENGTH;
+
+    // Pad driving strength
+    //   - PAD_DRV_STRENGTH_0: 4mA
+    //   - PAD_DRV_STRENGTH_1: 8mA   (Severe overshoot, not recommended to use it)
+    //   - PAD_DRV_STRENGTH_2: 12mA
+    //   - PAD_DRV_STRENGTH_3: 16mA  (Severe overshoot, not recommended to use it)
+    hal_gpio_drive_t drive = HAL_GPIO_DRIVE_DEFAULT;
+    switch(drvStrength) {
+        case PAD_DRV_STRENGTH_0: drive = HAL_GPIO_DRIVE_STANDARD; break;
+        case PAD_DRV_STRENGTH_2: drive = HAL_GPIO_DRIVE_HIGH; break;
+        // DVOS won't configure PAD_DRV_STRENGTH_1 and PAD_DRV_STRENGTH_3 due to the
+        // severe overshoot, so it is the default setting
+        default:
+            drive = HAL_GPIO_DRIVE_DEFAULT; break;
+    }
+
+    return drive;
+}
+
+int hal_gpio_configure_drive_strength(hal_pin_t pin, hal_gpio_drive_t drive) {
+    uint32_t rtlPin = hal_pin_to_rtl_pin(pin);
+    uint32_t drvStrength = PAD_DRV_STRENGTH_0;
+
+    // Pad driving strength
+    //   - PAD_DRV_STRENGTH_0: 4mA
+    //   - PAD_DRV_STRENGTH_1: 8mA   (Severe overshoot, not recommended to use it)
+    //   - PAD_DRV_STRENGTH_2: 12mA
+    //   - PAD_DRV_STRENGTH_3: 16mA  (Severe overshoot, not recommended to use it)
+    switch(drive) {
+        case HAL_GPIO_DRIVE_STANDARD: drvStrength = PAD_DRV_STRENGTH_0; break;
+        case HAL_GPIO_DRIVE_HIGH:     drvStrength = PAD_DRV_STRENGTH_2; break;
+        case HAL_GPIO_DRIVE_DEFAULT:  drvStrength = PAD_DRV_STRENGTH_3; break;
+        default:
+            return SYSTEM_ERROR_INVALID_ARGUMENT;
+    }
+
+    uint32_t temp = 0;
+
+    /* get PADCTR */
+    temp = PINMUX->PADCTR[rtlPin];
+
+    /* clear Pin_Num drvStrength contrl */
+    temp &= ~(PAD_BIT_MASK_DRIVING_STRENGTH << PAD_BIT_SHIFT_DRIVING_STRENGTH);
+
+    /* set needs drvStrength */
+    temp |= (drvStrength & PAD_BIT_MASK_DRIVING_STRENGTH) << PAD_BIT_SHIFT_DRIVING_STRENGTH;
+
+    /* set PADCTR register */
+    PINMUX->PADCTR[rtlPin] = temp;
+
+    return SYSTEM_ERROR_NONE;
+}

--- a/hal/src/rtl872x/gpio_hal.cpp
+++ b/hal/src/rtl872x/gpio_hal.cpp
@@ -159,7 +159,7 @@ int hal_gpio_configure(hal_pin_t pin, const hal_gpio_config_t* conf, void* reser
         }
 
         Pinmux_Config(hal_pin_to_rtl_pin(pin), PINMUX_FUNCTION_GPIO);
-        hal_gpio_configure_drive_strength(pin, HAL_GPIO_DRIVE_DEFAULT);
+        hal_gpio_set_drive_strength(pin, HAL_GPIO_DRIVE_DEFAULT);
 
         // Pre-set the output value if requested to avoid a glitch
         if (conf->set_value && (mode == OUTPUT || mode == OUTPUT_OPEN_DRAIN || mode == OUTPUT_OPEN_DRAIN_PULLUP)) {
@@ -462,7 +462,7 @@ int hal_gpio_get_drive_strength(hal_pin_t pin, hal_gpio_drive_t* drive) {
     return SYSTEM_ERROR_NONE;
 }
 
-int hal_gpio_configure_drive_strength(hal_pin_t pin, hal_gpio_drive_t drive) {
+int hal_gpio_set_drive_strength(hal_pin_t pin, hal_gpio_drive_t drive) {
     uint32_t rtlPin = hal_pin_to_rtl_pin(pin);
     uint32_t drvStrength = PAD_DRV_STRENGTH_0;
 

--- a/hal/src/rtl872x/i2c_hal.cpp
+++ b/hal/src/rtl872x/i2c_hal.cpp
@@ -148,8 +148,8 @@ public:
         PAD_PullCtrl(hal_pin_to_rtl_pin(sdaPin_), GPIO_PuPd_UP);
 	    PAD_PullCtrl(hal_pin_to_rtl_pin(sclPin_), GPIO_PuPd_UP);
 
-        hal_gpio_configure_drive_strength(sclPin_, HAL_GPIO_DRIVE_HIGH);
-        hal_gpio_configure_drive_strength(sdaPin_, HAL_GPIO_DRIVE_HIGH);
+        hal_gpio_set_drive_strength(sclPin_, HAL_GPIO_DRIVE_HIGH);
+        hal_gpio_set_drive_strength(sdaPin_, HAL_GPIO_DRIVE_HIGH);
 
         if (mode == I2C_MODE_MASTER) {
             i2cInitStruct_.I2CMaster  = I2C_MASTER_MODE;
@@ -212,8 +212,8 @@ public:
             // RCC_PeriphClockCmd(APBPeriph_I2C0, APBPeriph_I2C0_CLOCK, DISABLE);
             Pinmux_Config(hal_pin_to_rtl_pin(sdaPin_), PINMUX_FUNCTION_GPIO);
             Pinmux_Config(hal_pin_to_rtl_pin(sclPin_), PINMUX_FUNCTION_GPIO);
-            hal_gpio_configure_drive_strength(sdaPin_, HAL_GPIO_DRIVE_DEFAULT);
-            hal_gpio_configure_drive_strength(sclPin_, HAL_GPIO_DRIVE_DEFAULT);
+            hal_gpio_set_drive_strength(sdaPin_, HAL_GPIO_DRIVE_DEFAULT);
+            hal_gpio_set_drive_strength(sclPin_, HAL_GPIO_DRIVE_DEFAULT);
         }
         return SYSTEM_ERROR_NONE;
     }

--- a/hal/src/rtl872x/i2c_hal.cpp
+++ b/hal/src/rtl872x/i2c_hal.cpp
@@ -102,10 +102,10 @@ public:
             }
             // Configured, but new buffers are smaller
             if (conf->rx_buffer_size <= rxBuffer_.size() ||
-               conf->tx_buffer_size <= txBuffer_.size()) {    
+               conf->tx_buffer_size <= txBuffer_.size()) {
                unlock();
                return SYSTEM_ERROR_NOT_ENOUGH_DATA;
-            } 
+            }
             CHECK(deInit());
         }
         if (isConfigValid(conf)) {
@@ -145,8 +145,11 @@ public:
         // RCC_PeriphClockCmd(APBPeriph_I2C0, APBPeriph_I2C0_CLOCK, ENABLE);
         Pinmux_Config(hal_pin_to_rtl_pin(sdaPin_), PINMUX_FUNCTION_I2C);
 	    Pinmux_Config(hal_pin_to_rtl_pin(sclPin_), PINMUX_FUNCTION_I2C);
-        PAD_PullCtrl(hal_pin_to_rtl_pin(sdaPin_), GPIO_PuPd_UP);               
+        PAD_PullCtrl(hal_pin_to_rtl_pin(sdaPin_), GPIO_PuPd_UP);
 	    PAD_PullCtrl(hal_pin_to_rtl_pin(sclPin_), GPIO_PuPd_UP);
+
+        hal_gpio_configure_drive_strength(sclPin_, HAL_GPIO_DRIVE_HIGH);
+        hal_gpio_configure_drive_strength(sdaPin_, HAL_GPIO_DRIVE_HIGH);
 
         if (mode == I2C_MODE_MASTER) {
             i2cInitStruct_.I2CMaster  = I2C_MASTER_MODE;
@@ -201,7 +204,7 @@ public:
             if (i2cInitStruct_.I2CMaster == I2C_SLAVE_MODE) {
                 InterruptDis(I2C0_IRQ_LP);
 	            InterruptUnRegister(I2C0_IRQ_LP);
-                I2C_INTConfig(i2cDev_, (BIT_IC_INTR_MASK_M_START_DET | BIT_IC_INTR_MASK_M_RX_FULL | BIT_IC_INTR_MASK_M_STOP_DET | 
+                I2C_INTConfig(i2cDev_, (BIT_IC_INTR_MASK_M_START_DET | BIT_IC_INTR_MASK_M_RX_FULL | BIT_IC_INTR_MASK_M_STOP_DET |
                                         BIT_IC_INTR_MASK_M_RD_REQ | BIT_IC_INTR_MASK_M_RX_DONE), DISABLE);
             }
             I2C_Cmd(i2cDev_, DISABLE);
@@ -209,6 +212,8 @@ public:
             // RCC_PeriphClockCmd(APBPeriph_I2C0, APBPeriph_I2C0_CLOCK, DISABLE);
             Pinmux_Config(hal_pin_to_rtl_pin(sdaPin_), PINMUX_FUNCTION_GPIO);
             Pinmux_Config(hal_pin_to_rtl_pin(sclPin_), PINMUX_FUNCTION_GPIO);
+            hal_gpio_configure_drive_strength(sdaPin_, HAL_GPIO_DRIVE_DEFAULT);
+            hal_gpio_configure_drive_strength(sclPin_, HAL_GPIO_DRIVE_DEFAULT);
         }
         return SYSTEM_ERROR_NONE;
     }
@@ -720,7 +725,7 @@ private:
     bool configured_;
     volatile hal_i2c_state_t state_;
     volatile uint8_t slaveStatus_;
-    
+
     particle::services::RingBuffer<uint8_t> txBuffer_;
     particle::services::RingBuffer<uint8_t> rxBuffer_;
     bool heapBuffer_;

--- a/hal/src/rtl872x/pwm_hal.cpp
+++ b/hal/src/rtl872x/pwm_hal.cpp
@@ -24,6 +24,7 @@ extern "C" {
 #endif
 #include <cstring>
 #include "pwm_hal.h"
+#include "gpio_hal.h"
 
 #define RTL_PWM_INSTANCE_NUM        2
 #define KM0_PWM_INSTANCE            0
@@ -170,6 +171,7 @@ int pwmPinInit(uint16_t pin) {
         } else {
             Pinmux_Config(rtlPin, PINMUX_FUNCTION_PWM_HS);
         }
+        hal_gpio_configure_drive_strength(pin, HAL_GPIO_DRIVE_HIGH);
         hal_pin_set_function(pin, PF_PWM);
     }
     return 0;
@@ -184,6 +186,7 @@ int pwmPinDeinit(uint16_t pin) {
     if (channelState == PWM_STATE_ENABLED) {
         const uint32_t rtlPin = hal_pin_to_rtl_pin(pin);
         Pinmux_Config(rtlPin, PINMUX_FUNCTION_GPIO);
+        hal_gpio_configure_drive_strength(pin, HAL_GPIO_DRIVE_DEFAULT);
 
         pwmInfo[instance].channels[channel].state = PWM_STATE_DISABLED;
         hal_pin_set_function(pin, PF_NONE);
@@ -274,7 +277,7 @@ void hal_pwm_update_duty_cycle_ext(uint16_t pin, uint32_t value) {
     if (!isPwmPin(pin)) {
         return;
     }
-    
+
     const hal_pin_info_t* pinInfo = hal_pin_map() + pin;
     const uint8_t instance = pinInfo->pwm_instance;
     const uint32_t channel = pinInfo->pwm_channel;
@@ -360,7 +363,7 @@ void hal_pwm_set_resolution(uint16_t pin, uint8_t resolution) {
     if (!isPwmPin(pin) || resolution > RTL_PWM_TIM_MAX_RESOLUTION || resolution < RTL_PWM_TIM_MIN_RESOLUTION) {
         return;
     }
-    
+
     const hal_pin_info_t* pinInfo = hal_pin_map() + pin;
     const uint8_t instance = pinInfo->pwm_instance;
     uint8_t channel = pinInfo->pwm_channel;

--- a/hal/src/rtl872x/pwm_hal.cpp
+++ b/hal/src/rtl872x/pwm_hal.cpp
@@ -171,7 +171,7 @@ int pwmPinInit(uint16_t pin) {
         } else {
             Pinmux_Config(rtlPin, PINMUX_FUNCTION_PWM_HS);
         }
-        hal_gpio_configure_drive_strength(pin, HAL_GPIO_DRIVE_HIGH);
+        hal_gpio_set_drive_strength(pin, HAL_GPIO_DRIVE_HIGH);
         hal_pin_set_function(pin, PF_PWM);
     }
     return 0;
@@ -186,7 +186,7 @@ int pwmPinDeinit(uint16_t pin) {
     if (channelState == PWM_STATE_ENABLED) {
         const uint32_t rtlPin = hal_pin_to_rtl_pin(pin);
         Pinmux_Config(rtlPin, PINMUX_FUNCTION_GPIO);
-        hal_gpio_configure_drive_strength(pin, HAL_GPIO_DRIVE_DEFAULT);
+        hal_gpio_set_drive_strength(pin, HAL_GPIO_DRIVE_DEFAULT);
 
         pwmInfo[instance].channels[channel].state = PWM_STATE_DISABLED;
         hal_pin_set_function(pin, PF_NONE);

--- a/hal/src/rtl872x/spi_hal.cpp
+++ b/hal/src/rtl872x/spi_hal.cpp
@@ -298,9 +298,9 @@ public:
         }
         SSI_Init(SPI_DEV_TABLE[rtlSpiIndex_].SPIx, &SSI_InitStruct);
 
-        hal_gpio_configure_drive_strength(sclkPin_, HAL_GPIO_DRIVE_HIGH);
-        hal_gpio_configure_drive_strength(mosiPin_, HAL_GPIO_DRIVE_HIGH);
-        hal_gpio_configure_drive_strength(misoPin_, HAL_GPIO_DRIVE_HIGH);
+        hal_gpio_set_drive_strength(sclkPin_, HAL_GPIO_DRIVE_HIGH);
+        hal_gpio_set_drive_strength(mosiPin_, HAL_GPIO_DRIVE_HIGH);
+        hal_gpio_set_drive_strength(misoPin_, HAL_GPIO_DRIVE_HIGH);
 
         uint32_t phase = SCPH_TOGGLES_IN_MIDDLE;
         uint32_t polarity = SCPOL_INACTIVE_IS_LOW;
@@ -403,9 +403,9 @@ public:
         Pinmux_Config(hal_pin_to_rtl_pin(sclkPin_), PINMUX_FUNCTION_GPIO);
         Pinmux_Config(hal_pin_to_rtl_pin(mosiPin_), PINMUX_FUNCTION_GPIO);
         Pinmux_Config(hal_pin_to_rtl_pin(misoPin_), PINMUX_FUNCTION_GPIO);
-        hal_gpio_configure_drive_strength(sclkPin_, HAL_GPIO_DRIVE_DEFAULT);
-        hal_gpio_configure_drive_strength(mosiPin_, HAL_GPIO_DRIVE_DEFAULT);
-        hal_gpio_configure_drive_strength(misoPin_, HAL_GPIO_DRIVE_DEFAULT);
+        hal_gpio_set_drive_strength(sclkPin_, HAL_GPIO_DRIVE_DEFAULT);
+        hal_gpio_set_drive_strength(mosiPin_, HAL_GPIO_DRIVE_DEFAULT);
+        hal_gpio_set_drive_strength(misoPin_, HAL_GPIO_DRIVE_DEFAULT);
 
         // Update state
         status_.state = HAL_SPI_STATE_DISABLED;

--- a/hal/src/rtl872x/spi_hal.cpp
+++ b/hal/src/rtl872x/spi_hal.cpp
@@ -298,6 +298,10 @@ public:
         }
         SSI_Init(SPI_DEV_TABLE[rtlSpiIndex_].SPIx, &SSI_InitStruct);
 
+        hal_gpio_configure_drive_strength(sclkPin_, HAL_GPIO_DRIVE_HIGH);
+        hal_gpio_configure_drive_strength(mosiPin_, HAL_GPIO_DRIVE_HIGH);
+        hal_gpio_configure_drive_strength(misoPin_, HAL_GPIO_DRIVE_HIGH);
+
         uint32_t phase = SCPH_TOGGLES_IN_MIDDLE;
         uint32_t polarity = SCPOL_INACTIVE_IS_LOW;
         spiModeToPolAndPha(config_.dataMode, &polarity, &phase);
@@ -399,6 +403,9 @@ public:
         Pinmux_Config(hal_pin_to_rtl_pin(sclkPin_), PINMUX_FUNCTION_GPIO);
         Pinmux_Config(hal_pin_to_rtl_pin(mosiPin_), PINMUX_FUNCTION_GPIO);
         Pinmux_Config(hal_pin_to_rtl_pin(misoPin_), PINMUX_FUNCTION_GPIO);
+        hal_gpio_configure_drive_strength(sclkPin_, HAL_GPIO_DRIVE_DEFAULT);
+        hal_gpio_configure_drive_strength(mosiPin_, HAL_GPIO_DRIVE_DEFAULT);
+        hal_gpio_configure_drive_strength(misoPin_, HAL_GPIO_DRIVE_DEFAULT);
 
         // Update state
         status_.state = HAL_SPI_STATE_DISABLED;


### PR DESCRIPTION
### Problem

During the EVT test, we observed significant overshoot. This issue occurs on every high-speed bus, including SPI, I2C, PWM, I2S, and DMIC.

### Solution

There are four drive strength can be configured for RTL872x, all the GPIO were configured to `PAD_DRV_STRENGTH_3` at boot.
- PAD_DRV_STRENGTH_0: 4mA
- PAD_DRV_STRENGTH_1: 8mA   (Severe overshoot, not recommended to use it)
- PAD_DRV_STRENGTH_2: 12mA
- PAD_DRV_STRENGTH_3: 16mA  (Severe overshoot, not recommended to use it)

We compared the overshoot issue with each drive strength configuration and found `PAD_DRV_STRENGTH_0` and `PAD_DRV_STRENGTH_2` were better than `PAD_DRV_STRENGTH_1` and `PAD_DRV_STRENGTH_3`

Below is the clock pin of SPI0@50MHz
<img width="755" alt="Screenshot 2023-08-02 at 15 19 33" src="https://github.com/particle-iot/device-os/assets/7424522/f56140b8-118d-48b2-afd3-30ac18d5e8d6">

Selecting PAD_DRV_STRENGTH_2 could be a solution to avoid the overshoot issue while maintaining a high drive strength.

Below, you will find a more detailed comparison between PAD_DRV_STRENGTH_2 and PAD_DRV_STRENGTH_3 across different buses on the Orson platform.

![Screenshot 2023-08-04 at 16 01 42](https://github.com/particle-iot/device-os/assets/7424522/c3b9d7f2-0b08-4e56-b601-1e5d2f3bce1e)

### Steps to Test

- Compare the waveforms of each high-speed bus on P2 or Orson before and after applying the fix.

### References

[CH119867]
[CH119866]
[CH120087]
[CH119868]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
