### PR TITLE
[eg91e][eg91ex] enable 921600 baud rate

### DIFF
--- a/hal/network/ncp_client/quectel/quectel_ncp_client.h
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.h
@@ -116,10 +116,12 @@ private:
     unsigned registrationInterventions_;
     volatile bool inFlowControl_ = false;
     bool checkImsi_ = false;
+    unsigned int fwVersion_ = 0;
 
     int queryAndParseAtCops(CellularSignalQuality* qual);
     int initParser(Stream* stream);
     int waitReady(bool powerOn = false);
+    int getAppFirmwareVersion();
     int initReady(ModemState state);
     int checkRuntimeState(ModemState& state);
     int initMuxer();


### PR DESCRIPTION
### Problem

- EG91-E modems require A08 or above modem firmware version to support 921600 baud speeds, otherwise the default 460800 should be used.
- EG91-EX modems all support 921600 baud, but still using 460800.

### Solution

- Add a check for modem firmware version for EG91-E modems only at this time, and adjust the baud rate appropriately.
- Set EG91-EX to 921600 baud.

### Steps to Test

- With an EG91-E/EX modem, verify the appropriate baud rate is selected when using `APP=tinker-serial1-debugging` based on it's current firmware version.  You may manually set the result of `fwVersion_` to force a specific baud rate. [ @avtolstoy @Cheong2K would you please help verify this? ]
- Ensure no change with non EG91-E/EX modems [checked with B504]

### References

[sc-128144]
