### PR TITLE
Makes the Ethernet interrupt pin optional.

### DIFF
--- a/hal/network/lwip/wiznet/wiznetif.cpp
+++ b/hal/network/lwip/wiznet/wiznetif.cpp
@@ -337,7 +337,7 @@ void WizNetif::loop(void* arg) {
         if (p) {
             self->output(p);
         }
-        if (self->inRecv_) {
+        if (self->inRecv_ || self->interrupt_ == PIN_INVALID) {
             int r = 1;
             if (!p) {
                 r = self->input();

--- a/hal/network/lwip/wiznet/wiznetif.cpp
+++ b/hal/network/lwip/wiznet/wiznetif.cpp
@@ -116,6 +116,7 @@ const hal_spi_info_t WIZNET_DEFAULT_CONFIG = {
 };
 
 const int WIZNET_DEFAULT_TIMEOUT = 500;
+const int WIZNET_DEFAULT_TIMEOUT_POLL = 250;
 /* FIXME */
 const unsigned int WIZNET_INRECV_NEXT_BACKOFF = 50;
 const unsigned int WIZNET_DEFAULT_RX_FRAMES_PER_ITERATION = PBUF_POOL_SIZE / 2;
@@ -333,7 +334,7 @@ void WizNetif::loop(void* arg) {
     while(!self->exit_) {
         pbuf* p = nullptr;
         os_queue_take(self->queue_, (void*)&p, timeout, nullptr);
-        timeout = WIZNET_DEFAULT_TIMEOUT;
+        timeout = (self->interrupt_ == PIN_INVALID) ? WIZNET_DEFAULT_TIMEOUT_POLL : WIZNET_DEFAULT_TIMEOUT;
         if (p) {
             self->output(p);
         }

--- a/hal/network/lwip/wiznet/wiznetif_config.cpp
+++ b/hal/network/lwip/wiznet/wiznetif_config.cpp
@@ -147,9 +147,6 @@ int WizNetifConfig::getConfigData(WizNetifConfigData* configData) {
     if (configData->reset_pin == PIN_INVALID) {
         configData->reset_pin = HAL_PLATFORM_ETHERNET_WIZNETIF_RESET_PIN_DEFAULT;
     }
-    if (configData->int_pin == PIN_INVALID) {
-        configData->int_pin = HAL_PLATFORM_ETHERNET_WIZNETIF_INT_PIN_DEFAULT;
-    }
     logWizNetifConfigData(wizNetifConfigData_);
 
     return SYSTEM_ERROR_NONE;
@@ -168,8 +165,7 @@ int WizNetifConfig::validateWizNetifConfigData(const WizNetifConfigData* configD
     if (configData->size != sizeof(WizNetifConfigData) ||
             configData->version != WIZNETIF_CONFIG_DATA_VERSION ||
             !isPinValid(configData->cs_pin) ||
-            !isPinValid(configData->reset_pin) ||
-            !isPinValid(configData->int_pin)) {
+            !isPinValid(configData->reset_pin)) {
         LOG(ERROR, "configData not valid! size:%u ver:%u cs_pin:%u reset_pin:%u int_pin:%u",
                 configData->size,
                 configData->version,


### PR DESCRIPTION
**NOTE: this PR is targeting the `feature/muon-som-evb` branch**

### Problem

Currently W5500 interrupt pin is essential for Ethernet to be functional. However, for the Ethernet feather wing from Adafruit doesn't expose the interrupt pin to side headers, indicating that the interrupt pin is optional to the Ethernet interface.

### Solution

Allow the `int_pin` in `WizNetifConfigData` to be `PIN_INVALID` and use query scheme in `WizNetif` when the interrupt pin is not present.

### Steps to Test

1. Use the M.2 SoM breakout board and install the Ethernet feather wing from Adafruit. Do not fly wire the IRQ pin on the wing to any of the Particle SoM's IOs.
2. Run the following test app.

### Example App

```cpp
#include "application.h"

SYSTEM_MODE(SEMI_AUTOMATIC);

SerialLogHandler l(LOG_LEVEL_ALL);

STARTUP(
    System.enableFeature(FEATURE_ETHERNET_DETECTION);

    if_wiznet_pin_remap remap = {};
    remap.base.type = IF_WIZNET_DRIVER_SPECIFIC_PIN_REMAP;
    remap.cs_pin = PIN_INVALID; // default
    remap.reset_pin = PIN_INVALID; // default
    remap.int_pin = PIN_INVALID;
    if_request(nullptr, IF_REQ_DRIVER_SPECIFIC, &remap, sizeof(remap), nullptr);
);

void setup() {
    while (!Serial.isConnected()) {
        delay(100);
    }
    Log.info("Application started");
}

void loop() {
    if (Serial.available()) {
        char c = Serial.read();
        switch (c) {
            case 'i': {
                if_list* ifs = nullptr;
                if_get_list(&ifs);
                for (if_list* iface = ifs; iface != nullptr; iface = iface->next) {
                    if (iface->iface) {
                        uint8_t idx;
                        if_get_index(iface->iface, &idx);
                        Log.info("Interface %d: %s", idx, iface->iface->name);
                    }
                }
                if_free_list(ifs);
                break;
            }
            case 'p': {
                Log.info("Connecting to Particle Cloud...");
                Particle.connect();
                break;
            }
            case 'e': {
                Log.info("Connecting to Ethernet...");
                Ethernet.connect();
                break;
            }
            case 'd': {
                Log.info("Connecting to Particle Cloud...");
                Particle.disconnect();
                break;
            }
            default: break;
        }
    }
}
```

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] (REQUIRED) Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
