### PR TITLE
Fix deprecated docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,7 +230,7 @@ jobs:
       - checkout
       # https://support.circleci.com/hc/en-us/articles/360050934711
       - setup_remote_docker:
-          version: 19.03.13
+          version: docker23
       - run:
           name: "Install bash"
           command: |


### PR DESCRIPTION
### Problem

[Circle CI is deprecating our docker image](https://support.circleci.com/hc/en-us/articles/23614965074459-2024-Image-Deprecations-and-Brownouts-Android-Linux-VM-Remote-Docker-Linux-VM)

### Solution

Update docker version

### Steps to Test

Builds in CI
