### PR TITLE
Improve bg95 connection speed by only setting nwscanseq if needed

### DIFF
--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -1450,8 +1450,8 @@ int QuectelNcpClient::registerNet() {
                 CHECK_TRUE(r == 1, SYSTEM_ERROR_UNKNOWN);
                 r = CHECK_PARSER(respNwScanSeq.readResult());
                 CHECK_TRUE(r == AtResponse::OK, SYSTEM_ERROR_UNKNOWN);
-                if (nwScanSeq != 201) { // i.e. 0201
-                    CHECK_PARSER(parser_.execCommand("AT+QCFG=\"nwscanseq\",0201,1")); // LTE 02, then GSM 01
+                if (nwScanSeq != 20103) { // i.e. 020103
+                    CHECK_PARSER(parser_.execCommand("AT+QCFG=\"nwscanseq\",020103,1")); // LTE 02, then GSM 01, then NBIOT 03
                 }
             }
         #else 
@@ -1463,7 +1463,7 @@ int QuectelNcpClient::registerNet() {
 
         if (isQuecCatNBxDevice()) {
             // Configure Network Category to be searched
-            // Set to use LTE Cat-M1 ONLY if not already set, take effect immediately
+            // Set to use LTE Cat-M1 ONLY (exclude NBIOT) if not already set, take effect immediately
             auto respOpMode = parser_.sendCommand("AT+QCFG=\"iotopmode\"") ;
 
             int iotOpMode = -1;


### PR DESCRIPTION
### Problem

On warm boot, msom/BG95-M5 platforms consistently experience a dregistration event 18 seconds after boot. This causes the ongoing PPP link / server socket to fail and cellular registration to start over. This increases time for the platform to come online

### Solution
The `nwscanseq` setting is being set on every boot, which triggers the network de-registration. This should only be set when needed. The network scan order should be LTE > 2G > NBIOT. We cannot specifically exclude NBIOT with the `nwscanseq` command. NBIOT will be excluded in the `iotopmode` command

### Steps to Test

Run this branch. Let modem register on network. Press reset button. Device should reconnect to the particle cloud around 10 seconds. It should not be deregistered from the cell network

### Example App
any

### References

[slack discussion](https://s.slack.com/archives/C046BM6DBLL/p1706673451637339)

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
