### PR TITLE
[msom][ci] Build prebootloader, fix macos builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
           platform: << parameters.platform >>
   build-for-darwin:
     macos:
-      xcode: "13.2.1"
+      xcode: "14.2"
     parameters:
       tasks:
         type: string

--- a/build/release.sh
+++ b/build/release.sh
@@ -407,7 +407,7 @@ eval $MAKE_COMMAND
 release_binary "bootloader" "bootloader" "$SUFFIX" "$DEBUG_BUILD" "$USE_SWD_JTAG"
 
 # Prebootloader
-if [ $PLATFORM_ID -eq 28 ] || [ $PLATFORM_ID -eq 32 ]; then
+if [ $PLATFORM_ID -eq 28 ] || [ $PLATFORM_ID -eq 32 ] || [ $PLATFORM_ID -eq 35 ]; then
 cd ../bootloader/prebootloader
 
 COMPILE_LTO="n"


### PR DESCRIPTION
### Problem

1. MSoM platform builds were not building `prebootloader-mbr` and `prebootloader-part1` binaries
2. Macos builds were failing due to deprecation warnings for intel based macos versions

### Solution

1. Add MSoM platform ID to prebootloader build script
2. Update macos xcode circle ci config to last supported version

### Steps to Test

run pipeline

### Example App
build fix only

### References

[Circle CI deprecation notice](https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718)

