### PR TITLE
[quectel] fixes PPP resume during warm boot

### DIFF
--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -136,7 +136,7 @@ const int IMSI_MAX_RETRY_CNT = 10;
 const int CCID_MAX_RETRY_CNT = 2;
 
 const int DATA_MODE_BREAK_ATTEMPTS = 5;
-const int PPP_ECHO_REQUEST_ATTEMPTS = 3;
+const int PPP_ECHO_REQUEST_ATTEMPTS = 10;
 const int CGDCONT_ATTEMPTS = 5;
 
 const int COPS_MAX_RETRY_CNT = 3;
@@ -1573,7 +1573,10 @@ int QuectelNcpClient::enterDataMode() {
         // Send data mode break
         const char breakCmd[] = "+++";
         muxerDataStream_->write(breakCmd, sizeof(breakCmd) - 1);
-        skipAll(muxerDataStream_.get(), 1000);
+        // XXX: EG91-NAX required 1000ms delay after +++ needs to be at least 1004ms to resolve a
+        //      bug during warm boot where PPP LCP echo requests will not be sent out of the modem
+        //      on the hardware UART interface. Setting 100ms higher based on Quectel's recommendation.
+        skipAll(muxerDataStream_.get(), (1000 + 100));
 
         dataParser_.reset();
         responsive = waitAtResponse(dataParser_, 1000, 500) == 0;


### PR DESCRIPTION
### Problem

- `slo/connect_time` failing warm boot times of < 30s on EG91-NAX due to PPP data link not resuming, requiring a modem power cycle and cold boot, which adds ~30s to the connection time.  So instead of 6-10s warm boot times, we were seeing 31-33s warm boot times about 50% of the time.

### Solution

- After a lengthy investigation, the root cause was found to be related to the 1s delay requirement after the +++ command (which switches PPP back to command mode).  This required by spec delay needed to be increased by at least 4ms.  We'll set this delay to 1100ms based on some feedback from Quectel.
- Additionally, during testing it was rarely seen that the PPP_ECHO_REQUEST_ATTEMPTS could sometimes be higher than 3 but lower than 10 and still work.  So we'll bump this up to 10 just to avoid a cold boot in that case, which would add another ~30s to the ~3s delay of trying all 3 attempts and failing.  If it should ever exceed 10 attempts, it will take about ~40s to boot, but I personally have not seen this occur in over 1000 warm boots.

### Steps to Test

- Included below is a diff to speed up testing of the `slo/connect_time` test.  It can be run locally in a loop, and should not fail, nor should any of the warm boot times be anywhere near 30s.  Typically they are in the 6-10s range.
<details>
  <summary><i>connect_time_test.diff</i></summary>

```
diff --git i/user/tests/integration/slo/connect_time/connect_time.cpp w/user/tests/integration/slo/connect_time/connect_time.cpp
index aa398dec2..9732f1e1f 100644
--- i/user/tests/integration/slo/connect_time/connect_time.cpp
+++ w/user/tests/integration/slo/connect_time/connect_time.cpp
@@ -160,7 +160,7 @@ size_t serializeStatsAsJson(char* buf, size_t size) {
 }
 
 bool testCloudConnectTimeFromColdBoot() {
-    if (stats.coldBootCount >= CONNECT_COUNT) {
+    if (stats.coldBootCount >= 1) {
         return false;
     }
     const auto t0 = millis();
@@ -315,13 +315,13 @@ void loop() {
     }
 
 DEFINE_COLD_BOOT_TEST(01)
-DEFINE_COLD_BOOT_TEST(02)
-DEFINE_COLD_BOOT_TEST(03)
-DEFINE_COLD_BOOT_TEST(04)
-DEFINE_COLD_BOOT_TEST(05)
-DEFINE_COLD_BOOT_TEST(06)
-DEFINE_COLD_BOOT_TEST(07)
-DEFINE_COLD_BOOT_TEST(08)
+// DEFINE_COLD_BOOT_TEST(02)
+// DEFINE_COLD_BOOT_TEST(03)
+// DEFINE_COLD_BOOT_TEST(04)
+// DEFINE_COLD_BOOT_TEST(05)
+// DEFINE_COLD_BOOT_TEST(06)
+// DEFINE_COLD_BOOT_TEST(07)
+// DEFINE_COLD_BOOT_TEST(08)
 
 DEFINE_WARM_BOOT_TEST(01)
 DEFINE_WARM_BOOT_TEST(02)
diff --git i/user/tests/integration/slo/connect_time/connect_time.spec.js w/user/tests/integration/slo/connect_time/connect_time.spec.js
index 276213f4a..ccb5b3b0d 100644
--- i/user/tests/integration/slo/connect_time/connect_time.spec.js
+++ w/user/tests/integration/slo/connect_time/connect_time.spec.js
@@ -54,7 +54,7 @@ before(function() {
 
 // TODO: The test runner doesn't support resetting the device in a loop from within a test
 // FIXME: it does now, the tests need to be fixed
-for (let i = 1; i <= CONNECT_COUNT; ++i) {
+for (let i = 1; i <= 1; ++i) {
 	test(`cloud_connect_time_from_cold_boot_${i.toString().padStart(2, '0')}`, async () => {
 		// dump any failure logs from this test
 		let testLog = await fetchLog();

```
</details>
