### PR TITLE
[system] battery state might be wrong when it is detached

### DIFF
--- a/system/src/system_power_manager.cpp
+++ b/system/src/system_power_manager.cpp
@@ -671,7 +671,14 @@ void PowerManager::batteryStateTransitioningTo(battery_state_t targetState, bool
       battMonitorPeriod_ = BATTERY_STATE_CHANGE_CHECK_PERIOD;
       DBG_PWR("notChargingDebounceCount_: %d", notChargingDebounceCount_);
       if (notChargingDebounceCount_ >= BATTERY_NOT_CHARGING_DEBOUNCE_COUNT) {
-        confirmBatteryState(g_batteryState, BATTERY_STATE_NOT_CHARGING);
+        PMIC power(true);
+        uint8_t status = power.getSystemStatus();
+        if (status & 0x01) {
+            // In VSYSMIN regulation (BAT < VSYSMIN), it's probably disconnected
+            confirmBatteryState(g_batteryState, BATTERY_STATE_DISCONNECTED);
+        } else {
+            confirmBatteryState(g_batteryState, BATTERY_STATE_NOT_CHARGING);
+        }
       }
     }
   } else if (targetState == BATTERY_STATE_CHARGING) {


### PR DESCRIPTION
**NOTE: this PR is targeting the `feature/muon-som-evb` branch**
### Problem
Under some circumstances, battery state remains not charging even if the battery is detached. For instance, on the M.2 breakout board, when it is powered through DC jack only.

### Solution
When power is good and battery is in not charging state and VBAT < VSYSMIN (i.e. in VSYSMIN regulation), we assume that the battery is disconnected.

### Steps to Test
1. Build and run the attached test app on a SoM module that is installed on M.2 breakout board
2. Power the M.2 breakout board through the DC jack only.

### Example App
```cpp
#include "application.h"

SYSTEM_MODE(MANUAL);

SerialLogHandler logHandler(LOG_LEVEL_ALL);

void setup() {
}

void loop() {
    static system_tick_t lastTime = 0;
    if (millis() - lastTime > 3000) {
        lastTime = millis();
        PMIC power;
        Log.info("Bat state: %d, Charge enabled: %d, isHot: %d, status: %d, fault: %d",
                 System.batteryState(), power.isChargingEnabled(), power.isHot(), power.getSystemStatus(), power.getFault());
    }
}
```

### References
N/A

---

### Completeness
- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
