### PR TITLE
[RTL872x] multiple SPI fixes

### DIFF
--- a/hal/src/nRF52840/spi_hal.cpp
+++ b/hal/src/nRF52840/spi_hal.cpp
@@ -160,7 +160,7 @@ static void spiSlaveEventHandler(nrfx_spis_evt_t const * p_event, void * p_conte
             return;
         }
         
-        spiMap[spi].transfer_length = p_event->rx_amount;
+        spiMap[spi].transfer_length = std::max(p_event->rx_amount, p_event->tx_amount);
         spiMap[spi].transmitting = false;
         
         // We should notify application, despite of how many data we received.

--- a/hal/src/rtl872x/spi_hal.cpp
+++ b/hal/src/rtl872x/spi_hal.cpp
@@ -445,7 +445,6 @@ public:
 
     uint8_t transfer(uint8_t data) {
         CHECK_TRUE(isEnabled(), 0);
-        CHECK_TRUE(isBusy() == false, 0);
         CHECK_TRUE(config_.spiMode == SPI_MODE_MASTER, 0);
 
         // Wait for last SPI transfer finished

--- a/user/tests/wiring/spi_master_slave/spi_master/spi_master.cpp
+++ b/user/tests/wiring/spi_master_slave/spi_master/spi_master.cpp
@@ -237,7 +237,6 @@ bool SPI_Master_Slave_Change_Mode(uint8_t mode, uint8_t bitOrder, std::function<
 
     uint32_t requestedLength = 0;
     uint32_t switchMode = ((uint32_t)mode) | ((uint32_t)bitOrder << 8) | (0x8DC6 << 16);
-    memset(SPI_Master_Tx_Buffer, 0, sizeof(SPI_Master_Tx_Buffer));
 
     memset(SPI_Master_Tx_Buffer, 0, sizeof(SPI_Master_Tx_Buffer));
     memset(SPI_Master_Rx_Buffer, 0, sizeof(SPI_Master_Rx_Buffer));
@@ -317,7 +316,7 @@ void SPI_Master_Slave_Master_Test_Routine(std::function<void(uint8_t*, uint8_t*,
 
         // Received a good first reply from Slave
         // Now read out requestedLength bytes
-        memset(SPI_Master_Rx_Buffer, 0xaa, sizeof(SPI_Master_Rx_Buffer));
+        memset(SPI_Master_Rx_Buffer, '\0', sizeof(SPI_Master_Rx_Buffer));
         transferFunc(NULL, SPI_Master_Rx_Buffer, requestedLength);
         // Deselect
         digitalWrite(MY_CS, HIGH);
@@ -542,6 +541,9 @@ test(23_SPI_Master_Slave_Master_Variable_Length_Transfer_DMA_Synchronous_MODE2_L
 // The following tests inherit the last mode and bit order being set above
 test(24_SPI_Master_Slave_Master_Const_String_Transfer_DMA)
 {
+    // FIXME: On Gen4, slave's usb serial log may take longer before the next test is ready for a new transaction
+    delay(300);
+
     // Select
     // Workaround for some platforms requiring the CS to be high when configuring
     // the DMA buffers
@@ -566,6 +568,9 @@ test(24_SPI_Master_Slave_Master_Const_String_Transfer_DMA)
 
 test(25_SPI_Master_Slave_Master_Reception)
 {
+    // FIXME: On Gen4, slave's usb serial log may take longer before the next test is ready for a new transaction
+    delay(300);
+
     memset(SPI_Master_Rx_Buffer_Supper, '\0', sizeof(SPI_Master_Rx_Buffer_Supper));
 
     // Select

--- a/user/tests/wiring/spi_master_slave/spi_slave/spi_slave.cpp
+++ b/user/tests/wiring/spi_master_slave/spi_slave/spi_slave.cpp
@@ -149,9 +149,9 @@
  *
  * Master             Slave       Master              Slave
  * CS   D5 <-------> D5 CS        CS   S3 <---------> D5 CS
- * MISO D4 <-------> D3 MISO      MISO S1 <---------> D3 MISO
- * MOSI D3 <-------> D2 MOSI      MOSI S0 <---------> D2 MOSI
- * SCK  D2 <-------> D4 SCK       SCK  S2 <---------> D4 SCK
+ * MISO D3 <-------> D3 MISO      MISO S1 <---------> D3 MISO
+ * MOSI D2 <-------> D2 MOSI      MOSI S0 <---------> D2 MOSI
+ * SCK  D4 <-------> D4 SCK       SCK  S2 <---------> D4 SCK
  *
  *********************************************************************************************
  *
@@ -277,8 +277,8 @@ test(00_SPI_Master_Slave_Slave_Transfer)
             Serial.println();
         }
 
-        Serial.printlnf("< (%u) ", MY_SPI.available());
-        Serial.println((const char *)SPI_Slave_Rx_Buffer);
+        // Serial.printlnf("< (%u) ", MY_SPI.available());
+        // Serial.println((const char *)SPI_Slave_Rx_Buffer);
 
         /* Check how many bytes we have received */
         assertEqual(MY_SPI.available(), TRANSFER_LENGTH_1);
@@ -314,8 +314,8 @@ test(00_SPI_Master_Slave_Slave_Transfer)
 
         memcpy(SPI_Slave_Tx_Buffer, SLAVE_TEST_MESSAGE_2, requestedLength);
         SPI_Slave_Tx_Buffer[requestedLength] = '\0';
-        Serial.print("> ");
-        Serial.println((const char *)SPI_Slave_Tx_Buffer);
+        // Serial.print("> ");
+        // Serial.println((const char *)SPI_Slave_Tx_Buffer);
 
         SPI_Transfer_DMA(SPI_Slave_Tx_Buffer, SPI_Slave_Rx_Buffer, requestedLength, count % 2 == 0 ? &SPI_DMA_Completed_Callback : NULL);
         /* Check that we have transferred requestedLength bytes as requested */

--- a/user/tests/wiring/spi_master_slave/spi_slave/spi_slave.cpp
+++ b/user/tests/wiring/spi_master_slave/spi_slave/spi_slave.cpp
@@ -345,8 +345,8 @@ test(01_SPI_Master_Slave_Slave_Receiption)
 
     SPI_Transfer_DMA(nullptr, SPI_Slave_Rx_Buffer_Supper, sizeof(SPI_Slave_Rx_Buffer_Supper), &SPI_DMA_Completed_Callback);
 
-    Serial.print("< ");
-    Serial.println((const char *)SPI_Slave_Rx_Buffer_Supper);
+    // Serial.print("< ");
+    // Serial.println((const char *)SPI_Slave_Rx_Buffer_Supper);
     /* Check how many bytes we have received */
     assertEqual(MY_SPI.available(), strlen(txString));
 
@@ -363,7 +363,7 @@ test(02_SPI_Master_Slave_Slave_Const_String_Transfer_DMA)
     // FIXME: The rx_buffer has to be nullptr, otherwise, the the rx_buffer will overflow
     // as the length of the rx buffer given in this file is not equal to the length of tx data
     MY_SPI.transfer(txString, nullptr, strlen(txString), NULL);
-    assertEqual(MY_SPI.available(), 0);
+    assertEqual(MY_SPI.available(), strlen(txString));
 }
 
 #endif // #ifdef MY_SPI


### PR DESCRIPTION
### Problem
1. `SPI.transfer(byte)` may lose data
2. SPI settings before `SPI.begin()` won't apply
3. `SPI.transfer(txBuf, nullptr, size, callback)` will lose data if CS pin is deasserted after the callback is invoked
4. SPI slave DMA state machine is messed up if master just toggles the CS pin

### Steps to Test
`user/tests/wiring/spi_master_slave`

### References
N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
