### PR TITLE
[build] include alignment into section size calculations

### DIFF
--- a/build/macros.mk
+++ b/build/macros.mk
@@ -52,3 +52,5 @@ target_files_dirs = $(foreach d,$(call remove_slash,$1),$(patsubst $d/%,$(notdir
 check_modular = $(if $(PLATFORM_DYNALIB_MODULES),,$(error "Platform '$(PLATFORM)' does not support dynamic modules"))
 
 get_module_start_address = 0x$(word 1,$(shell $(OBJDUMP) --syms $(TARGET_BASE).elf | grep 'link_module_start'))
+
+get_section_size_with_alignment = $(shell echo $$(($(shell $(OBJDUMP) -h --section=$1 $2 | grep -E '$1' | awk '{ print "0x"$$3" + "$$7" -1"}'))))

--- a/modules/shared/nRF52840/build_linker_script.mk
+++ b/modules/shared/nRF52840/build_linker_script.mk
@@ -5,18 +5,16 @@ COMMA := ,
 
 COMMON_BUILD=../../../build
 include $(COMMON_BUILD)/arm-tools.mk
+include $(COMMON_BUILD)/macros.mk
 
 ifneq (,$(PREBUILD))
 # Should declare enough RAM for inermediate linker script: 89K
 USER_SRAM_LENGTH = 89K
 else
-DATA_SECTION_LEN  = $(shell $(OBJDUMP) -h --section=.data $(INTERMEDIATE_ELF) | grep -E '^\s*[0-9]+\s+\.data\s+')
-DATA_SECTION_LEN := 0x$(word 3,$(DATA_SECTION_LEN))
-BSS_SECTION_LEN   = $(shell $(OBJDUMP) -h --section=.bss $(INTERMEDIATE_ELF) | grep -E '^\s*[0-9]+\s+\.bss\s+')
-BSS_SECTION_LEN  := 0x$(word 3,$(BSS_SECTION_LEN))
+DATA_SECTION_LEN  = $(call get_section_size_with_alignment,.data,$(INTERMEDIATE_ELF))
+BSS_SECTION_LEN   = $(call get_section_size_with_alignment,.bss,$(INTERMEDIATE_ELF))
 
-# Note: reserving 16 bytes for alignment just in case
-USER_SRAM_LENGTH = ( $(DATA_SECTION_LEN) + $(BSS_SECTION_LEN) + 16 )
+USER_SRAM_LENGTH = ( $(DATA_SECTION_LEN) + $(BSS_SECTION_LEN) )
 
 all: $(INTERMEDIATE_ELF)
 endif

--- a/modules/shared/rtl872x/build_linker_script.mk
+++ b/modules/shared/rtl872x/build_linker_script.mk
@@ -12,6 +12,7 @@ COMMA := ,
 
 COMMON_BUILD=../../../build
 include $(COMMON_BUILD)/arm-tools.mk
+include $(COMMON_BUILD)/macros.mk
 
 ifneq (,$(PREBUILD))
 # Should declare enough RAM for inermediate linker script: 128K
@@ -20,26 +21,21 @@ USER_SRAM_LENGTH = 128K
 USER_PSRAM_LENGTH = 1536K
 USER_FLASH_LENGTH = 1536K
 else
-TEXT_SECTION_LEN  = $(shell $(SIZE) --format=berkeley $(INTERMEDIATE_ELF) | $(AWK) 'NR==2 {print $$1}')
-DATA_SECTION_LEN  = $(shell $(SIZE) --format=berkeley $(INTERMEDIATE_ELF) | $(AWK) 'NR==2 {print $$2}')
-BSS_SECTION_LEN   = $(shell $(SIZE) --format=berkeley $(INTERMEDIATE_ELF) | $(AWK) 'NR==2 {print $$3}')
+TEXT_SECTION_LEN  = $(call get_section_size_with_alignment,.text,$(INTERMEDIATE_ELF))
+DATA_SECTION_LEN  = $(call get_section_size_with_alignment,.data,$(INTERMEDIATE_ELF))
+BSS_SECTION_LEN   = $(call get_section_size_with_alignment,.bss,$(INTERMEDIATE_ELF))
 
-PSRAM_TEXT_SECTION_LEN  = $(shell $(OBJDUMP) -h --section=.psram_text $(INTERMEDIATE_ELF) | grep -E '.psram_text')
-PSRAM_TEXT_SECTION_LEN := 0x$(word 3,$(PSRAM_TEXT_SECTION_LEN))
-PSRAM_DATA_SECTION_LEN  = $(shell $(OBJDUMP) -h --section=.data_alt $(INTERMEDIATE_ELF) | grep -E '.data_alt')
-PSRAM_DATA_SECTION_LEN := 0x$(word 3,$(PSRAM_DATA_SECTION_LEN))
-PSRAM_BSS_SECTION_LEN  = $(shell $(OBJDUMP) -h --section=.bss_alt $(INTERMEDIATE_ELF) | grep -E '.bss_alt')
-PSRAM_BSS_SECTION_LEN := 0x$(word 3,$(PSRAM_BSS_SECTION_LEN))
-PSRAM_DYNALIB_SECTION_LEN  = $(shell $(OBJDUMP) -h --section=.dynalib $(INTERMEDIATE_ELF) | grep -E '.dynalib')
-PSRAM_DYNALIB_SECTION_LEN := 0x$(word 3,$(PSRAM_DYNALIB_SECTION_LEN))
+PSRAM_TEXT_SECTION_LEN  = $(call get_section_size_with_alignment,.psram_text,$(INTERMEDIATE_ELF))
+PSRAM_DATA_SECTION_LEN  = $(call get_section_size_with_alignment,.data_alt,$(INTERMEDIATE_ELF))
+PSRAM_BSS_SECTION_LEN  = $(call get_section_size_with_alignment,.bss_alt,$(INTERMEDIATE_ELF))
+PSRAM_DYNALIB_SECTION_LEN  = $(call get_section_size_with_alignment,.dynalib,$(INTERMEDIATE_ELF))
 USER_MODULE_END = 0x$(shell $(OBJDUMP) -t $(INTERMEDIATE_ELF) | grep link_module_info_crc_end | $(AWK) '{ print $$1 }')
 USER_MODULE_START = 0x$(shell $(OBJDUMP) -t $(INTERMEDIATE_ELF) | grep link_module_start | $(AWK) '{ print $$1 }')
 USER_MODULE_SUFFIX_START = 0x$(shell $(OBJDUMP) -t $(INTERMEDIATE_ELF) | grep link_module_info_static_start | $(AWK) '{ print $$1 }')
 MODULE_INFO_SUFFIX_LEN := ( $(USER_MODULE_END) - $(USER_MODULE_SUFFIX_START) )
 
-# Note: reserving 16 bytes for alignment just in case
-USER_SRAM_LENGTH = ( $(DATA_SECTION_LEN) + $(BSS_SECTION_LEN) + 16 )
-USER_PSRAM_LENGTH = ( $(PSRAM_TEXT_SECTION_LEN) + $(PSRAM_DATA_SECTION_LEN) + $(PSRAM_BSS_SECTION_LEN) + $(PSRAM_DYNALIB_SECTION_LEN) + 16)
+USER_SRAM_LENGTH = ( $(DATA_SECTION_LEN) + $(BSS_SECTION_LEN) )
+USER_PSRAM_LENGTH = ( $(PSRAM_TEXT_SECTION_LEN) + $(PSRAM_DATA_SECTION_LEN) + $(PSRAM_BSS_SECTION_LEN) + $(PSRAM_DYNALIB_SECTION_LEN) )
 
 USER_FLASH_LENGTH = $(shell let var=($(USER_MODULE_END) - $(USER_MODULE_START) + 16); echo $$var)
 USER_FLASH_LENGTH := $(shell echo $$((($(USER_FLASH_LENGTH) + 4095) / 4096 * 4096)))

--- a/user/tests/wiring/no_fixture/misc.cpp
+++ b/user/tests/wiring/no_fixture/misc.cpp
@@ -28,3 +28,9 @@ test(MISC_01_map) {
     assertEqual(map(5.0, 0.0, 10.0, 0.0, 15.0), 7.5);
     assertEqual(map(5.5, 10.0, 10.0, 10.0, 10.0), 5.5); // Shouldn't cause division by zero
 }
+
+test(MISC_02_alignment) {
+    // This should just build correctly
+    static __attribute__((used, aligned(256))) uint8_t test[63] = {};
+    assertEqual((int)test[0], 0);
+}


### PR DESCRIPTION
### Problem

Some applications that use non-trivial alignments (32, 128 etc) may fail to build with SRAM or other section overflow.

#2665 is somewhat relevant.

### Solution

Account for section alignment requirements when calculating its size. Objdump provides this:
```
Sections:
Idx Name          Size      VMA       LMA       File off  Algn
  3 .dynalib      00000008  023e0b88  085e00b0  00010b88  2**3
```
The calculation is a bit trivial but should work for what we are doing: `size + algn - 1`

### Steps to Test

- `wiring/no_fixture` with `MISC_02_alignment` should build on all platforms

### Example App

This should build:

```
__attribute__((used, aligned(256))) uint8_t test[63] = {};

/* executes once at startup */
void setup() {
    // To avoid compiler optimizing 'test' out
    LOG(INFO, "%d", (int)test[0]);
}
```

### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
