### PR TITLE
Query 2g registration status in addition to lte with BG95m5 modem

### DIFF
--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -661,7 +661,7 @@ int QuectelNcpClient::getCellularGlobalIdentity(CellularGlobalIdentity* cgi) {
     // Fill in LAC and Cell ID based on current RAT, prefer PSD and EPS
     // fallback to CSD
     CHECK_PARSER_OK(parser_.execCommand("AT+CEREG?"));
-    if (isQuecCat1Device()) {
+    if (isQuecCat1Device() || ncpId() == PLATFORM_NCP_QUECTEL_BG95_M5) {
         CHECK_PARSER_OK(parser_.execCommand("AT+CGREG?"));
         CHECK_PARSER_OK(parser_.execCommand("AT+CREG?"));
     }

--- a/system/src/system_ble_prov.cpp
+++ b/system/src/system_ble_prov.cpp
@@ -70,7 +70,6 @@ int system_ble_prov_mode(bool enabled, void* reserved) {
 }
 
 bool system_ble_prov_get_status(void* reserved) {
-    SYSTEM_THREAD_CONTEXT_SYNC(system_ble_prov_get_status(reserved));
     return BleProvisioningModeHandler::instance()->getProvModeStatus();
 }
 


### PR DESCRIPTION
### Problem
Dioptra app calls `getCellularGlobalIdentity()` to determine MCC / LAC / CELL ID
M404 / BG95M5 devices support 2g registration
`getCellularGlobalIdentity()` only queries LTE registration status on M404

### Solution
Query both 2g and LTE registration for BG95m5 modules in case they are on either network

### Steps to Test

Run dioptra

### Example App

Dioptra

### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
