### PR TITLE
Fix 5.8.2 test failures

### DIFF
--- a/hal/network/lwip/realtek/rtlncpnetif.cpp
+++ b/hal/network/lwip/realtek/rtlncpnetif.cpp
@@ -158,7 +158,7 @@ void RealtekNcpNetif::loop(void* arg) {
             if (self->expectedNcpState_ == NcpState::ON && self->wifiMan_->ncpClient()->ncpState() != NcpState::ON) {
                 auto r = self->wifiMan_->ncpClient()->on();
                 if (r != SYSTEM_ERROR_NONE && r != SYSTEM_ERROR_ALREADY_EXISTS) {
-                    LOG(ERROR, "Failed to initialize cellular NCP client: %d", r);
+                    LOG(ERROR, "Failed to initialize Realtek NCP client: %d", r);
                 }
             }
             if (self->expectedConnectionState_ == NcpConnectionState::CONNECTED &&
@@ -304,12 +304,12 @@ void RealtekNcpNetif::ncpEventHandlerCb(const NcpEvent& ev, void* ctx) {
     auto self = (RealtekNcpNetif*)ctx;
     if (ev.type == NcpEvent::CONNECTION_STATE_CHANGED) {
         LwipTcpIpCoreLock lk;
+        const auto& cev = static_cast<const NcpConnectionStateChangedEvent&>(ev);
+        LOG(TRACE, "State changed event: %d", (int)cev.state);
         if (!netif_is_up(self->interface())) {
             LOG(WARN,"NCP connection state event ignored, netif not up");
             return;
         }
-        const auto& cev = static_cast<const NcpConnectionStateChangedEvent&>(ev);
-        LOG(TRACE, "State changed event: %d", (int)cev.state);
         if (cev.state == NcpConnectionState::DISCONNECTED) {
             netif_set_link_down(self->interface());
         } else if (cev.state == NcpConnectionState::CONNECTED) {

--- a/system/src/system_listening_mode.cpp
+++ b/system/src/system_listening_mode.cpp
@@ -72,7 +72,6 @@ int ListeningModeHandler::enter(unsigned int timeout) {
         return SYSTEM_ERROR_INVALID_STATE;
     }
 
-    active_ = true;
     LOG(INFO, "Entering listening mode");
 
     /* Disconnect from cloud and network */
@@ -107,6 +106,7 @@ int ListeningModeHandler::enter(unsigned int timeout) {
     console_.reset(new WiFiSetupConsole(config));
 #endif // HAL_PLATFORM_WIFI
 
+    active_ = true;
     return 0;
 }
 
@@ -121,14 +121,13 @@ int ListeningModeHandler::exit() {
 
     console_.reset();
 
-    active_ = false;
-
     system_notify_event(setup_end, HAL_Timer_Get_Milli_Seconds() - timestampStarted_);
 
 #if HAL_PLATFORM_BLE
     BleProvisioningModeHandler::instance()->exit();
 #endif /* HAL_PLATFORM_BLE */
 
+    active_ = false;
     return 0;
 }
 

--- a/system/src/system_network_manager.cpp
+++ b/system/src/system_network_manager.cpp
@@ -541,7 +541,7 @@ void NetworkManager::handleIfLink(if_t iface, const struct if_event* ev) {
     uint8_t netIfIndex = 0;
     if_get_index(iface, &netIfIndex);
     bool disconnectCloud = false;
-    auto options = CloudDisconnectOptions().reconnect(true);
+    auto options = CloudDisconnectOptions();
 
     if (ev->ev_if_link->state) {
         /* Interface link state changed to UP */
@@ -620,7 +620,7 @@ void NetworkManager::handleIfLink(if_t iface, const struct if_event* ev) {
         // If the preferred network becomes available, close the cloud connection to force migration to this network
         if (ConnectionManager::instance()->getPreferredNetwork() == netIfIndex) {
             LOG(INFO, "Preferred network %u available, moving cloud connection", netIfIndex);
-            options.graceful(true);
+            options.graceful(true).reconnect(true);
             disconnectCloud = true;
         }
 

--- a/user/tests/integration/ota/min_max_app_size/min_max_app_size.spec.js
+++ b/user/tests/integration/ota/min_max_app_size/min_max_app_size.spec.js
@@ -16,8 +16,9 @@ let deviceId = null;
 let origAppData = null;
 let maxAppData = null;
 let maxAppSize = 0;
+const flashTimeoutMinutes = 40;
 
-async function flash(ctx, data, name, { timeout = 35 * 60 * 1000, retry = 5 } = {}) {
+async function flash(ctx, data, name, { timeout = flashTimeoutMinutes * 60 * 1000, retry = 5 } = {}) {
 	let ok = false;
 	for (let i = 0; i < retry; i++) {
 		await delayMs(i * 5000);
@@ -259,7 +260,7 @@ test('26_ota_max_application_busy_start', async function () {
 	await generateMaxApp();
 	expect(maxAppData.length).to.equal(maxAppSize);
 	const appFile = await tempy.write(maxAppData, { name: 'max_app.bin' });
-	this.timeout(35 * 60 * 1000);
+	this.timeout(flashTimeoutMinutes * 60 * 1000);
 	await flash(this, appFile);
 });
 


### PR DESCRIPTION
### Problem
5.8.2 integration testing [shows various failures](https://s.slack.com/archives/CS0T32ZKK/p1718325908065589?thread_ts=1718296230.094369&cid=CS0T32ZKK)

### Solution

- Fix reconnect options to address wifi test failures
- Increase OTA test timeout again
- Fix `LISTENING_05_ENABLE_BLE_PROV_AFTER_LISTENING_MODE` failure by fixing conditions for being in/out of listening mode in `waitListening()`
- Minor logging cleanup
- Minor cleanup of connection manager

### Steps to Test

Build/Run integration apps for P2 platform, specicially `wiring/no_fixture` and `ota/min_max_app_size`
```
device-os-test --test-dir ~/develop/device-os/user/tests/integration/ --device-os-dir ~/develop/device-os/ build p2 -v -- -fixture
```
