### PR TITLE
[msom] Fix ethernet cs, reset, interrupt GPIO pins for M2 eval

### DIFF
--- a/hal/src/msom/network/network.cpp
+++ b/hal/src/msom/network/network.cpp
@@ -158,7 +158,7 @@ int if_init_platform(void*) {
     CHECK(hal_get_mac_address(HAL_DEVICE_MAC_ETHERNET, mac, HAL_DEVICE_MAC_ADDR_SIZE, nullptr));
 
     if (HAL_Feature_Get(FEATURE_ETHERNET_DETECTION)) {
-        en2 = new WizNetif(HAL_SPI_INTERFACE1, D5, D3, D4, mac);
+        en2 = new WizNetif(HAL_SPI_INTERFACE1, D8, D28, D22, mac);
     }
 
     uint8_t dummy;


### PR DESCRIPTION
### Problem

GPIO pins for ethernet on msom platform were not updated to match M2 eval board pinout

### Solution

Fix it

### Steps to Test

Enable ethernet feature
```
System.enableFeature(FEATURE_ETHERNET_DETECTION);
```

Reset and try ethernet on M2 eval 

### Example App

Use snippet to print ethernet configuration / state

```c
auto conf = Ethernet.getConfig();
uint8_t ethernet_mac[6] = {};
Ethernet.macAddress(ethernet_mac);
Log.info("MAC: %02X:%02X:%02X:%02X:%02X:%02X",
    ethernet_mac[0],ethernet_mac[1],ethernet_mac[2],
    ethernet_mac[3],ethernet_mac[4],ethernet_mac[5]);


Log.info("localIP: %s", Ethernet.localIP().toString().c_str());
Log.info("DHCP: %s", Ethernet.dhcpServerIP().toString().c_str());
Log.info("Gateway IP: %s", Ethernet.gatewayIP().toString().c_str());
Log.info("Subnet Mask: %s", Ethernet.subnetMask().toString().c_str());


for (const auto& addr: conf.addresses()) {
    Log.info("Addr: %s/%u (%s) - family = %d", addr.address().address().toString().c_str(), (unsigned)addr.prefixLength(), addr.mask().address().toString().c_str(), addr.family());
}
for (const auto& addr: conf.dns()) {
    Log.info("DNS: %s", addr.toString().c_str());
}
Log.info("Gateway: %s", conf.gateway().toString().c_str());
Log.info("Source: %d/%d", (int)conf.source(AF_INET), (int)conf.source(AF_INET6));
```

### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
