### PR TITLE
Fixes ncp-client not waiting for modem ready on cold boot

### DIFF
--- a/hal/network/ncp_client/quectel/quectel_ncp_client.h
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.h
@@ -128,6 +128,8 @@ private:
     int checkNetConfForImsi();
     int selectSimCard();
     int checkSimCard();
+    int getModuleFunctionality();
+    int setModuleFunctionality(CellularFunctionality cfun, bool check);
     int configureApn(const CellularNetworkConfig& conf);
     int registerNet();
     int changeBaudRate(unsigned int baud);


### PR DESCRIPTION
### Problem

- After the UART fixes of #2698, the UART is a bit faster now and that has surfaced some lurking issues.  The Quectel NCP Client was not waiting for the modem to be ready on cold boot, causing a boot loop from CFUN=1,0 failing in initReady()

### Solution

- Add a retry scheme for CFUN=1,0 on initReady() only at this time.

### Steps to Test

- Cold boot the device and ensure any CFUN errors are handled, retried and the device boots successfully.
- All integration tests should pass, especially the cold boot SLO test.

### References

#2698 

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
