### PR TITLE
[system] Fix bad int to bool conversion for clearCredentials

### DIFF
--- a/system/inc/system_network.h
+++ b/system/inc/system_network.h
@@ -102,6 +102,15 @@ typedef WLanCredentials NetworkCredentials;
  * @return 0 on success.
  */
 int network_set_credentials(network_handle_t network, uint32_t flags, NetworkCredentials* creds, void* reserved);
+/**
+ *
+ * @param network   The network to configure the credentials.
+ * @param flags     Flags. set to 0.
+ * @param creds     The credentials to set. Set to NULL.
+ * @param reserved  For future expansion. Set to NULL.
+ * @return true     Successfully cleared the given network credentials
+ * @return false    Failed to clear the given network credentials
+ */
 bool network_clear_credentials(network_handle_t network, uint32_t flags, NetworkCredentials* creds, void* reserved);
 
 void network_setup(network_handle_t network, uint32_t flags, void* reserved);

--- a/system/src/system_network_manager_api.cpp
+++ b/system/src/system_network_manager_api.cpp
@@ -438,7 +438,7 @@ bool network_clear_credentials(network_handle_t network, uint32_t, NetworkCreden
     } else {
         if_t iface;
         if (!if_get_by_index(network, &iface)) {
-            return NetworkManager::instance()->clearConfiguration(iface);
+            return NetworkManager::instance()->clearConfiguration(iface) == 0;
         }
     }
     return false;


### PR DESCRIPTION
### Problem

It was reported that `WiFi.clearCredentials()` was returning a bad value for success in this Community post [WiFi.clearCredentials() fails? on p2 @ 5.4.1](https://community.particle.io/t/wifi-clearcredentials-fails-on-p2-5-4-1).

Rick dug into the issue and saw that there was an integer to bool conversion gone bad.

### Solution

Added a comparison to zero with the `int clearConfiguration()` call so that `int() == 0` results in a boolean `true` in `network_clear_credentials()`.

Added comments for `network_clear_credentials()` usage.

### Steps to Test

Run this while credentials are set on the device.

```cpp
if(!WiFi.clearCredentials()) {
    Log.warn("clear credentials failed!");
}
```

### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
