### PR TITLE
[rtl872x] wifi: reset the stack when there are no scan results and scan is requested to connect to AP

### DIFF
--- a/hal/network/ncp/wifi/wifi_ncp_client.h
+++ b/hal/network/ncp/wifi/wifi_ncp_client.h
@@ -26,7 +26,7 @@ class WifiNcpClient: public NcpClient {
 public:
     virtual int connect(const char* ssid, const MacAddress& bssid, WifiSecurity sec, const WifiCredentials& cred) = 0;
     virtual int getNetworkInfo(WifiNetworkInfo* info) = 0;
-    virtual int scan(WifiScanCallback callback, void* data) = 0;
+    virtual int scan(WifiScanCallback callback, void* data, bool forConnect = false) = 0;
     virtual int getMacAddress(MacAddress* addr) = 0;
     virtual int getFirmwareModuleVersion(uint16_t* version) = 0;
 };

--- a/hal/network/ncp/wifi/wifi_network_manager.cpp
+++ b/hal/network/ncp/wifi/wifi_network_manager.cpp
@@ -230,7 +230,7 @@ int WifiNetworkManager::connect(const char* ssid) {
             auto scanResults = (Vector<WifiScanResult>*)data;
             CHECK_TRUE(scanResults->append(std::move(result)), SYSTEM_ERROR_NO_MEMORY);
             return 0;
-        }, &scanResults));
+        }, &scanResults, /* forConnect*/ true));
         // Sort discovered networks by RSSI
         sortByRssi(&scanResults);
         // Try to connect to any known network among the discovered ones
@@ -309,7 +309,7 @@ int WifiNetworkManager::setNetworkConfig(WifiNetworkConfig conf, WifiNetworkConf
                 const auto networks = (Vector<WifiScanResult>*)data;
                 CHECK_TRUE(networks->append(std::move(network)), SYSTEM_ERROR_NO_MEMORY);
                 return 0;
-            }, &networks));
+            }, &networks, /* forConnect*/ true));
             for (auto network : networks) {
                 if (!strcmp(conf.ssid(), network.ssid())) {
                     conf.security((WifiSecurity)network.security());

--- a/hal/network/ncp_client/esp32/esp32_ncp_client.cpp
+++ b/hal/network/ncp_client/esp32/esp32_ncp_client.cpp
@@ -442,7 +442,7 @@ int Esp32NcpClient::getNetworkInfo(WifiNetworkInfo* info) {
     return 0;
 }
 
-int Esp32NcpClient::scan(WifiScanCallback callback, void* data) {
+int Esp32NcpClient::scan(WifiScanCallback callback, void* data, bool forConnect) {
     const NcpClientLock lock(this);
     CHECK(checkParser());
     auto resp = parser_.sendCommand("AT+CWLAP");

--- a/hal/network/ncp_client/esp32/esp32_ncp_client.h
+++ b/hal/network/ncp_client/esp32/esp32_ncp_client.h
@@ -67,7 +67,7 @@ public:
     // Reimplemented from WifiNcpClient
     int connect(const char* ssid, const MacAddress& bssid, WifiSecurity sec, const WifiCredentials& cred) override;
     int getNetworkInfo(WifiNetworkInfo* info) override;
-    int scan(WifiScanCallback callback, void* data) override;
+    int scan(WifiScanCallback callback, void* data, bool forConnect) override;
     int getMacAddress(MacAddress* addr) override;
 
 private:

--- a/hal/network/ncp_client/realtek/rtl_ncp_client.cpp
+++ b/hal/network/ncp_client/realtek/rtl_ncp_client.cpp
@@ -381,7 +381,7 @@ int RealtekNcpClient::getNetworkInfo(WifiNetworkInfo* info) {
     return SYSTEM_ERROR_NONE;
 }
 
-int RealtekNcpClient::scan(WifiScanCallback callback, void* data) {
+int RealtekNcpClient::scan(WifiScanCallback callback, void* data, bool forConnect) {
     CHECK_FALSE(needsReset_, SYSTEM_ERROR_BUSY);
     CHECK_TRUE(ncpState_ == NcpState::ON, SYSTEM_ERROR_INVALID_STATE);
 
@@ -459,7 +459,7 @@ int RealtekNcpClient::scan(WifiScanCallback callback, void* data) {
     }
 
     // XXX:
-    if ((rtlError /* keeping this for now */ && ctx.results.size() == 0) || rtlError == RTW_TIMEOUT) {
+    if ((forConnect && ctx.results.size() == 0) || rtlError == RTW_TIMEOUT) {
         // Workaround for a weird state we might enter where the wifi driver
         // is not returning any results
         needsReset_ = true;

--- a/hal/network/ncp_client/realtek/rtl_ncp_client.h
+++ b/hal/network/ncp_client/realtek/rtl_ncp_client.h
@@ -52,7 +52,7 @@ public:
     // Reimplemented from WifiNcpClient
     int connect(const char* ssid, const MacAddress& bssid, WifiSecurity sec, const WifiCredentials& cred) override;
     int getNetworkInfo(WifiNetworkInfo* info) override;
-    int scan(WifiScanCallback callback, void* data) override;
+    int scan(WifiScanCallback callback, void* data, bool forConnect) override;
     int getMacAddress(MacAddress* addr) override;
 
     virtual int getFirmwareVersionString(char* buf, size_t size) override;


### PR DESCRIPTION
### Description

This was reverted in 5.8.0, still seeing this happen in some cases so bringing it back in with some minor changes (`forConnect`)


