### PR TITLE
[rtl872x] SPI hal: set sample delay for SPI0@25MHz

### DIFF
--- a/hal/src/rtl872x/spi_hal.cpp
+++ b/hal/src/rtl872x/spi_hal.cpp
@@ -274,8 +274,8 @@ public:
             u32 rtlClockDivider = 256;
             clockDivToRtlClockDiv(config_.clockDiv, &rtlClockDivider);
             SSI_SetBaudDiv(SPI_DEV_TABLE[rtlSpiIndex_].SPIx, rtlClockDivider);
-            // Set sample delay for SPI0@50MHz
-            if (rtlClockDivider == 2 && SPI_DEV_TABLE[rtlSpiIndex_].SPIx == SPI0_DEV) {
+            // Set sample delay for SPI0@50MHz/25MHz
+            if (rtlClockDivider <= 4 && SPI_DEV_TABLE[rtlSpiIndex_].SPIx == SPI0_DEV) {
                 SSI_SetSampleDelay(SPI_DEV_TABLE[rtlSpiIndex_].SPIx, 0x1);
             } else {
                 SSI_SetSampleDelay(SPI_DEV_TABLE[rtlSpiIndex_].SPIx, 0x0);


### PR DESCRIPTION
### Problem
Under some circumstances, e.g. on the M.2 breakout board v0.5, the SPI0@25MHz may receive incorrect data on MISO.

### Solution
Set the RX sample delay to 1 when SPI0's clock speed is set to 25MHz.

### Example App
`user/tests/wiring/spi_master_slave`

### References
N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
