### PR TITLE
Process system tasks while cloud handshake is in progress

### DIFF
--- a/system/inc/system_task.h
+++ b/system/inc/system_task.h
@@ -63,6 +63,7 @@ extern volatile uint8_t SPARK_WLAN_CONNECT_RESTORE;
 extern volatile uint8_t SPARK_WLAN_STARTED;
 extern volatile uint8_t SPARK_CLOUD_SOCKETED;
 extern volatile uint8_t SPARK_CLOUD_CONNECTED;
+extern volatile uint8_t SPARK_CLOUD_PROTOCOL_HANDSHAKE_IN_PROGRESS;
 extern volatile uint8_t SPARK_CLOUD_HANDSHAKE_PENDING;
 extern volatile uint8_t SPARK_CLOUD_HANDSHAKE_NOTIFY_DONE;
 extern volatile uint8_t SPARK_FLASH_UPDATE;

--- a/system/src/system_cloud_connection.cpp
+++ b/system/src/system_cloud_connection.cpp
@@ -253,8 +253,7 @@ int Spark_Receive_UDP(unsigned char *buf, uint32_t buflen, void* reserved)
     }
 
     int r = system_cloud_recv(buf, buflen, 0);
-    if (r == 0 && SPARK_CLOUD_SOCKETED && !SPARK_CLOUD_CONNECTED) {
-        // Process system events while the handshake is in progress
+    if (r == 0 && SPARK_CLOUD_PROTOCOL_HANDSHAKE_IN_PROGRESS) {
         SystemISRTaskQueue.process();
     }
     return r;

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -1223,7 +1223,10 @@ int Spark_Handshake(bool presence_announce)
     cloud_socket_aborted = false; // Clear cancellation flag for socket operations
     LOG(INFO,"Starting handshake: presense_announce=%d", presence_announce);
     bool session_resumed = false;
+    // TODO: Perform the DTLS handshake and receive a response for the Hello message asynchronously
+    SPARK_CLOUD_PROTOCOL_HANDSHAKE_IN_PROGRESS = 1;
     int err = spark_protocol_handshake(sp);
+    SPARK_CLOUD_PROTOCOL_HANDSHAKE_IN_PROGRESS = 0;
 
 #if HAL_PLATFORM_MUXER_MAY_NEED_DELAY_IN_TX
     // XXX: Adding a delay only for platforms Boron and BSoM, because older cell versions of

--- a/system/src/system_update.cpp
+++ b/system/src/system_update.cpp
@@ -57,6 +57,7 @@ ymodem_serial_flash_update_handler Ymodem_Serial_Flash_Update_Handler = NULL;
 // TODO: Use a single state variable instead of SPARK_CLOUD_XXX flags
 volatile uint8_t SPARK_CLOUD_SOCKETED;
 volatile uint8_t SPARK_CLOUD_CONNECTED;
+volatile uint8_t SPARK_CLOUD_PROTOCOL_HANDSHAKE_IN_PROGRESS = 0;
 volatile uint8_t SPARK_CLOUD_HANDSHAKE_PENDING = 0;
 volatile uint8_t SPARK_CLOUD_HANDSHAKE_NOTIFY_DONE = 0;
 volatile uint8_t SPARK_FLASH_UPDATE;


### PR DESCRIPTION
### Problem

System tasks in `SystemISRTaskQueue` are not processed while the DTLS handshake or Hello request is in progress, which, among other things, prevents control requests from working. Story details: [sc-125370](https://app.shortcut.com/particle/story/125370/usb-control-requests-stuck-while-connecting-to-the-cloud).

### Solution

Process the task queue while the handshake with the Cloud is in progress.
