### PR TITLE
[rtl872x] Fix unintentional pin changes for Serial1 RTS/CTS

### DIFF
--- a/hal/src/rtl872x/usart_hal.cpp
+++ b/hal/src/rtl872x/usart_hal.cpp
@@ -196,11 +196,11 @@ public:
         PAD_PullCtrl(hal_pin_to_rtl_pin(txPin_), GPIO_PuPd_NOPULL);
         PAD_PullCtrl(hal_pin_to_rtl_pin(rxPin_), GPIO_PuPd_NOPULL);
         // Configure CTS/RTS pins
-        if (ctsPin_ != PIN_INVALID) {
+        if (ctsPin_ != PIN_INVALID && (conf.config & SERIAL_FLOW_CONTROL_CTS)) {
             Pinmux_Config(hal_pin_to_rtl_pin(ctsPin_), PINMUX_FUNCTION_UART_RTSCTS);
             PAD_PullCtrl(hal_pin_to_rtl_pin(ctsPin_), GPIO_PuPd_UP);
         }
-        if (rtsPin_ != PIN_INVALID) {
+        if (rtsPin_ != PIN_INVALID && (conf.config & SERIAL_FLOW_CONTROL_RTS)) {
             Pinmux_Config(hal_pin_to_rtl_pin(rtsPin_), PINMUX_FUNCTION_UART_RTSCTS);
             PAD_PullCtrl(hal_pin_to_rtl_pin(rtsPin_), GPIO_PuPd_UP);
         }
@@ -647,10 +647,10 @@ private:
         // Do not change the pull ability to not mess up the peer device.
         Pinmux_Config(hal_pin_to_rtl_pin(txPin_), PINMUX_FUNCTION_GPIO);
         Pinmux_Config(hal_pin_to_rtl_pin(rxPin_), PINMUX_FUNCTION_GPIO);
-        if (ctsPin_ != PIN_INVALID) {
+        if (ctsPin_ != PIN_INVALID && (config_.config & SERIAL_FLOW_CONTROL_CTS)) {
             Pinmux_Config(hal_pin_to_rtl_pin(ctsPin_), PINMUX_FUNCTION_GPIO);
         }
-        if (rtsPin_ != PIN_INVALID) {
+        if (rtsPin_ != PIN_INVALID && (config_.config & SERIAL_FLOW_CONTROL_RTS)) {
             Pinmux_Config(hal_pin_to_rtl_pin(rtsPin_), PINMUX_FUNCTION_GPIO);
         }
 


### PR DESCRIPTION
### Problem

Starting Serial1 causes the RTS and CTS lines to be assigned as hardware handshake signals without regard to whether they are previously set for GPIO.

### Solution

Check if flow control is requested on the given interface and if the pins are assigned already.  Configure for handshaking only if requested; otherwise, leave pins alone.

Before:
```
         ___________________
RTS   __/                     ...
          ________  _________
CTS   ___/        ||          ...
          <------->
             50ms
```
After:
```
         ___________           ______
RTS   __/           \_________/       ...
          ___________           _____
CTS   ___/           \_________/      ...
          <---------><--------->
              150ms      100ms
```
### Steps to Reproduce

```cpp
#define SERIAL          (Serial1)
#define SERIAL_RTS      (RTS)
#define SERIAL_CTS      (CTS)

// #define SERIAL          (Serial2)
// #define SERIAL_RTS      (RTS1)
// #define SERIAL_CTS      (CTS1)

// #define SERIAL          (Serial3)
// #define SERIAL_RTS      (RTS2)
// #define SERIAL_CTS      (CTS2)

void setup() {
  Serial.begin(115200);
  waitFor(Serial.isConnected, 10000);  // Wait until we're ready to capture waveforms

  pinMode(SERIAL_RTS, OUTPUT);
  digitalWrite(SERIAL_RTS, HIGH);
  pinMode(SERIAL_CTS, OUTPUT);
  digitalWrite(SERIAL_CTS, HIGH);
  delay(50);
  SERIAL.begin(115200);
  //SERIAL.begin(115200, SERIAL_FLOW_CONTROL_RTS_CTS);
  delay(100);
  digitalWrite(SERIAL_RTS, LOW);
  digitalWrite(SERIAL_CTS, LOW);
  delay(100);
  digitalWrite(SERIAL_RTS, HIGH);
  digitalWrite(SERIAL_CTS, HIGH);
}
```

### References

sc-118986

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
