### PR TITLE
[services] add long long support to printf/scanf

### DIFF
--- a/build/arm-tools.mk
+++ b/build/arm-tools.mk
@@ -11,7 +11,7 @@ AR = $(GCC_ARM_PATH)$(GCC_PREFIX)gcc-ar
 
 # Newlib has a bug in fake stdin/stdout/stderr implementation and leaks memory
 # Stub printf/fprintf out
-CFLAGS += -fno-builtin-puts -fno-builtin-printf -Wl,--wrap=puts -Wl,--wrap=printf
+CFLAGS += -fno-builtin-puts -fno-builtin-printf -Wl,--wrap=puts -Wl,--wrap=printf -Wl,--wrap=_printf_i -Wl,--wrap=_svfprintf_r
 
 #
 # default flags for targeting ARM Cortex-M3

--- a/build/arm-tools.mk
+++ b/build/arm-tools.mk
@@ -10,8 +10,10 @@ include $(COMMON_BUILD)/common-tools.mk
 AR = $(GCC_ARM_PATH)$(GCC_PREFIX)gcc-ar
 
 # Newlib has a bug in fake stdin/stdout/stderr implementation and leaks memory
-# Stub printf/fprintf out
-CFLAGS += -fno-builtin-puts -fno-builtin-printf -Wl,--wrap=puts -Wl,--wrap=printf -Wl,--wrap=_printf_i -Wl,--wrap=_svfprintf_r
+# Stub printf/fprintf out, override printf/scanf for 64-bit int/unsigned support
+CFLAGS += -fno-builtin-puts -fno-builtin-printf -Wl,--wrap=puts -Wl,--wrap=printf
+CFLAGS += -Wl,--wrap=_printf_i -Wl,--wrap=_svfprintf_r
+CFLAGS += -Wl,--wrap=_scanf_i -Wl,--wrap=__ssvfscanf_r
 
 #
 # default flags for targeting ARM Cortex-M3

--- a/services/src/printf_export.c
+++ b/services/src/printf_export.c
@@ -122,7 +122,7 @@ typedef short *  short_ptr_t;
 /* ifdef _NO_LONGLONG, make QUADINT equivalent to LONGINT, so
    that %lld behaves the same as %ld, not as %d, as expected if:
    sizeof (long long) = sizeof long > sizeof int.  */
-#define QUADINT		0x200
+#define QUADINT	  0x200
 #define FPT		0x400		/* Floating point number.  */
 /* Define as 0, to make SARG and UARG occupy fewer instructions.  */
 # define CHARINT	0
