### PR TITLE
[gen3] fix stack overflow for the timer service thread.

### DIFF
--- a/hal/src/nRF52840/ble_hal.cpp
+++ b/hal/src/nRF52840/ble_hal.cpp
@@ -1456,7 +1456,7 @@ int BleObject::Observer::stopScanning() {
     // Ignore the returned value, as the SoftDevice might be messed up considering the device is not in scanning state,
     // but wee neeed to give the semaphore to unblock the thread that initiated the scanning procedure.
     if (sd_ble_gap_scan_stop() != NRF_SUCCESS) {
-        LOG(ERROR, "Device is not in scanning state.");
+        // LOG(ERROR, "Device is not in scanning state.");
     }
     bool give = false;
     ATOMIC_BLOCK() {
@@ -2243,7 +2243,7 @@ void BleObject::ConnectionsManager::onConnParamsUpdateTimerExpired(os_timer_t ti
         connMgr->periphConnParamUpdateHandle_ = BLE_INVALID_CONN_HANDLE;
         connMgr->connParamsUpdateAttempts_ = 0;
         sd_ble_gap_disconnect(connMgr->periphConnParamUpdateHandle_, BLE_HCI_CONN_INTERVAL_UNACCEPTABLE);
-        LOG_DEBUG(TRACE, "Disconnecting. Update BLE connection parameters failed.");
+        // LOG_DEBUG(TRACE, "Disconnecting. Update BLE connection parameters failed.");
         return;
     }
     connMgr->connParamsUpdateAttempts_++;
@@ -3303,10 +3303,10 @@ int BleObject::GattClient::exchangeAttMtu(hal_ble_conn_handle_t connHandle) {
         attMtuExchangeConnHandle_ = BLE_INVALID_CONN_HANDLE;
         os_timer_change(attMtuExchangeTimer_, OS_TIMER_CHANGE_STOP, false, 0, 0, nullptr);
     }
-    LOG_DEBUG(TRACE, "Request to change ATT_MTU from %d to %d for connection: %d", curAttMtu, desiredAttMtu, connHandle);
+    // LOG_DEBUG(TRACE, "Request to change ATT_MTU from %d to %d for connection: %d", curAttMtu, desiredAttMtu, connHandle);
     int ret = sd_ble_gattc_exchange_mtu_request(connHandle, desiredAttMtu);
     if (ret != NRF_SUCCESS) {
-        LOG(ERROR, "sd_ble_gattc_exchange_mtu_request() failed: %d.", ret);
+        // LOG(ERROR, "sd_ble_gattc_exchange_mtu_request() failed: %d.", ret);
         return nrf_system_error(ret);
     }
     return SYSTEM_ERROR_NONE;
@@ -3318,10 +3318,10 @@ void BleObject::GattClient::onAttMtuExchangeTimerExpired(os_timer_t timer) {
     if (gattc->exchangeAttMtu(gattc->attMtuExchangeConnHandle_) == SYSTEM_ERROR_BUSY) {
         gattc->attMtuExchangeRetries_--;
         if (gattc->attMtuExchangeRetries_ > 0) {
-            LOG_DEBUG(TRACE, "Retry to perform ATT MTU exchange procedure.");
+            // LOG_DEBUG(TRACE, "Retry to perform ATT MTU exchange procedure.");
             os_timer_change(gattc->attMtuExchangeTimer_, OS_TIMER_CHANGE_START, false, 0, 0, nullptr);
         } else {
-            LOG(ERROR, "Automatically perform ATT MTU exchange procedure failed.");
+            // LOG(ERROR, "Automatically perform ATT MTU exchange procedure failed.");
         }
     }
 }


### PR DESCRIPTION
### Problem

[SC124588] Device panics with 13 blinks SOS pattern, which is stack overflow. This issue is introduced since https://github.com/particle-iot/device-os/pull/2696.

### Solution

Remove logging in timer service routine in BLE HAL.

### Steps to Test

1. Use an Argon to run the `user/tests/app/ble/uart_peripheral` app. You need to make a little bit change to this app:
 ```c
    BleAdvertisingData data;
    // data.appendServiceUUID(serviceUuid);
    data.appendLocalName("Argon-123abc");
    BLE.advertise(&data);
 ```
3. Use a Boron to run the attached test app.

### Example App

```c
#include "Particle.h"

SYSTEM_MODE(MANUAL);

SYSTEM_THREAD(ENABLED);

// Show system, cloud connectivity, and application logs over USB
// View logs with CLI using 'particle serial monitor --follow'
SerialLogHandler logHandler(LOG_LEVEL_TRACE);

BlePeerDevice OTAPeerDevice;
BleScanResult result;

void setup() {
    uint32_t count;

    waitFor(Serial.isConnected, 30000);
   
    Log.trace("OTA-SETUP");
    delay(1000);

    BLE.on();
    count = BLE.scanWithFilter(BleScanFilter().deviceName("Argon-123abc"), &result, 1);
    BLE.stopScanning();

    if (!count) { 
        Log.trace("NO DEVICE FOUND");
        return;
    }
    
    Log.trace(result.address().toString());
    OTAPeerDevice = BLE.connect(result.address());

    Log.trace("POST CONNECT");
    if (!OTAPeerDevice.connected()) {
        Log.trace("NOT CONNECTED");
        return;
    }
}

void loop() {
}
```

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
