### PR TITLE
Fix communication loop errors when handling ACKs for Describe messages

### DIFF
--- a/communication/inc/coap.h
+++ b/communication/inc/coap.h
@@ -57,7 +57,8 @@ namespace CoAPMessageType {
     UPDATE_START_V3,
     UPDATE_FINISH_V3,
     UPDATE_CHUNK_V3,
-    SERVER_MOVED
+    SERVER_MOVED,
+    UNKNOWN
   };
 }
 

--- a/communication/src/description.cpp
+++ b/communication/src/description.cpp
@@ -381,7 +381,8 @@ ProtocolError Description::receiveRequest(const Message& msg) {
     return ProtocolError::NO_ERROR;
 }
 
-ProtocolError Description::receiveAckOrRst(const Message& msg, int* descFlags) {
+ProtocolError Description::receiveAckOrRst(const Message& msg, int* descFlags, bool* handled) {
+    *handled = false;
     if (!activeReq_.has_value() && acks_.isEmpty()) {
         return ProtocolError::NO_ERROR;
     }
@@ -398,6 +399,7 @@ ProtocolError Description::receiveAckOrRst(const Message& msg, int* descFlags) {
     }
     const auto ackId = dec.id();
     if (activeReq_.has_value() && activeReq_->msgId == ackId) {
+        *handled = true;
         if (isRst) {
             activeReq_.reset();
             return ProtocolError::MESSAGE_RESET;
@@ -420,6 +422,7 @@ ProtocolError Description::receiveAckOrRst(const Message& msg, int* descFlags) {
     } else {
         for (int i = 0; i < acks_.size(); ++i) {
             if (acks_[i].msgId == ackId) {
+                *handled = true;
                 // Received an ACK for a regular request, regular response or the last block of a
                 // blockwise response
                 const auto flags = acks_[i].flags;

--- a/communication/src/description.h
+++ b/communication/src/description.h
@@ -48,7 +48,7 @@ public:
 
     ProtocolError sendRequest(int descFlags);
     ProtocolError receiveRequest(const Message& msg);
-    ProtocolError receiveAckOrRst(const Message& msg, int* descFlags);
+    ProtocolError receiveAckOrRst(const Message& msg, int* descFlags, bool* handled);
     ProtocolError processTimeouts();
 
     ProtocolError serialize(Appender* appender, int descFlags);

--- a/communication/src/firmware_update.cpp
+++ b/communication/src/firmware_update.cpp
@@ -80,7 +80,8 @@ void FirmwareUpdate::destroy() {
     reset();
 }
 
-ProtocolError FirmwareUpdate::responseAck(Message* msg) {
+ProtocolError FirmwareUpdate::responseAck(Message* msg, bool* handled) {
+    *handled = false;
     if (!updating_) {
         return ProtocolError::INVALID_STATE;
     }
@@ -98,6 +99,7 @@ ProtocolError FirmwareUpdate::responseAck(Message* msg) {
         return ProtocolError::INTERNAL;
     }
     if (d.id() == finishRespId_) {
+        *handled = true;
         finishRespId_ = -1;
         stats_.updateFinishTime = millis();
         LOG(INFO, "Update time: %u", (unsigned)(stats_.updateFinishTime - stats_.updateStartTime));
@@ -122,6 +124,7 @@ ProtocolError FirmwareUpdate::responseAck(Message* msg) {
             updating_ = false;
         }
     } else if (d.id() == errorRespId_) {
+        *handled = true;
         LOG(ERROR, "Firmware update failed");
         cancelUpdate();
         return ProtocolError::OTA_UPDATE_ERROR;

--- a/communication/src/firmware_update.h
+++ b/communication/src/firmware_update.h
@@ -134,7 +134,7 @@ public:
     ProtocolError startRequest(Message* msg);
     ProtocolError finishRequest(Message* msg);
     ProtocolError chunkRequest(Message* msg);
-    ProtocolError responseAck(Message* msg);
+    ProtocolError responseAck(Message* msg, bool* handled);
     ProtocolError process();
 
     const FirmwareUpdateStats& stats() const;

--- a/communication/src/messages.cpp
+++ b/communication/src/messages.cpp
@@ -120,7 +120,7 @@ CoAPMessageType::Enum Messages::decodeType(const uint8_t* buf, size_t length)
 	default:
 		break;
 	}
-	return CoAPMessageType::ERROR;
+	return CoAPMessageType::UNKNOWN;
 }
 
 size_t Messages::hello(uint8_t* buf, message_id_t message_id, uint16_t flags, uint16_t platform_id, uint16_t system_version,

--- a/test/unit_tests/communication/description.cpp
+++ b/test/unit_tests/communication/description.cpp
@@ -132,7 +132,8 @@ public:
             }
             case CoAPMessageType::EMPTY_ACK: {
                 descAckFlags_ = 0;
-                r = desc_.receiveAckOrRst(m, &descAckFlags_);
+                bool handled = false;
+                r = desc_.receiveAckOrRst(m, &descAckFlags_, &handled);
                 break;
             }
             default:

--- a/test/unit_tests/communication/firmware_update.cpp
+++ b/test/unit_tests/communication/firmware_update.cpp
@@ -137,7 +137,8 @@ public:
                 break;
             }
             case CoAPMessageType::EMPTY_ACK: {
-                r = responseAck(&m);
+                bool handled = false;
+                r = responseAck(&m, &handled);
                 break;
             }
             default:

--- a/test/unit_tests/communication/messages.cpp
+++ b/test/unit_tests/communication/messages.cpp
@@ -48,9 +48,9 @@ SCENARIO("determining message type from a CoAP GET message")
 	WHEN("a message is an unknown GET request")
 	{
 		uint8_t buf[] = { 1, 1, 0, 0, 0, 0x91, '!'};
-		THEN("then message is recognized as a ERROR")
+		THEN("then message is recognized as an UNKNOWN")
 		{
-			REQUIRE(Messages::decodeType(buf, sizeof(buf))==CoAPMessageType::ERROR);
+			REQUIRE(Messages::decodeType(buf, sizeof(buf))==CoAPMessageType::UNKNOWN);
 		}
 	}
 }
@@ -124,9 +124,9 @@ SCENARIO("determining message type from a CoAP POST message")
 	WHEN("a message is an unknown POST request")
 	{
 		uint8_t buf[] = { 1, 1, 0, 0, 0, 0x91, '!'};
-		THEN("then message is recognized as a ERROR")
+		THEN("then message is recognized as an UNKNOWN")
 		{
-			REQUIRE(Messages::decodeType(buf, sizeof(buf))==CoAPMessageType::ERROR);
+			REQUIRE(Messages::decodeType(buf, sizeof(buf))==CoAPMessageType::UNKNOWN);
 		}
 	}
 }
@@ -174,9 +174,9 @@ SCENARIO("determining message type from a CoAP PUT message")
 	WHEN("a message is an unknown PUT request")
 	{
 		uint8_t buf[] = { 1, 3, 0, 0, 0, 0x91, '!'};
-		THEN("then message is recognized as a ERROR")
+		THEN("then message is recognized as an UNKNOWN")
 		{
-			REQUIRE(Messages::decodeType(buf, sizeof(buf))==CoAPMessageType::ERROR);
+			REQUIRE(Messages::decodeType(buf, sizeof(buf))==CoAPMessageType::UNKNOWN);
 		}
 	}
 }


### PR DESCRIPTION
### Problem

When handling a CoAP ACK for a Describe or OTAv3 message, the protocol implementation still forwards the message to the new CoAP implementation which causes an error if the code that handled the ACK in the first place happened to overwrite the contents of the shared message buffer.

### Solution

Stop further processing of the ACK message if it was handled by one of the aforementioned subsystems.

### Steps to Test

Run the `communication/*` tests.
