### PR TITLE
Export hal_spi_get_clock_divider()

### DIFF
--- a/hal/inc/hal_dynalib_spi.h
+++ b/hal/inc/hal_dynalib_spi.h
@@ -63,6 +63,7 @@ DYNALIB_FN(17, hal_spi, hal_spi_release, int32_t(hal_spi_interface_t, void*))
 #define BASE_IDX 16
 #endif
 DYNALIB_FN(BASE_IDX + 0, hal_spi, hal_spi_sleep, int(hal_spi_interface_t, bool, void*))
+DYNALIB_FN(BASE_IDX + 1, hal_spi, hal_spi_get_clock_divider, int(hal_spi_interface_t, uint32_t, void*))
 DYNALIB_END(hal_spi)
 
 #undef BASE_IDX


### PR DESCRIPTION
**NOTE: this PR is targeting the `feature/muon-som-evb` branch**

### Problem
The `hal_spi_get_clock_divider()` is invoked by spi_lock.h. Under some circumstances, e.g. the IO expander driver that is copied from DVOS and is used in user application, the user application may fail to compile.

### Solution
Add `hal_spi_get_clock_divider()` to the dynalib table.

### References
N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
