### PR TITLE
Fix CircleCI Darwin builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,8 @@ jobs:
           platform: << parameters.platform >>
   build-for-darwin:
     macos:
-      xcode: "14.2"
+      xcode: "14.3.1"
+    resource_class: macos.m1.medium.gen1
     parameters:
       tasks:
         type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ tag_filters: &tag_filters
 
 orbs:
   win: circleci/windows@2.4.0
+  macos: circleci/macos@2.4.1
 
 aliases:
   - &tasks ["compile:all clean:all", "compile:user clean:user", "compile:debug clean:debug"]
@@ -112,6 +113,7 @@ jobs:
       platform:
         type: string
     steps:
+      - macos/install-rosetta
       - checkout
       - run: git submodule update --init --recursive
       - install-prtcl-darwin


### PR DESCRIPTION
### Problem

Since June 20 CircleCI is deprecating x86 darwin workers.

### Solution

Update to use M1 workers and use Rosetta to avoid x86/ARM woes.

### Steps to Test

See https://app.circleci.com/pipelines/github/particle-iot/device-os/3190/workflows/71591f16-efee-41bc-a296-2b8583848419

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
