### PR TITLE
[rtl872x] fix openocd FreeRTOS thread view

### DIFF
--- a/hal/src/nRF52840/concurrent_hal.cpp
+++ b/hal/src/nRF52840/concurrent_hal.cpp
@@ -42,7 +42,7 @@
 #include "service_debug.h"
 
 // For OpenOCD FreeRTOS support
-extern const int  __attribute__((used)) uxTopUsedPriority = configMAX_PRIORITIES;
+extern const int  __attribute__((used)) uxTopUsedPriority = configMAX_PRIORITIES - 1;
 
 // use the newer name
 typedef xTaskHandle TaskHandle_t;

--- a/hal/src/rtl872x/concurrent_hal.cpp
+++ b/hal/src/rtl872x/concurrent_hal.cpp
@@ -48,7 +48,7 @@
 #endif // PLATFORM_ID == 6 || PLATFORM_ID == 8
 
 // For OpenOCD FreeRTOS support
-extern const int  __attribute__((used)) uxTopUsedPriority = configMAX_PRIORITIES;
+extern const int  __attribute__((used)) uxTopUsedPriority = configMAX_PRIORITIES - 1;
 
 // use the newer name
 typedef xTaskHandle TaskHandle_t;


### PR DESCRIPTION
### Problem

Openocd experiences an error when attempting to retrieve the Freertos symbols needed to debug on RTL872X platforms. 
The error is related to the `uxTopUsedPriority` definition. This definition is used by openocd to determine how many lists of threads exist. Openocd will search for threads beyond the number of existing thread lists, return an error when trying to parse a random memory location and abandon using FreeRTOS symbols at all. 

I dont know why the NRF platforms do not have this issue, since they should also be "off by 1" with the number of tasks/priorities.

### Solution

Decrement `uxTopUsedPriority` to not search beyond the list of valid threads

### Steps to Test

Flash device os from this branch, attach debugger, run `info threads` command. All FreeRTOS threads should be enumerated. 

### Example App
any

### References

[Openocd section 20.6](https://openocd.org/doc/html/GDB-and-OpenOCD.html)

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
