### PR TITLE
Fix wifi setup not connecting when in listening mode

### DIFF
--- a/hal/network/lwip/realtek/rtlncpnetif.cpp
+++ b/hal/network/lwip/realtek/rtlncpnetif.cpp
@@ -305,7 +305,7 @@ void RealtekNcpNetif::ncpEventHandlerCb(const NcpEvent& ev, void* ctx) {
     if (ev.type == NcpEvent::CONNECTION_STATE_CHANGED) {
         LwipTcpIpCoreLock lk;
         if (!netif_is_up(self->interface())) {
-            // Ignore
+            LOG(WARN,"NCP connection state event ignored, netif not up");
             return;
         }
         const auto& cev = static_cast<const NcpConnectionStateChangedEvent&>(ev);

--- a/hal/network/ncp/wifi/wifi_network_manager.cpp
+++ b/hal/network/ncp/wifi/wifi_network_manager.cpp
@@ -332,6 +332,7 @@ int WifiNetworkManager::setNetworkConfig(WifiNetworkConfig conf, WifiNetworkConf
             }
         });
         CHECK(connect(conf));
+        client_->disconnect();
     } else {
         lock.unlock();
     }

--- a/hal/network/ncp/wifi/wifi_network_manager.cpp
+++ b/hal/network/ncp/wifi/wifi_network_manager.cpp
@@ -332,7 +332,7 @@ int WifiNetworkManager::setNetworkConfig(WifiNetworkConfig conf, WifiNetworkConf
             }
         });
         CHECK(connect(conf));
-        client_->disconnect();
+        CHECK(client_->disconnect());
     } else {
         lock.unlock();
     }

--- a/hal/network/ncp_client/realtek/rtl_ncp_client.cpp
+++ b/hal/network/ncp_client/realtek/rtl_ncp_client.cpp
@@ -505,6 +505,7 @@ void RealtekNcpClient::ncpPowerState(NcpPowerState state) {
         return;
     }
     pwrState_ = state;
+    LOG(TRACE, "NCP power state changed: %d", (int)pwrState_);
     const auto handler = conf_.eventHandler();
     if (handler) {
         NcpPowerStateChangedEvent event = {};

--- a/system/src/control/wifi_new.cpp
+++ b/system/src/control/wifi_new.cpp
@@ -134,6 +134,11 @@ int joinNewNetwork(ctrl_request* req) {
     // FIXME: synchronize NCP client / NcpNetif and system network manager state
     CHECK(ncpClient->enable());
     CHECK(ncpClient->on());
+    // Set new configuration
+    CHECK(wifiMgr->setNetworkConfig(conf, WifiNetworkConfigFlag::VALIDATE));
+    // TODO: Not adding NetworkCredentials for now as this object needs to be allocated on heap and then cleaned up
+    system_notify_event(network_credentials, network_credentials_added);
+
     network_connect(NETWORK_INTERFACE_WIFI_STA, NETWORK_CONNECT_FLAG_FORCE, 0, nullptr);
     NAMED_SCOPE_GUARD(networkDisconnectGuard, {
         // FIXME: synchronize NCP client / NcpNetif and system network manager state
@@ -141,10 +146,6 @@ int joinNewNetwork(ctrl_request* req) {
             network_disconnect(NETWORK_INTERFACE_WIFI_STA, NETWORK_DISCONNECT_REASON_USER, nullptr);
         }
     });
-    // Set new configuration
-    CHECK(wifiMgr->setNetworkConfig(conf, WifiNetworkConfigFlag::VALIDATE));
-    // TODO: Not adding NetworkCredentials for now as this object needs to be allocated on heap and then cleaned up
-    system_notify_event(network_credentials, network_credentials_added);
     networkDisconnectGuard.dismiss();
     return 0;
 }

--- a/system/src/system_network_manager_api.cpp
+++ b/system/src/system_network_manager_api.cpp
@@ -169,7 +169,7 @@ void network_connect(network_handle_t network, uint32_t flags, uint32_t param, v
 
         bool listenFlagSet = testAndClearListeningModeFlag();
         bool enterListen = listenFlagSet || !NetworkManager::instance()->isConfigured();
-        if (enterListen && ~(flags & NETWORK_CONNECT_FLAG_FORCE)) {
+        if (enterListen && !(flags & NETWORK_CONNECT_FLAG_FORCE)) {
             network_listen(0, 0, 0);
             return;
         }

--- a/system/src/system_network_manager_api.cpp
+++ b/system/src/system_network_manager_api.cpp
@@ -167,10 +167,9 @@ void network_connect(network_handle_t network, uint32_t flags, uint32_t param, v
         SPARK_WLAN_SLEEP = 0;
         s_forcedDisconnect = false;
 
-        bool val = testAndClearListeningModeFlag();
-        val = val || !NetworkManager::instance()->isConfigured();
-        if (val) {
-            /* Enter listening mode */
+        bool listenFlagSet = testAndClearListeningModeFlag();
+        bool enterListen = listenFlagSet || !NetworkManager::instance()->isConfigured();
+        if (enterListen && ~(flags & NETWORK_CONNECT_FLAG_FORCE)) {
             network_listen(0, 0, 0);
             return;
         }


### PR DESCRIPTION
### Problem
When a P2/Photon 2 device does not have any wifi credentials set, it will boot into listening mode.
When using `particle wifi join` or using setup.particle.io to set credentials on the device, the credentials will be stored to the device, but the device will not connect to the network and remain blinking green (ie network connecting). 
See comment [here](https://s.slack.com/archives/C8QH35A73/p1717971924968089)

The root of the problem is a state mismatch between Network Manager and the RTK NCP Netif.
When validating the network credentials, the RTK NCP client will connect to the given SSID. When `network_connect()` is called, the NCP client is already connected, but the NCP connection event is ignored since it does not expect to be in that state. 

Additionally, `network_connect()` will not connect at all if no credentials are stored, even with the `NETWORK_CONNECT_FLAG_FORCE` flag set.

### Solution

When validating network credentials in JoinNewNetwork, disconnect after validating in order to ensure correct state of NCP client when networking is enabled at the system level

Allow `network_connect()` to activate + enable interfaces even when credentials have not been set 

### Steps to Test

setup.particle.io will flash a device with 5.8.0, so cannot be used to validate this branch

To validate locally, flash device with this branch, clear all settings via holding down mode button until flashing white + booting into listening mode. Use `particle wifi join`, verify that it connects and goes breathing cyan

### Example App
any

