### PR TITLE
[usb][rtl872x] Resolves deadlocks on boot with usbd_isr_ and app threads

### DIFF
--- a/hal/src/rtl872x/usbd_driver.cpp
+++ b/hal/src/rtl872x/usbd_driver.cpp
@@ -127,7 +127,6 @@ int usb_hal_read_packet(void* ptr, uint32_t size, void* unknown);
 int __real_usb_hal_read_packet(void* ptr, uint32_t size, void* unknown);
 
 int __wrap_usb_hal_read_packet(void* ptr, uint32_t size, void* unknown) {
-    std::lock_guard<RtlUsbDriver> lk(*RtlUsbDriver::instance());
     int r = __real_usb_hal_read_packet(ptr, size, unknown);
     bool fixed = false;
     if (size == sizeof(sLastUsbSetupRequest)) {


### PR DESCRIPTION
### Problem

MSOM devices deadlock when a USB serial terminal is left connected to them on boot. Examples are when doing DFU flashing via command line / workbench with either minicom or `particle serial monitor` running. 

### Solution

This PR avoids a lock between the app thread and the USB ISR thread that happens early on boot when attempting to log before system thread is started. See discussion [here](https://s.slack.com/archives/CS0T32ZKK/p1713466304638579?thread_ts=1713199783.482679&cid=CS0T32ZKK)

### Steps to Test

Connect minicom / `particle serial monitor` to follow a device.
Flash via DFU / workbench
USB serial should re-enumerate when the device boots and runs

### Example App
Any
