### PR TITLE
ACM MVP Behavior changes

### DIFF
--- a/system/inc/system_cloud.h
+++ b/system/inc/system_cloud.h
@@ -126,7 +126,8 @@ const CloudVariableTypeDouble DOUBLE;
  */
 enum CloudDisconnectFlag {
     CLOUD_DISCONNECT_GRACEFULLY = 0x01, ///< Disconnect gracefully.
-    CLOUD_DISCONNECT_DONT_CLOSE = 0x02 ///< Do not close the socket.
+    CLOUD_DISCONNECT_DONT_CLOSE = 0x02, ///< Do not close the socket.
+    CLOUD_DISCONNECT_RECONNECT_IMMEDIATELY = 0x03 ///< Close the socket, but leave the cloud connect flag set
 };
 
 /**
@@ -313,7 +314,8 @@ bool spark_cloud_flag_auto_connect(void);
 typedef enum spark_cloud_disconnect_option_flag {
     SPARK_CLOUD_DISCONNECT_OPTION_GRACEFUL = 0x01, ///< The `graceful` option is set.
     SPARK_CLOUD_DISCONNECT_OPTION_TIMEOUT = 0x02, ///< The `timeout` option is set.
-    SPARK_CLOUD_DISCONNECT_OPTION_CLEAR_SESSION = 0x04 ///< The `clear_session` option is set.
+    SPARK_CLOUD_DISCONNECT_OPTION_CLEAR_SESSION = 0x04, ///< The `clear_session` option is set.
+    SPARK_CLOUD_DISCONNECT_OPTION_RECONNECT_IMMEDIATELY = 0x08 ///< The `reconnect_immediately` option is set.
 } spark_cloud_disconnect_option_flag;
 
 /**
@@ -325,6 +327,7 @@ typedef struct spark_cloud_disconnect_options {
     uint8_t graceful; ///< Enables graceful disconnection if set to a non-zero value.
     uint32_t timeout; ///< Maximum time in milliseconds to wait for message acknowledgements.
     uint8_t clear_session; ///< Clears the session after disconnecting if set to a non-zero value.
+    uint8_t reconnect_immediately;
 } spark_cloud_disconnect_options;
 
 /**

--- a/system/inc/system_cloud.h
+++ b/system/inc/system_cloud.h
@@ -354,8 +354,7 @@ typedef enum spark_connection_property {
     SPARK_CLOUD_MAX_EVENT_DATA_SIZE = 3, ///< Maximum size of event data (get).
     SPARK_CLOUD_MAX_VARIABLE_VALUE_SIZE = 4, ///< Maximum size of a variable value (get).
     SPARK_CLOUD_MAX_FUNCTION_ARGUMENT_SIZE = 5, ///< Maximum size of a function call argument (get).
-    SPARK_CLOUD_BIND_NETWORK_INTERFACE = 6, ///< The cloud connection should only use a specified network interface
-    SPARK_CLOUD_GET_NETWORK_INTERFACE = 7 ///< Which interface is being used for the current cloud connection
+    SPARK_CLOUD_GET_NETWORK_INTERFACE = 6 ///< Which interface is being used for the current cloud connection
 } spark_connection_property;
 
 int spark_set_connection_property(unsigned property, unsigned value, const void* data, void* reserved);

--- a/system/inc/system_task.h
+++ b/system/inc/system_task.h
@@ -55,8 +55,6 @@ inline void Spark_Idle() { Spark_Idle_Events(false); }
 void SPARK_WLAN_Loop(void) __attribute__ ((deprecated("Please use Particle.process() instead.")));
 inline void SPARK_WLAN_Loop(void) { spark_process(); }
 
-void disconnect_cloud();
-
 extern volatile uint8_t SPARK_WLAN_RESET;
 extern volatile uint8_t SPARK_WLAN_SLEEP;
 extern volatile uint8_t SPARK_WLAN_CONNECT_RESTORE;

--- a/system/src/system_cloud.cpp
+++ b/system/src/system_cloud.cpp
@@ -302,10 +302,6 @@ int spark_set_connection_property(unsigned property, unsigned value, const void*
         const auto r = spark_protocol_set_connection_property(sp, property, value, d, reserved);
         return spark_protocol_to_system_error(r);
     }
-    case SPARK_CLOUD_BIND_NETWORK_INTERFACE: {
-        CloudConnectionSettings::instance()->setBoundInterface((network_interface_t)value);
-        return 0;
-    }
     
     default:
         return SYSTEM_ERROR_INVALID_ARGUMENT;
@@ -331,13 +327,6 @@ int spark_get_connection_property(unsigned property, void* data, size_t* size, v
             return SYSTEM_ERROR_INVALID_STATE;
         }
         return getConnectionProperty(protocol::Connection::MAX_FUNCTION_ARGUMENT_SIZE, data, size);
-    case SPARK_CLOUD_BIND_NETWORK_INTERFACE: {
-        if (*size >= sizeof(network_interface_t)) {
-            *((network_interface_t*)data) = CloudConnectionSettings::instance()->getBoundInterface();
-            return 0;    
-        }
-        return SYSTEM_ERROR_INVALID_ARGUMENT;
-    }
     case SPARK_CLOUD_GET_NETWORK_INTERFACE: {
         if (*size >= sizeof(network_interface_t)) {
 #if HAL_PLATFORM_AUTOMATIC_CONNECTION_MANAGEMENT

--- a/system/src/system_cloud.cpp
+++ b/system/src/system_cloud.cpp
@@ -329,7 +329,7 @@ int spark_get_connection_property(unsigned property, void* data, size_t* size, v
         return getConnectionProperty(protocol::Connection::MAX_FUNCTION_ARGUMENT_SIZE, data, size);
     case SPARK_CLOUD_GET_NETWORK_INTERFACE: {
         if (*size >= sizeof(network_interface_t)) {
-#if HAL_PLATFORM_AUTOMATIC_CONNECTION_MANAGEMENT
+#if HAL_PLATFORM_IFAPI
             *((network_interface_t*)data) = ConnectionManager::instance()->getCloudConnectionNetwork();
 #else
             *((network_interface_t*)data) = NETWORK_INTERFACE_ALL;

--- a/system/src/system_cloud_connection_posix.cpp
+++ b/system/src/system_cloud_connection_posix.cpp
@@ -209,7 +209,11 @@ int system_cloud_connect(int protocol, const ServerAddress* address, sockaddr* s
             if_index_to_name(cloudInterface, ifr.ifr_name);
 
             auto sockOptRet = sock_setsockopt(s, SOL_SOCKET, SO_BINDTODEVICE, &ifr, sizeof(ifr));
-            LOG(TRACE, "%d Bound cloud socket to lwip interface %s", sockOptRet, ifr.ifr_name);
+            if (sockOptRet) {
+                LOG(WARN, "Failed to bind cloud socket to interface %u error: %d", cloudInterface, sockOptRet);
+            } else {
+                LOG(INFO, "Bound cloud socket to lwip interface %s", ifr.ifr_name);
+            }
         }
 
         /* FIXME: timeout for TCP */

