### PR TITLE
[msom] M404/BG95M5 disable 2g, only scan for LTEM

### DIFF
--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -1439,8 +1439,12 @@ int QuectelNcpClient::registerNet() {
             r = CHECK_PARSER(respNwMode.readResult());
             CHECK_TRUE(r == AtResponse::OK, SYSTEM_ERROR_UNKNOWN);
         #if PLATFORM_ID == PLATFORM_MSOM
-            if (nwScanMode != 0) {
-                CHECK_PARSER(parser_.execCommand("AT+QCFG=\"nwscanmode\",0,1")); // AUTO
+            // M404/BG95M5 should be LTEM only, ie scan mode 3
+            // M524/EG91EX should be AUTO (both LTEM and 2G), ie scan mode 0
+            int desiredNwScanMode = (ncpId() == PLATFORM_NCP_QUECTEL_BG95_M5) ? 3 : 0;
+
+            if (nwScanMode != desiredNwScanMode) {
+                CHECK_PARSER(parser_.execCommand("AT+QCFG=\"nwscanmode\",%d,1", desiredNwScanMode));
             }
 
             if (ncpId() == PLATFORM_NCP_QUECTEL_BG95_M5) {


### PR DESCRIPTION
### Problem

Seeing unexplained connectivity / DNS errors on 2g connections sometimes with MSOM

### Solution

Disable 2g networks until we can investigate further

### Steps to Test
Run any app
