### PR TITLE
[rtl872x] usb: small fix for holdoff

### DIFF
--- a/hal/src/rtl872x/usbd_cdc.cpp
+++ b/hal/src/rtl872x/usbd_cdc.cpp
@@ -422,7 +422,7 @@ int CdcClassDriver::startTx(bool holdoff) {
         return 0;
     }
 
-    if (holdoff) {
+    if (holdoff && consumable < cdc::MAX_DATA_PACKET_SIZE) {
         stopTxTimer();
         return startTxTimer();
     }

--- a/hal/src/rtl872x/usbd_driver.h
+++ b/hal/src/rtl872x/usbd_driver.h
@@ -95,7 +95,7 @@ private:
     usb_dev_t* rtlDev_ = nullptr;
     bool setupError_ = false;
 
-    const uint8_t RTL_USBD_ISR_PRIORITY = 7;
+    const uint8_t RTL_USBD_ISR_PRIORITY = OS_THREAD_PRIORITY_NETWORK - 1;
     __attribute__((aligned(4))) uint8_t tempBuffer_[rtl::TEMP_BUFFER_SIZE];
 
     // TODO: Validate whether these are required to be present at all times
@@ -105,7 +105,7 @@ private:
         .rx_fifo_size = USBD_MAX_RX_FIFO_SIZE,
         .nptx_fifo_size = USBD_MAX_NPTX_FIFO_SIZE,
         .ptx_fifo_size = USBD_MAX_PTX_FIFO_SIZE,
-        .speed = USB_SPEED_FULL,
+        .speed = USB_SPEED_HIGH,
         .dma_enable = 0, // ?
         .self_powered = 1,
         .isr_priority = RTL_USBD_ISR_PRIORITY,


### PR DESCRIPTION
### Problem

1. Hold-off mechanism for USB CDC to avoid scheduling small IN transfers does not account for maximum transfer size
2. USB thread processing ISRs should be below network thread to avoid affecting network performance

### Steps to Test

N/A

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
