### PR TITLE
Makes the Ethernet reset pin optional.

### DIFF
--- a/hal/network/lwip/wiznet/wiznetif.h
+++ b/hal/network/lwip/wiznet/wiznetif.h
@@ -43,7 +43,7 @@ public:
 
     virtual int getPowerState(if_power_state_t* state) const override;
     virtual int getNcpState(unsigned int* state) const override;
-    bool isPresent();
+    bool isPresent(bool retry = false);
 
     static WizNetif* instance() {
         return instance_;
@@ -59,6 +59,7 @@ private:
     err_t initInterface();
 
     void hwReset();
+    void swReset();
 
     static void interruptCb(void* arg);
     static void loop(void* arg);

--- a/hal/network/lwip/wiznet/wiznetif_config.cpp
+++ b/hal/network/lwip/wiznet/wiznetif_config.cpp
@@ -161,7 +161,7 @@ int WizNetifConfig::validateWizNetifConfigData(const WizNetifConfigData* configD
     // XXX: If we add a new version in the future this will need to handle that
     if (configData->size != sizeof(WizNetifConfigData) ||
             configData->version != WIZNETIF_CONFIG_DATA_VERSION ||
-            !isPinValid(configData->cs_pin) {
+            !isPinValid(configData->cs_pin)) {
         LOG(ERROR, "configData not valid! size:%u ver:%u cs_pin:%u reset_pin:%u int_pin:%u",
                 configData->size,
                 configData->version,

--- a/hal/network/lwip/wiznet/wiznetif_config.cpp
+++ b/hal/network/lwip/wiznet/wiznetif_config.cpp
@@ -144,9 +144,6 @@ int WizNetifConfig::getConfigData(WizNetifConfigData* configData) {
     if (configData->cs_pin == PIN_INVALID) {
         configData->cs_pin = HAL_PLATFORM_ETHERNET_WIZNETIF_CS_PIN_DEFAULT;
     }
-    if (configData->reset_pin == PIN_INVALID) {
-        configData->reset_pin = HAL_PLATFORM_ETHERNET_WIZNETIF_RESET_PIN_DEFAULT;
-    }
     logWizNetifConfigData(wizNetifConfigData_);
 
     return SYSTEM_ERROR_NONE;
@@ -164,8 +161,7 @@ int WizNetifConfig::validateWizNetifConfigData(const WizNetifConfigData* configD
     // XXX: If we add a new version in the future this will need to handle that
     if (configData->size != sizeof(WizNetifConfigData) ||
             configData->version != WIZNETIF_CONFIG_DATA_VERSION ||
-            !isPinValid(configData->cs_pin) ||
-            !isPinValid(configData->reset_pin)) {
+            !isPinValid(configData->cs_pin) {
         LOG(ERROR, "configData not valid! size:%u ver:%u cs_pin:%u reset_pin:%u int_pin:%u",
                 configData->size,
                 configData->version,

--- a/hal/src/b5som/network/network.cpp
+++ b/hal/src/b5som/network/network.cpp
@@ -157,12 +157,16 @@ int if_init_platform_postpone(void*) {
         uint8_t dummy;
         if (!if_get_index(en2->interface(), &dummy)) {
             auto wizNetif = reinterpret_cast<WizNetif*>(en2);
-            if (wizNetif->isPresent()) {
-                return 0;
+            for (uint8_t retries = 0; retries < 5; retries++) {
+                if (wizNetif->isPresent()) {
+                    LOG(INFO, "W5500 present");
+                    return 0;
+                }
+                HAL_Delay_Milliseconds(50);
             }
+            LOG(INFO, "Remove Ethernet interface");
             netifapi_netif_remove(en2->interface());
         }
-        LOG(INFO, "Ethernet interface is not present");
         delete en2;
         en2 = nullptr;
     }

--- a/hal/src/b5som/network/network.cpp
+++ b/hal/src/b5som/network/network.cpp
@@ -157,7 +157,7 @@ int if_init_platform_postpone(void*) {
         uint8_t dummy;
         if (!if_get_index(en2->interface(), &dummy)) {
             auto wizNetif = reinterpret_cast<WizNetif*>(en2);
-            for (uint8_t retries = 0; retries < 5; retries++) {
+            for (uint8_t retries = 0; retries < 10; retries++) {
                 if (wizNetif->isPresent()) {
                     LOG(INFO, "W5500 present");
                     return 0;

--- a/hal/src/b5som/network/network.cpp
+++ b/hal/src/b5som/network/network.cpp
@@ -157,12 +157,9 @@ int if_init_platform_postpone(void*) {
         uint8_t dummy;
         if (!if_get_index(en2->interface(), &dummy)) {
             auto wizNetif = reinterpret_cast<WizNetif*>(en2);
-            for (uint8_t retries = 0; retries < 10; retries++) {
-                if (wizNetif->isPresent()) {
-                    LOG(INFO, "W5500 present");
-                    return 0;
-                }
-                HAL_Delay_Milliseconds(50);
+            if (wizNetif->isPresent(true)) {
+                LOG(INFO, "W5500 present");
+                return 0;
             }
             LOG(INFO, "Remove Ethernet interface");
             netifapi_netif_remove(en2->interface());

--- a/hal/src/boron/network/network.cpp
+++ b/hal/src/boron/network/network.cpp
@@ -162,7 +162,7 @@ int if_init_platform_postpone(void*) {
         uint8_t dummy;
         if (!if_get_index(en2->interface(), &dummy)) {
             auto wizNetif = reinterpret_cast<WizNetif*>(en2);
-            for (uint8_t retries = 0; retries < 5; retries++) {
+            for (uint8_t retries = 0; retries < 10; retries++) {
                 if (wizNetif->isPresent()) {
                     LOG(INFO, "W5500 present");
                     return 0;

--- a/hal/src/boron/network/network.cpp
+++ b/hal/src/boron/network/network.cpp
@@ -162,12 +162,9 @@ int if_init_platform_postpone(void*) {
         uint8_t dummy;
         if (!if_get_index(en2->interface(), &dummy)) {
             auto wizNetif = reinterpret_cast<WizNetif*>(en2);
-            for (uint8_t retries = 0; retries < 10; retries++) {
-                if (wizNetif->isPresent()) {
-                    LOG(INFO, "W5500 present");
-                    return 0;
-                }
-                HAL_Delay_Milliseconds(50);
+            if (wizNetif->isPresent(true)) {
+                LOG(INFO, "W5500 present");
+                return 0;
             }
             LOG(INFO, "Remove Ethernet interface");
             netifapi_netif_remove(en2->interface());

--- a/hal/src/boron/network/network.cpp
+++ b/hal/src/boron/network/network.cpp
@@ -162,12 +162,16 @@ int if_init_platform_postpone(void*) {
         uint8_t dummy;
         if (!if_get_index(en2->interface(), &dummy)) {
             auto wizNetif = reinterpret_cast<WizNetif*>(en2);
-            if (wizNetif->isPresent()) {
-                return 0;
+            for (uint8_t retries = 0; retries < 5; retries++) {
+                if (wizNetif->isPresent()) {
+                    LOG(INFO, "W5500 present");
+                    return 0;
+                }
+                HAL_Delay_Milliseconds(50);
             }
+            LOG(INFO, "Remove Ethernet interface");
             netifapi_netif_remove(en2->interface());
         }
-        LOG(INFO, "Ethernet interface is not present");
         delete en2;
         en2 = nullptr;
     }

--- a/hal/src/msom/network/network.cpp
+++ b/hal/src/msom/network/network.cpp
@@ -205,7 +205,7 @@ int if_init_platform_postpone(void*) {
         uint8_t dummy;
         if (!if_get_index(en2->interface(), &dummy)) {
             auto wizNetif = reinterpret_cast<WizNetif*>(en2);
-            for (uint8_t retries = 0; retries < 5; retries++) {
+            for (uint8_t retries = 0; retries < 10; retries++) {
                 if (wizNetif->isPresent()) {
                     LOG(INFO, "W5500 present");
                     return 0;

--- a/hal/src/msom/network/network.cpp
+++ b/hal/src/msom/network/network.cpp
@@ -205,12 +205,9 @@ int if_init_platform_postpone(void*) {
         uint8_t dummy;
         if (!if_get_index(en2->interface(), &dummy)) {
             auto wizNetif = reinterpret_cast<WizNetif*>(en2);
-            for (uint8_t retries = 0; retries < 10; retries++) {
-                if (wizNetif->isPresent()) {
-                    LOG(INFO, "W5500 present");
-                    return 0;
-                }
-                HAL_Delay_Milliseconds(50);
+            if (wizNetif->isPresent(true)) {
+                LOG(INFO, "W5500 present");
+                return 0;
             }
             LOG(INFO, "Remove Ethernet interface");
             netifapi_netif_remove(en2->interface());

--- a/hal/src/msom/network/network.cpp
+++ b/hal/src/msom/network/network.cpp
@@ -205,8 +205,12 @@ int if_init_platform_postpone(void*) {
         uint8_t dummy;
         if (!if_get_index(en2->interface(), &dummy)) {
             auto wizNetif = reinterpret_cast<WizNetif*>(en2);
-            if (wizNetif->isPresent()) {
-                return 0;
+            for (uint8_t retries = 0; retries < 5; retries++) {
+                if (wizNetif->isPresent()) {
+                    LOG(INFO, "W5500 present");
+                    return 0;
+                }
+                HAL_Delay_Milliseconds(50);
             }
             LOG(INFO, "Remove Ethernet interface");
             netifapi_netif_remove(en2->interface());


### PR DESCRIPTION
**NOTE: this PR is targeting the `feature/auxiliary-power-control` branch**

### Problem
The Ethernet reset pin on Muon is controlled by a reset IC, instead of GPIO. The reset IC will delay up to 200ms after the Ethernet interface is powered up to reset the Ethernet, which is too late to add the Ethernet interface.

### Solution
1. Makes the reset pin of Ethernet optional, so that user can set the reset pin to `PIN_INVALID`
2. Does retries to detect the Ethernet interface so that we can detect it after the reset IC resets it.

### Steps to Test
Build and run the test app on MSoM/B5SoM/BSoM that is installed on the Muon.

### Example App
```cpp
#include "application.h"

SYSTEM_MODE(SEMI_AUTOMATIC);

Serial1LogHandler l(115200, LOG_LEVEL_ALL);

uint8_t auxPwrPin = D7;

STARTUP(System.enableFeature(FEATURE_ETHERNET_DETECTION));

STARTUP({
    System.setPowerConfiguration(SystemPowerConfiguration().auxPowerControlPin(auxPwrPin).feature(SystemPowerFeature::PMIC_DETECTION));

    System.enableFeature(FEATURE_ETHERNET_DETECTION);

    if_wiznet_pin_remap remap = {};
    remap.base.type = IF_WIZNET_DRIVER_SPECIFIC_PIN_REMAP;
    remap.cs_pin = A3;
    remap.reset_pin = PIN_INVALID;
    remap.int_pin = A4;
    if_request(nullptr, IF_REQ_DRIVER_SPECIFIC, &remap, sizeof(remap), nullptr);
});

void setup() {
    Log.info("Application started");
}

void loop() {
    if (Serial.available()) {
        char c = Serial.read();
        switch (c) {
            case 'i': {
                if_list* ifs = nullptr;
                if_get_list(&ifs);
                for (if_list* iface = ifs; iface != nullptr; iface = iface->next) {
                    if (iface->iface) {
                        uint8_t idx;
                        if_get_index(iface->iface, &idx);
                        Log.info("Interface %d: %s", idx, iface->iface->name);
                    }
                }
                if_free_list(ifs);
                break;
            }
            case 'p': {
                Log.info("Connecting to Particle Cloud...");
                Particle.connect();
                break;
            }
            case 'e': {
                Log.info("Connecting to Ethernet...");
                Ethernet.connect();
                break;
            }
            default: break;
        }
    }
}
```

### References
N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