--- a/system/src/system_cloud_connection_posix.cpp
+++ b/system/src/system_cloud_connection_posix.cpp
@@ -166,7 +166,6 @@ int system_cloud_connect(int protocol, const ServerAddress* address, sockaddr* s
                 break;
             }
         }
-        LOG(INFO, "Cloud socket=%d, connecting to %s#%u", s, serverHost, serverPort);
 
         /* We are using fixed source port only for IPv6 connections */
         if (protocol == IPPROTO_UDP && a->ai_family == AF_INET6) {
@@ -203,6 +202,8 @@ int system_cloud_connect(int protocol, const ServerAddress* address, sockaddr* s
 
         network_interface_t cloudInterface = particle::system::ConnectionManager::instance()->selectCloudConnectionNetwork();
 
+        LOG(INFO, "Cloud socket=%d, connecting to %s#%u using if %d", s, serverHost, serverPort, cloudInterface);
+
         if (cloudInterface != NETWORK_INTERFACE_ALL) {    
             // Bind to specific netif
             struct ifreq ifr = {};
@@ -212,7 +213,7 @@ int system_cloud_connect(int protocol, const ServerAddress* address, sockaddr* s
             if (sockOptRet) {
                 LOG(WARN, "Failed to bind cloud socket to interface %u error: %d", cloudInterface, sockOptRet);
             } else {
-                LOG(INFO, "Bound cloud socket to lwip interface %u name \"%s\" ", cloudInterface, ifr.ifr_name);
+                LOG(INFO, "Bound cloud socket to lwip if %u (\"%s\")", cloudInterface, ifr.ifr_name);
             }
         }
 

--- a/system/src/system_cloud_connection_posix.cpp
+++ b/system/src/system_cloud_connection_posix.cpp
@@ -212,7 +212,7 @@ int system_cloud_connect(int protocol, const ServerAddress* address, sockaddr* s
             if (sockOptRet) {
                 LOG(WARN, "Failed to bind cloud socket to interface %u error: %d", cloudInterface, sockOptRet);
             } else {
-                LOG(INFO, "Bound cloud socket to lwip interface %s", ifr.ifr_name);
+                LOG(INFO, "Bound cloud socket to lwip interface %u name \"%s\" ", cloudInterface, ifr.ifr_name);
             }
         }
 

--- a/system/src/system_cloud_internal.h
+++ b/system/src/system_cloud_internal.h
@@ -144,8 +144,7 @@ public:
             defaultDisconnectTimeout_(DEFAULT_DISCONNECT_TIMEOUT),
             defaultDisconnectGracefully_(DEFAULT_DISCONNECT_GRACEFULLY),
             defaultDisconnectClearSession_(DEFAULT_DISCONNECT_CLEAR_SESSION),
-            defaultDisconnectReconnect_(DEFAULT_RECONNECT),
-            boundInterface_(NETWORK_INTERFACE_ALL) {
+            defaultDisconnectReconnect_(DEFAULT_RECONNECT) {
     }
 
     void setDefaultDisconnectOptions(const CloudDisconnectOptions& options) {
@@ -205,14 +204,6 @@ public:
 
     static CloudConnectionSettings* instance();
 
-    void setBoundInterface(network_interface_t network) {
-        boundInterface_ = network;
-    }
-
-    network_interface_t getBoundInterface() {
-        return boundInterface_;
-    }
-
 private:
     SimpleAtomicFlagMutex mutex_;
     // Default disconnection options can only be set in the context of the system thread.
@@ -223,7 +214,6 @@ private:
     // Pending disconnection options are set atomically and guarded by a spinlock
     CloudDisconnectOptions pendingDisconnectOptions_;
     bool defaultDisconnectReconnect_;
-    network_interface_t boundInterface_;
 };
 
 // Use this function instead of Particle.publish() in the system code

--- a/system/src/system_cloud_internal.h
+++ b/system/src/system_cloud_internal.h
@@ -138,11 +138,13 @@ public:
     static const bool DEFAULT_DISCONNECT_GRACEFULLY = false;
     static const unsigned DEFAULT_DISCONNECT_TIMEOUT = 30000;
     static const bool DEFAULT_DISCONNECT_CLEAR_SESSION = false;
+    static const bool DEFAULT_RECONNECT = false;
 
     CloudConnectionSettings() :
             defaultDisconnectTimeout_(DEFAULT_DISCONNECT_TIMEOUT),
             defaultDisconnectGracefully_(DEFAULT_DISCONNECT_GRACEFULLY),
             defaultDisconnectClearSession_(DEFAULT_DISCONNECT_CLEAR_SESSION),
+            defaultDisconnectReconnect_(DEFAULT_RECONNECT),
             boundInterface_(NETWORK_INTERFACE_ALL) {
     }
 
@@ -155,6 +157,9 @@ public:
         }
         if (options.isClearSessionSet()) {
             defaultDisconnectClearSession_ = options.clearSession();
+        }
+        if (options.isReconnectSet()) {
+            defaultDisconnectReconnect_ = options.reconnect();
         }
     }
 
@@ -190,6 +195,11 @@ public:
         } else {
             result.clearSession(defaultDisconnectClearSession_);
         }
+        if (pending.isReconnectSet()) {
+            result.reconnect(pending.reconnect());
+        } else {
+            result.reconnect(defaultDisconnectReconnect_);
+        }
         return result;
     }
 
