### PR TITLE
[rtl872x] hal: fix false TX DMA completion in SPI HAL.

### DIFF
--- a/hal/src/rtl872x/spi_hal.cpp
+++ b/hal/src/rtl872x/spi_hal.cpp
@@ -711,8 +711,13 @@ public:
         return status_.state == HAL_SPI_STATE_ENABLED;
     }
 
+    // FIXME: The TX DMA exception is notified just when the source data
+    // is transferred to the SPI FIFO, not when the data is actually clocked out.
+    // Whereas the RX DMA exception is notified when the data is actually clocked in and out.
+    // When the RX buffer is not supplied, we may lose some TX data due to the false SPI completion.
+    // Hence, we add the SSI_Busy() check here.
     bool isBusy() const {
-        return status_.transmitting || status_.receiving;
+        return status_.transmitting || status_.receiving || SSI_Busy(SPI_DEV_TABLE[rtlSpiIndex_].SPIx);
     }
 
     bool isSuspended() const {


### PR DESCRIPTION
### Problem
`SPIClass::transfer(const void* tx_buffer, void* rx_buffer, size_t length, wiring_spi_dma_transfercomplete_callback_t user_callback)` exits even if the data is not fully clocked out when RX buffer is `nullptr`. If the CS pin is deasserted following the API, the on-going SPI transaction is ended up unexpectedly.

### Solution
Check the busy state of the SPI peripheral, instead of only relying on internal flags.

### Steps to Test
Run the attached test app.

### Example App
```cpp
#include "application.h"

SYSTEM_MODE(MANUAL);

#define SPI_TRANSACTION_LEN     (4096 * 3 + 9)

Serial1LogHandler l(115200, LOG_LEVEL_ALL);

uint8_t txBuf[SPI_TRANSACTION_LEN] = {0x00};
uint8_t rxBuf[SPI_TRANSACTION_LEN];

void setup() {
    while (!Serial.isConnected());
    Log.info("Starting...");

    pinMode(SS, OUTPUT);
    SPI.setClockSpeed(1000000);
    SPI.begin(SPI_MODE_MASTER);

    for (uint16_t i = 0; i < SPI_TRANSACTION_LEN; i++) {
        txBuf[i] = i;
    }

    delay(1s);
}

void loop() {
    digitalWrite(SS, LOW);

    // 1. No RX buffer
    SPI.transfer(txBuf, nullptr, SPI_TRANSACTION_LEN, nullptr);

    // 2. With RX buffer
    // SPI.transfer(txBuf, rxBuf, SPI_TRANSACTION_LEN, nullptr);

    // 3. No TX buffer (but there is an internal dummy buffer)
    // SPI.transfer(nullptr, rxBuf, SPI_TRANSACTION_LEN, nullptr);

    digitalWrite(SS, HIGH);

    delay(1s);
    Log.info("loop");
}
```

### References
https://app.shortcut.com/particle/story/125500/fram-read-write-failures-for-jacuzzi-on-msom

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
