### PR TITLE
[system] power: add method to specify the PMIC/FuelGauge interrupt pin.

### DIFF
--- a/hal/inc/power_hal.h
+++ b/hal/inc/power_hal.h
@@ -68,7 +68,8 @@ typedef struct hal_power_config {
     uint8_t soc_bits; // bits precision for SoC calculation (18 (default) or 19)
     uint8_t aux_pwr_ctrl_pin; // pin number for auxiliary power control
     uint8_t aux_pwr_ctrl_pin_level; // active level for auxiliary power control
-    uint8_t reserved2[3];
+    uint8_t int_pin; // pin number for PMIC/FuelGauge interrupt
+    uint8_t reserved2[2];
     uint32_t reserved3[3];
 } __attribute__((packed)) hal_power_config;
 static_assert(sizeof(hal_power_config) == 32, "hal_power_config size changed");

--- a/system/src/system_power_manager.cpp
+++ b/system/src/system_power_manager.cpp
@@ -82,6 +82,7 @@ constexpr hal_power_config defaultPowerConfig = {
   .soc_bits = DEFAULT_SOC_18_BIT_PRECISION,
   .aux_pwr_ctrl_pin = PIN_INVALID,
   .aux_pwr_ctrl_pin_level = 1,
+  .int_pin = PIN_INVALID, // Use the default: LOW_BAT_UC
   .reserved2 = {0},
   .reserved3 = {0}
 };
@@ -149,6 +150,21 @@ void PowerManager::enableAuxPwr() {
   }
 }
 
+hal_pin_t PowerManager::getIntPin() const {
+  hal_pin_t pin = LOW_BAT_UC;
+#if PLATFORM_ID == PLATFORM_MSOM
+  uint32_t revision = 0xFFFFFFFF;
+  hal_get_device_hw_version(&revision, nullptr);
+  if (revision == 1) {
+    pin = LOW_BAT_DEPRECATED;
+  }
+#endif
+  if (config_.version >= HAL_POWER_CONFIG_VERSION_1 && config_.int_pin != PIN_INVALID) {
+    pin = config_.int_pin;
+  }
+  return pin;
+}
+
 void PowerManager::init() {
   // Load configuration
   loadConfig();
@@ -195,14 +211,7 @@ void PowerManager::init() {
   attachInterrupt(PMIC_INT, &PowerManager::isrHandler, FALLING);
 #endif // HAL_PLATFORM_SHARED_INTERRUPT
 #endif // HAL_PLATFORM_PMIC_INT_PIN_PRESENT
-  hal_pin_t pmicIntPin = LOW_BAT_UC;
-#if PLATFORM_ID == PLATFORM_MSOM
-  uint32_t revision = 0xFFFFFFFF;
-  hal_get_device_hw_version(&revision, nullptr);
-  if (revision == 1) {
-    pmicIntPin = LOW_BAT_DEPRECATED;
-  }
-#endif
+  hal_pin_t pmicIntPin = getIntPin();
 
   hal_gpio_mode(pmicIntPin, INPUT_PULLUP);
   attachInterrupt(pmicIntPin, &PowerManager::isrHandler, FALLING);
@@ -974,14 +983,15 @@ void PowerManager::deinit() {
     }
   }
 
-  hal_pin_t pmicIntPin = LOW_BAT_UC;
-#if PLATFORM_ID == PLATFORM_MSOM
-  uint32_t revision = 0xFFFFFFFF;
-  hal_get_device_hw_version(&revision, nullptr);
-  if (revision == 1) {
-    pmicIntPin = LOW_BAT_DEPRECATED;
-  }
+#if HAL_PLATFORM_PMIC_INT_PIN_PRESENT
+#if HAL_PLATFORM_SHARED_INTERRUPT
+  hal_interrupt_detach_ext(PMIC_INT, 0, (void*)isrHandlerEx);
+#else
+  detachInterrupt(PMIC_INT);
+#endif // HAL_PLATFORM_SHARED_INTERRUPT
 #endif
+
+  hal_pin_t pmicIntPin = getIntPin();
   detachInterrupt(pmicIntPin);
 
   g_batteryState = BATTERY_STATE_UNKNOWN;

--- a/system/src/system_power_manager.h
+++ b/system/src/system_power_manager.h
@@ -70,6 +70,7 @@ private:
   void clearIntermediateBatteryState(uint8_t state);
 
   void enableAuxPwr();
+  hal_pin_t getIntPin() const;
 
   static power_source_t powerSourceFromStatus(uint8_t status);
 

--- a/wiring/inc/spark_wiring_system_power.h
+++ b/wiring/inc/spark_wiring_system_power.h
@@ -118,16 +118,16 @@ public:
         return conf_.aux_pwr_ctrl_pin;
     }
 
-    uint8_t auxPowerControlActiveLevel() const {
+    uint8_t auxiliaryPowerControlActiveLevel() const {
         return conf_.aux_pwr_ctrl_pin_level;
     }
     
-    SystemPowerConfiguration& intPin(uint8_t pin) {
+    SystemPowerConfiguration& interruptPin(uint8_t pin) {
         conf_.int_pin = pin;
         return *this;
     }
 
-    uint8_t intPin() const {
+    uint8_t interruptPin() const {
         return conf_.int_pin;
     }
 

--- a/wiring/inc/spark_wiring_system_power.h
+++ b/wiring/inc/spark_wiring_system_power.h
@@ -42,6 +42,7 @@ public:
         conf_.size = sizeof(conf_);
         conf_.version = HAL_POWER_CONFIG_VERSION;
         conf_.aux_pwr_ctrl_pin = PIN_INVALID;
+        conf_.int_pin = PIN_INVALID;
     }
 
     SystemPowerConfiguration(SystemPowerConfiguration&&) = default;
@@ -119,6 +120,15 @@ public:
 
     uint8_t auxPowerControlActiveLevel() const {
         return conf_.aux_pwr_ctrl_pin_level;
+    }
+    
+    SystemPowerConfiguration& intPin(uint8_t pin) {
+        conf_.int_pin = pin;
+        return *this;
+    }
+
+    uint8_t intPin() const {
+        return conf_.int_pin;
     }
 
     const hal_power_config* config() const {


### PR DESCRIPTION
**NOTE: this PR is targeting the `feature/auxiliary-power-control` branch**

### Problem
1. Currently the pin for PMIC interrupt is pre-defined per platform in DVOS and customer has to designed their own board according to the pin number for the PMIC interrupt.

2. We have allocated the A6 pin for the PMIC interrupt on the MSoM. For Muon, we'd like to make PMIC be capable of waking up device from hibernate mode, however the A6 pin doesn't not have this ability. Thus, for Muon we connect the PMIC interrupt pin to A7, which is capable of doing what we want. But DVOS doesn't has a method to change the default pin for PMIC interrupt.

### Solution
Introduce a new method `SystemPowerConfiguration::intPin(pin)` to specify another pin for PMIC/FuelGauge interrupt.

### Steps to Test

Hardware: SoM Eval board + MSoM

1. Flash the attached test app
2. Remove the `PM_INT` jumper on the SoM EVAL board
3. Fly wire the `A7` with the `PM_INT` pin
4. See if the system power manager behaves as expected

### Example App

```cpp
#include "application.h"
 
STARTUP(  
    System.setPowerConfiguration(SystemPowerConfiguration().feature(SystemPowerFeature::PMIC_DETECTION).intPin(A7));
);

SYSTEM_MODE(MANUAL);
Serial1LogHandler logHandler(115200, LOG_LEVEL_ALL);

void setup() {
}

void loop() {
}
```

### References
N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
