### PR TITLE
Scan needs NcpState to be ON

### DIFF
--- a/system/src/control/wifi_new.cpp
+++ b/system/src/control/wifi_new.cpp
@@ -94,6 +94,8 @@ int joinNewNetwork(ctrl_request* req) {
     const NcpClientLock lock(ncpClient);
 #if HAL_PLATFORM_RTL872X
     if (!conf.hidden()) {
+        // scan checks that the NcpState is ON
+        CHECK(ncpClient->on());
         // Scan for networks to detect the network security type
         Vector<WifiScanResult> networks;
         CHECK(ncpClient->scan([](WifiScanResult network, void* data) -> int {


### PR DESCRIPTION
### Problem

For a brand new factory fresh P2, joining a new network via control requests throws an error.

### Solution

It appears that the `joinNewNetwork` for realtek performs a scan that requires the NcpState to be `ON`. There is nothing that's turning the NcpState `ON` so I added in that functionality.

### Open question
Is the `scan` call needed and why, and if the flow can be simplified?

### Steps to Test

1. Clear all wifi networks on the device
2. Reset the device
3. Attempt to join a new network

Latest Particle-CLI branch can help perform the above steps. See `particle wifi xxx` commands.

### Example App

```c
void setup() {
  /* A minimal example app is super helpful 
   * for testing new features and fixes. 
   * A link to a Docs PR is even better!
   */
}

void loop() {

}
```

### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
