### PR TITLE
Fixes NETWORK_02 msom test

### DIFF
--- a/user/tests/wiring/no_fixture_long_running/network.cpp
+++ b/user/tests/wiring/no_fixture_long_running/network.cpp
@@ -201,6 +201,10 @@ test(NETWORK_02_network_connection_recovers_after_ncp_failure) {
 
     Network.on();
     Network.connect();
+#if PLATFORM_ID == PLATFORM_MSOM
+    // Force cloud connection to recover using Cellular USART / interface
+    WiFi.disconnect();
+#endif
     Particle.connect();
     waitFor(Particle.connected, WAIT_TIMEOUT);
     assertTrue(Particle.connected());

--- a/user/tests/wiring/no_fixture_wifi/wifi.cpp
+++ b/user/tests/wiring/no_fixture_wifi/wifi.cpp
@@ -32,6 +32,7 @@ test(WIFI_00_connect)
     WiFi.on();
     WiFi.connect();
     Particle.connect();
+    assertTrue(waitFor(WiFi.ready, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
     assertTrue(waitFor(Particle.connected, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
 }
 


### PR DESCRIPTION
### Problem

`NETWORK_02_network_connection_recovers_after_ncp_failure` Started failing for msom platforms.
Root cause was due to network manager incorrectly disabling the cloud auto reconnect flag when a network interface is brought link down.

_Unrelated, but this test was also potentially not working as intended on msom, due to the wifi network being enabled and the cloud connection failing over to it. The test will explicitly verify that the cellular USART/interface can be recovered_

_Also not explicitly related, but the `wifi_no_fixture` test `WIFI_01_resolve_3_levels` fails sometimes on msom platforms. I believe this is due to the assumption that the device will connect to the cloud only via wifi and that sometimes msoms are connected on cellular before wifi in this test, and then wifi DNS resolution fails even though the cloud is connected. I added a check to explicitly wait for wifi to be ready before continuing the tests_

### Solution
System network manager will only close and re-open the cloud connection in the following scenarios
1. "Hard cloud connection preference" : If a network comes link up, and we have an established cloud connection on another interface. close the current socket and reconnect on the preferred network
2. "Fast fail over": If a network goes link down, and we have other interfaces that are IP configured, abandon the cloud connection and reconnect using the already up network.

### Steps to Test

Both P2 and MSOM platforms should pass both `wiring/no_fixture_long_running` and `wiring/network_config` test suites
Also tested fast failover and connection migration behavior with the `connection-manager` test app

