### PR TITLE
[system] network: force IFF_UP if requested and no credentials exist

### DIFF
--- a/system/inc/system_network.h
+++ b/system/inc/system_network.h
@@ -46,6 +46,11 @@ typedef enum network_ready_type {
 typedef network_interface_t    network_handle_t;
 const network_interface_t NIF_DEFAULT = 0;
 
+typedef enum network_connect_flag {
+    NETWORK_CONNECT_FLAG_NONE = 0,
+    NETWORK_CONNECT_FLAG_FORCE = 1
+} network_connect_flag;
+
 /**
  * This is a bridge from the wiring layer to the system layer.
  * @return

--- a/system/src/control/wifi_new.cpp
+++ b/system/src/control/wifi_new.cpp
@@ -132,7 +132,7 @@ int joinNewNetwork(ctrl_request* req) {
     // FIXME: synchronize NCP client / NcpNetif and system network manager state
     CHECK(ncpClient->enable());
     CHECK(ncpClient->on());
-    network_connect(NETWORK_INTERFACE_WIFI_STA, 0, 0, nullptr);
+    network_connect(NETWORK_INTERFACE_WIFI_STA, NETWORK_CONNECT_FLAG_FORCE, 0, nullptr);
     NAMED_SCOPE_GUARD(networkDisconnectGuard, {
         // FIXME: synchronize NCP client / NcpNetif and system network manager state
         if (!needToConnect) {

--- a/system/src/system_network_manager.cpp
+++ b/system/src/system_network_manager.cpp
@@ -927,10 +927,10 @@ int NetworkManager::disableInterface(if_t iface, network_disconnect_reason reaso
     return 0;
 }
 
-int NetworkManager::syncInterfaceStates() {
+int NetworkManager::syncInterfaceStates(if_t forceIface) {
     if (isEstablishingConnections() || isConnectivityAvailable()) {
         CHECK(for_each_iface([&](if_t iface, unsigned int flags) {
-            if (!haveLowerLayerConfiguration(iface)) {
+            if (!haveLowerLayerConfiguration(iface) && (forceIface != iface)) {
                 return;
             }
 

--- a/system/src/system_network_manager.h
+++ b/system/src/system_network_manager.h
@@ -76,7 +76,7 @@ public:
     int disableInterface(if_t iface = nullptr, network_disconnect_reason reason = NETWORK_DISCONNECT_REASON_UNKNOWN);
     bool isInterfaceEnabled(if_t iface) const;
     int countEnabledInterfaces();
-    int syncInterfaceStates();
+    int syncInterfaceStates(if_t forceIface = nullptr);
 
     int powerInterface(if_t iface = nullptr, bool enable = true);
 

--- a/system/src/system_network_manager_api.cpp
+++ b/system/src/system_network_manager_api.cpp
@@ -162,7 +162,7 @@ void network_connect(network_handle_t network, uint32_t flags, uint32_t param, v
     //     asm volatile ("NOP");
     // }
     /* TODO: WIFI_CONNECT_SKIP_LISTEN is unhandled */
-    SYSTEM_THREAD_CONTEXT_ASYNC_CALL([network]() {
+    SYSTEM_THREAD_CONTEXT_ASYNC_CALL(([network, flags]() {
         SPARK_WLAN_STARTED = 1;
         SPARK_WLAN_SLEEP = 0;
         s_forcedDisconnect = false;
@@ -179,7 +179,11 @@ void network_connect(network_handle_t network, uint32_t flags, uint32_t param, v
             if_t iface;
             if (!if_get_by_index(network, &iface)) {
                 NetworkManager::instance()->enableInterface(iface);
-                NetworkManager::instance()->syncInterfaceStates();
+                if (flags & NETWORK_CONNECT_FLAG_FORCE) {
+                    NetworkManager::instance()->syncInterfaceStates(iface);
+                } else {
+                    NetworkManager::instance()->syncInterfaceStates();
+                }
             }
         } else {
             // Mainly to populate the list
@@ -193,7 +197,7 @@ void network_connect(network_handle_t network, uint32_t flags, uint32_t param, v
         if (NetworkManager::instance()->isConfigured()) {
             NetworkManager::instance()->activateConnections();
         }
-    }());
+    }()));
 }
 
 void network_disconnect(network_handle_t network, uint32_t reason, void* reserved) {


### PR DESCRIPTION
### Description

WiFi should be connected after `joinNewNetwork` when there were no wifi credentials on the device at all as well as there were some present before.