### PR TITLE
[cellular] To enable high-speed baud rate support for the EG91-NAX

### DIFF
--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -91,6 +91,7 @@ inline system_tick_t millis() {
 const auto QUECTEL_NCP_DEFAULT_SERIAL_BAUDRATE = 115200;
 const auto QUECTEL_NCP_RUNTIME_SERIAL_BAUDRATE = 460800;
 const auto QUECTEL_NCP_RUNTIME_SERIAL_BAUDRATE_BG95_M5 = 921600;
+const auto QUECTEL_NCP_RUNTIME_SERIAL_BAUDRATE_EG91_NAX = 921600;
 
 const auto QUECTEL_NCP_MAX_MUXER_FRAME_SIZE = 1509;
 const auto QUECTEL_NCP_KEEPALIVE_PERIOD = 5000; // milliseconds
@@ -1070,6 +1071,8 @@ int QuectelNcpClient::getRuntimeBaudrate() {
         // Only change for MSoM, and currently MSoM only uses BG95_M5.
         // Not testing for PLATFORM_ID == PLATFORM_MSOM because another modem type might not support 921600.
         runtimeBaudrate = QUECTEL_NCP_RUNTIME_SERIAL_BAUDRATE_BG95_M5;
+    } else if (ncpId() == PLATFORM_NCP_QUECTEL_EG91_NAX) {
+        runtimeBaudrate = QUECTEL_NCP_RUNTIME_SERIAL_BAUDRATE_EG91_NAX;
     }
     return runtimeBaudrate;
 }


### PR DESCRIPTION
### Problem
[[SC124878](https://app.shortcut.com/particle/story/124878/eg91-nax-to-enable-high-speed-baud-rate-support-for-the-eg91-nax)] Add support for the `921600` baud-rate on the EG91-NAX modem for the B5SoM module.

### Solution
To enable high-speed baud rate support for the EG91-NAX.

### Steps to Test
Observe the modem’s serial communication waveform through an oscilloscope.

### Example App
```c
const auto QUECTEL_NCP_RUNTIME_SERIAL_BAUDRATE_EG91_NAX = 921600;

int QuectelNcpClient::getRuntimeBaudrate() {
    auto runtimeBaudrate = QUECTEL_NCP_RUNTIME_SERIAL_BAUDRATE;
    if (ncpId() == PLATFORM_NCP_QUECTEL_BG95_M5) {
        // Only change for MSoM, and currently MSoM only uses BG95_M5.
        // Not testing for PLATFORM_ID == PLATFORM_MSOM because another modem type might not support 921600.
        runtimeBaudrate = QUECTEL_NCP_RUNTIME_SERIAL_BAUDRATE_BG95_M5;
    } else if (ncpId() == PLATFORM_NCP_QUECTEL_EG91_NAX) {
        runtimeBaudrate = QUECTEL_NCP_RUNTIME_SERIAL_BAUDRATE_EG91_NAX;
    }
    return runtimeBaudrate;
}
```

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
