### PR TITLE
[msom] increase NCP baudrate to 921600, doubling throughput

### DIFF
--- a/hal/network/ncp_client/quectel/quectel_ncp_client.h
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.h
@@ -153,6 +153,7 @@ private:
     bool isQuecCatNBxDevice();
     /** Is this a Quectel BG95* device ? */
     bool isQuecBG95xDevice();
+    int getRuntimeBaudrate();
     int modemInit() const;
     bool waitModemPowerState(bool onOff, system_tick_t timeout);
     int modemPowerOn();


### PR DESCRIPTION
### Problem

- The runtime baud rate of MSoM platform (only BG95-M5 modems for now) is set at 460800, and could be increased to 921600.

### Solution

- Increase the runtime baudrate for BG95-M5 modems to 921600 baud, doubling throughput.

### Steps to Test

- TCPClient large file download test on 460800 and 921600 baud.  (Note: Must use Serial1 output for any logging and set the rate to 230400 baud or higher, so that it doesn't throttle the download).
- Device OS release testing