### PR TITLE
[bootloader] Implement bootloader reset reasons

### DIFF
--- a/bootloader/prebootloader/src/rtl872x/part1/rtl_support.c
+++ b/bootloader/prebootloader/src/rtl872x/part1/rtl_support.c
@@ -223,7 +223,7 @@ static uint32_t boot_reason_set(void) {
     /* backup boot reason to REG_LP_SYSTEM_CFG2 */
     temp_bootcfg = HAL_READ32(SYSTEM_CTRL_BASE_LP, REG_LP_SYSTEM_CFG2);
     temp_bootcfg |= tmp_reason;
-    HAL_WRITE32(SYSTEM_CTRL_BASE_LP, REG_LP_SYSTEM_CFG2, tmp_reason); // Should tmp_reason be `temp_bootcfg`? If we have deepsleep or brownout boots, we will clear some of the bits in REG_LP_SYSTEM_CFG2
+    HAL_WRITE32(SYSTEM_CTRL_BASE_LP, REG_LP_SYSTEM_CFG2, tmp_reason);
     
     return 0;
 }

--- a/bootloader/prebootloader/src/rtl872x/part1/rtl_support.c
+++ b/bootloader/prebootloader/src/rtl872x/part1/rtl_support.c
@@ -223,7 +223,7 @@ static uint32_t boot_reason_set(void) {
     /* backup boot reason to REG_LP_SYSTEM_CFG2 */
     temp_bootcfg = HAL_READ32(SYSTEM_CTRL_BASE_LP, REG_LP_SYSTEM_CFG2);
     temp_bootcfg |= tmp_reason;
-    HAL_WRITE32(SYSTEM_CTRL_BASE_LP, REG_LP_SYSTEM_CFG2, tmp_reason);
+    HAL_WRITE32(SYSTEM_CTRL_BASE_LP, REG_LP_SYSTEM_CFG2, tmp_reason); // Should tmp_reason be `temp_bootcfg`? If we have deepsleep or brownout boots, we will clear some of the bits in REG_LP_SYSTEM_CFG2
     
     return 0;
 }

--- a/bootloader/src/rtl872x/core_hal.c
+++ b/bootloader/src/rtl872x/core_hal.c
@@ -27,6 +27,8 @@ void HAL_Delay_Microseconds(uint32_t uSec) {
 }
 
 void HAL_Core_System_Reset_Ex(int reason, uint32_t data, void *reserved) {
+    HAL_Core_Write_Backup_Register(BKP_DR_02, reason);
+    HAL_Core_Write_Backup_Register(BKP_DR_03, data);
     HAL_Core_System_Reset();
 }
 

--- a/platform/MCU/rtl872x/src/hw_config.c
+++ b/platform/MCU/rtl872x/src/hw_config.c
@@ -425,8 +425,7 @@ void Finish_Update()
 
     // USB_Cable_Config(DISABLE);
 
-    // FIXME: reset reason?
-    HAL_Core_System_Reset_Ex(0, 0, NULL);
+    HAL_Core_System_Reset_Ex(RESET_REASON_UPDATE, 0, NULL);
 }
 
 __attribute__((section(".retained_system_flags"))) platform_system_flags_t system_flags;

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -1277,16 +1277,6 @@ int Spark_Handshake(bool presence_announce)
             publishEvent("spark/device/claim/code", buf);
         }
 
-        // open up for possibility of retrieving multiple ID datums
-        if (!HAL_Get_Device_Identifier(NULL, buf, sizeof(buf), 0, NULL) && *buf) {
-            LOG(INFO,"Send spark/device/ident/0 event");
-            publishEvent("spark/device/ident/0", buf);
-        }
-
-        publishSafeModeEventIfNeeded();
-        publishResetReasonIfNeeded();
-        Send_Firmware_Update_Flags();
-
         if (presence_announce) {
             Multicast_Presence_Announcement();
         }
@@ -1294,14 +1284,15 @@ int Spark_Handshake(bool presence_announce)
     } else {
         LOG(INFO,"cloud connected from existing session.");
 
-        publishSafeModeEventIfNeeded();
-        publishResetReasonIfNeeded();
-        Send_Firmware_Update_Flags();
-
         if (!hal_rtc_time_is_valid(nullptr) && spark_sync_time_last(nullptr, nullptr) == 0) {
             spark_protocol_send_time_request(sp);
         }
     }
+
+    publishSafeModeEventIfNeeded();
+    publishResetReasonIfNeeded();
+    Send_Firmware_Update_Flags();
+
     if (system_mode() != AUTOMATIC || APPLICATION_SETUP_DONE) {
         err = sendApplicationDescription();
         if (err != 0) {

--- a/user/tests/wiring/watchdog/watchdog.cpp
+++ b/user/tests/wiring/watchdog/watchdog.cpp
@@ -47,7 +47,8 @@ test(WATCHDOG_00_setup_disconnect_power_off_ncp) {
     Cellular.off();
     waitFor(Cellular.isOff, 120000);
     assertTrue(Cellular.isOff());
-#elif Wiring_WiFi
+#endif
+#if Wiring_WiFi
     WiFi.disconnect();
     waitForNot(WiFi.ready, 60000);
     WiFi.off();


### PR DESCRIPTION
### Problem
The RTL bootloader has not been updated to use the backup register HAL to communicate reset reason to the system part application. This leads to undefined reset reasons in the following scenarios

1. When completing OTA bootloader update
2. When completing DFU update via button reset/hold

### Solution
The backup register HAL is implemented on RTL platform via retained SRAM, the bootloader just needs to write the "registers"

### Steps to Test
Checkout branch, compile bootloader, flash
Flash app via reset button hold and DFU
Log reset reason ie (`Log.info("Last Reset Reason %d", System.resetReason());`)
Verify that it is correct (`70` = firmware update, `40` = pin/power reset):
```
0000008051 [app] INFO: Last Reset Reason 70
```

Without bootloader update, the values are undefined:
```
0000058978 [app] INFO: Last Reset Reason -49520187
```

### Example App

### References

See comment [here](https://s.slack.com/archives/C06G6BGTNS0/p1713393224076049)

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
