### PR TITLE
MSoM: enable session resumption

### DIFF
--- a/hal/src/rtl872x/core_hal.c
+++ b/hal/src/rtl872x/core_hal.c
@@ -942,6 +942,7 @@ retained_system SessionPersistDataOpaque session;
 
 int HAL_System_Backup_Save(size_t offset, const void* buffer, size_t length, void* reserved)
 {
+    SYSTEM_FLAG(restore_backup_ram) |= SYSTEM_FLAG_SESSION_DATA_STALE_MASK;
     if (offset==0 && length==sizeof(SessionPersistDataOpaque))
     {
         memcpy(&session, buffer, length);

--- a/platform/MCU/rtl872x/inc/hw_config.h
+++ b/platform/MCU/rtl872x/inc/hw_config.h
@@ -26,6 +26,8 @@ extern "C" {
 extern uint8_t USE_SYSTEM_FLAGS;
 extern uint16_t tempFlag;
 
+#define SYSTEM_FLAG_RESTOR_BACKUP_RAM_MASK 0x0001
+#define SYSTEM_FLAG_SESSION_DATA_STALE_MASK 0x0002
 
 #define SYSTEM_FLAG(x) (system_flags.x)
 void Load_SystemFlags(void);

--- a/platform/MCU/rtl872x/inc/platform_system_flags.h
+++ b/platform/MCU/rtl872x/inc/platform_system_flags.h
@@ -36,6 +36,8 @@ typedef struct __attribute__((packed)) platform_system_flags {
     uint8_t FeaturesEnabled_SysFlag;        // default is 0xFF all features enabled. If any bits are cleared in the bottom 4-bits, then the upper 4 bits should be the logical inverse of these.
                                             // This is to prevent against corrupted data causing the bootloader to be unavailable.
     uint32_t RCC_CSR_SysFlag;
+    // bit 0: 1: restore backup ram from flash
+    // bit 1: 1: session data in flash is stale
     uint16_t restore_backup_ram;
     uint16_t reserved[3];
 } platform_system_flags_t;

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -522,16 +522,11 @@ int Spark_Save(const void* buffer, size_t length, uint8_t type, void* reserved)
 
 int Spark_Restore(void* buffer, size_t max_length, uint8_t type, void* reserved)
 {
-#if PLATFORM_ID == PLATFORM_MSOM
-    // FIXME: Force new session handshake for now
-    return 0;
-#else
 	size_t length = 0;
 	int error = HAL_System_Backup_Restore(0, buffer, max_length, &length, nullptr);
 	if (error)
 		length = 0;
 	return length;
-#endif
 }
 
 void update_persisted_state(std::function<void(SessionPersistOpaque&)> fn)


### PR DESCRIPTION
As the title describes.

### Problem

1. Session resumption is currentlly disabled on MSoM
2. When session resumption is enabled, it may use stale session info that is restored from backup flash, which results in long connection time.

### Solution

1. Use the session info in KM4 RAM if it is valid.
2. Otherwise, use the session info in backup flash if it is valid.
3. Invalidate the session info in backup flash once it is restored.
4. If there is no valid session info, force a new handshake.

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