@@ -212,6 +222,7 @@ private:
     bool defaultDisconnectClearSession_;
     // Pending disconnection options are set atomically and guarded by a spinlock
     CloudDisconnectOptions pendingDisconnectOptions_;
+    bool defaultDisconnectReconnect_;
     network_interface_t boundInterface_;
 };
 

--- a/system/src/system_connection_manager.cpp
+++ b/system/src/system_connection_manager.cpp
@@ -130,16 +130,6 @@ network_handle_t ConnectionManager::getCloudConnectionNetwork() {
 network_handle_t ConnectionManager::selectCloudConnectionNetwork() {
     network_handle_t bestNetwork = NETWORK_INTERFACE_ALL;
 
-    // 1: If there is a bound network connection. Do not use anything else, regardless of network state
-    network_handle_t boundNetwork = NETWORK_INTERFACE_ALL;
-    size_t n = sizeof(boundNetwork);
-    spark_get_connection_property(SPARK_CLOUD_BIND_NETWORK_INTERFACE, &boundNetwork, &n, nullptr);
-
-    if (boundNetwork != NETWORK_INTERFACE_ALL) {
-        LOG_DEBUG(TRACE, "Using bound network: %lu", boundNetwork);
-        return boundNetwork;
-    }
-
     // 2: If no bound network, use preferred network
     if (preferredNetwork_ != NETWORK_INTERFACE_ALL && network_ready(spark::Network.from(preferredNetwork_), 0, nullptr)) {
         LOG_DEBUG(TRACE, "Using preferred network: %lu", preferredNetwork_);

--- a/system/src/system_connection_manager.cpp
+++ b/system/src/system_connection_manager.cpp
@@ -373,7 +373,7 @@ int ConnectionTester::testConnections() {
             auto network = spark::Network.from(connectionMetrics.interface);
             if (network == spark::Network) {
                 LOG(ERROR, "No Network associated with interface %d", connectionMetrics.interface);
-                continue;
+                return SYSTEM_ERROR_NETWORK;
             }
             if (!network_ready(network, 0, nullptr)) {
                 LOG_DEBUG(TRACE,"%s not ready, skipping test", netifToName(connectionMetrics.interface));

--- a/system/src/system_connection_manager.cpp
+++ b/system/src/system_connection_manager.cpp
@@ -96,7 +96,13 @@ ConnectionManager* ConnectionManager::instance() {
 void ConnectionManager::setPreferredNetwork(network_handle_t network, bool preferred) {
     if (preferred) {
         if (network != NETWORK_INTERFACE_ALL) {
-            preferredNetwork_ = network;    
+            preferredNetwork_ = network;
+
+            // If preferred network is set, and it is up, move cloud connection to it immediately
+            if (network_ready(spark::Network.from(preferredNetwork_), 0, nullptr)) {
+                auto options = CloudDisconnectOptions().graceful(true).reconnect(true).toSystemOptions();
+                spark_cloud_disconnect(&options, nullptr);
+            }
         }
     } else {
         if (network == preferredNetwork_ || network == NETWORK_INTERFACE_ALL) {

--- a/system/src/system_connection_manager.cpp
+++ b/system/src/system_connection_manager.cpp
@@ -130,15 +130,14 @@ network_handle_t ConnectionManager::getCloudConnectionNetwork() {
 network_handle_t ConnectionManager::selectCloudConnectionNetwork() {
     network_handle_t bestNetwork = NETWORK_INTERFACE_ALL;
 
-    // 2: If no bound network, use preferred network
     if (preferredNetwork_ != NETWORK_INTERFACE_ALL && network_ready(spark::Network.from(preferredNetwork_), 0, nullptr)) {
         LOG_DEBUG(TRACE, "Using preferred network: %lu", preferredNetwork_);
         return preferredNetwork_;
     }
 
-    // 3: If no preferred network, use the 'best' network based on criteria
-    // 3.1: Network is ready: ie configured + connected (see ipv4 routable hook)
-    // 3.2: Network has best criteria based on network tester results
+    // If no preferred network, use the 'best' network based on criteria
+    // Network is ready: ie configured + connected (see ipv4 routable hook)
+    // Network has best criteria based on network tester results
     for (auto& i: bestNetworks_) {
         if (network_ready(spark::Network.from(i), 0, nullptr)) {
             LOG_DEBUG(TRACE, "Using best network: %lu", i);

--- a/system/src/system_connection_manager.cpp
+++ b/system/src/system_connection_manager.cpp
@@ -372,7 +372,7 @@ int ConnectionTester::testConnections() {
             auto network = spark::Network.from(connectionMetrics.interface);
             if (network == spark::Network) {
                 LOG(ERROR, "No Network associated with interface %d", connectionMetrics.interface);
-                return SYSTEM_ERROR_NETWORK;
+                return SYSTEM_ERROR_BAD_DATA;
             }
             if (!network_ready(network, 0, nullptr)) {
                 LOG_DEBUG(TRACE,"%s not ready, skipping test", netifToName(connectionMetrics.interface));
@@ -481,13 +481,13 @@ const Vector<ConnectionMetrics> ConnectionTester::getConnectionMetrics(){
 const Vector<network_interface_t> ConnectionTester::getSupportedInterfaces() {
     const Vector<network_interface_t> interfaceList = { 
 #if HAL_PLATFORM_ETHERNET
-    static_cast<network_interface_t>(NetworkDiagnosticsInterface::ETHERNET),
+    NETWORK_INTERFACE_ETHERNET,
 #endif
 #if HAL_PLATFORM_WIFI 
-    static_cast<network_interface_t>(NetworkDiagnosticsInterface::WIFI_STA),
+    NETWORK_INTERFACE_WIFI_STA,
 #endif
 #if HAL_PLATFORM_CELLULAR
-    static_cast<network_interface_t>(NetworkDiagnosticsInterface::CELLULAR)
+    NETWORK_INTERFACE_CELLULAR
 #endif
     };
 

--- a/system/src/system_network_manager.cpp
+++ b/system/src/system_network_manager.cpp
@@ -646,7 +646,7 @@ void NetworkManager::handleIfLink(if_t iface, const struct if_event* ev) {
         }
     }
 
-    if (disconnectCloud) {
+    if (spark_cloud_flag_connected() && disconnectCloud) {
         auto systemOptions = options.toSystemOptions();
         spark_cloud_disconnect(&systemOptions, nullptr);
     }

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -692,6 +692,10 @@ void cloud_disconnect(unsigned flags, cloud_disconnect_reason cloudReason, netwo
             spark_cloud_socket_disconnect(graceful);
         }
 
+        if (opts.reconnect()) {
+            spark_cloud_flag_connect();
+        }
+
         // Note: Invoking the protocol's DISCONNECT or TERMINATE command cancels the ongoing firmware
         // if the device is being updated OTA, so there's no need to explicitly cancel the update here
         SPARK_CLOUD_CONNECTED = 0;

--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -380,8 +380,7 @@ public:
 
     static bool connected(void) { return spark_cloud_flag_connected(); }
     static bool disconnected(void) { return !connected(); }
-    static void connect(const spark::NetworkClass& network = spark::Network) {
-        spark_set_connection_property(SPARK_CLOUD_BIND_NETWORK_INTERFACE, static_cast<network_interface_t>(network), nullptr, nullptr);
+    static void connect(void) {
         spark_cloud_flag_connect();
     }
     static void disconnect(const CloudDisconnectOptions& options = CloudDisconnectOptions());

--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -91,6 +91,10 @@ public:
     bool clearSession() const;
     bool isClearSessionSet() const;
 
+    CloudDisconnectOptions& reconnect(bool enabled);
+    bool reconnect() const;
+    bool isReconnectSet() const;
+
     spark_cloud_disconnect_options toSystemOptions() const;
     static CloudDisconnectOptions fromSystemOptions(const spark_cloud_disconnect_options* options);
 
@@ -99,8 +103,9 @@ private:
     system_tick_t timeout_;
     bool graceful_;
     bool clearSession_;
+    bool reconnect_;
 
-    CloudDisconnectOptions(unsigned flags, system_tick_t timeout, bool graceful, bool clearSession);
+    CloudDisconnectOptions(unsigned flags, system_tick_t timeout, bool graceful, bool clearSession, bool reconnect = false);
 };
 
 class CloudClass {
@@ -605,15 +610,16 @@ extern CloudClass Spark __attribute__((deprecated("Spark is now Particle.")));
 extern CloudClass Particle;
 
 inline CloudDisconnectOptions::CloudDisconnectOptions() :
-        CloudDisconnectOptions(0, 0, false, false) {
+        CloudDisconnectOptions(0, 0, false, false, false) {
 }
 
 inline CloudDisconnectOptions::CloudDisconnectOptions(unsigned flags, system_tick_t timeout, bool graceful,
-        bool clearSession) :
+        bool clearSession, bool reconnect) :
         flags_(flags),
         timeout_(timeout),
         graceful_(graceful),
-        clearSession_(clearSession) {
+        clearSession_(clearSession),
+        reconnect_(reconnect) {
 }
 
 inline CloudDisconnectOptions& CloudDisconnectOptions::graceful(bool enabled) {
@@ -660,6 +666,20 @@ inline bool CloudDisconnectOptions::clearSession() const {
 
 inline bool CloudDisconnectOptions::isClearSessionSet() const {
     return (flags_ & SPARK_CLOUD_DISCONNECT_OPTION_CLEAR_SESSION);
+}
+
+inline CloudDisconnectOptions& CloudDisconnectOptions::reconnect(bool enabled) {
+    reconnect_ = enabled;
+    flags_ |= SPARK_CLOUD_DISCONNECT_OPTION_RECONNECT_IMMEDIATELY;
+    return *this;
+}
+
+inline bool CloudDisconnectOptions::reconnect() const {
+    return reconnect_;
+}
+
+inline bool CloudDisconnectOptions::isReconnectSet() const {
+    return (flags_ & SPARK_CLOUD_DISCONNECT_OPTION_RECONNECT_IMMEDIATELY);
 }
 
 inline particle::Future<bool> CloudClass::publish(const char* name) {

--- a/wiring/src/spark_wiring_cloud.cpp
+++ b/wiring/src/spark_wiring_cloud.cpp
@@ -29,6 +29,7 @@ spark_cloud_disconnect_options CloudDisconnectOptions::toSystemOptions() const
     opts.graceful = graceful_;
     opts.timeout = timeout_;
     opts.clear_session = clearSession_;
+    opts.reconnect_immediately = reconnect_;
     return opts;
 }
 
@@ -39,7 +40,7 @@ CloudDisconnectOptions CloudDisconnectOptions::fromSystemOptions(const spark_clo
             sizeof(spark_cloud_disconnect_options::clear_session)) {
         clearSession = options->clear_session;
     }
-    return CloudDisconnectOptions(options->flags, options->timeout, options->graceful, clearSession);
+    return CloudDisconnectOptions(options->flags, options->timeout, options->graceful, clearSession, options->reconnect_immediately);
 }
 
 int CloudClass::call_raw_user_function(void* data, const char* param, void* reserved)


### PR DESCRIPTION
### Problem
Changes in ACM behavior as [discussed internally](https://docs.google.com/document/d/1NuUm1-8cwR9g8Mn3gbSiZAzSM92ri-FKNh0i-qzcsBw/edit#heading=h.9249cc2g3my), and as in this [epic](https://app.shortcut.com/particle/epic/125329/automatic-connectivity-manager-acm-firmware-changes?group_by=none&vc_group_by=day&ct_workflow=all&cf_workflow=500127125)

### Solution

-Remove ability to bind cloud connection to specific networks interfaces
-Disconnect cloud connection if the network interface reports link down in order to "fail over" faster
-Implement Hard preference for cloud connection. 
- If a connection is set to be preferred, and the cloud is connected, and that network is available: disconnect the cloud and reconnect with the preferred interface immediately
- If a preferred connection becomes ready, and the cloud is connected on a different connection: disconnect the cloud and reconnect with the preferred interface immediately


### Steps to Test

Run connection-manager app

### Example App

Run connection-manager app
```
make PLATFORM=msom APPDIR=../user/tests/app/connection-manager all program-dfu
```

