### PR TITLE
Erase factory reset app after test runner completes

### DIFF
--- a/user/tests/integration/ota/factory_reset/factory_reset.cpp
+++ b/user/tests/integration/ota/factory_reset/factory_reset.cpp
@@ -230,4 +230,11 @@ test(10_validate_factory_reset_worked) {
     validate_factory_reset_worked();
 }
 
+test(11_cleanup_factory_slot) {
+    InvalidateDctModuleSlot(FAC_RESET_SLOT);
+
+    // Erase entire Factory Module
+    assertEqual(hal_storage_erase(HAL_STORAGE_ID_EXTERNAL_FLASH, EXTERNAL_FLASH_FAC_ADDRESS, EXTERNAL_FLASH_FAC_LENGTH), EXTERNAL_FLASH_FAC_LENGTH);
+}
+
 #endif // HAL_PLATFORM_NRF52840


### PR DESCRIPTION
### Problem
On device tests may fail due to interactions between asset OTA and factory reset images in flash that are left over from on device testing

### Solution
Erase the factory reset module location and DCT entry when `ota/factory_reset` tests complete

### Steps to Test
```
device-os-test --test-dir ~/develop/device-os/user/tests/integration/ --device-os-dir ~/develop/device-os/ build boron ota/factory_reset -v -- -fixture

device-os-test --test-dir ~/develop/device-os/user/tests/integration/ --device-os-dir ~/develop/device-os/ run boron ota/factory_reset -v -- -fixture  
```

### Example App
Use `ota/factory_reset` test app

### References
Before this PR, after the `ota/factory_reset` test completes, the test application is both the running user app as well as present in the factory reset slot:
```
particle serial inspect
Platform: 13 - Boron
Modules
  Bootloader module #0 - version 2300, main location, 49152 bytes max size
    Integrity: PASS
    Address Range: PASS
    Platform: PASS
    Dependencies: PASS
  System module #1 - version 5501, main location, 671744 bytes max size
    Integrity: PASS
    Address Range: PASS
    Platform: PASS
    Dependencies: PASS
      Bootloader module #0 - version 2300
      Radio stack module #0 - version 202
  User module #2 - version 6, main location, 262144 bytes max size
    UUID: BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
    Integrity: PASS
    Address Range: PASS
    Platform: PASS
    Dependencies: PASS
      System module #1 - version 5501
  User module #2 - version 6, factory location, 262144 bytes max size
    UUID: BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
    Integrity: PASS
    Address Range: PASS
    Platform: PASS
    Dependencies: PASS
      System module #1 - version 5501
  Radio stack module #0 - version 202, main location, 192512 bytes max size
    Integrity: PASS
    Address Range: PASS
    Platform: PASS
    Dependencies: PASS
```

After this PR, it is not in the factory_reset slot:
```
particle serial inspect     
Platform: 13 - Boron
Modules
  Bootloader module #0 - version 2300, main location, 49152 bytes max size
    Integrity: PASS
    Address Range: PASS
    Platform: PASS
    Dependencies: PASS
  System module #1 - version 5501, main location, 671744 bytes max size
    Integrity: PASS
    Address Range: PASS
    Platform: PASS
    Dependencies: PASS
      Bootloader module #0 - version 2300
      Radio stack module #0 - version 202
  User module #2 - version 6, main location, 262144 bytes max size
    UUID: BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
    Integrity: PASS
    Address Range: PASS
    Platform: PASS
    Dependencies: PASS
      System module #1 - version 5501
  Radio stack module #0 - version 202, main location, 192512 bytes max size
    Integrity: PASS
    Address Range: PASS
    Platform: PASS
    Dependencies: PASS
```
