### PR TITLE
[acm] Fix Network.preferred() -> Network.prefer()

### DIFF
--- a/system/inc/system_dynalib_net.h
+++ b/system/inc/system_dynalib_net.h
@@ -53,7 +53,7 @@ DYNALIB_FN(17, system_net, network_is_off, bool(network_handle_t, void*))
 DYNALIB_FN(18, system_net, network_set_configuration, int(network_handle_t, const network_configuration_t*, void*))
 DYNALIB_FN(19, system_net, network_get_configuration, int(network_handle_t, network_configuration_t**, size_t*, const char*, size_t, void*))
 DYNALIB_FN(20, system_net, network_free_configuration, int(network_configuration_t*, size_t, void*))
-DYNALIB_FN(21, system_net, network_preferred, network_handle_t(network_handle_t, bool, void*))
+DYNALIB_FN(21, system_net, network_prefer, network_handle_t(network_handle_t, bool, void*))
 DYNALIB_FN(22, system_net, network_is_preferred, bool(network_handle_t, void*))
 
 DYNALIB_END(system_net)

--- a/system/inc/system_network.h
+++ b/system/inc/system_network.h
@@ -63,7 +63,7 @@ void network_off(network_handle_t network, uint32_t flags, uint32_t param1, void
 bool network_is_on(network_handle_t network, void* reserved);
 bool network_is_off(network_handle_t network, void* reserved);
 int network_connect_cancel(network_handle_t network, uint32_t flags, uint32_t param1, void* reserved);
-network_handle_t network_preferred(network_handle_t network, bool preferred, void* reserved);
+network_handle_t network_prefer(network_handle_t network, bool prefer, void* reserved);
 bool network_is_preferred(network_handle_t network, void* reserved); 
 
 #define NETWORK_LISTEN_EXIT (1<<0)

--- a/system/src/system_connection_manager.cpp
+++ b/system/src/system_connection_manager.cpp
@@ -95,9 +95,13 @@ ConnectionManager* ConnectionManager::instance() {
 
 void ConnectionManager::setPreferredNetwork(network_handle_t network, bool preferred) {
     if (preferred) {
-        preferredNetwork_ = network;
-    } else if (network == preferredNetwork_) {
-        preferredNetwork_ = NETWORK_INTERFACE_ALL;
+        if (network != NETWORK_INTERFACE_ALL) {
+            preferredNetwork_ = network;    
+        }
+    } else {
+        if (network == preferredNetwork_ || network == NETWORK_INTERFACE_ALL) {
+            preferredNetwork_ = NETWORK_INTERFACE_ALL;
+        }
     }
 }
 

--- a/system/src/system_network_compat.cpp
+++ b/system/src/system_network_compat.cpp
@@ -249,7 +249,7 @@ int network_listen_command(network_handle_t network, network_listen_command_t co
     return 0;
 }
 
-network_handle_t network_preferred(network_handle_t network, bool preferred, void* reserved) {
+network_handle_t network_prefer(network_handle_t network, bool prefer, void* reserved) {
     return network;
 }
 

--- a/system/src/system_network_manager_api.cpp
+++ b/system/src/system_network_manager_api.cpp
@@ -406,8 +406,8 @@ int network_listen_command(network_handle_t network, network_listen_command_t co
     return ListeningModeHandler::instance()->enqueueCommand(command, arg);
 }
 
-network_handle_t network_preferred(network_handle_t network, bool preferred, void* reserved) {
-    ConnectionManager::instance()->setPreferredNetwork(network, preferred);
+network_handle_t network_prefer(network_handle_t network, bool prefer, void* reserved) {
+    ConnectionManager::instance()->setPreferredNetwork(network, prefer);
     return ConnectionManager::instance()->getPreferredNetwork();
 }
 

--- a/test/unit_tests/stub/system_network.cpp
+++ b/test/unit_tests/stub/system_network.cpp
@@ -63,7 +63,7 @@ int network_connect_cancel(network_handle_t network, uint32_t flags, uint32_t pa
     return 0;
 }
 
-network_handle_t network_preferred(network_handle_t network, bool preferred, void* reserved) {
+network_handle_t network_prefer(network_handle_t network, bool prefer, void* reserved) {
     return network;
 }
 

--- a/user/tests/app/connection-manager/application.cpp
+++ b/user/tests/app/connection-manager/application.cpp
@@ -187,6 +187,36 @@ void loop() {
             // Run the internal connection test
             system_internal(4, nullptr);
         }
+        else if(c == '2') {
+            // Prefer wifi
+            WiFi.prefer();
+            // Confirm that we prefer wifi 
+            if (Network.prefer() == WiFi) {
+                Log.info("Wifi is preferred");
+            }
+            // No longer prefer wifi, revert to default
+            WiFi.prefer(false);
+            if (Network.prefer() == Network) {
+                Log.info("Default is preferred");
+            }
+
+            // Prefer cellular
+            Cellular.prefer();
+            // Confirm cellular is preferred 
+            if (Network.prefer() == Cellular) {
+                Log.info("Cellular is preferred");
+            }
+            // Confirm calling Network does not change preference
+            Network.prefer();
+            if (Network.prefer() == Cellular) {
+                Log.info("Cellular is still preferred");
+            }
+            // Clear any set network preference
+            Network.prefer(false);
+            if (Network.prefer() == Network) {
+                Log.info("Default is preferred");
+            }
+        }
         else if(c == '3') {
             Particle.disconnect(CloudDisconnectOptions().clearSession(true));
             waitUntil(Particle.disconnected);

--- a/wiring/inc/spark_wiring_network.h
+++ b/wiring/inc/spark_wiring_network.h
@@ -62,7 +62,7 @@ public:
     virtual void setListenTimeout(uint16_t timeout);
     virtual uint16_t getListenTimeout();
     virtual bool listening();
-    virtual NetworkClass& preferred(bool preferred = true);
+    virtual NetworkClass& prefer(bool prefer = true);
     virtual bool isPreferred();
 
     operator network_interface_t() const {

--- a/wiring/src/spark_wiring_network.cpp
+++ b/wiring/src/spark_wiring_network.cpp
@@ -101,8 +101,8 @@ bool NetworkClass::listening() {
     return network_listening(*this, 0, nullptr);
 }
 
-NetworkClass& NetworkClass::preferred(bool preferred) {
-    network_handle_t network = network_preferred(*this, preferred, nullptr);
+NetworkClass& NetworkClass::prefer(bool prefer) {
+    network_handle_t network = network_prefer(*this, prefer, nullptr);
     return Network.from(network);
 }
 


### PR DESCRIPTION
### Problem

1. `Network.preferred()` is less clear than simply `Cellular.prefer()`
2. `Network.preferred()` will both set the desired network back to default, and then return `Network` instead of the actual preferred network reference.

### Solution

1. `Network.preferred()` renamed to be clearer ie: `WiFi.prefer(true)`
3. `Network.prefer()` will not reset the default network. The supported ways to clear any network preference are: 
a) `Network.prefer(false)` and b) explicitly calling `.prefer(false)` with the preferred interface, ie `WiFi.prefer(false)`

### Steps to Test

Use `connection-manager` test application, item 2

### Example App
`connection-manager`

### References

[ACM MVP API](https://www.notion.so/particle/ACM-Device-OS-APIs-MVP-8aaad940c70d419a898661f1dc8c7808)

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
