### PR TITLE
Ensure consistent BLE scan behavior

### DIFF
--- a/user/tests/app/ble/scanner/application.cpp
+++ b/user/tests/app/ble/scanner/application.cpp
@@ -17,7 +17,7 @@
 
 #include "Particle.h"
 
-#define SCAN_RESULT_COUNT       30
+#define SCAN_RESULT_COUNT       100
 #define BLE_ADV_DATA_MAX        31
 
 SYSTEM_MODE(MANUAL);
@@ -31,13 +31,23 @@ void setup() {
 
 }
 
+bool flag = false;
+
 void loop() {
-    int count = BLE.scan(results, SCAN_RESULT_COUNT);
+    int count;
+    flag = !flag;
+    if (flag) {
+        Log.info(">>>> start scanning, filter duplicates");
+        count = BLE.scan(results, SCAN_RESULT_COUNT);
+    } else {
+        Log.info(">>>> start scanning, allow duplicates");
+        count = BLE.scanWithFilter(BleScanFilter().allowDuplicates(true), results, SCAN_RESULT_COUNT);
+    }
 
     if (count > 0) {
         Log.info("%d devices are found:", count);
         for (int i = 0; i < count; i++) {
-            Log.info(" -------- MAC: %s | RSSI: %dBm --------", results[i].address().toString().c_str(), results[i].rssi());
+            Log.info(" -------- MAC: %s | RSSI: %d dBm --------", results[i].address().toString().c_str(), results[i].rssi());
 
             String name = results[i].advertisingData().deviceName();
             if (name.length() > 0) {

--- a/user/tests/wiring/api/ble.cpp
+++ b/user/tests/wiring/api/ble.cpp
@@ -594,6 +594,9 @@ test(ble_scan_filter) {
 
     API_COMPILE({ uint8_t buf[1]; BleScanFilter f = filter.customData(buf, 0); (void)f; });
     API_COMPILE({ size_t len; const uint8_t* buf = filter.customData(&len); (void)len; (void)buf; });
+
+    API_COMPILE({ BleScanFilter f = filter.allowDuplicates(true); (void)f; });
+    API_COMPILE({ bool ret = filter.allowDuplicates(); (void)ret; });
 }
 
 test(ble_peer_device) {

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -716,7 +716,8 @@ public:
             : minRssi_(BLE_RSSI_INVALID),
               maxRssi_(BLE_RSSI_INVALID),
               customData_(nullptr),
-              customDataLen_(0) {
+              customDataLen_(0),
+              allowDuplicates_(false) {
     }
     ~BleScanFilter() = default;
 
@@ -813,6 +814,15 @@ public:
         return *this;
     }
 
+    BleScanFilter& allowDuplicates(bool allow) {
+        allowDuplicates_ = allow;
+        return *this;
+    }
+
+    bool allowDuplicates() const {
+        return allowDuplicates_;
+    }
+
 private:
     Vector<String> deviceNames_;
     Vector<BleUuid> serviceUuids_;
@@ -822,6 +832,7 @@ private:
     int8_t maxRssi_;
     const uint8_t* customData_;
     size_t customDataLen_;
+    bool allowDuplicates_;
 };
 
 

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -2378,6 +2378,12 @@ private:
      */
     static void onScanResultCallback(const hal_ble_scan_result_evt_t* event, void* context) {
         BleScanDelegator* delegator = static_cast<BleScanDelegator*>(context);
+
+        if (!delegator->filter_.allowDuplicates() && delegator->isCachedDevice(event->peer_addr)) {
+            return;
+        }
+        delegator->cachedDevices_.append(event->peer_addr);
+
         BleScanResult result = {};
         result.address(event->peer_addr).rssi(event->rssi)
               .scanResponse(event->sr_data, event->sr_data_len)
@@ -2554,6 +2560,15 @@ private:
         return true;
     }
 
+    bool isCachedDevice(const BleAddress& address) const {
+        for (const auto& addr : cachedDevices_) {
+            if (address == addr) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     Vector<BleScanResult> resultsVector_;
     BleScanResult* resultsPtr_;
     size_t targetCount_;
@@ -2561,6 +2576,7 @@ private:
     std::function<void(const BleScanResult*)> scanResultCallback_;
     BleOnScanResultStdFunction scanResultCallbackRef_;
     BleScanFilter filter_;
+    Vector<BleAddress> cachedDevices_;
 };
 
 int BleLocalDevice::setScanTimeout(uint16_t timeout) const {

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -2379,10 +2379,12 @@ private:
     static void onScanResultCallback(const hal_ble_scan_result_evt_t* event, void* context) {
         BleScanDelegator* delegator = static_cast<BleScanDelegator*>(context);
 
-        if (!delegator->filter_.allowDuplicates() && delegator->isCachedDevice(event->peer_addr)) {
-            return;
+        if (!delegator->filter_.allowDuplicates()) {
+            if (delegator->isCachedDevice(event->peer_addr)) {
+                return;
+            }
+            delegator->cachedDevices_.append(event->peer_addr);
         }
-        delegator->cachedDevices_.append(event->peer_addr);
 
         BleScanResult result = {};
         result.address(event->peer_addr).rssi(event->rssi)


### PR DESCRIPTION
### Problem

`BLE.scan()` and `BLE.scanWithFilter()` filter duplicate results on Gen3, but it's not true on Gen4.

### Solution

Make the BLE HAL report all of the scanned results and implement a filtering mechanism in wiring layer instead.

### Steps to Test
Build and  run the `tests/app/ble/scanner` app.

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
