### PR TITLE
[cellular] fixes handling of 00 or 000 MNC

### DIFF
--- a/hal/network/ncp/cellular/cellular_hal.cpp
+++ b/hal/network/ncp/cellular/cellular_hal.cpp
@@ -286,12 +286,12 @@ cellular_result_t cellular_global_identity(CellularGlobalIdentity* cgi, void* re
     const auto client = mgr->ncpClient();
     CHECK_TRUE(client, SYSTEM_ERROR_UNKNOWN);
 
-    // Load cached data into result struct
+    // Load data into result struct
     CHECK(client->getCellularGlobalIdentity(cgi));
 
     // Validate cache
     CHECK_TRUE(0 != cgi->mobile_country_code, SYSTEM_ERROR_BAD_DATA);
-    CHECK_TRUE(0 != cgi->mobile_network_code, SYSTEM_ERROR_BAD_DATA);
+    // MNC may be 00 or 000. In case of incorrect parsing getCellularGlobalIdentity() should have failed anyway
     CHECK_TRUE(0xFFFF != cgi->location_area_code, SYSTEM_ERROR_BAD_DATA);
     CHECK_TRUE(0xFFFFFFFF != cgi->cell_id, SYSTEM_ERROR_BAD_DATA);
 

--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -609,8 +609,12 @@ int QuectelNcpClient::queryAndParseAtCops(CellularSignalQuality* qual) {
         cgi_.cgi_flags &= ~CGI_FLAG_TWO_DIGIT_MNC;
     }
 
-    // `atoi` returns zero on error, which is an invalid `mcc` and `mnc`
+    // NOTE: MCC cannot be zero, MNC may be 00 or even 000
+    // We should not need to check whether str -> int coversion works
+    // as scanf() above along with the return value check guarantees that we've
+    // scanned the correct MCC MNC combo returned from +COPS.
     cgi_.mobile_country_code = static_cast<uint16_t>(::atoi(mobileCountryCode));
+    CHECK_TRUE(cgi_.mobile_country_code != 0, SYSTEM_ERROR_BAD_DATA);
     cgi_.mobile_network_code = static_cast<uint16_t>(::atoi(mobileNetworkCode));
 
     switch (static_cast<CellularAccessTechnology>(act)) {

--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -681,8 +681,12 @@ int SaraNcpClient::queryAndParseAtCops(CellularSignalQuality* qual) {
         cgi_.cgi_flags &= ~CGI_FLAG_TWO_DIGIT_MNC;
     }
 
-    // `atoi` returns zero on error, which is an invalid `mcc` and `mnc`
+    // NOTE: MCC cannot be zero, MNC may be 00 or even 000
+    // We should not need to check whether str -> int coversion works
+    // as scanf() above along with the return value check guarantees that we've
+    // scanned the correct MCC MNC combo returned from +COPS.
     cgi_.mobile_country_code = static_cast<uint16_t>(::atoi(mobileCountryCode));
+    CHECK_TRUE(cgi_.mobile_country_code != 0, SYSTEM_ERROR_BAD_DATA);
     cgi_.mobile_network_code = static_cast<uint16_t>(::atoi(mobileNetworkCode));
 
     if (ncpId() == PLATFORM_NCP_SARA_R410 || ncpId() == PLATFORM_NCP_SARA_R510) {


### PR DESCRIPTION
### Description

Fixes handling of 00 (plenty of examples e.g. China Mobile: MCC=450 MNC=00) or 000 MNC (MCC=350 MNC=000 for One in Bermuda).

### Steps to Test

N/A

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
