### PR TITLE
[gen3] hal: fix gpio glitch

### DIFF
--- a/hal/src/nRF52840/gpio_hal.cpp
+++ b/hal/src/nRF52840/gpio_hal.cpp
@@ -76,12 +76,17 @@ int hal_gpio_configure(hal_pin_t pin, const hal_gpio_config_t* conf, void* reser
         }
 
         // Pre-set the output value if requested to avoid a glitch
-        if (conf->set_value && (mode == OUTPUT || mode == OUTPUT_OPEN_DRAIN || mode == OUTPUT_OPEN_DRAIN_PULLUP)) {
-            if (conf->value) {
-                nrf_gpio_pin_set(nrfPin);
-            } else {
-                nrf_gpio_pin_clear(nrfPin);
+        if (conf->set_value) {
+            if (mode == OUTPUT || mode == OUTPUT_OPEN_DRAIN || mode == OUTPUT_OPEN_DRAIN_PULLUP) {
+                if (conf->value) {
+                    nrf_gpio_pin_set(nrfPin);
+                } else {
+                    nrf_gpio_pin_clear(nrfPin);
+                }
             }
+        } else if (mode == OUTPUT_OPEN_DRAIN || mode == OUTPUT_OPEN_DRAIN_PULLUP) {
+            // Release the pin control by default
+            nrf_gpio_pin_set(nrfPin);
         }
 
         switch (mode) {


### PR DESCRIPTION
### Problem
`pinMode(pin, OUTPUT_OPEN_DRAIN)` or `pinMode(pin, OUTPUT_OPEN_DRAIN_PULLUP)` cause I/O glitch.

### Solution
When configuring a pin as `OUTPUT_OPEN_DRAIN` or `OUTPUT_OPEN_DRAIN_PULLUP` using `pinMode()`, it sets the output value to 1 to release the pin control.

### Steps to Test
Flash the following test app and use logic analyzer or oscilloscope to monitor the state of the pin being configured

### Example App
```cpp
#include "application.h"

SYSTEM_MODE(SEMI_AUTOMATIC);

void setup() {
    delay(5s);
    pinMode(D0, OUTPUT_OPEN_DRAIN); // or OUTPUT_OPEN_DRAIN_PULLUP
}

void loop() {
}
```

### References
N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
