### PR TITLE
Refactor WiFi credential check; [Gen 4] WiFi thread safety issues, USB re-enumeration bugfix for weird USB hubs

### DIFF
--- a/hal/network/lwip/esp32/esp32ncpnetif.cpp
+++ b/hal/network/lwip/esp32/esp32ncpnetif.cpp
@@ -322,7 +322,9 @@ int Esp32NcpNetif::upImpl() {
     // Ensure that we are disconnected
     downImpl();
     r = wifiMan_->connect();
-    if (r) {
+    // FIXME: with just cleared configuration and no 'NetifEvent::Down' issued from SystemNetworkManager
+    // we are still attempting to connect. For now simply suppress the log.
+    if (r && wifiMan_->hasNetworkConfig()) {
         LOG(TRACE, "Failed to connect to WiFi: %d", r);
     }
     return r;

--- a/hal/network/lwip/realtek/rtlncpnetif.cpp
+++ b/hal/network/lwip/realtek/rtlncpnetif.cpp
@@ -287,7 +287,9 @@ int RealtekNcpNetif::upImpl() {
     // Ensure that we are disconnected
     downImpl();
     r = wifiMan_->connect();
-    if (r) {
+    // FIXME: with just cleared configuration and no 'NetifEvent::Down' issued from SystemNetworkManager
+    // we are still attempting to connect. For now simply suppress the log.
+    if (r && wifiMan_->hasNetworkConfig()) {
         LOG(TRACE, "Failed to connect to WiFi: %d", r);
     }
     return r;

--- a/hal/network/ncp/wifi/wifi_network_manager.cpp
+++ b/hal/network/ncp/wifi/wifi_network_manager.cpp
@@ -36,6 +36,7 @@
 #include "network/ncp/wifi/ncp.h"
 #include "ifapi.h"
 #include "system_network.h"
+#include "system_threading.h"
 
 #define PB(_name) particle_firmware_##_name
 #define PB_WIFI(_name) particle_ctrl_wifi_##_name
@@ -348,6 +349,8 @@ int WifiNetworkManager::connect(const char* ssid) {
 }
 
 int WifiNetworkManager::setNetworkConfig(WifiNetworkConfig conf, uint8_t flags) {
+    SYSTEM_THREAD_CONTEXT_SYNC(setNetworkConfig(conf, flags));
+
     CHECK_TRUE(conf.ssid(), SYSTEM_ERROR_INVALID_ARGUMENT);
     Vector<WifiNetworkConfig> networks;
     CHECK(loadConfig(&networks));

--- a/hal/network/ncp/wifi/wifi_network_manager.h
+++ b/hal/network/ncp/wifi/wifi_network_manager.h
@@ -45,6 +45,12 @@ enum class WifiSecurity {
     WPA2_WPA3_PSK = 6
 };
 
+enum WiFiSetConfigFlags {
+    NONE = 0x00,
+    VALIDATE = 0x01,
+    KEEP_CONNECTED = 0x02
+};
+
 class WifiCredentials {
 public:
     enum Type {
@@ -151,10 +157,22 @@ public:
     explicit WifiNetworkManager(WifiNcpClient* client);
     ~WifiNetworkManager();
 
+    /*
+     * It will connect to the network with given configuration.
+     * It will NOT store the credentials if the network is not stored previously.
+     */
+    int connect(WifiNetworkConfig conf);
+    /*
+     * It will connect to the network with given SSID if its credentials is stored.
+     * If nullptr is provided, it will connect to any network that is available and has credentials stored.
+     */
     int connect(const char* ssid);
+    /*
+     * It will connect to any network that is available and has credentials stored.
+     */
     int connect();
 
-    static int setNetworkConfig(WifiNetworkConfig conf, bool validate = false);
+    static int setNetworkConfig(WifiNetworkConfig conf, uint8_t flags = WiFiSetConfigFlags::NONE);
     static int getNetworkConfig(const char* ssid, WifiNetworkConfig* conf);
     static int getNetworkConfig(GetNetworkConfigCallback callback, void* data);
     static void removeNetworkConfig(const char* ssid);
@@ -333,10 +351,6 @@ inline WifiScanResult& WifiScanResult::rssi(int rssi) {
 
 inline int WifiScanResult::rssi() const {
     return rssi_;
-}
-
-inline int WifiNetworkManager::connect() {
-    return connect(nullptr);
 }
 
 inline WifiNcpClient* WifiNetworkManager::ncpClient() const {

--- a/hal/network/ncp/wifi/wifi_network_manager.h
+++ b/hal/network/ncp/wifi/wifi_network_manager.h
@@ -21,6 +21,7 @@
 #include "c_string.h"
 
 #include <cstdint>
+#include "enumflags.h"
 
 namespace particle {
 
@@ -45,11 +46,15 @@ enum class WifiSecurity {
     WPA2_WPA3_PSK = 6
 };
 
-enum WiFiSetConfigFlags {
+enum class WifiNetworkConfigFlag {
     NONE = 0x00,
     VALIDATE = 0x01,
-    KEEP_CONNECTED = 0x02
+    TURN_ON = 0x02
 };
+
+typedef EnumFlags<WifiNetworkConfigFlag> WifiNetworkConfigFlags;
+
+ENABLE_ENUM_CLASS_BITWISE(WifiNetworkConfigFlag);
 
 class WifiCredentials {
 public:
@@ -157,22 +162,11 @@ public:
     explicit WifiNetworkManager(WifiNcpClient* client);
     ~WifiNetworkManager();
 
-    /*
-     * It will connect to the network with given configuration.
-     * It will NOT store the credentials if the network is not stored previously.
-     */
-    int connect(WifiNetworkConfig conf);
-    /*
-     * It will connect to the network with given SSID if its credentials is stored.
-     * If nullptr is provided, it will connect to any network that is available and has credentials stored.
-     */
     int connect(const char* ssid);
-    /*
-     * It will connect to any network that is available and has credentials stored.
-     */
+    int connect(WifiNetworkConfig conf);
     int connect();
 
-    static int setNetworkConfig(WifiNetworkConfig conf, uint8_t flags = WiFiSetConfigFlags::NONE);
+    int setNetworkConfig(WifiNetworkConfig conf, WifiNetworkConfigFlags flags = WifiNetworkConfigFlag::NONE);
     static int getNetworkConfig(const char* ssid, WifiNetworkConfig* conf);
     static int getNetworkConfig(GetNetworkConfigCallback callback, void* data);
     static void removeNetworkConfig(const char* ssid);
@@ -351,6 +345,10 @@ inline WifiScanResult& WifiScanResult::rssi(int rssi) {
 
 inline int WifiScanResult::rssi() const {
     return rssi_;
+}
+
+inline int WifiNetworkManager::connect() {
+    return connect(nullptr);
 }
 
 inline WifiNcpClient* WifiNetworkManager::ncpClient() const {

--- a/hal/network/ncp/wifi/wlan_hal.cpp
+++ b/hal/network/ncp/wifi/wlan_hal.cpp
@@ -182,9 +182,10 @@ int wlan_set_credentials(WLanCredentials* halCred) {
     conf.credentials(std::move(cred));
     const auto mgr = wifiNetworkManager();
     CHECK_TRUE(mgr, SYSTEM_ERROR_UNKNOWN);
-    uint8_t flags = 0;
+    WifiNetworkConfigFlags flags = WifiNetworkConfigFlag::NONE;
     if (halCred->flags & WLAN_SET_CREDENTIALS_FLAGS_VALIDATE) {
-        flags |= WiFiSetConfigFlags::VALIDATE;
+        flags |= WifiNetworkConfigFlag::VALIDATE;
+        flags |= WifiNetworkConfigFlag::TURN_ON;
     }
     CHECK(mgr->setNetworkConfig(std::move(conf), flags));
     return 0;

--- a/hal/network/ncp/wifi/wlan_hal.cpp
+++ b/hal/network/ncp/wifi/wlan_hal.cpp
@@ -182,7 +182,11 @@ int wlan_set_credentials(WLanCredentials* halCred) {
     conf.credentials(std::move(cred));
     const auto mgr = wifiNetworkManager();
     CHECK_TRUE(mgr, SYSTEM_ERROR_UNKNOWN);
-    CHECK(mgr->setNetworkConfig(std::move(conf), halCred->flags & WLAN_SET_CREDENTIALS_FLAGS_VALIDATE));
+    uint8_t flags = 0;
+    if (halCred->flags & WLAN_SET_CREDENTIALS_FLAGS_VALIDATE) {
+        flags |= WiFiSetConfigFlags::VALIDATE;
+    }
+    CHECK(mgr->setNetworkConfig(std::move(conf), flags));
     return 0;
 }
 

--- a/hal/network/ncp_client/realtek/rtl_ncp_client.cpp
+++ b/hal/network/ncp_client/realtek/rtl_ncp_client.cpp
@@ -299,6 +299,7 @@ NcpConnectionState RealtekNcpClient::connectionState() {
 }
 
 int RealtekNcpClient::connect(const char* ssid, const MacAddress& bssid, WifiSecurity sec, const WifiCredentials& cred) {
+    CHECK_FALSE(needsReset_, SYSTEM_ERROR_BUSY);
     int rtlError = RTW_ERROR;
     for (int i = 0; i < 2; i++) {
         {
@@ -333,8 +334,8 @@ int RealtekNcpClient::connect(const char* ssid, const MacAddress& bssid, WifiSec
 }
 
 int RealtekNcpClient::getNetworkInfo(WifiNetworkInfo* info) {
-    const NcpClientLock lock(this);
     CHECK_TRUE(connState_ == NcpConnectionState::CONNECTED, SYSTEM_ERROR_INVALID_STATE);
+    const NcpClientLock lock(this);
 
     int rtlError = 0;
     // LOG(INFO, "RNCP getNetworkInfo");
@@ -381,9 +382,10 @@ int RealtekNcpClient::getNetworkInfo(WifiNetworkInfo* info) {
 }
 
 int RealtekNcpClient::scan(WifiScanCallback callback, void* data) {
-    const NcpClientLock lock(this);
-
+    CHECK_FALSE(needsReset_, SYSTEM_ERROR_BUSY);
     CHECK_TRUE(ncpState_ == NcpState::ON, SYSTEM_ERROR_INVALID_STATE);
+
+    const NcpClientLock lock(this);
     struct Context {
         WifiScanCallback callback = nullptr;
         void* data = nullptr;
@@ -455,17 +457,19 @@ int RealtekNcpClient::scan(WifiScanCallback callback, void* data) {
     for (int i = 0; i < ctx.results.size(); i++) {
         callback(ctx.results[i], data);
     }
-    if (ctx.results.size() == 0 || rtlError == RTW_TIMEOUT) {
+
+    // XXX:
+    if ((rtlError /* keeping this for now */ && ctx.results.size() == 0) || rtlError == RTW_TIMEOUT) {
         // Workaround for a weird state we might enter where the wifi driver
         // is not returning any results
-        rtwRadioReset();
-        return rtl_error_to_system(rtlError);
+        needsReset_ = true;
     }
 
     return rtl_error_to_system(rtlError);
 }
 
 int RealtekNcpClient::getMacAddress(MacAddress* addr) {
+    const NcpClientLock lock(this);
     char mac[6*2 + 5 + 1] = {};
     wifi_get_mac_address(mac);
     CHECK_TRUE(macAddressFromString(addr, mac), SYSTEM_ERROR_UNKNOWN);
@@ -565,8 +569,14 @@ int RealtekNcpClient::dataChannelWrite(int id, const uint8_t* data, size_t size)
 int RealtekNcpClient::dataChannelFlowControl(bool state) {
     return SYSTEM_ERROR_NONE;
 }
+
 void RealtekNcpClient::processEvents() {
+    if (needsReset_) {
+        rtwRadioReset();
+        needsReset_ = false;
+    }
 }
+
 int RealtekNcpClient::checkParser() {
     return SYSTEM_ERROR_NONE;
 }

--- a/hal/network/ncp_client/realtek/rtl_ncp_client.h
+++ b/hal/network/ncp_client/realtek/rtl_ncp_client.h
@@ -73,6 +73,7 @@ private:
     volatile NcpState prevNcpState_;
     volatile NcpConnectionState connState_;
     volatile NcpPowerState pwrState_;
+    volatile bool needsReset_ = false;
 
     void ncpState(NcpState state);
     void ncpPowerState(NcpPowerState state);

--- a/hal/src/rtl872x/lwip/lwip_rtlk.cpp
+++ b/hal/src/rtl872x/lwip/lwip_rtlk.cpp
@@ -18,44 +18,44 @@ extern void restore_flags(void);
 }
 
 unsigned char is_promisc_enabled(void) {
-    LOG(INFO, "is_promisc_enabled");
+    // LOG(INFO, "is_promisc_enabled");
     return 0;
 }
 
 int promisc_set(rtw_rcr_level_t enabled, void (*callback)(unsigned char*, unsigned int, void*), unsigned char len_used) {
-    LOG(INFO, "promisc_set TODO");
+    // LOG(INFO, "promisc_set TODO");
     return -1;
 }
 
 void promisc_deinit(void *padapter) {
-    LOG(INFO, "promisc_deinit TODO");
+    // LOG(INFO, "promisc_deinit TODO");
 }
 
 int promisc_recv_func(void *padapter, void *rframe) {
-    LOG(INFO, "promisc_recv_func TODO");
+    // LOG(INFO, "promisc_recv_func TODO");
     return 0;
 }
 
 void eap_autoreconnect_hdl(uint8_t method_id) {
-    LOG(INFO, "eap_autoreconnect_hdl");
+    // LOG(INFO, "eap_autoreconnect_hdl");
 }
 
 int get_eap_phase(void) {
-    LOG(INFO, "get_eap_phase");
+    // LOG(INFO, "get_eap_phase");
     return 0;
 }
 
 int get_eap_method(void) {
-    LOG(INFO, "get_eap_method");
+    // LOG(INFO, "get_eap_method");
     return 0;
 }
 
 void netif_post_sleep_processing(void) {
-    LOG(INFO, "netif_post_sleep_processing TODO");
+    // LOG(INFO, "netif_post_sleep_processing TODO");
 }
 
 void netif_pre_sleep_processing(void) {
-    LOG(INFO, "netif_pre_sleep_processing TODO");
+    // LOG(INFO, "netif_pre_sleep_processing TODO");
 }
 
 int netif_get_idx(struct netif* pnetif) {

--- a/hal/src/rtl872x/rtl_sdk_support.cpp
+++ b/hal/src/rtl872x/rtl_sdk_support.cpp
@@ -157,8 +157,9 @@ void rtwCoexStop() {
 }
 
 void rtwRadioReset() {
-    std::lock_guard<RecursiveMutex> lk(radioMutex);
+    // XXX: the order of the locks has to be BLE -> radioMutex
     hal_ble_lock(nullptr);
+    std::unique_lock<RecursiveMutex> lk(radioMutex);
     bool bleInitialized = hal_ble_is_initialized(nullptr);
     bool advertising = hal_ble_gap_is_advertising(nullptr) ||
                        hal_ble_gap_is_connecting(nullptr, nullptr) ||
@@ -175,6 +176,7 @@ void rtwRadioReset() {
             hal_ble_gap_start_advertising(nullptr);
         }
     }
+    lk.unlock();
     hal_ble_unlock(nullptr);
 }
 

--- a/hal/src/rtl872x/usbd_driver.h
+++ b/hal/src/rtl872x/usbd_driver.h
@@ -144,6 +144,7 @@ private:
     volatile bool initialized_ = false;
     volatile bool needsReset_ = false;
     volatile int config_ = 0;
+    volatile unsigned int resetCount_ = 0;
 };
 
 } // namespace usbd

--- a/system/src/control/wifi_new.cpp
+++ b/system/src/control/wifi_new.cpp
@@ -117,11 +117,33 @@ int joinNewNetwork(ctrl_request* req) {
     conf.security((WifiSecurity)pbReq.security);
 #endif
     conf.credentials(std::move(cred));
-    uint8_t flags = WiFiSetConfigFlags::VALIDATE | WiFiSetConfigFlags::KEEP_CONNECTED;
+    // Connect to the network
+    CHECK(ncpClient->on());
+    // FIXME: synchronize NCP client / NcpNetif and system network manager state
+    bool needToConnect = network_connecting(NETWORK_INTERFACE_WIFI_STA, 0, nullptr) ||
+            network_ready(NETWORK_INTERFACE_WIFI_STA, NETWORK_READY_TYPE_ANY, nullptr);
+    // To unblock
+    ncpClient->disable();
+    CHECK(ncpClient->enable());
+    // These two are in sync now
+    ncpClient->disconnect(); // ignore the error
+    network_disconnect(NETWORK_INTERFACE_WIFI_STA, NETWORK_DISCONNECT_REASON_USER, nullptr);
+    // FIXME: We are wiating for ncpNetif to potentially fully disconnect
+    // FIXME: synchronize NCP client / NcpNetif and system network manager state
+    CHECK(ncpClient->enable());
+    CHECK(ncpClient->on());
+    network_connect(NETWORK_INTERFACE_WIFI_STA, 0, 0, nullptr);
+    NAMED_SCOPE_GUARD(networkDisconnectGuard, {
+        // FIXME: synchronize NCP client / NcpNetif and system network manager state
+        if (!needToConnect) {
+            network_disconnect(NETWORK_INTERFACE_WIFI_STA, NETWORK_DISCONNECT_REASON_USER, nullptr);
+        }
+    });
     // Set new configuration
-    CHECK(wifiMgr->setNetworkConfig(conf, flags));
+    CHECK(wifiMgr->setNetworkConfig(conf, WifiNetworkConfigFlag::VALIDATE));
     // TODO: Not adding NetworkCredentials for now as this object needs to be allocated on heap and then cleaned up
     system_notify_event(network_credentials, network_credentials_added);
+    networkDisconnectGuard.dismiss();
     return 0;
 }
 

--- a/system/src/control/wifi_new.cpp
+++ b/system/src/control/wifi_new.cpp
@@ -117,8 +117,9 @@ int joinNewNetwork(ctrl_request* req) {
     conf.security((WifiSecurity)pbReq.security);
 #endif
     conf.credentials(std::move(cred));
+    uint8_t flags = WiFiSetConfigFlags::VALIDATE | WiFiSetConfigFlags::KEEP_CONNECTED;
     // Set new configuration
-    CHECK(wifiMgr->setNetworkConfig(conf, true));
+    CHECK(wifiMgr->setNetworkConfig(conf, flags));
     // TODO: Not adding NetworkCredentials for now as this object needs to be allocated on heap and then cleaned up
     system_notify_event(network_credentials, network_credentials_added);
     return 0;

--- a/user/tests/wiring/wifi_cred_check/wifi_cred_check.cpp
+++ b/user/tests/wiring/wifi_cred_check/wifi_cred_check.cpp
@@ -25,7 +25,7 @@ test(Test_00_Init) {
     credentials.setValidate(true);
 }
 
-test(Test_01_WiFi_Credentials_Check_When_WiFi_Is_Off) {
+test(Test_01_WiFi_Credentials_Check_And_WiFi_State_Consistency) {
     for (uint8_t test = 0; test < WiFiState::MAX; test++) {
         Serial.printlnf(" > Set WiFi state to %s", (test ? (test == 1 ? "ON" : "CONNECTED") : "OFF"));
         switch (test) {

--- a/wiring/inc/spark_wiring_wifi.h
+++ b/wiring/inc/spark_wiring_wifi.h
@@ -243,16 +243,16 @@ public:
         return (network_set_credentials(*this, 0, &creds, NULL) == 0);
     }
 
-    void setCredentials(const char* ssid, WiFiCredentials credentials) {
+    bool setCredentials(const char* ssid, WiFiCredentials credentials) {
         WLanCredentials creds = credentials.getHalCredentials();
         creds.ssid = ssid;
         creds.ssid_len = ssid ? strlen(ssid) : 0;
-        network_set_credentials(*this, 0, &creds, NULL);
+        return network_set_credentials(*this, 0, &creds, NULL) == 0;
     }
 
-    void setCredentials(WiFiCredentials credentials) {
+    bool setCredentials(WiFiCredentials credentials) {
         WLanCredentials creds = credentials.getHalCredentials();
-        network_set_credentials(*this, 0, &creds, NULL);
+        return network_set_credentials(*this, 0, &creds, NULL) == 0;
     }
 
     bool hasCredentials(void) {


### PR DESCRIPTION
### Problem
1. Device will save invalid credentials if there is valid crdentials with other SSID present
2. BLE provisioning breaks due to the Wi-Fi disconnection after setting credentials

### Solution
1. Validate credentials before saving
2. Add a flag to not disconnect Wi-Fi connection after validating the credentials

### Steps to Test
1. `tests/wiring/wifi_cred_check`
2. Go through BLE provisioning process

### References
N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
