### PR TITLE
Fix/ble stop scanning

### DIFF
--- a/hal/src/rtl872x/ble_hal.cpp
+++ b/hal/src/rtl872x/ble_hal.cpp
@@ -1898,8 +1898,6 @@ int BleGap::connect(const hal_ble_conn_cfg_t* config, hal_ble_conn_handle_t* con
     // Make sure that event dispatching is started
     CHECK(start());
 
-    // Stop scanning first to give the scanning semaphore if possible.
-    CHECK(stopScanning());
     SCOPE_GUARD ({
         connectingAddr_ = {};
         connecting_ = false;

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -1051,6 +1051,7 @@ public:
     }
 
     int stopScanning() const;
+    bool scanning() const;
 
     // Access local characteristics
     BleCharacteristic addCharacteristic(const BleCharacteristic& characteristic);

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -2677,6 +2677,10 @@ int BleLocalDevice::stopScanning() const {
     return hal_ble_gap_stop_scan(nullptr);
 }
 
+bool BleLocalDevice::scanning() const {
+    return hal_ble_gap_is_scanning(nullptr);
+}
+
 int BleLocalDevice::setPPCP(uint16_t minInterval, uint16_t maxInterval, uint16_t latency, uint16_t timeout) const {
     hal_ble_conn_params_t ppcp = {};
     ppcp.size = sizeof(hal_ble_conn_params_t);


### PR DESCRIPTION
### Problem

1. `BLE.stopScanning()` on Gen 4 is broken since 5.8.2 from inside ble scan result callback.
2. In general behavior of Gen 3/4 `scan()` and `stopScanning()` is currently slightly different. Also different with indefinite/timed scans.
3. No-fixture tests are missing for this.

### Solution

1. Fix this by making sure that only the scan caller semaphore is unblocked if `hal_ble_gap_stop_scanning()` is called from inside the ble event thread (the one ble results are being notified to the application from)
2. Streamline the behavior to be:
2.1. `BLE.scan()` is blocking no matter the timeout, but once scanning is started - BLE lock is not held, allowing other BLE operations to be performed.
2.2. `BLE.stopScanning()` works correctly when called both from inside the scan result callback/other BLE callbacks and from some other thread (be that application/system/timer/custom etc).
2.3. If called from a normal thread `BLE.stopScanning()` is a blocking operation and scanning MUST be stopped once its execution completes.
3. Add a set of tests to validate scan/stopScanning.

### Steps to Test

- wiring/no_fixture_ble
- wiring/ble_central_peripheral
- wiring/ble_scanner_broadcaster

For cross-platform testing with test runner: https://github.com/particle-iot/device-os-test-runner/pull/28

### Example App

```c
void setup() {
  /* A minimal example app is super helpful 
   * for testing new features and fixes. 
   * A link to a Docs PR is even better!
   */
}

void loop() {

}
```

### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
