### PR TITLE
[rtl872x] remove the delay in UART flush().

### DIFF
--- a/hal/src/rtl872x/usart_hal.cpp
+++ b/hal/src/rtl872x/usart_hal.cpp
@@ -334,7 +334,6 @@ public:
         CHECK_TRUE(isEnabled(), SYSTEM_ERROR_INVALID_STATE);
         while (true) {
             while (transmitting_) {
-                HAL_Delay_Milliseconds(5);
                 // FIXME: busy loop
             }
             {


### PR DESCRIPTION
### Problem

The delay in UART `flush()` may cause user app fail to synchronize with the peer UART device.

The delay actinng as a hacky workaround was introduced in this PR2586: https://github.com/particle-iot/device-os/pull/2586 and may be potentially fixed by another PR2581: https://github.com/particle-iot/device-os/pull/2581

### Solution

Remove the delay. 

### Steps to Test

Re-run the test app that is shown in the PR2586 and it turned out to be working fine after removing the delay, i.e. device can enter sleep as expected and it doesn't leak power in sleep mode.

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
