### PR TITLE
Device protection fixes

### DIFF
--- a/bootloader/src/nRF52840/usbd_dfu.cpp
+++ b/bootloader/src/nRF52840/usbd_dfu.cpp
@@ -218,8 +218,9 @@ int DfuClassDriver::handleDfuUpload(SetupRequest* req) {
         transferBuf_[1] = detail::DFUSE_COMMAND_SET_ADDRESS_POINTER;
         transferBuf_[2] = detail::DFUSE_COMMAND_ERASE;
         transferBuf_[3] = detail::DFUSE_COMMAND_ENTER_SAFE_MODE;
+        transferBuf_[4] = detail::DFUSE_COMMAND_CLEAR_SECURITY_MODE_OVERRIDE;
         setState(detail::dfuIDLE);
-        dev_->setupReply(req, transferBuf_, 4);
+        dev_->setupReply(req, transferBuf_, 5);
       } else if (req_.wValue > 1) {
         /* Normal request */
         setState(detail::dfuUPLOAD_IDLE);
@@ -273,6 +274,7 @@ int DfuClassDriver::handleDfuGetStatus(SetupRequest* req) {
             auto cmd = (detail::DfuseCommand)transferBuf_[0];
             switch (cmd) {
             case detail::DFUSE_COMMAND_ENTER_SAFE_MODE:
+            case detail::DFUSE_COMMAND_CLEAR_SECURITY_MODE_OVERRIDE:
               error = false;
               break;
             default:
@@ -509,6 +511,10 @@ int DfuClassDriver::inDone(uint8_t ep, unsigned status) {
             HAL_Core_Write_Backup_Register(BKP_DR_01, ENTER_SAFE_MODE_APP_REQUEST);
             setState(detail::dfuMANIFEST_SYNC);
             setStatus(detail::OK);
+            break;
+          }
+          case detail::DFUSE_COMMAND_CLEAR_SECURITY_MODE_OVERRIDE: {
+            security_mode_clear_override();
             break;
           }
           case detail::DFUSE_COMMAND_READ_UNPROTECT: {

--- a/bootloader/src/nRF52840/usbd_dfu.cpp
+++ b/bootloader/src/nRF52840/usbd_dfu.cpp
@@ -515,6 +515,8 @@ int DfuClassDriver::inDone(uint8_t ep, unsigned status) {
           }
           case detail::DFUSE_COMMAND_CLEAR_SECURITY_MODE_OVERRIDE: {
             security_mode_clear_override();
+            setState(detail::dfuDNLOAD_IDLE);
+            setStatus(detail::OK);
             break;
           }
           case detail::DFUSE_COMMAND_READ_UNPROTECT: {

--- a/bootloader/src/nRF52840/usbd_dfu.h
+++ b/bootloader/src/nRF52840/usbd_dfu.h
@@ -167,7 +167,8 @@ enum DfuseCommand {
   DFUSE_COMMAND_SET_ADDRESS_POINTER = 0x21,
   DFUSE_COMMAND_ERASE               = 0x41,
   DFUSE_COMMAND_READ_UNPROTECT      = 0x92,
-  DFUSE_COMMAND_ENTER_SAFE_MODE     = 0xfa /* Particle's extension */
+  DFUSE_COMMAND_ENTER_SAFE_MODE     = 0xfa, /* Particle's extension */
+  DFUSE_COMMAND_CLEAR_SECURITY_MODE_OVERRIDE = 0xfb /* ditto */
 };
 
 #pragma pack(push, 1)

--- a/bootloader/src/rtl872x/usbd_dfu.cpp
+++ b/bootloader/src/rtl872x/usbd_dfu.cpp
@@ -500,6 +500,8 @@ int DfuClassDriver::dataIn(unsigned ep, particle::usbd::EndpointEvent ev, size_t
           }
           case detail::DFUSE_COMMAND_CLEAR_SECURITY_MODE_OVERRIDE: {
             security_mode_clear_override();
+            setState(detail::dfuDNLOAD_IDLE);
+            setStatus(detail::OK);
             break;
           }
           case detail::DFUSE_COMMAND_READ_UNPROTECT: {

--- a/bootloader/src/rtl872x/usbd_dfu.cpp
+++ b/bootloader/src/rtl872x/usbd_dfu.cpp
@@ -268,7 +268,21 @@ int DfuClassDriver::handleDfuGetStatus(SetupRequest* req) {
          */
         setState(detail::dfuDNBUSY);
         if (security_mode_get(nullptr) == MODULE_INFO_SECURITY_MODE_PROTECTED) {
-          setError(detail::DfuDeviceStatus::errVENDOR, false /* stall */, PROTECTED_MODE_ERROR);
+          bool error = true;
+          if (req_.wValue == 0) {
+            // Certain DfuSe commands are allowed when the device is protected
+            auto cmd = (detail::DfuseCommand)transferBuf_[0];
+            switch (cmd) {
+            case detail::DFUSE_COMMAND_ENTER_SAFE_MODE:
+              error = false;
+              break;
+            default:
+              break;
+            }
+          }
+          if (error) {
+            setError(detail::DfuDeviceStatus::errVENDOR, false /* stall */, PROTECTED_MODE_ERROR);
+          }
         }
         /* Ask MAL to update bwPollTimeout depending on the current DfuSe command */
         currentMal()->getStatus(&status_, dfuseCmd_);

--- a/bootloader/src/rtl872x/usbd_dfu.cpp
+++ b/bootloader/src/rtl872x/usbd_dfu.cpp
@@ -219,8 +219,9 @@ int DfuClassDriver::handleDfuUpload(SetupRequest* req) {
         transferBuf_[1] = detail::DFUSE_COMMAND_SET_ADDRESS_POINTER;
         transferBuf_[2] = detail::DFUSE_COMMAND_ERASE;
         transferBuf_[3] = detail::DFUSE_COMMAND_ENTER_SAFE_MODE;
+        transferBuf_[4] = detail::DFUSE_COMMAND_CLEAR_SECURITY_MODE_OVERRIDE;
         setState(detail::dfuIDLE);
-        dev_->setupReply(req, transferBuf_, 4);
+        dev_->setupReply(req, transferBuf_, 5);
       } else if (req_.wValue > 1) {
         /* Normal request */
         setState(detail::dfuUPLOAD_IDLE);
@@ -274,6 +275,7 @@ int DfuClassDriver::handleDfuGetStatus(SetupRequest* req) {
             auto cmd = (detail::DfuseCommand)transferBuf_[0];
             switch (cmd) {
             case detail::DFUSE_COMMAND_ENTER_SAFE_MODE:
+            case detail::DFUSE_COMMAND_CLEAR_SECURITY_MODE_OVERRIDE:
               error = false;
               break;
             default:
@@ -494,6 +496,10 @@ int DfuClassDriver::dataIn(unsigned ep, particle::usbd::EndpointEvent ev, size_t
             HAL_Core_Write_Backup_Register(BKP_DR_01, ENTER_SAFE_MODE_APP_REQUEST);
             setState(detail::dfuMANIFEST_SYNC);
             setStatus(detail::OK);
+            break;
+          }
+          case detail::DFUSE_COMMAND_CLEAR_SECURITY_MODE_OVERRIDE: {
+            security_mode_clear_override();
             break;
           }
           case detail::DFUSE_COMMAND_READ_UNPROTECT: {

--- a/bootloader/src/rtl872x/usbd_dfu.h
+++ b/bootloader/src/rtl872x/usbd_dfu.h
@@ -163,7 +163,8 @@ enum DfuseCommand {
   DFUSE_COMMAND_SET_ADDRESS_POINTER = 0x21,
   DFUSE_COMMAND_ERASE               = 0x41,
   DFUSE_COMMAND_READ_UNPROTECT      = 0x92,
-  DFUSE_COMMAND_ENTER_SAFE_MODE     = 0xfa /* Particle's extension */
+  DFUSE_COMMAND_ENTER_SAFE_MODE     = 0xfa, /* Particle's extension */
+  DFUSE_COMMAND_CLEAR_SECURITY_MODE_OVERRIDE = 0xfb /* ditto */
 };
 
 #pragma pack(push, 1)


### PR DESCRIPTION
### Problem

The custom DfuSe command for resetting the device in safe mode (see https://github.com/particle-iot/device-os/pull/2770) doesn't work if the device is protected.

### Solution

Allow certain DfuSe commands when the device is protected.

This PR also adds another DfuSe command that allows re-enabling device protection without leaving DFU mode.

### Steps to Test

See https://github.com/particle-iot/particle-usb/pull/114.
