### PR TITLE
[rtl872x] SPI and UART HAL minor fix.

### DIFF
--- a/hal/src/rtl872x/spi_hal.cpp
+++ b/hal/src/rtl872x/spi_hal.cpp
@@ -717,7 +717,7 @@ public:
     // When the RX buffer is not supplied, we may lose some TX data due to the false SPI completion.
     // Hence, we add the SSI_Busy() check here.
     bool isBusy() const {
-        return status_.transmitting || status_.receiving || SSI_Busy(SPI_DEV_TABLE[rtlSpiIndex_].SPIx);
+        return status_.transmitting || status_.receiving || ((config_.spiMode == SPI_MODE_MASTER) && SSI_Busy(SPI_DEV_TABLE[rtlSpiIndex_].SPIx));
     }
 
     bool isSuspended() const {

--- a/hal/src/rtl872x/usart_hal.cpp
+++ b/hal/src/rtl872x/usart_hal.cpp
@@ -149,11 +149,17 @@ public:
         void* txBuf = conf.tx_buffer;
         size_t txBufSize = conf.tx_buffer_size;
         if (((uintptr_t)rxBuf & portBYTE_ALIGNMENT_MASK) != 0) {
-            rxBuf = std::align(portBYTE_ALIGNMENT, conf.rx_buffer_size, rxBuf, rxBufSize);
+            if (conf.rx_buffer_size < portBYTE_ALIGNMENT) {
+                return SYSTEM_ERROR_NOT_ENOUGH_DATA;
+            }
+            rxBuf = std::align(portBYTE_ALIGNMENT, conf.rx_buffer_size - portBYTE_ALIGNMENT, rxBuf, rxBufSize);
             rxBufSize = (rxBufSize / portBYTE_ALIGNMENT) * portBYTE_ALIGNMENT;
         }
         if (((uintptr_t)txBuf & portBYTE_ALIGNMENT_MASK) != 0) {
-            txBuf = std::align(portBYTE_ALIGNMENT, conf.tx_buffer_size, txBuf, txBufSize);
+            if (conf.tx_buffer_size < portBYTE_ALIGNMENT) {
+                return SYSTEM_ERROR_NOT_ENOUGH_DATA;
+            }
+            txBuf = std::align(portBYTE_ALIGNMENT, conf.tx_buffer_size - portBYTE_ALIGNMENT, txBuf, txBufSize);
             txBufSize = (txBufSize / portBYTE_ALIGNMENT) * portBYTE_ALIGNMENT;
         }
         CHECK_TRUE(rxBuf, SYSTEM_ERROR_NOT_ENOUGH_DATA);


### PR DESCRIPTION
### Problem
1. SPI slave is busy once enabled
2. Providing unaligned ring buffer for UART will result initialization failure

### Solution
1. Only check the busy status for SPI master mode
2. Make sure the aligned size is smaller than the given buffer size

### Steps to Test
1. wiring/no_fixture_spi
2. Run the attached test app

### Example App
```cpp
#include <iostream>
#include <cstdint>
#include <cstdio>
#include <cstdlib>
#include <memory>
#include <cstring>
#include <chrono>

uint8_t __attribute__((aligned(4))) buf[168];
size_t bufLen = sizeof(buf);

int main(int argc, char* argv[]) {
    void* pBuf = buf;
    size_t alignment = 32;
    size_t size = bufLen;
    
    void* newPtr = std::align(alignment, size, pBuf, bufLen);
    printf("PTR: %08X -> %08X, %d\r\n", (uint32_t)buf, (uint32_t)newPtr, (uint8_t*)newPtr - (uint8_t*)buf);
    printf("After aligned: %d\r\n", bufLen);

    size = bufLen - alignment;
    newPtr = std::align(alignment, size, pBuf, bufLen);
    printf("PTR: %08X -> %08X, %d\r\n", (uint32_t)buf, (uint32_t)newPtr, (uint8_t*)newPtr - (uint8_t*)buf);
    printf("After aligned: %d\r\n", bufLen);
    return 0;
}
```

### References
N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
