### PR TITLE
Reduce latency of the system loop

### DIFF
--- a/hal/src/nRF52840/concurrent_hal.cpp
+++ b/hal/src/nRF52840/concurrent_hal.cpp
@@ -225,7 +225,7 @@ os_result_t os_thread_delay_until(system_tick_t *previousWakeTime, system_tick_t
 
 os_thread_notify_t os_thread_wait(system_tick_t ms, void* reserved)
 {
-    return ulTaskNotifyTake(pdTRUE, ms);
+    return ulTaskNotifyTake(pdFALSE, ms);
 }
 
 int os_thread_notify(os_thread_t thread, void* reserved)

--- a/hal/src/rtl872x/concurrent_hal.cpp
+++ b/hal/src/rtl872x/concurrent_hal.cpp
@@ -244,7 +244,7 @@ os_result_t os_thread_delay_until(system_tick_t *previousWakeTime, system_tick_t
 
 os_thread_notify_t os_thread_wait(system_tick_t ms, void* reserved)
 {
-    return ulTaskNotifyTake(pdTRUE, ms);
+    return ulTaskNotifyTake(pdFALSE, ms);
 }
 
 int os_thread_notify(os_thread_t thread, void* reserved)


### PR DESCRIPTION
### Problem

When waking up the system thread to process pending events, we're resetting the notification counter for the system thread instead of decrementing it, which causes the system thread to go to sleep until a new event is put in the queue and ignore events that are already in the queue.
