### PR TITLE
[gen3] hal: fixes the issue that UARTE RX may loss data.

### DIFF
--- a/services/inc/ringbuffer.h
+++ b/services/inc/ringbuffer.h
@@ -357,11 +357,21 @@ inline size_t RingBuffer<T>::curSpace() const {
 
 template <typename T>
 inline size_t RingBuffer<T>::curData() const {
-    if (head_ >= tail_ && !full_) {
-        return head_ - tail_;
+    // Tail is only modified by the consumer/reader, we don't care about it
+    // head_, curSize_ and full_ are the ones that are modified by producer and would
+    // usually be modified in ISR.
+    size_t head = head_;
+
+    if (head > tail_) {
+        return head - tail_;
+    } else if (head == tail_ && !full_) {
+        return 0;
     } else {
-        return curSize_ + head_ - tail_;
+        // NOTE: this might not work well without locking for multiple concurrent acquirable regions
+        // For a single region, curSize_ cannot change if head is already behind tail.
+        return curSize_ + head - tail_;
     }
+
 }
 
 template <typename T>


### PR DESCRIPTION
Please check out: https://github.com/particle-iot/device-os/pull/2685

The main idea to fix this issue is to make sure the ENDRX event is handled ASAP so that the UARTE receiver is started in time to accept incoming data.

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
