### PR TITLE
[network] Wiznet Ethernet performance improvements

### DIFF
--- a/hal/network/lwip/wiznet/wiznetif.cpp
+++ b/hal/network/lwip/wiznet/wiznetif.cpp
@@ -115,7 +115,7 @@ const hal_spi_info_t WIZNET_DEFAULT_CONFIG = {
     .ss_pin = PIN_INVALID
 };
 
-const int WIZNET_DEFAULT_TIMEOUT = 1000;
+const int WIZNET_DEFAULT_TIMEOUT = 500;
 /* FIXME */
 const unsigned int WIZNET_INRECV_NEXT_BACKOFF = 50;
 const unsigned int WIZNET_DEFAULT_RX_FRAMES_PER_ITERATION = PBUF_POOL_SIZE / 2;

--- a/hal/src/rtl872x/interrupts_hal.cpp
+++ b/hal/src/rtl872x/interrupts_hal.cpp
@@ -363,7 +363,7 @@ int hal_interrupt_attach(uint16_t pin, hal_interrupt_handler_t handler, void* da
 
         GPIO_Init_HAL(&GPIO_InitStruct, pinInfo->gpio_port);
         GPIO_UserRegIrq(rtlPin, (VOID*)gpioIntHandler, (void*)((uint32_t)pin));
-        GPIO_INTMode_HAL(rtlPin, pinInfo->gpio_port, ENABLE, GPIO_InitStruct.GPIO_ITTrigger, GPIO_InitStruct.GPIO_ITPolarity, GPIO_INT_DEBOUNCE_ENABLE);
+        GPIO_INTMode_HAL(rtlPin, pinInfo->gpio_port, ENABLE, GPIO_InitStruct.GPIO_ITTrigger, GPIO_InitStruct.GPIO_ITPolarity, GPIO_INT_DEBOUNCE_DISABLE);
 
 #if MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
         if (!config || (config && !(config->appendHandler))) {


### PR DESCRIPTION
### Problem

Ethernet performance on P2 platforms is slower and less reliable compared to gen3 implementations

### Solution

This PR improves ethernet performance with a number of changes

- [p2][photon2] Improve ethernet speed by disabling debounce detection on wiznet interrupt pin
- [all] Filter IPV6 packets, as they are not currently fully supported
- [all] Limit the number of frames the wiznet driver can input into the lwip stack based on number of packet buffers available
- [all] Avoid dropping packets if the size header can be read but there is no buffer available for the packet data itself. 

### Steps to Test

Enable ethernet on a P2/Photon2 platform

### Example App
See tinker

### References
Credit to @avtolstoy as original author