@@ -326,12 +326,13 @@ int __wrap__svfprintf_r (struct _reent *data,
       flag_chars = "hlL";
       if ((cp = memchr (flag_chars, *fmt, 3)) != NULL)
 	{
-	  prt_data.flags |= (SHORTINT << (cp - flag_chars));
-	  fmt++;
+      fmt++;
       // %llu/%lld/%llx etc support
       if (*fmt == 'l' && *cp == 'l') {
         prt_data.flags |= QUADINT;
         fmt++;
+      } else {
+        prt_data.flags |= (SHORTINT << (cp - flag_chars));
       }
 	}
 
@@ -396,7 +397,7 @@ int __wrap__printf_i (struct _reent *data, struct _prt_data_t *pdata, FILE *fp,
     case 'd':
     case 'i':
       _uquad = SARG (pdata->flags);
-      if ((long) _uquad < 0)
+      if ((quad_t)_uquad < 0)
 	{
 	  _uquad = -_uquad;
 	  pdata->l_buf[0] = '-';

--- a/services/src/printf_export.c
+++ b/services/src/printf_export.c
@@ -1,0 +1,522 @@
+/*
+ * Copyright (c) 2023 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platforms.h"
+
+#if PLATFORM_ID != PLATFORM_GCC
+
+#define __MISC_VISIBLE (1)
+#include <sys/types.h>
+#include <string.h>
+#include <malloc.h>
+#include <errno.h>
+#include "printf_export.h"
+
+// Copy of nano-vfprint.c, nano-vfprintf_i.c nano-vfprintf_local.h
+// Original copyright notices:
+
+/*
+ * Copyright (c) 1990 The Regents of the University of California.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * Chris Torek.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*
+ * Copyright (c) 2012-2014 ARM Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the company may not be used to endorse or promote
+ *    products derived from this software without specific prior written
+ *    permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ARM LTD ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ARM LTD BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#define	to_digit(c)	((c) - '0')
+#define is_digit(c)	((unsigned)to_digit (c) <= 9)
+
+extern int _printf_common (struct _reent *data,
+		struct _prt_data_t *pdata,
+		int *realsz,
+		FILE *fp,
+		int (*pfunc)(struct _reent *, FILE *,
+			     const char *, size_t len));
+
+#define quad_t long long
+#define u_quad_t unsigned long long
+typedef quad_t * quad_ptr_t;
+typedef void *void_ptr_t;
+typedef char *   char_ptr_t;
+typedef long *   long_ptr_t;
+typedef int  *   int_ptr_t;
+typedef short *  short_ptr_t;
+
+/* Flags used during conversion.  */
+#define	ALT		0x001		/* Alternate form.  */
+#define	LADJUST		0x002		/* Left adjustment.  */
+#define	ZEROPAD		0x004		/* Zero (as opposed to blank) pad.  */
+#define PLUSSGN		0x008		/* Plus sign flag.  */
+#define SPACESGN	0x010		/* Space flag.  */
+#define	HEXPREFIX	0x020		/* Add 0x or 0X prefix.  */
+#define	SHORTINT	0x040		/* Short integer.  */
+#define	LONGINT		0x080		/* Long integer.  */
+#define	LONGDBL		0x100		/* Long double.  */
+/* ifdef _NO_LONGLONG, make QUADINT equivalent to LONGINT, so
+   that %lld behaves the same as %ld, not as %d, as expected if:
+   sizeof (long long) = sizeof long > sizeof int.  */
+#define QUADINT		0x200
+#define FPT		0x400		/* Floating point number.  */
+/* Define as 0, to make SARG and UARG occupy fewer instructions.  */
+# define CHARINT	0
+
+/* Macros to support positional arguments.  */
+#define GET_ARG(n, ap, type) (va_arg ((ap), type))
+
+/* To extend shorts properly, we need both signed and unsigned
+   argument extraction methods.  Also they should be used in nano-vfprintf_i.c
+   and nano-vfprintf_float.c only, since ap is a pointer to va_list.  */
+#define	SARG(flags) \
+	(flags&QUADINT ? GET_ARG (N, (*ap), long long) : \
+       flags&LONGINT ? GET_ARG (N, (*ap), long) : \
+	    flags&SHORTINT ? (long)(short)GET_ARG (N, (*ap), int) : \
+	    flags&CHARINT ? (long)(signed char)GET_ARG (N, (*ap), int) : \
+	    (long)GET_ARG (N, (*ap), int))
+#define	UARG(flags) \
+	(flags&QUADINT ? GET_ARG (N, (*ap), unsigned long long) : \
+       flags&LONGINT ? GET_ARG (N, (*ap), u_long) : \
+	    flags&SHORTINT ? (u_long)(u_short)GET_ARG (N, (*ap), int) : \
+	    flags&CHARINT ? (u_long)(unsigned char)GET_ARG (N, (*ap), int) : \
+	    (u_long)GET_ARG (N, (*ap), u_int))
+
+/* BEWARE, these `goto error' on error. And they are used
+   in more than one functions.
+
+   Following macros are each referred about twice in printf for integer,
+   so it is not worth to rewrite them into functions. This situation may
+   change in the future.  */
+#define PRINT(ptr, len) {		\
+	if (pfunc (data, fp, (ptr), (len)) == EOF) \
+		goto error;		\
+}
+
+#define PAD(howmany, ch) {             \
+       int temp_i = 0;                 \
+       while (temp_i < (howmany))      \
+       {                               \
+               if (pfunc (data, fp, &(ch), 1) == EOF) \
+                       goto error;     \
+               temp_i++;               \
+       }			       \
+}
+
+#define STRING_ONLY
+
+#ifdef STRING_ONLY
+# define __SPRINT __ssputs_r
+extern int __ssputs_r (struct _reent *, FILE *, const char *, size_t);
+#else
+# define __SPRINT __sfputs_r
+#endif
+
+/* Do not need FLUSH for all sprintf functions.  */
+#ifdef STRING_ONLY
+# define FLUSH()
+#else
+# define FLUSH()
+#endif
+
+int __wrap__svfprintf_r (struct _reent *data,
+       FILE * fp,
+       const char *fmt0,
+       va_list ap)
+{
+  register char *fmt;	/* Format string.  */
+  register int n, m;	/* Handy integers (short term usage).  */
+  register char *cp;	/* Handy char pointer (short term usage).  */
+  const char *flag_chars;
+  struct _prt_data_t prt_data;	/* All data for decoding format string.  */
+  va_list ap_copy;
+
+  /* Output function pointer.  */
+  int (*pfunc)(struct _reent *, FILE *, const char *, size_t len);
+
+  pfunc = __SPRINT;
+
+#ifndef STRING_ONLY
+  /* Initialize std streams if not dealing with sprintf family.  */
+  CHECK_INIT (data, fp);
+  _newlib_flockfile_start (fp);
+
+  /* Sorry, fprintf(read_only_file, "") returns EOF, not 0.  */
+  if (cantwrite (data, fp))
+    {
+      _newlib_flockfile_exit (fp);
+      return (EOF);
+    }
+
+#else
+  /* Create initial buffer if we are called by asprintf family.  */
+  if (fp->_flags & __SMBF && !fp->_bf._base)
+    {
+      fp->_bf._base = fp->_p = _malloc_r (data, 64);
+      if (!fp->_p)
+	{
+	  data->_errno = ENOMEM;
+	  return EOF;
+	}
+      fp->_bf._size = 64;
+    }
+#endif
+
+  fmt = (char *)fmt0;
+  prt_data.ret = 0;
+  prt_data.blank = ' ';
+  prt_data.zero = '0';
+
+  /* GCC PR 14577 at https://gcc.gnu.org/bugzilla/show_bug.cgi?id=14557 */
+  va_copy (ap_copy, ap);
+
+  /* Scan the format for conversions (`%' character).  */
+  for (;;)
+    {
+      cp = fmt;
+      while (*fmt != '\0' && *fmt != '%')
+	fmt += 1;
+
+      if ((m = fmt - cp) != 0)
+	{
+	  PRINT (cp, m);
+	  prt_data.ret += m;
+	}
+      if (*fmt == '\0')
+	goto done;
+
+      fmt++;		/* Skip over '%'.  */
+
+      prt_data.flags = 0;
+      prt_data.width = 0;
+      prt_data.prec = -1;
+      prt_data.dprec = 0;
+      prt_data.l_buf[0] = '\0';
+#ifdef FLOATING_POINT
+      prt_data.lead = 0;
+#endif
+      /* The flags.  */
+      /*
+       * ``Note that 0 is taken as a flag, not as the
+       * beginning of a field width.''
+       *	-- ANSI X3J11
+       */
+      flag_chars = "#-0+ ";
+      for (; (cp = memchr (flag_chars, *fmt, 5)); fmt++)
+	prt_data.flags |= (1 << (cp - flag_chars));
+
+      if (prt_data.flags & SPACESGN)
+	prt_data.l_buf[0] = ' ';
+
+      /*
+       * ``If the space and + flags both appear, the space
+       * flag will be ignored.''
+       *	-- ANSI X3J11
+       */
+      if (prt_data.flags & PLUSSGN)
+	prt_data.l_buf[0] = '+';
+
+      /* The width.  */
+      if (*fmt == '*')
+	{
+	  /*
+	   * ``A negative field width argument is taken as a
+	   * - flag followed by a positive field width.''
+	   *	-- ANSI X3J11
+	   * They don't exclude field widths read from args.
+	   */
+	  prt_data.width = GET_ARG (n, ap_copy, int);
+	  if (prt_data.width < 0)
+	    {
+	      prt_data.width = -prt_data.width;
+	      prt_data.flags |= LADJUST;
+	    }
+	  fmt++;
+	}
+      else
+        {
+	  for (; is_digit (*fmt); fmt++)
+	    prt_data.width = 10 * prt_data.width + to_digit (*fmt);
+	}
+
+      /* The precision.  */
+      if (*fmt == '.')
+	{
+	  fmt++;
+	  if (*fmt == '*')
+	    {
+	      fmt++;
+	      prt_data.prec = GET_ARG (n, ap_copy, int);
+	      if (prt_data.prec < 0)
+		prt_data.prec = -1;
+	    }
+	  else
+	    {
+	      prt_data.prec = 0;
+	      for (; is_digit (*fmt); fmt++)
+		prt_data.prec = 10 * prt_data.prec + to_digit (*fmt);
+	    }
+	}
+
+      /* The length modifiers.  */
+      flag_chars = "hlL";
+      if ((cp = memchr (flag_chars, *fmt, 3)) != NULL)
+	{
+	  prt_data.flags |= (SHORTINT << (cp - flag_chars));
+	  fmt++;
+      // %llu/%lld/%llx etc support
+      if (*fmt == 'l' && *cp == 'l') {
+        prt_data.flags |= QUADINT;
+        fmt++;
+      }
+	}
+
+      /* The conversion specifiers.  */
+      prt_data.code = *fmt++;
+      cp = memchr ("efgEFG", prt_data.code, 6);
+#ifdef FLOATING_POINT
+      /* If cp is not NULL, we are facing FLOATING POINT NUMBER.  */
+      if (cp)
+	{
+	  /* Consume floating point argument if _printf_float is not
+	     linked.  */
+	  if (_printf_float == NULL)
+	    {
+	      if (prt_data.flags & LONGDBL)
+		GET_ARG (N, ap_copy, _LONG_DOUBLE);
+	      else
+		GET_ARG (N, ap_copy, double);
+	    }
+	  else
+            n = _printf_float (data, &prt_data, fp, pfunc, &ap_copy);
+	}
+      else
+#endif
+	n = _printf_i (data, &prt_data, fp, pfunc, &ap_copy);
+
+      if (n == -1)
+	goto error;
+
+      prt_data.ret += n;
+    }
+done:
+  FLUSH ();
+error:
+#ifndef STRING_ONLY
+  _newlib_flockfile_end (fp);
+#endif
+  va_end (ap_copy);
+  return (__sferror (fp) ? EOF : prt_data.ret);
+}
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+int __wrap__printf_i (struct _reent *data, struct _prt_data_t *pdata, FILE *fp,
+	   int (*pfunc)(struct _reent *, FILE *, const char *, size_t len),
+	   va_list *ap) {
+  /* Field size expanded by dprec.  */
+  int realsz;
+  u_quad_t _uquad;
+  int base;
+  int n;
+  char *cp = pdata->buf + BUF;
+  char *xdigs = "0123456789ABCDEF";
+
+  /* Decoding the conversion specifier.  */
+  switch (pdata->code)
+    {
+    case 'c':
+      *--cp = GET_ARG (N, *ap, int);
+      pdata->size = 1;
+      goto non_number_nosign;
+    case 'd':
+    case 'i':
+      _uquad = SARG (pdata->flags);
+      if ((long) _uquad < 0)
+	{
+	  _uquad = -_uquad;
+	  pdata->l_buf[0] = '-';
+	}
+      base = 10;
+      goto number;
+    case 'u':
+    case 'o':
+      _uquad = UARG (pdata->flags);
+      base = (pdata->code == 'o') ? 8 : 10;
+      goto nosign;
+    case 'X':
+      pdata->l_buf[2] = 'X';
+      goto hex;
+    case 'p':
+      /*
+       * ``The argument shall be a pointer to void.  The
+       * value of the pointer is converted to a sequence
+       * of printable characters, in an implementation-
+       * defined manner.''
+       *	-- ANSI X3J11
+       */
+      pdata->flags |= HEXPREFIX;
+      if (sizeof (void*) > sizeof (int))
+	pdata->flags |= LONGINT;
+      /* NOSTRICT.  */
+    case 'x':
+      pdata->l_buf[2] = 'x';
+      xdigs = "0123456789abcdef";
+hex:
+      _uquad = UARG (pdata->flags);
+      base = 16;
+      if (pdata->flags & ALT)
+	pdata->flags |= HEXPREFIX;
+
+      /* Leading 0x/X only if non-zero.  */
+      if (_uquad == 0)
+	pdata->flags &= ~HEXPREFIX;
+
+      /* Unsigned conversions.  */
+nosign:
+      pdata->l_buf[0] = '\0';
+      /*
+       * ``... diouXx conversions ... if a precision is
+       * specified, the 0 flag will be ignored.''
+       *	-- ANSI X3J11
+       */
+number:
+      if ((pdata->dprec = pdata->prec) >= 0)
+	pdata->flags &= ~ZEROPAD;
+
+      /*
+       * ``The result of converting a zero value with an
+       * explicit precision of zero is no characters.''
+       *	-- ANSI X3J11
+       */
+      if (_uquad != 0 || pdata->prec != 0)
+	{
+	  do
+	    {
+	      *--cp = xdigs[_uquad % base];
+	      _uquad /= base;
+	    }
+	  while (_uquad);
+	}
+      /* For 'o' conversion, '#' increases the precision to force the first
+	 digit of the result to be zero.  */
+      if (base == 8 && (pdata->flags & ALT) && pdata->prec <= pdata->size)
+	*--cp = '0';
+
+      pdata->size = pdata->buf + BUF - cp;
+      break;
+    case 'n':
+      if (pdata->flags & LONGINT)
+	*GET_ARG (N, *ap, long_ptr_t) = pdata->ret;
+      else if (pdata->flags & SHORTINT)
+	*GET_ARG (N, *ap, short_ptr_t) = pdata->ret;
+      else
+	*GET_ARG (N, *ap, int_ptr_t) = pdata->ret;
+    case '\0':
+      pdata->size = 0;
+      break;
+    case 's':
+      cp = GET_ARG (N, *ap, char_ptr_t);
+      /* Precision gives the maximum number of chars to be written from a
+	 string, and take prec == -1 into consideration.
+	 Use normal Newlib approach here to support case where cp is not
+	 nul-terminated.  */
+      char *p = memchr (cp, 0, pdata->prec);
+
+      if (p != NULL)
+	pdata->prec = p - cp;
+
+      pdata->size = pdata->prec;
+      goto non_number_nosign;
+    default:
+      /* "%?" prints ?, unless ? is NUL.  */
+      /* Pretend it was %c with argument ch.  */
+      *--cp = pdata->code;
+      pdata->size = 1;
+non_number_nosign:
+      pdata->l_buf[0] = '\0';
+      break;
+    }
+
+    /* Output.  */
+    n = _printf_common (data, pdata, &realsz, fp, pfunc);
+    if (n == -1)
+      goto error;
+
+    PRINT (cp, pdata->size);
+    /* Left-adjusting padding (always blank).  */
+    if (pdata->flags & LADJUST)
+      PAD (pdata->width - realsz, pdata->blank);
+
+    return (pdata->width > realsz ? pdata->width : realsz);
+error:
+    return -1;
+}
+
+#pragma GCC diagnostic pop
+
+#endif // PLATFORM_ID != PLATFORM_GCC

--- a/services/src/scanf_export.c
+++ b/services/src/scanf_export.c
@@ -1,0 +1,607 @@
+/*
+ * Copyright (c) 2023 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "platforms.h"
+
+#if PLATFORM_ID != PLATFORM_GCC
+
+#define __MISC_VISIBLE (1)
+#include <sys/types.h>
+#include <string.h>
+#include <malloc.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <limits.h>
+#include <ctype.h>
+#include <stdlib.h>
+
+// Copy of nano-vfscanf.c, nano-vfscanf_i.c nano-vfscanf_local.h
+// Original copyright notices:
+
+/*
+ * Copyright (c) 1990 The Regents of the University of California.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * Chris Torek.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*
+ * Copyright (c) 2012-2014 ARM Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the company may not be used to endorse or promote
+ *    products derived from this software without specific prior written
+ *    permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ARM LTD ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ARM LTD BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define STRING_ONLY
+
+#ifndef NO_FLOATING_POINT
+#define FLOATING_POINT
+#endif
+
+extern int
+_sungetc_r (struct _reent *data,
+	int c,
+	register FILE *fp);
+
+extern int
+__ssrefill_r (struct _reent * ptr,
+       register FILE * fp);
+
+#ifdef STRING_ONLY
+#undef _newlib_flockfile_start
+#undef _newlib_flockfile_exit
+#undef _newlib_flockfile_end
+#define _newlib_flockfile_start(x) {}
+#define _newlib_flockfile_exit(x) {}
+#define _newlib_flockfile_end(x) {}
+#define _ungetc_r _sungetc_r
+#define __srefill_r __ssrefill_r
+#endif
+
+#ifdef FLOATING_POINT
+#include <math.h>
+#include <float.h>
+
+/* Currently a test is made to see if long double processing is warranted.
+   This could be changed in the future should the _ldtoa_r code be
+   preferred over _dtoa_r.  */
+#define _NO_LONGDBL
+
+#ifdef _NO_LONGDBL
+/* 11-bit exponent (VAX G floating point) is 308 decimal digits */
+#define	MAXEXP		308
+#else  /* !_NO_LONGDBL */
+/* 15-bit exponent (Intel extended floating point) is 4932 decimal digits */
+#define MAXEXP          4932
+#endif /* !_NO_LONGDBL */
+/* 128 bit fraction takes up 39 decimal digits; max reasonable precision */
+#define	MAXFRACT	39
+
+#if ((MAXEXP+MAXFRACT+3) > MB_LEN_MAX)
+/* "3 = sign + decimal point + NUL".  */
+# define BUF (MAXEXP+MAXFRACT+3)
+#else
+# define BUF MB_LEN_MAX
+#endif
+
+/* An upper bound for how long a long prints in decimal.  4 / 13 approximates
+   log (2).  Add one char for roundoff compensation and one for the sign.  */
+#define MAX_LONG_LEN ((CHAR_BIT * sizeof (long)  - 1) * 4 / 13 + 2)
+#else
+#define	BUF	40
+#endif
+
+
+#define _NO_LONGLONG
+#undef _WANT_IO_C99_FORMATS
+#undef _WANT_IO_POS_ARGS
+
+#define _NO_POS_ARGS
+
+/* Macros for converting digits to letters and vice versa.  */
+#define	to_digit(c)	((c) - '0')
+#define is_digit(c)	((unsigned)to_digit (c) <= 9)
+#define	to_char(n)	((n) + '0')
+
+/*
+ * Flags used during conversion.
+ */
+
+#define	SHORT		0x01	/* "h": short.  */
+#define	LONG		0x02	/* "l": long or double.  */
+#define	LONGDBL		0x04	/* "L/ll": long double or long long.  */
+#define CHAR		0x08	/* "hh": 8 bit integer.  */
+#define	SUPPRESS	0x10	/* Suppress assignment.  */
+#define	POINTER		0x20	/* Weird %p pointer (`fake hex').  */
+#define	NOSKIP		0x40	/* Do not skip blanks */
+
+/* The following are used in numeric conversions only:
+   SIGNOK, NDIGITS, DPTOK, and EXPOK are for floating point;
+   SIGNOK, NDIGITS, PFXOK, and NZDIGITS are for integral.  */
+
+#define	SIGNOK		0x80	/* "+/-" is (still) legal.  */
+#define	NDIGITS		0x100	/* No digits detected.  */
+
+#define	DPTOK		0x200	/* (Float) decimal point is still legal.  */
+#define	EXPOK		0x400	/* (Float) exponent (e+3, etc) still legal.  */
+
+#define	PFXOK		0x200	/* "0x" prefix is (still) legal.  */
+#define	NZDIGITS	0x400	/* No zero digits detected.  */
+#define	NNZDIGITS	0x800	/* No non-zero digits detected.  */
+
+/* Conversion types.  */
+
+#define	CT_CHAR		0	/* "%c" conversion.  */
+#define	CT_CCL		1	/* "%[...]" conversion.  */
+#define	CT_STRING	2	/* "%s" conversion.  */
+#define	CT_INT		3	/* Integer, i.e., strtol.  */
+#define	CT_UINT		4	/* Unsigned integer, i.e., strtoul.  */
+#define	CT_FLOAT	5	/* Floating, i.e., strtod.  */
+
+#define u_char unsigned char
+#define u_long unsigned long
+#define u_quad unsigned long long
+
+extern u_char *__sccl (char *, u_char *fmt);
+
+/* Macro to support positional arguments.  */
+#define GET_ARG(n, ap, type) (va_arg ((ap), type))
+
+#define MATCH_FAILURE	1
+#define INPUT_FAILURE	2
+
+
+/* All data needed to decode format string are kept in below struct.  */
+struct _scan_data_t
+{
+  int flags;            /* Flags.  */
+  int base;             /* Base.  */
+  size_t width;         /* Width.  */
+  int nassigned;        /* Number of assignments so far.  */
+  int nread;            /* Number of chars read so far.  */
+  char *ccltab;         /* Table used for [ format.  */
+  int code;             /* Current conversion specifier.  */
+  char buf[BUF];        /* Internal buffer for scan.  */
+  /* Internal buffer for scan.  */
+  int (*pfn_ungetc)(struct _reent*, int, FILE*);
+  /* Internal buffer for scan.  */
+  int (*pfn_refill)(struct _reent*, FILE*);
+};
+
+extern int
+_scanf_chars (struct _reent *rptr,
+	      struct _scan_data_t *pdata,
+	      FILE *fp, va_list *ap);
+
+extern int
+_scanf_i (struct _reent *rptr,
+	  struct _scan_data_t *pdata,
+	  FILE *fp, va_list *ap);
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+
+extern int
+_scanf_float (struct _reent *rptr,
+	      struct _scan_data_t *pdata,
+	      FILE *fp, va_list *ap) _ATTRIBUTE((__weak__));
+
+
+int
+__wrap___ssvfscanf_r (struct _reent *rptr,
+       register FILE *fp,
+       char const *fmt0,
+       va_list ap)
+{
+  register u_char *fmt = (u_char *) fmt0;
+  register int c;		/* Character from format, or conversion.  */
+  register char *p;		/* Points into all kinds of strings.  */
+  char ccltab[256];		/* Character class table for %[...].  */
+  va_list ap_copy;
+
+  int ret;
+  char *cp;
+
+  struct _scan_data_t scan_data;
+
+  _newlib_flockfile_start (fp);
+
+  scan_data.nassigned = 0;
+  scan_data.nread = 0;
+  scan_data.ccltab = ccltab;
+  scan_data.pfn_ungetc = _ungetc_r;
+  scan_data.pfn_refill = __srefill_r;
+
+  /* GCC PR 14577 at https://gcc.gnu.org/bugzilla/show_bug.cgi?id=14557 */
+  va_copy (ap_copy, ap);
+
+  for (;;)
+    {
+      if (*fmt == 0)
+	goto all_done;
+
+      if (isspace (*fmt))
+	{
+	  while ((fp->_r > 0 || !scan_data.pfn_refill(rptr, fp))
+		 && isspace (*fp->_p))
+	    {
+	      scan_data.nread++;
+	      fp->_r--;
+	      fp->_p++;
+	    }
+	  fmt++;
+	  continue;
+	}
+      if ((c = *fmt++) != '%')
+	goto literal;
+
+      scan_data.width = 0;
+      scan_data.flags = 0;
+
+      if (*fmt == '*')
+	{
+	  scan_data.flags |= SUPPRESS;
+	  fmt++;
+	}
+
+      for (; is_digit (*fmt); fmt++)
+	scan_data.width = 10 * scan_data.width + to_digit (*fmt);
+
+      /* The length modifiers.  */
+      p = "hlL";
+      if ((cp = memchr (p, *fmt, 3)) != NULL) {
+	    fmt++;
+        if (*cp == 'l' && *fmt == 'l') {
+            scan_data.flags |= LONGDBL;
+            fmt++;
+        } else {
+            scan_data.flags |= (SHORT << (cp - p));
+        }
+      }
+
+      /* Switch on the format.  continue if done; break once format
+	 type is derived.  */
+      c = *fmt++;
+      switch (c)
+	{
+	case '%':
+	literal:
+	  if ((fp->_r <= 0 && scan_data.pfn_refill(rptr, fp)))
+	    goto input_failure;
+	  if (*fp->_p != c)
+	    goto match_failure;
+	  fp->_r--, fp->_p++;
+	  scan_data.nread++;
+	  continue;
+
+	case 'p':
+	  scan_data.flags |= POINTER;
+	case 'x':
+	case 'X':
+	  scan_data.flags |= PFXOK;
+	  scan_data.base = 16;
+	  goto number;
+	case 'd':
+	case 'u':
+	  scan_data.base = 10;
+	  goto number;
+	case 'i':
+	  scan_data.base = 0;
+	  goto number;
+	case 'o':
+	  scan_data.base = 8;
+	number:
+	  scan_data.code = (tolower(c) < 'o') ? CT_INT : CT_UINT;
+	  break;
+
+	case '[':
+	  fmt = (u_char *) __sccl (ccltab, (unsigned char *) fmt);
+	  scan_data.flags |= NOSKIP;
+	  scan_data.code = CT_CCL;
+	  break;
+	case 'c':
+	  scan_data.flags |= NOSKIP;
+	  scan_data.code = CT_CHAR;
+	  break;
+	case 's':
+	  scan_data.code = CT_STRING;
+	  break;
+
+	case 'n':
+	  if (scan_data.flags & SUPPRESS)	/* ???  */
+	    continue;
+
+	  if (scan_data.flags & SHORT)
+	    *GET_ARG (N, ap_copy, short *) = scan_data.nread;
+	  else if (scan_data.flags & LONG)
+	    *GET_ARG (N, ap_copy, long *) = scan_data.nread;
+      else if (scan_data.flags & LONGDBL)
+        *GET_ARG (N, ap_copy, long long*) = scan_data.nread;
+	  else
+	    *GET_ARG (N, ap_copy, int *) = scan_data.nread;
+
+	  continue;
+
+	/* Disgusting backwards compatibility hacks.	XXX.  */
+	case '\0':		/* compat.  */
+	  _newlib_flockfile_exit (fp);
+	  va_end (ap_copy);
+	  return EOF;
+
+#ifdef FLOATING_POINT
+	case 'e': case 'E':
+	case 'f': case 'F':
+	case 'g': case 'G':
+	  scan_data.code = CT_FLOAT;
+	  break;
+#endif
+	default:		/* compat.  */
+	  scan_data.code = CT_INT;
+	  scan_data.base = 10;
+	  break;
+	}
+
+      /* We have a conversion that requires input.  */
+      if ((fp->_r <= 0 && scan_data.pfn_refill (rptr, fp)))
+	goto input_failure;
+
+      /* Consume leading white space, except for formats that
+	 suppress this.  */
+      if ((scan_data.flags & NOSKIP) == 0)
+	{
+	  while (isspace (*fp->_p))
+	    {
+	      scan_data.nread++;
+	      if (--fp->_r > 0)
+		fp->_p++;
+	      else if (scan_data.pfn_refill (rptr, fp))
+		goto input_failure;
+	    }
+	  /* Note that there is at least one character in the
+	     buffer, so conversions that do not set NOSKIP ca
+	     no longer result in an input failure.  */
+	}
+      ret = 0;
+      if (scan_data.code < CT_INT)
+	ret = _scanf_chars (rptr, &scan_data, fp, &ap_copy);
+      else if (scan_data.code < CT_FLOAT)
+	ret = _scanf_i (rptr, &scan_data, fp, &ap_copy);
+#ifdef FLOATING_POINT
+      else if (_scanf_float)
+	ret = _scanf_float (rptr, &scan_data, fp, &ap_copy);
+#endif
+
+      if (ret == MATCH_FAILURE)
+	goto match_failure;
+      else if (ret == INPUT_FAILURE)
+	goto input_failure;
+    }
+input_failure:
+  /* On read failure, return EOF failure regardless of matches; errno
+     should have been set prior to here.  On EOF failure (including
+     invalid format string), return EOF if no matches yet, else number
+     of matches made prior to failure.  */
+  _newlib_flockfile_exit (fp);
+  va_end (ap_copy);
+  return scan_data.nassigned && !(fp->_flags & __SERR) ? scan_data.nassigned
+						       : EOF;
+match_failure:
+all_done:
+  /* Return number of matches, which can be 0 on match failure.  */
+  _newlib_flockfile_end (fp);
+  va_end (ap_copy);
+  return scan_data.nassigned;
+}
+
+int
+__wrap__scanf_i (struct _reent *rptr,
+	  struct _scan_data_t *pdata,
+	  FILE *fp, va_list *ap)
+{
+#define CCFN_PARAMS	(struct _reent *, const char *, char **, int)
+  /* Conversion function (strtol/strtoul).  */
+  u_long (*ccfn)CCFN_PARAMS=0;
+  u_quad (*ccfnq)CCFN_PARAMS=0;
+  char *p;
+  int n;
+  char *xdigits = "A-Fa-f8901234567]";
+  char *prefix_chars[3] = {"+-", "00", "xX"};
+
+  /* Scan an integer as if by strtol/strtoul.  */
+  unsigned width_left = 0;
+  int skips = 0;
+
+  ccfn = (pdata->code == CT_INT) ? (u_long (*)CCFN_PARAMS)_strtol_r : _strtoul_r;
+  ccfnq = (pdata->code == CT_INT) ? (u_quad (*)CCFN_PARAMS)_strtoll_r : _strtoull_r;
+#ifdef hardway
+  if (pdata->width == 0 || pdata->width > BUF - 1)
+#else
+  /* size_t is unsigned, hence this optimisation.  */
+  if (pdata->width - 1 > BUF - 2)
+#endif
+    {
+      width_left = pdata->width - (BUF - 1);
+      pdata->width = BUF - 1;
+    }
+  p = pdata->buf;
+  pdata->flags |= NDIGITS | NZDIGITS | NNZDIGITS;
+
+  /* Process [sign] [0] [xX] prefixes sequently.  */
+  for (n = 0; n < 3; n++)
+    {
+      if (!memchr (prefix_chars[n], *fp->_p, 2))
+	continue;
+
+      if (n == 1)
+	{
+	  if (pdata->base == 0)
+	    {
+	      pdata->base = 8;
+	      pdata->flags |= PFXOK;
+	    }
+	  pdata->flags &= ~(NZDIGITS | NDIGITS);
+	}
+      else if (n == 2)
+	{
+	  if ((pdata->flags & (PFXOK | NZDIGITS)) != PFXOK)
+	    continue;
+	  pdata->base = 16;
+
+	  /* We must reset the NZDIGITS and NDIGITS
+	     flags that would have been unset by seeing
+	     the zero that preceded the X or x.
+
+	     ??? It seems unnecessary to reset the NZDIGITS.  */
+	  pdata->flags |= NDIGITS;
+	}
+      if (pdata->width-- > 0)
+	{
+	  *p++ = *fp->_p++;
+	  fp->_r--;
+	  if ((fp->_r <= 0 && pdata->pfn_refill (rptr, fp)))
+	    goto match_end;
+	}
+    }
+
+  if (pdata->base == 0)
+    pdata->base = 10;
+
+  /* The check is un-necessary if xdigits points to exactly the string:
+     "A-Fa-f8901234567]".  The code is kept only for reading's sake.  */
+#if 0
+  if (pdata->base != 16)
+#endif
+  xdigits = xdigits + 16 - pdata->base;
+
+  /* Initilize ccltab according to pdata->base.  */
+  __sccl (pdata->ccltab, (unsigned char *) xdigits);
+  for (; pdata->width; pdata->width--)
+    {
+      n = *fp->_p;
+      if (pdata->ccltab[n] == 0)
+	break;
+      else if (n == '0' && (pdata->flags & NNZDIGITS))
+	{
+	  ++skips;
+	  if (width_left)
+	    {
+	      width_left--;
+	      pdata->width++;
+	    }
+	  goto skip;
+	}
+      pdata->flags &= ~(NDIGITS | NNZDIGITS);
+      /* Char is legal: store it and look at the next.  */
+      *p++ = *fp->_p;
+skip:
+      if (--fp->_r > 0)
+	fp->_p++;
+      else if (pdata->pfn_refill (rptr, fp))
+	/* "EOF".  */
+	break;
+    }
+  /* If we had only a sign, it is no good; push back the sign.
+     If the number ends in `x', it was [sign] '0' 'x', so push back
+     the x and treat it as [sign] '0'.
+     Use of ungetc here and below assumes ASCII encoding; we are only
+     pushing back 7-bit characters, so casting to unsigned char is
+     not necessary.  */
+match_end:
+  if (pdata->flags & NDIGITS)
+    {
+      if (p > pdata->buf)
+	pdata->pfn_ungetc (rptr, *--p, fp); /* "[-+xX]".  */
+
+      if (p == pdata->buf)
+	return MATCH_FAILURE;
+    }
+  if ((pdata->flags & SUPPRESS) == 0)
+    {
+      u_quad ul;
+      *p = 0;
+      if (!(pdata->flags & LONGDBL)) {
+        ul = (*ccfn) (rptr, pdata->buf, (char **) NULL, pdata->base);
+      } else {
+        ul = (*ccfnq) (rptr, pdata->buf, (char **) NULL, pdata->base);
+      }
+      if (pdata->flags & POINTER)
+	*GET_ARG (N, *ap, void **) = (void *) (uintptr_t) ul;
+      else if (pdata->flags & SHORT)
+	*GET_ARG (N, *ap, short *) = ul;
+      else if (pdata->flags & LONG)
+	*GET_ARG (N, *ap, long *) = ul;
+      else if (pdata->flags & LONGDBL)
+    *GET_ARG (N, *ap, long long*) = ul;
+      else
+	*GET_ARG (N, *ap, int *) = ul;
+      
+      pdata->nassigned++;
+    }
+  pdata->nread += p - pdata->buf + skips;
+  return 0;
+}
+
+#pragma GCC diagnostic pop
+
+#endif // PLATFORM_ID != PLATFORM_GCC

--- a/user/tests/integration/wiring/strformat
+++ b/user/tests/integration/wiring/strformat
@@ -1,0 +1,1 @@
+../../wiring/strformat

--- a/user/tests/wiring/strformat/application.cpp
+++ b/user/tests/wiring/strformat/application.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef PARTICLE_TEST_RUNNER
+
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+SYSTEM_MODE(SEMI_AUTOMATIC);
+
+// make clean all TEST=wiring/network_config PLATFORM=boron -s COMPILE_LTO=n program-dfu DEBUG_BUILD=y
+// make clean all TEST=wiring/network_config PLATFORM=boron -s COMPILE_LTO=n program-dfu DEBUG_BUILD=y USE_THREADING=y
+//
+// Serial1LogHandler logHandler(115200, LOG_LEVEL_ALL, {
+//     { "comm", LOG_LEVEL_NONE }, // filter out comm messages
+//     { "system", LOG_LEVEL_INFO } // only info level for system messages
+// });
+
+UNIT_TEST_APP();
+
+// Enable threading if compiled with "USE_THREADING=y"
+#if PLATFORM_THREADING == 1 && USE_THREADING == 1
+SYSTEM_THREAD(ENABLED);
+#endif
+
+#endif // PARTICLE_TEST_RUNNER

--- a/user/tests/wiring/strformat/printf_scanf.cpp
+++ b/user/tests/wiring/strformat/printf_scanf.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+namespace {
+
+template <typename T>
+struct FormatTest {
+    const char* fmt;
+    T value;
+    const char* expected;
+};
+
+} // anonymous
+
+test(STRFORMAT_01_PRINTF_SCANF_INT_UINT) {
+    constexpr FormatTest<uint64_t> u64Test[] = {
+        {"%llu", UINT64_MAX, "18446744073709551615"},
+        {"%llx", UINT64_MAX, "ffffffffffffffff"},
+        {"%llX", UINT64_MAX, "FFFFFFFFFFFFFFFF"},
+        {"%" PRIu64, UINT64_MAX, "18446744073709551615"},
+        {"%" PRIx64, UINT64_MAX, "ffffffffffffffff"},
+        {"%" PRIX64, UINT64_MAX, "FFFFFFFFFFFFFFFF"},
+        {nullptr, 0, nullptr}
+    };
+
+    constexpr FormatTest<uint32_t> u32Test[] = {
+        {"%lu", UINT32_MAX, "4294967295"},
+        {"%lx", UINT32_MAX, "ffffffff"},
+        {"%lX", UINT32_MAX, "FFFFFFFF"},
+        {"%u", UINT32_MAX, "4294967295"},
+        {"%x", UINT32_MAX, "ffffffff"},
+        {"%X", UINT32_MAX, "FFFFFFFF"},
+        {"%" PRIu32, UINT32_MAX, "4294967295"},
+        {"%" PRIx32, UINT32_MAX, "ffffffff"},
+        {"%" PRIX32, UINT32_MAX, "FFFFFFFF"},
+        {nullptr, 0, nullptr}
+    };
+
+    constexpr FormatTest<uint16_t> u16Test[] = {
+        {"%hu", UINT16_MAX, "65535"},
+        {"%hx", UINT16_MAX, "ffff"},
+        {"%hX", UINT16_MAX, "FFFF"},
+        {"%" PRIu16, UINT16_MAX, "65535"},
+        {"%" PRIx16, UINT16_MAX, "ffff"},
+        {"%" PRIX16, UINT16_MAX, "FFFF"},
+        {nullptr, 0, nullptr}
+    };
+
+    constexpr FormatTest<int64_t> i64Test[] = {
+        {"%lld", INT64_MAX, "9223372036854775807"},
+        {"%lld", INT64_MIN, "-9223372036854775808"},
+        {"%" PRId64, INT64_MAX, "9223372036854775807"},
+        {"%" PRId64, INT64_MIN, "-9223372036854775808"},
+        {nullptr, 0, nullptr}
+    };
+
+    constexpr FormatTest<int32_t> i32Test[] = {
+        {"%ld", INT32_MAX, "2147483647"},
+        {"%ld", INT32_MIN, "-2147483648"},
+        {"%d", INT32_MAX, "2147483647"},
+        {"%d", INT32_MIN, "-2147483648"},
+        {"%" PRId32, INT32_MAX, "2147483647"},
+        {"%" PRId32, INT32_MIN, "-2147483648"},
+        {nullptr, 0, nullptr}
+    };
+
+    constexpr FormatTest<int16_t> i16Test[] = {
+        {"%hd", INT16_MAX, "32767"},
+        {"%hd", INT16_MIN, "-32768"},
+        {"%" PRId16, INT16_MAX, "32767"},
+        {"%" PRId16, INT16_MIN, "-32768"},
+        {nullptr, 0, nullptr}
+    };
+
+    const auto runTest = [&](const auto& test) -> void {
+        for (int i = 0; test[i].fmt != nullptr; i++) {
+            char tmp[256] = {};
+            snprintf(tmp, sizeof(tmp), test[i].fmt, test[i].value);
+            decltype(test[i].value) parsed = 0;
+            int scanfRes = sscanf(tmp, test[i].fmt, &parsed);
+            assertEqual(String(tmp), String(test[i].expected));
+            assertEqual(scanfRes, 1);
+            assertTrue(parsed == test[i].value);
+            assertEqual(parsed, test[i].value);
+        }
+    };
+    auto tuple = std::make_tuple(u64Test, u32Test, u16Test, i64Test, i32Test, i16Test);
+    std::apply([runTest](auto&&... args) {
+        ((runTest(args)), ...);
+    }, tuple);
+}

--- a/user/tests/wiring/strformat/strformat.spec.js
+++ b/user/tests/wiring/strformat/strformat.spec.js
@@ -1,0 +1,3 @@
+suite('String format');
+
+platform('gen3');

--- a/user/tests/wiring/strformat/test.mk
+++ b/user/tests/wiring/strformat/test.mk
@@ -1,0 +1,18 @@
+INCLUDE_DIRS += $(SOURCE_PATH)/$(USRSRC)  # add user sources to include path
+# add C and CPP files - if USRSRC is not empty, then add a slash
+CPPSRC += $(call target_files,$(USRSRC_SLASH),*.cpp)
+CSRC += $(call target_files,$(USRSRC_SLASH),*.c)
+
+APPSOURCES=$(call target_files,$(USRSRC_SLASH),*.cpp)
+APPSOURCES+=$(call target_files,$(USRSRC_SLASH),*.c)
+ifeq ($(strip $(APPSOURCES)),)
+$(error "No sources found in $(SOURCE_PATH)/$(USRSRC)")
+endif
+
+ifeq ("${USE_THREADING}","y")
+USE_THREADING_VALUE=1
+else
+USE_THREADING_VALUE=0
+endif
+
+CFLAGS += -DUSE_THREADING=${USE_THREADING_VALUE}


### PR DESCRIPTION
### Description

Patches nano variants of `_printf_i`, `_vsfprintf_r`, `__ssvfscanf_r` and `_scanf_i` to support 64-bit format specifiers.

Also fixes a bug with `%X` scanf format, which was incorrectly parsing as signed integer (whereas `%x` worked as intended).

### Steps to Test

- `wiring/strformat`

#### After
```
0000002561 [app] INFO: 18446744073709551615 ("%llu" == "18446744073709551615") parsed=18446744073709551615
0000002570 [app] INFO: ffffffffffffffff ("%llx" == "ffffffffffffffff") parsed=ffffffffffffffff
0000002578 [app] INFO: FFFFFFFFFFFFFFFF ("%llX" == "FFFFFFFFFFFFFFFF") parsed=FFFFFFFFFFFFFFFF
0000002586 [app] INFO: 18446744073709551615 ("%PRIu64" == "18446744073709551615") parsed=18446744073709551615
0000002595 [app] INFO: ffffffffffffffff ("%PRIx64" == "ffffffffffffffff") parsed=ffffffffffffffff
0000002604 [app] INFO: FFFFFFFFFFFFFFFF ("%PRIX64" == "FFFFFFFFFFFFFFFF") parsed=FFFFFFFFFFFFFFFF
0000002615 [app] INFO: 4294967295 ("%lu" == "4294967295") parsed=4294967295
0000002622 [app] INFO: ffffffff ("%lx" == "ffffffff") parsed=ffffffff
0000002627 [app] INFO: FFFFFFFF ("%lX" == "FFFFFFFF") parsed=FFFFFFFF
0000002633 [app] INFO: 4294967295 ("%u" == "4294967295") parsed=4294967295
0000002640 [app] INFO: ffffffff ("%x" == "ffffffff") parsed=ffffffff
0000002645 [app] INFO: FFFFFFFF ("%X" == "FFFFFFFF") parsed=FFFFFFFF
0000002652 [app] INFO: 4294967295 ("%PRIu32" == "4294967295") parsed=4294967295
0000002658 [app] INFO: ffffffff ("%PRIx32" == "ffffffff") parsed=ffffffff
0000002665 [app] INFO: FFFFFFFF ("%PRIX32" == "FFFFFFFF") parsed=FFFFFFFF
0000002673 [app] INFO: 65535 ("%hu" == "65535") parsed=65535
0000002678 [app] INFO: ffff ("%hx" == "ffff") parsed=ffff
0000002683 [app] INFO: FFFF ("%hX" == "FFFF") parsed=FFFF
0000002689 [app] INFO: 65535 ("%PRIu16" == "65535") parsed=65535
0000002695 [app] INFO: ffff ("%PRIx16" == "ffff") parsed=ffff
0000002699 [app] INFO: FFFF ("%PRIX16" == "FFFF") parsed=FFFF
0000002707 [app] INFO: 9223372036854775807 ("%lld" == "9223372036854775807") parsed=9223372036854775807
0000002717 [app] INFO: -9223372036854775808 ("%lld" == "-9223372036854775808") parsed=-9223372036854775808
0000002726 [app] INFO: 9223372036854775807 ("%PRId64" == "9223372036854775807") parsed=9223372036854775807
0000002736 [app] INFO: -9223372036854775808 ("%PRId64" == "-9223372036854775808") parsed=-9223372036854775808
0000002749 [app] INFO: 2147483647 ("%ld" == "2147483647") parsed=2147483647
0000002756 [app] INFO: -2147483648 ("%ld" == "-2147483648") parsed=-2147483648
0000002763 [app] INFO: 2147483647 ("%d" == "2147483647") parsed=2147483647
0000002769 [app] INFO: -2147483648 ("%d" == "-2147483648") parsed=-2147483648
0000002776 [app] INFO: 2147483647 ("%PRId32" == "2147483647") parsed=2147483647
0000002784 [app] INFO: -2147483648 ("%PRId32" == "-2147483648") parsed=-2147483648
0000002793 [app] INFO: 32767 ("%hd" == "32767") parsed=32767
0000002798 [app] INFO: -32768 ("%hd" == "-32768") parsed=-32768
0000002803 [app] INFO: 32767 ("%PRId16" == "32767") parsed=32767
0000002808 [app] INFO: -32768 ("%PRId16" == "-32768") parsed=-32768
```

### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
