### PR TITLE
[rtl872x][bootloader] Fix bootloop if system module header corrupted

### DIFF
--- a/platform/MCU/rtl872x/src/flash_mal.c
+++ b/platform/MCU/rtl872x/src/flash_mal.c
@@ -607,7 +607,8 @@ int FLASH_AddMfgSystemModuleSlot(void) {
                     (uint32_t)info.module_start_address, copyLength, MOD_FUNC_SYSTEM_PART, slotFlags)) {
                 ret = SYSTEM_ERROR_NO_MEMORY;
             }
-        }
+        } else {
+            ret = SYSTEM_ERROR_BAD_DATA;
     }
     return ret;
 }

--- a/platform/MCU/rtl872x/src/flash_mal.c
+++ b/platform/MCU/rtl872x/src/flash_mal.c
@@ -609,6 +609,7 @@ int FLASH_AddMfgSystemModuleSlot(void) {
             }
         } else {
             ret = SYSTEM_ERROR_BAD_DATA;
+        }
     }
     return ret;
 }


### PR DESCRIPTION
### Problem

A gen4 device was stuck in a bootloop. Examination showed that the system part binary was partially erased, starting from the start of the binary onwards. Gen4 bootloader will validate the system-part1 module CRC and detect a corrupted system part binary. If the system part is invalid, the bootloader should remain in DFU mode. This was not happening

### Solution

Part of the boot process if the system part is not valid is to check if the factory manufacturing app is in place and needs to be replaced with our system binary. 
This check is done in `FLASH_AddMfgSystemModuleSlot()` here
```
ret = FLASH_ModuleInfo(&info, FLASH_INTERNAL, systemPartOffset, NULL);
        if (ret == SYSTEM_ERROR_NONE && info.module_function == MODULE_FUNCTION_SYSTEM_PART && module_info_matches_platform(&info)) {
...
```
`ret` will almost always be `0` since `FLASH_ModuleInfo()` should always be able to read flash successfully (this says nothing about the validity of the contents, just that it was able to read flash).
`info.module_function` will NOT be equal to system part, since this is likely to be overwritten flash data.
`module_info_matches_platform(&info)` also will likely be false, since this is looking at overwritten data.

However, `ret` will still be returned and we have a false positive.
The solution is to set `ret` to an error if the system part image is not found in flash

### Steps to Test

Check out this branch, build + flash this bootloader, flash a corrupted system part1 binary
--> The device should remain in DFU mode. 

### Example App

N/A

### References
[Discussion/Discovery](https://s.slack.com/archives/C046BM6DBLL/p1706130403280529)

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
