### PR TITLE
[gen4] set sleep timer upper bounds

### DIFF
--- a/hal/src/rtl872x/sleep_hal.cpp
+++ b/hal/src/rtl872x/sleep_hal.cpp
@@ -409,7 +409,10 @@ private:
     }
 
     int validateRtcWakeupSource(hal_sleep_mode_t mode, const hal_wakeup_source_rtc_t* rtc) {
-        if ((rtc->ms / 1000) == 0) {
+        // It uses a 32.768KHz timer, max counter = 0x3FFFFFFF/32768 * 1000 = 32768000(ms).
+        // But due to the simplified calculation formula in SOCPS_AONTimer(), the maximum
+        // argument is 32767933, otherwise, the calculated timer counter will overflow.
+        if ((rtc->ms / 1000) == 0 || rtc->ms > 32767933) {
             return SYSTEM_ERROR_INVALID_ARGUMENT;
         }
         return SYSTEM_ERROR_NONE;


### PR DESCRIPTION
### Problem
The timer for waking up device on Gen4 has restricted counter value up to `0x3FFFFFFF`, which is `32768000` in miliseconds. However, DVOS doesn't check the upper bounds and may result in unexpected sleep duration.

### Solution
Restrict the valid sleep duration from 1000ms to 32767933ms (Why not 32768000ms? See the comment for the changes)

### Example App

```cpp
#include "application.h"

SYSTEM_MODE(MANUAL);

void setup() {
    delay(2s);
    System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::ULTRA_LOW_POWER).duration(32767933)); // Try with 32768000
}

void loop() {
}
```

### References
https://community.particle.io/t/p2-maximum-hibernate-time/67287

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
