### PR TITLE
Add new DFU string index to show device state

### DIFF
--- a/bootloader/src/nRF52840/usbd_device.cpp
+++ b/bootloader/src/nRF52840/usbd_device.cpp
@@ -187,6 +187,7 @@ const uint8_t USBD_MsftStrDesc[] = {
   )
 };
 
+
 char* device_id_as_string(char* buf) {
   uint8_t deviceId[HAL_DEVICE_ID_SIZE] = {};
   unsigned deviceIdLen = hal_get_device_id(deviceId, sizeof(deviceId));
@@ -196,15 +197,13 @@ char* device_id_as_string(char* buf) {
 
 char* device_state_as_string(char* buf) {
     int mode = security_mode_get(nullptr);
-    const char* state;
     
     if (mode == MODULE_INFO_SECURITY_MODE_NONE) {
-        state = security_mode_is_overridden() ? "sm=s" : "sm=o";
+      memcpy(buf, security_mode_is_overridden() ? "sm=s" : "sm=o", 4);
     } else {
-        state = "sm=p";
+      memcpy(buf, "sm=p", 4);
     }
-    
-    memcpy(buf, state, 4); // "sm=?" is always 4 bytes
+
     return buf;
 }
 
@@ -770,7 +769,7 @@ const uint8_t* NrfDevice::getString(SetupRequest* r, uint16_t* len) {
     case STRING_IDX_DEVICE_STATE: {
       /* No conversion to UTF-16 */
       char deviceStateStr[8] = {0};
-      return getUnicodeString(device_state_as_string(deviceStateStr), sizeof(deviceStateStr)-1, len, false);
+      return getUnicodeString(device_state_as_string(deviceStateStr), sizeof(deviceStateStr), len, false);
     }
     default: {
       if (drv_) {

--- a/bootloader/src/nRF52840/usbd_device.h
+++ b/bootloader/src/nRF52840/usbd_device.h
@@ -112,7 +112,8 @@ public:
     STRING_IDX_SERIAL       = 0x03,
     STRING_IDX_CONFIG       = 0x04,
     STRING_IDX_INTERFACE    = 0x05,
-    STRING_IDX_MSFT         = 0xee
+    STRING_IDX_MSFT         = 0xee,
+    STRING_IDX_DEVICE_STATE = 0xfa
   };
 
   enum Feature {

--- a/hal/src/rtl872x/usbd_device.cpp
+++ b/hal/src/rtl872x/usbd_device.cpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include "appender.h"
 #include "device_code.h"
+#include "security_mode.h"
 
 using namespace particle::usbd;
 
@@ -51,15 +52,13 @@ char* device_id_as_string(char* buf) {
 
 char* device_state_as_string(char* buf) {
     int mode = security_mode_get(nullptr);
-    const char* state;
     
     if (mode == MODULE_INFO_SECURITY_MODE_NONE) {
-        state = security_mode_is_overridden() ? "sm=s" : "sm=o";
+      memcpy(buf, security_mode_is_overridden() ? "sm=s" : "sm=o", 4);
     } else {
-        state = "sm=p";
+      memcpy(buf, "sm=p", 4);
     }
-    
-    memcpy(buf, state, 4); // "sm=?" is always 4 bytes
+
     return buf;
 }
 
@@ -375,7 +374,7 @@ int Device::getString(unsigned id, uint16_t langId, uint8_t* buf, size_t len) {
     case STRING_IDX_DEVICE_STATE: {
       /* No conversion to UTF-16 */
       char deviceStateStr[8] = {0};
-      return getUnicodeString(device_state_as_string(deviceStateStr), sizeof(deviceStateStr)-1, len, false);
+      return getUnicodeString(device_state_as_string(deviceStateStr), sizeof(deviceStateStr), buf, len);
     }
     default: {
         for (auto& cls: classDrivers_) {

--- a/hal/src/rtl872x/usbd_device.cpp
+++ b/hal/src/rtl872x/usbd_device.cpp
@@ -49,6 +49,20 @@ char* device_id_as_string(char* buf) {
     return buf;
 }
 
+char* device_state_as_string(char* buf) {
+    int mode = security_mode_get(nullptr);
+    const char* state;
+    
+    if (mode == MODULE_INFO_SECURITY_MODE_NONE) {
+        state = security_mode_is_overridden() ? "sm=s" : "sm=o";
+    } else {
+        state = "sm=p";
+    }
+    
+    memcpy(buf, state, 4); // "sm=?" is always 4 bytes
+    return buf;
+}
+
 /* MS OS String Descriptor */
 const uint8_t MSFT_STR_DESC[] = {
     USB_WCID_MS_OS_STRING_DESCRIPTOR(
@@ -357,6 +371,11 @@ int Device::getString(unsigned id, uint16_t langId, uint8_t* buf, size_t len) {
     }
     case STRING_IDX_MSFT: {
         return getRawString((const char*)MSFT_STR_DESC, sizeof(MSFT_STR_DESC), buf, len);
+    }
+    case STRING_IDX_DEVICE_STATE: {
+      /* No conversion to UTF-16 */
+      char deviceStateStr[8] = {0};
+      return getUnicodeString(device_state_as_string(deviceStateStr), sizeof(deviceStateStr)-1, len, false);
     }
     default: {
         for (auto& cls: classDrivers_) {

--- a/hal/src/rtl872x/usbd_device.h
+++ b/hal/src/rtl872x/usbd_device.h
@@ -115,7 +115,8 @@ enum StringIndex {
     STRING_IDX_SERIAL = 0x03,
     STRING_IDX_CONFIG = 0x04,
     STRING_IDX_INTERFACE = 0x05,
-    STRING_IDX_MSFT = 0xee
+    STRING_IDX_MSFT = 0xee,
+    STRING_IDX_DEVICE_STATE = 0xfa
 };
 
 enum DeviceFeature {


### PR DESCRIPTION
### Problem

Currently, there is no way to distinguish between Open and Protected Devices in Service Mode when the device is in DFU mode by checking the DFU segments

### Solution

Add a new string index which can be queried by reading the string descriptor that gives the device state

### Steps to Test

1. Build and flash this bootloader
2. Use particle-usb to test this. https://github.com/particle-iot/particle-usb/pull/115

### Example App

```c
void setup() {
  /* A minimal example app is super helpful 
   * for testing new features and fixes. 
   * A link to a Docs PR is even better!
   */
}

void loop() {

}
```

### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
