### PR TITLE
[msom] Add GNSS test FQC command

### DIFF
--- a/user/applications/tinker/src/burnin_test.cpp
+++ b/user/applications/tinker/src/burnin_test.cpp
@@ -519,7 +519,7 @@ static int callbackGPSGGA(int type, const char* buf, int len, bool* gnssLocked) 
     strlcpy(gpggaSentence, buf, MAX_GPGGA_STR_LEN);
 
     String lattitudeLongitude("LAT/LONG:");
-    int numberSattelites = 0;
+    int numberSatellites = 0;
     
     const char * delimiters = ",";
     char * token = strtok(gpggaSentence, delimiters);
@@ -543,10 +543,10 @@ static int callbackGPSGGA(int type, const char* buf, int len, bool* gnssLocked) 
                 lattitudeLongitude.concat(token);
                 break;
             case 8: // Number satellites
-                numberSattelites = (int)String(token).toInt();
-                if (numberSattelites > 0) {
+                numberSatellites = (int)String(token).toInt();
+                if (numberSatellites > 0) {
                     *gnssLocked = true;    
-                    Log.info("%s Satellites: %d", lattitudeLongitude.c_str(), numberSattelites);
+                    Log.info("%s Satellites: %d", lattitudeLongitude.c_str(), numberSatellites);
                 }
                 break;
             default:

--- a/user/applications/tinker/src/burnin_test.h
+++ b/user/applications/tinker/src/burnin_test.h
@@ -14,6 +14,7 @@ public:
 
     void setup(bool forceEnable = false);
     void loop();
+    bool initGnss();
 
     enum class BurninTestState : uint32_t {
         NONE,

--- a/user/applications/tinker/src/fqc_test.cpp
+++ b/user/applications/tinker/src/fqc_test.cpp
@@ -565,10 +565,10 @@ static int callbackGPSGSV(int type, const char* buf, int len, FqcTest* self) {
         switch (i) {
             case 5: // TotalNumSat 
             {   
-                int numberSattelites = atoi(token);
-                //Log.info("numberSattelites %d", numberSattelites);
-                if (numberSattelites > 0) {
-                    self->gnssSatelliteCount_ = numberSattelites;    
+                int numberSatellites = atoi(token);
+                //Log.info("numberSatellites %d", numberSatellites);
+                if (numberSatellites > 0) {
+                    self->gnssSatelliteCount_ = numberSatellites;    
                 }
                 break;
             }

--- a/user/applications/tinker/src/fqc_test.h
+++ b/user/applications/tinker/src/fqc_test.h
@@ -24,21 +24,20 @@ public:
     uint32_t gnssSatelliteCount_ = 0;
 
 private:
+    static const uint32_t GNSS_POLL_TIMEOUT_DEFAULT_MS = 30000;
+
     void initWriter();
 
-    uint8_t tcpServer[4];
-    int tcpPort;
-    JSONBufferWriter writer; 
-    char json_response_buffer[2048];
-    TCPClient tcpClient;
+    uint8_t tcpServer_[4];
+    int tcpPort_;
+    JSONBufferWriter writer_; 
+    char json_response_buffer_[2048];
+    TCPClient tcpClient_;
     bool inited_;
 
     Thread* gnssThread_;
-    static const uint32_t GNSS_POLL_TIMEOUT_DEFAULT_MS = 30000;
     uint32_t gnssPollTimeoutMs_;
     std::atomic_bool gnssEnableSearch_;
-
-    // TODO: Vector for each type of sattelite?
     
     bool passResponse(bool success, String message = String(), int errorCode = 0);
     bool tcpErrorResponse(int tcpError);

--- a/user/applications/tinker/src/fqc_test.h
+++ b/user/applications/tinker/src/fqc_test.h
@@ -22,6 +22,7 @@ public:
     size_t replySize();
 
     uint32_t gnssSatelliteCount_ = 0;
+    String gnssGpsvStrings_;
 
 private:
     static const uint32_t GNSS_POLL_TIMEOUT_DEFAULT_MS = 30000;

--- a/user/applications/tinker/src/fqc_test.h
+++ b/user/applications/tinker/src/fqc_test.h
@@ -21,8 +21,8 @@ public:
     char * reply();
     size_t replySize();
 
-    uint32_t gnssSatelliteCount_ = 0;
-    String gnssGpsvStrings_;
+    uint32_t gnssFixQuality_ = 0;
+    String gnssNmeaOutput_;
 
 private:
     static const uint32_t GNSS_POLL_TIMEOUT_DEFAULT_MS = 30000;
@@ -39,6 +39,7 @@ private:
     Thread* gnssThread_;
     uint32_t gnssPollTimeoutMs_;
     std::atomic_bool gnssEnableSearch_;
+    uint32_t gnssTimeToFix_;
     
     bool passResponse(bool success, String message = String(), int errorCode = 0);
     bool tcpErrorResponse(int tcpError);

--- a/user/applications/tinker/src/fqc_test.h
+++ b/user/applications/tinker/src/fqc_test.h
@@ -21,6 +21,8 @@ public:
     char * reply();
     size_t replySize();
 
+    uint32_t gnssSatelliteCount_ = 0;
+
 private:
     void initWriter();
 
@@ -30,9 +32,18 @@ private:
     char json_response_buffer[2048];
     TCPClient tcpClient;
     bool inited_;
+
+    Thread* gnssThread_;
+    static const uint32_t GNSS_POLL_TIMEOUT_DEFAULT_MS = 30000;
+    uint32_t gnssPollTimeoutMs_;
+    std::atomic_bool gnssEnableSearch_;
+
+    // TODO: Vector for each type of sattelite?
     
-    bool passResponse(bool success);
+    bool passResponse(bool success, String message = String(), int errorCode = 0);
     bool tcpErrorResponse(int tcpError);
+
+    static void gnssLoop(void* arg);
 
     void parseIpAndPort(JSONValue parameters);
     int sendTCPMessage(const char * tx_data, char * rx_data_buffer, int rx_data_buffer_length, int response_poll_ms = 5000);
@@ -43,6 +54,7 @@ private:
     bool ioTest(JSONValue req);
     bool wifiNetcat(JSONValue req);
     bool wifiScanNetworks(JSONValue req);
+    bool gnssTest(JSONValue req);
 };
 
 } // namespace particle


### PR DESCRIPTION
### Problem

Msom hardware supports a built in GNSS engine along with the cellular modem. The mfg-cli needs to be updated to test this GNSS functionality as part of FQC testing at the factory. A new tinker:gnss-test command has been added to enable testing of both M404 (Quectel BG95-M5 modem/GNSS) and M524(Quectel EG91 modem/GNSS) hardware.

### Solution

Add support for the new `particlemfg tinker:gnss-test` command

### Steps to Test
Use `mfg-cli` to test [per instructions here](https://github.com/particle-iot/cli/pull/199)

### Example App

Use tinker

### References

See [CLI PR here](https://github.com/particle-iot/cli/pull/199)
See [slack here](https://s.slack.com/archives/C046BM6DBLL/p1703577091536279)
