### PR TITLE
Supports auxiliary power control.

### DIFF
--- a/hal/inc/power_hal.h
+++ b/hal/inc/power_hal.h
@@ -22,6 +22,11 @@
 #include <stddef.h>
 #include "static_assert.h"
 
+#define HAL_POWER_CONFIG_VERSION_0          0
+#define HAL_POWER_CONFIG_VERSION_1          1
+
+#define HAL_POWER_CONFIG_VERSION            HAL_POWER_CONFIG_VERSION_1
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */
@@ -61,13 +66,9 @@ typedef struct hal_power_config {
     uint16_t charge_current; // charge current
     uint16_t termination_voltage; // termination voltage
     uint8_t soc_bits; // bits precision for SoC calculation (18 (default) or 19)
-    /* Since the old firmware resets all the reserved fields to 0, we use this field
-     * to determine if the aux_pwr_ctrl_pin being 0 is set by user or just inherits
-     * from the old DCT due to firmware upgrading. */
-    uint8_t aux_pwr_ctrl;
     uint8_t aux_pwr_ctrl_pin; // pin number for auxiliary power control
     uint8_t aux_pwr_ctrl_pin_level; // active level for auxiliary power control
-    uint8_t reserved2[2];
+    uint8_t reserved2[3];
     uint32_t reserved3[3];
 } hal_power_config;
 static_assert(sizeof(hal_power_config) == 32, "hal_power_config size changed");

--- a/hal/inc/power_hal.h
+++ b/hal/inc/power_hal.h
@@ -70,7 +70,7 @@ typedef struct hal_power_config {
     uint8_t aux_pwr_ctrl_pin_level; // active level for auxiliary power control
     uint8_t reserved2[3];
     uint32_t reserved3[3];
-} hal_power_config;
+} __attribute__((packed)) hal_power_config;
 static_assert(sizeof(hal_power_config) == 32, "hal_power_config size changed");
 
 int hal_power_load_config(hal_power_config* conf, void* reserved);

--- a/hal/inc/power_hal.h
+++ b/hal/inc/power_hal.h
@@ -61,8 +61,13 @@ typedef struct hal_power_config {
     uint16_t charge_current; // charge current
     uint16_t termination_voltage; // termination voltage
     uint8_t soc_bits; // bits precision for SoC calculation (18 (default) or 19)
+    /* Since the old firmware resets all the reserved fields to 0, we use this field
+     * to determine if the aux_pwr_ctrl_pin being 0 is set by user or just inherits
+     * from the old DCT due to firmware upgrading. */
+    uint8_t aux_pwr_ctrl;
     uint8_t aux_pwr_ctrl_pin; // pin number for auxiliary power control
     uint8_t aux_pwr_ctrl_pin_level; // active level for auxiliary power control
+    uint8_t reserved2[2];
     uint32_t reserved3[3];
 } hal_power_config;
 static_assert(sizeof(hal_power_config) == 32, "hal_power_config size changed");

--- a/hal/inc/power_hal.h
+++ b/hal/inc/power_hal.h
@@ -61,8 +61,9 @@ typedef struct hal_power_config {
     uint16_t charge_current; // charge current
     uint16_t termination_voltage; // termination voltage
     uint8_t soc_bits; // bits precision for SoC calculation (18 (default) or 19)
-    uint8_t reserved2;
-    uint32_t reserved3[4];
+    uint8_t aux_pwr_ctrl_pin; // pin number for auxiliary power control
+    uint8_t aux_pwr_ctrl_pin_level; // active level for auxiliary power control
+    uint32_t reserved3[3];
 } hal_power_config;
 static_assert(sizeof(hal_power_config) == 32, "hal_power_config size changed");
 

--- a/hal/network/api/ifapi.h
+++ b/hal/network/api/ifapi.h
@@ -276,6 +276,7 @@ typedef struct if_wiznet_pin_remap {
 
 int if_init(void);
 int if_init_platform(void*);
+int if_init_platform_postpone(void*);
 
 int if_get_list(struct if_list** ifs);
 int if_free_list(struct if_list* ifs);

--- a/hal/network/lwip/ifapi.cpp
+++ b/hal/network/lwip/ifapi.cpp
@@ -350,6 +350,10 @@ __attribute__((weak)) int if_init_platform(void*) {
     return 0;
 }
 
+__attribute__((weak)) int if_init_platform_postpone(void*) {
+    return 0;
+}
+
 int if_get_list(struct if_list** ifs) {
     if (ifs == nullptr) {
         return -1;

--- a/hal/network/lwip/ifapi_impl.h
+++ b/hal/network/lwip/ifapi_impl.h
@@ -20,6 +20,7 @@
 
 #include "socket_hal_posix.h"
 #include <lwip/netif.h>
+#include <lwip/netifapi.h>
 
 #define IF_T_DEFINED
 typedef struct netif* if_t;

--- a/hal/network/lwip/wiznet/wiznetif.h
+++ b/hal/network/lwip/wiznet/wiznetif.h
@@ -35,7 +35,7 @@ namespace particle { namespace net {
 class WizNetif : public BaseNetif {
 public:
     WizNetif() = delete;
-    WizNetif(hal_spi_interface_t spi, hal_pin_t cs, hal_pin_t reset, hal_pin_t interrupt, const uint8_t mac[6]);
+    WizNetif(hal_spi_interface_t spi, hal_pin_t cs, hal_pin_t reset, hal_pin_t interrupt, const uint8_t mac[6], bool postpone = false);
     virtual ~WizNetif();
 
     virtual int powerUp() override;
@@ -43,6 +43,7 @@ public:
 
     virtual int getPowerState(if_power_state_t* state) const override;
     virtual int getNcpState(unsigned int* state) const override;
+    bool isPresent();
 
     static WizNetif* instance() {
         return instance_;
@@ -58,7 +59,6 @@ private:
     err_t initInterface();
 
     void hwReset();
-    bool isPresent();
 
     static void interruptCb(void* arg);
     static void loop(void* arg);
@@ -83,6 +83,7 @@ private:
     hal_pin_t cs_;
     hal_pin_t reset_;
     hal_pin_t interrupt_;
+    bool postpone_;
 
     std::atomic<if_power_state_t> pwrState_;
 

--- a/hal/src/b5som/network/network.cpp
+++ b/hal/src/b5som/network/network.cpp
@@ -152,6 +152,23 @@ int if_init_platform(void*) {
     return 0;
 }
 
+int if_init_platform_postpone(void*) {
+    if (en2) {
+        uint8_t dummy;
+        if (!if_get_index(en2->interface(), &dummy)) {
+            auto wizNetif = reinterpret_cast<WizNetif*>(en2);
+            if (wizNetif->isPresent()) {
+                return 0;
+            }
+            netifapi_netif_remove(en2->interface());
+        }
+        LOG(INFO, "Ethernet interface is not present");
+        delete en2;
+        en2 = nullptr;
+    }
+    return 0;
+}
+
 extern "C" {
 
 struct netif* lwip_hook_ip4_route_src(const ip4_addr_t* src, const ip4_addr_t* dst) {

--- a/hal/src/b5som/network/network.cpp
+++ b/hal/src/b5som/network/network.cpp
@@ -127,7 +127,7 @@ int if_init_platform(void*) {
         wizNetifConfigData.size = sizeof(WizNetifConfigData);
         wizNetifConfigData.version = WIZNETIF_CONFIG_DATA_VERSION;
         WizNetifConfig::instance()->getConfigData(&wizNetifConfigData);
-        en2 = new WizNetif(HAL_SPI_INTERFACE1, wizNetifConfigData.cs_pin, wizNetifConfigData.reset_pin, wizNetifConfigData.int_pin, mac, true);
+        en2 = new WizNetif(HAL_SPI_INTERFACE1, wizNetifConfigData.cs_pin, wizNetifConfigData.reset_pin, wizNetifConfigData.int_pin, mac, true /* postpone initialization */);
     }
 
     uint8_t dummy;

--- a/hal/src/b5som/network/network.cpp
+++ b/hal/src/b5som/network/network.cpp
@@ -127,7 +127,7 @@ int if_init_platform(void*) {
         wizNetifConfigData.size = sizeof(WizNetifConfigData);
         wizNetifConfigData.version = WIZNETIF_CONFIG_DATA_VERSION;
         WizNetifConfig::instance()->getConfigData(&wizNetifConfigData);
-        en2 = new WizNetif(HAL_SPI_INTERFACE1, wizNetifConfigData.cs_pin, wizNetifConfigData.reset_pin, wizNetifConfigData.int_pin, mac);
+        en2 = new WizNetif(HAL_SPI_INTERFACE1, wizNetifConfigData.cs_pin, wizNetifConfigData.reset_pin, wizNetifConfigData.int_pin, mac, true);
     }
 
     uint8_t dummy;

--- a/hal/src/boron/network/network.cpp
+++ b/hal/src/boron/network/network.cpp
@@ -127,7 +127,11 @@ int if_init_platform(void*) {
         wizNetifConfigData.size = sizeof(WizNetifConfigData);
         wizNetifConfigData.version = WIZNETIF_CONFIG_DATA_VERSION;
         WizNetifConfig::instance()->getConfigData(&wizNetifConfigData);
-        en2 = new WizNetif(HAL_SPI_INTERFACE1, wizNetifConfigData.cs_pin, wizNetifConfigData.reset_pin, wizNetifConfigData.int_pin, mac);
+        bool postpone = false;
+#if PLATFORM_ID == PLATFORM_BSOM
+        postpone = true;
+#endif
+        en2 = new WizNetif(HAL_SPI_INTERFACE1, wizNetifConfigData.cs_pin, wizNetifConfigData.reset_pin, wizNetifConfigData.int_pin, mac, postpone);
     }
 
     uint8_t dummy;

--- a/hal/src/boron/network/network.cpp
+++ b/hal/src/boron/network/network.cpp
@@ -129,7 +129,7 @@ int if_init_platform(void*) {
         WizNetifConfig::instance()->getConfigData(&wizNetifConfigData);
         bool postpone = false;
 #if PLATFORM_ID == PLATFORM_BSOM
-        postpone = true;
+        postpone = true; /* postpone initialization */
 #endif
         en2 = new WizNetif(HAL_SPI_INTERFACE1, wizNetifConfigData.cs_pin, wizNetifConfigData.reset_pin, wizNetifConfigData.int_pin, mac, postpone);
     }

--- a/hal/src/boron/network/network.cpp
+++ b/hal/src/boron/network/network.cpp
@@ -152,6 +152,25 @@ int if_init_platform(void*) {
     return 0;
 }
 
+#if PLATFORM_ID == PLATFORM_BSOM
+int if_init_platform_postpone(void*) {
+    if (en2) {
+        uint8_t dummy;
+        if (!if_get_index(en2->interface(), &dummy)) {
+            auto wizNetif = reinterpret_cast<WizNetif*>(en2);
+            if (wizNetif->isPresent()) {
+                return 0;
+            }
+            netifapi_netif_remove(en2->interface());
+        }
+        LOG(INFO, "Ethernet interface is not present");
+        delete en2;
+        en2 = nullptr;
+    }
+    return 0;
+}
+#endif
+
 extern "C" {
 
 struct netif* lwip_hook_ip4_route_src(const ip4_addr_t* src, const ip4_addr_t* dst) {

--- a/hal/src/msom/network/network.cpp
+++ b/hal/src/msom/network/network.cpp
@@ -163,7 +163,7 @@ int if_init_platform(void*) {
         wizNetifConfigData.size = sizeof(WizNetifConfigData);
         wizNetifConfigData.version = WIZNETIF_CONFIG_DATA_VERSION;
         WizNetifConfig::instance()->getConfigData(&wizNetifConfigData);
-        en2 = new WizNetif(HAL_SPI_INTERFACE1, wizNetifConfigData.cs_pin, wizNetifConfigData.reset_pin, wizNetifConfigData.int_pin, mac, true);
+        en2 = new WizNetif(HAL_SPI_INTERFACE1, wizNetifConfigData.cs_pin, wizNetifConfigData.reset_pin, wizNetifConfigData.int_pin, mac, true /* postpone initialization */);
     }
 
     uint8_t dummy;

--- a/hal/src/msom/network/network.cpp
+++ b/hal/src/msom/network/network.cpp
@@ -163,7 +163,7 @@ int if_init_platform(void*) {
         wizNetifConfigData.size = sizeof(WizNetifConfigData);
         wizNetifConfigData.version = WIZNETIF_CONFIG_DATA_VERSION;
         WizNetifConfig::instance()->getConfigData(&wizNetifConfigData);
-        en2 = new WizNetif(HAL_SPI_INTERFACE1, wizNetifConfigData.cs_pin, wizNetifConfigData.reset_pin, wizNetifConfigData.int_pin, mac);
+        en2 = new WizNetif(HAL_SPI_INTERFACE1, wizNetifConfigData.cs_pin, wizNetifConfigData.reset_pin, wizNetifConfigData.int_pin, mac, true);
     }
 
     uint8_t dummy;
@@ -208,9 +208,9 @@ int if_init_platform_postpone(void*) {
             if (wizNetif->isPresent()) {
                 return 0;
             }
+            LOG(INFO, "Remove Ethernet interface");
             netifapi_netif_remove(en2->interface());
         }
-        LOG(INFO, "Ethernet interface is not present");
         delete en2;
         en2 = nullptr;
     }

--- a/hal/src/msom/network/network.cpp
+++ b/hal/src/msom/network/network.cpp
@@ -200,6 +200,23 @@ int if_init_platform(void*) {
     return 0;
 }
 
+int if_init_platform_postpone(void*) {
+    if (en2) {
+        uint8_t dummy;
+        if (!if_get_index(en2->interface(), &dummy)) {
+            auto wizNetif = reinterpret_cast<WizNetif*>(en2);
+            if (wizNetif->isPresent()) {
+                return 0;
+            }
+            netifapi_netif_remove(en2->interface());
+        }
+        LOG(INFO, "Ethernet interface is not present");
+        delete en2;
+        en2 = nullptr;
+    }
+    return 0;
+}
+
 extern "C" {
 
 struct netif* lwip_hook_ip4_route_src(const ip4_addr_t* src, const ip4_addr_t* dst) {

--- a/system/inc/system_event.h
+++ b/system/inc/system_event.h
@@ -63,6 +63,7 @@ enum SystemEvents {
     out_of_memory = 1<<18,          // heap request was not satisfied
     ble_prov_mode = 1<<19,          // ble provisioning mode
     firmware_update_status = 1<<20, // firmware update status changed
+    aux_power_state = 1<<21,        // Auxiliary power status changed
 
     all_events = 0xFFFFFFFFFFFFFFFF
 };

--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -709,6 +709,12 @@ RunTimeInfoDiagnosticData g_usedRamDiagData(DIAG_ID_SYSTEM_USED_RAM, DIAG_NAME_S
     }
 );
 
+void if_init_postpone(system_event_t event, int param, void* pointer, void* context) {
+    if (event == aux_power_state) {
+        if_init_platform_postpone(nullptr);
+    }
+}
+
 } // namespace
 
 /*******************************************************************************
@@ -750,11 +756,11 @@ void app_setup_and_loop(void)
 
     LED_SIGNAL_START(NETWORK_OFF, BACKGROUND);
 
-    system_power_management_init();
-
 #if HAL_PLATFORM_LWIP
-    if_init_platform_postpone(nullptr);
+    system_subscribe_event(aux_power_state, if_init_postpone, nullptr);
 #endif /* HAL_PLATFORM_LWIP */
+
+    system_power_management_init();
 
     // Start the diagnostics service
     diag_command(DIAG_SERVICE_CMD_START, nullptr, nullptr);

--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -735,6 +735,11 @@ void app_setup_and_loop(void)
     }
 #endif // HAL_PLATFORM_ASSETS
 
+    // Reset all persistent settings to factory defaults if necessary
+    // This should be called before system_part2_post_init() so that the
+    // configurations set in STARTUP() is not reset by factory reset
+    resetSettingsToFactoryDefaultsIfNeeded();
+
     // NOTE: this calls user app global constructors
     system_part2_post_init();
 
@@ -744,9 +749,6 @@ void app_setup_and_loop(void)
     DECLARE_SYS_HEALTH(ENTERED_Main);
 
     LED_SIGNAL_START(NETWORK_OFF, BACKGROUND);
-
-    // Reset all persistent settings to factory defaults if necessary
-    resetSettingsToFactoryDefaultsIfNeeded();
 
     system_power_management_init();
 

--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -709,11 +709,13 @@ RunTimeInfoDiagnosticData g_usedRamDiagData(DIAG_ID_SYSTEM_USED_RAM, DIAG_NAME_S
     }
 );
 
+#if HAL_PLATFORM_LWIP
 void if_init_postpone(system_event_t event, int param, void* pointer, void* context) {
     if (event == aux_power_state) {
         if_init_platform_postpone(nullptr);
     }
 }
+#endif /* HAL_PLATFORM_LWIP */
 
 } // namespace
 

--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -750,6 +750,8 @@ void app_setup_and_loop(void)
 
     system_power_management_init();
 
+    if_init_platform_postpone(nullptr);
+
     // Start the diagnostics service
     diag_command(DIAG_SERVICE_CMD_START, nullptr, nullptr);
 

--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -752,7 +752,9 @@ void app_setup_and_loop(void)
 
     system_power_management_init();
 
+#if HAL_PLATFORM_LWIP
     if_init_platform_postpone(nullptr);
+#endif /* HAL_PLATFORM_LWIP */
 
     // Start the diagnostics service
     diag_command(DIAG_SERVICE_CMD_START, nullptr, nullptr);

--- a/system/src/system_power_manager.cpp
+++ b/system/src/system_power_manager.cpp
@@ -72,14 +72,13 @@ constexpr uint8_t BATTERY_REPEATED_CHARGED_COUNT = 2;
 
 constexpr hal_power_config defaultPowerConfig = {
   .flags = 0,
-  .version = 0,
+  .version = HAL_POWER_CONFIG_VERSION,
   .size = sizeof(hal_power_config),
   .vin_min_voltage = DEFAULT_INPUT_VOLTAGE_LIMIT,
   .vin_max_current = DEFAULT_INPUT_CURRENT_LIMIT,
   .charge_current = DEFAULT_CHARGE_CURRENT,
   .termination_voltage = DEFAULT_TERMINATION_VOLTAGE,
   .soc_bits = DEFAULT_SOC_18_BIT_PRECISION,
-  .aux_pwr_ctrl = 1,
   .aux_pwr_ctrl_pin = PIN_INVALID,
   .aux_pwr_ctrl_pin_level = 1,
   .reserved2 = {0},
@@ -145,7 +144,7 @@ void PowerManager::init() {
 
   // We should always initialize the aux power control pin,
   // in case that there is a Power Module for DC power supply present.
-  if (config_.aux_pwr_ctrl && config_.aux_pwr_ctrl_pin != PIN_INVALID) {
+  if (config_.version >= HAL_POWER_CONFIG_VERSION_1 && config_.aux_pwr_ctrl_pin != PIN_INVALID) {
     hal_gpio_mode(config_.aux_pwr_ctrl_pin, OUTPUT);
     hal_gpio_write(config_.aux_pwr_ctrl_pin, config_.aux_pwr_ctrl_pin_level);
   }

--- a/system/src/system_power_manager.cpp
+++ b/system/src/system_power_manager.cpp
@@ -79,8 +79,10 @@ constexpr hal_power_config defaultPowerConfig = {
   .charge_current = DEFAULT_CHARGE_CURRENT,
   .termination_voltage = DEFAULT_TERMINATION_VOLTAGE,
   .soc_bits = DEFAULT_SOC_18_BIT_PRECISION,
+  .aux_pwr_ctrl = 1,
   .aux_pwr_ctrl_pin = PIN_INVALID,
   .aux_pwr_ctrl_pin_level = 1,
+  .reserved2 = {0},
   .reserved3 = {0}
 };
 
@@ -143,12 +145,13 @@ void PowerManager::init() {
 
   // We should always initialize the aux power control pin,
   // in case that there is a Power Module for DC power supply present.
-  if (config_.aux_pwr_ctrl_pin != PIN_INVALID) {
+  if (config_.aux_pwr_ctrl && config_.aux_pwr_ctrl_pin != PIN_INVALID) {
     hal_gpio_mode(config_.aux_pwr_ctrl_pin, OUTPUT);
     hal_gpio_write(config_.aux_pwr_ctrl_pin, config_.aux_pwr_ctrl_pin_level);
   }
 
   if (config_.flags & HAL_POWER_MANAGEMENT_DISABLE) {
+    LOG(WARN, "Disabled by configuration");
     return;
   }
 

--- a/system/src/system_power_manager.cpp
+++ b/system/src/system_power_manager.cpp
@@ -142,6 +142,7 @@ PowerManager* PowerManager::instance() {
 void PowerManager::enableAuxPwr() {
   if (!auxPwrEnabled_ && config_.version >= HAL_POWER_CONFIG_VERSION_1 && config_.aux_pwr_ctrl_pin != PIN_INVALID) {
     LOG(INFO, "Enable auxiliary power");
+    hal_gpio_mode(config_.aux_pwr_ctrl_pin, OUTPUT);
     hal_gpio_write(config_.aux_pwr_ctrl_pin, config_.aux_pwr_ctrl_pin_level);
     auxPwrEnabled_ = true;
     system_notify_event(aux_power_state, 1);

--- a/system/src/system_power_manager.h
+++ b/system/src/system_power_manager.h
@@ -69,6 +69,8 @@ private:
   void batteryStateTransitioningTo(battery_state_t targetState, bool count = true);
   void clearIntermediateBatteryState(uint8_t state);
 
+  void enableAuxPwr();
+
   static power_source_t powerSourceFromStatus(uint8_t status);
 
 private:
@@ -110,6 +112,7 @@ private:
   uint8_t chargedFaultCount_ = 0;
   uint8_t repeatedChargedCount_ = 0;
   bool possibleChargedFault_ = false;
+  bool auxPwrEnabled_ = false;
 
   hal_power_config config_ = {};
 };

--- a/wiring/inc/spark_wiring_system_power.h
+++ b/wiring/inc/spark_wiring_system_power.h
@@ -40,6 +40,7 @@ public:
     SystemPowerConfiguration()
             : conf_{} {
         conf_.size = sizeof(conf_);
+        conf_.aux_pwr_ctrl = 1;
         conf_.aux_pwr_ctrl_pin = PIN_INVALID;
     }
 
@@ -107,6 +108,7 @@ public:
     }
 
     SystemPowerConfiguration& auxPowerControlPin(uint8_t pin, bool activeLevel = 1) {
+        conf_.aux_pwr_ctrl = 1;
         conf_.aux_pwr_ctrl_pin = pin;
         conf_.aux_pwr_ctrl_pin_level = activeLevel;
         return *this;

--- a/wiring/inc/spark_wiring_system_power.h
+++ b/wiring/inc/spark_wiring_system_power.h
@@ -40,7 +40,7 @@ public:
     SystemPowerConfiguration()
             : conf_{} {
         conf_.size = sizeof(conf_);
-        conf_.aux_pwr_ctrl = 1;
+        conf_.version = HAL_POWER_CONFIG_VERSION;
         conf_.aux_pwr_ctrl_pin = PIN_INVALID;
     }
 
@@ -108,7 +108,6 @@ public:
     }
 
     SystemPowerConfiguration& auxPowerControlPin(uint8_t pin, bool activeLevel = 1) {
-        conf_.aux_pwr_ctrl = 1;
         conf_.aux_pwr_ctrl_pin = pin;
         conf_.aux_pwr_ctrl_pin_level = activeLevel;
         return *this;

--- a/wiring/inc/spark_wiring_system_power.h
+++ b/wiring/inc/spark_wiring_system_power.h
@@ -40,6 +40,7 @@ public:
     SystemPowerConfiguration()
             : conf_{} {
         conf_.size = sizeof(conf_);
+        conf_.aux_pwr_ctrl_pin = PIN_INVALID;
     }
 
     SystemPowerConfiguration(SystemPowerConfiguration&&) = default;
@@ -103,6 +104,20 @@ public:
 
     uint8_t socBitPrecision() const {
         return conf_.soc_bits;
+    }
+
+    SystemPowerConfiguration& auxPowerControlPin(uint8_t pin, bool activeLevel = 1) {
+        conf_.aux_pwr_ctrl_pin = pin;
+        conf_.aux_pwr_ctrl_pin_level = activeLevel;
+        return *this;
+    }
+
+    uint8_t auxPowerControlPin() const {
+        return conf_.aux_pwr_ctrl_pin;
+    }
+
+    uint8_t auxPowerControlActiveLevel() const {
+        return conf_.aux_pwr_ctrl_pin_level;
     }
 
     const hal_power_config* config() const {

--- a/wiring/inc/spark_wiring_system_power.h
+++ b/wiring/inc/spark_wiring_system_power.h
@@ -107,13 +107,13 @@ public:
         return conf_.soc_bits;
     }
 
-    SystemPowerConfiguration& auxPowerControlPin(uint8_t pin, bool activeLevel = 1) {
+    SystemPowerConfiguration& auxiliaryPowerControlPin(uint8_t pin, bool activeLevel = 1) {
         conf_.aux_pwr_ctrl_pin = pin;
         conf_.aux_pwr_ctrl_pin_level = activeLevel;
         return *this;
     }
 
-    uint8_t auxPowerControlPin() const {
+    uint8_t auxiliaryPowerControlPin() const {
         return conf_.aux_pwr_ctrl_pin;
     }
 


### PR DESCRIPTION
**NOTE: this PR is targeting the `feature/muon-som-evb` branch**

### Example App

```cpp
#include "application.h"

SYSTEM_MODE(SEMI_AUTOMATIC);

#define M2_BREAKOUT_BOARD   1

Serial1LogHandler l(115200, LOG_LEVEL_ALL);

#if M2_BREAKOUT_BOARD
uint8_t auxPwrPin = D23;
#else // Muon
uint8_t auxPwrPin = D7;
#endif

STARTUP(
    System.enableFeature(FEATURE_ETHERNET_DETECTION);

    SystemPowerConfiguration conf;
    conf.powerSourceMinVoltage(3880)
        .powerSourceMaxCurrent(3000)
        .batteryChargeVoltage(4200)
        .batteryChargeCurrent(900)
        .auxPowerControlPin(auxPwrPin)
        .feature(SystemPowerFeature::PMIC_DETECTION);
        // .feature(SystemPowerFeature::DISABLE);
    System.setPowerConfiguration(conf);

    if_wiznet_pin_remap remap = {};
    remap.base.type = IF_WIZNET_DRIVER_SPECIFIC_PIN_REMAP;
#if M2_BREAKOUT_BOARD
    remap.cs_pin = HAL_PLATFORM_ETHERNET_WIZNETIF_CS_PIN_DEFAULT; // default
    remap.reset_pin = HAL_PLATFORM_ETHERNET_WIZNETIF_RESET_PIN_DEFAULT; // default
    remap.int_pin = PIN_INVALID;
#else // Muon
    remap.cs_pin = A3;
    remap.reset_pin = PIN_INVALID;
    remap.int_pin = A4;
#endif
    if_request(nullptr, IF_REQ_DRIVER_SPECIFIC, &remap, sizeof(remap), nullptr);
);

void setup() {
    Log.info("Application started");
}

void loop() {
    if (Serial1.available()) {
        char c = Serial1.read();
        switch (c) {
            case 'i': {
                if_list* ifs = nullptr;
                if_get_list(&ifs);
                for (if_list* iface = ifs; iface != nullptr; iface = iface->next) {
                    if (iface->iface) {
                        uint8_t idx;
                        if_get_index(iface->iface, &idx);
                        Log.info("Interface %d: %s", idx, iface->iface->name);
                    }
                }
                if_free_list(ifs);
                break;
            }
            case 'p': {
                Log.info("Connecting to Particle Cloud...");
                Particle.connect();
                break;
            }
            case 'e': {
                Log.info("Connecting to Ethernet...");
                Ethernet.connect();
                break;
            }
            case 'd': {
                Log.info("Connecting to Particle Cloud...");
                Particle.disconnect();
                break;
            }
            default: break;
        }
    }
}
```

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
