### PR TITLE
[ACM] Perform cloud ping or reachability test on network events; non-blocking background reachability test

### DIFF
--- a/build/arm-tools.mk
+++ b/build/arm-tools.mk
@@ -112,6 +112,11 @@ endif
 # We are using newlib-nano for all the platforms
 CFLAGS += --specs=nano.specs
 
+ifneq ($(LTO_EXTRA_OPTIMIZATIONS),)
+CFLAGS += -fmerge-all-constants
+LDFLAGS += -fmerge-all-constants
+endif
+
 # Check if the compiler version is the minimum required
 version_to_number=$(shell v=$1; v=($${v//./ }); echo $$((v[0] * 10000 + v[1] * 100 + v[2])))
 get_major_version=$(shell v=$1; v=($${v//./ }); echo $${v[0]})

--- a/hal/network/lwip/lwiphooks.c
+++ b/hal/network/lwip/lwiphooks.c
@@ -71,3 +71,6 @@ __attribute__((weak)) struct netif* lwip_hook_ip6_route(const ip6_addr_t* src, c
     return NULL;
 }
 
+__attribute__((weak)) struct netif* lwip_hook_dns_get_netif_for_server_index(int index) {
+    return NULL;
+}

--- a/hal/network/lwip/resolvapi.cpp
+++ b/hal/network/lwip/resolvapi.cpp
@@ -22,6 +22,7 @@
 #include "logging.h"
 #include "ifapi.h"
 #include <algorithm>
+#include "lwiphooks.h"
 
 using namespace particle::net;
 
@@ -220,4 +221,11 @@ int resolv_get_dns_server_priority_for_iface(if_t iface, int priority) {
 
     index = index * LWIP_DNS_SERVERS_PER_NETIF + std::min<int>(LWIP_DNS_SERVERS_PER_NETIF, priority);
     return index;
+}
+
+struct netif* lwip_hook_dns_get_netif_for_server_index(int index) {
+    uint8_t netifIdx = index / LWIP_DNS_SERVERS_PER_NETIF;
+    if_t iface = nullptr;
+    if_get_by_index(netifIdx, &iface);
+    return (netif*)iface;
 }

--- a/hal/src/nRF52840/lwip/lwiphooks.h
+++ b/hal/src/nRF52840/lwip/lwiphooks.h
@@ -28,6 +28,7 @@ int lwip_hook_ip4_input(struct pbuf *p, struct netif *inp);
 int lwip_hook_ip4_input_post_validation(struct pbuf* p, struct netif* inp);
 struct netif* lwip_hook_ip4_route_src(const ip4_addr_t* src, const ip4_addr_t* dst);
 int lwip_hook_ip4_input_pre_upper_layers(struct pbuf* p, const struct ip_hdr* iphdr, struct netif* inp);
+struct netif* lwip_hook_dns_get_netif_for_server_index(int index);
 #endif /* LWIP_IPV4 */
 
 /* IPv6 hooks */
@@ -47,6 +48,8 @@ void lwip_hook_memp_free(memp_t type, unsigned available, unsigned size);
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
+
+#define LWIP_HOOK_DNS_GET_NETIF_FOR_SERVER_INDEX(index) lwip_hook_dns_get_netif_for_server_index(index)
 
 /**
  * LWIP_HOOK_TCP_ISN:

--- a/hal/src/nRF52840/lwip/lwipopts.h
+++ b/hal/src/nRF52840/lwip/lwipopts.h
@@ -753,6 +753,13 @@ void sys_unlock_tcpip_core(void);
  * LWIP_NETBUF_RECVINFO==1: append destination addr and port to every netbuf.
  */
 #define LWIP_NETBUF_RECVINFO            0
+
+
+/**
+ * LWIP_NETBUF_TIMESTAMP==1: append timestamp to netbufs
+ */
+#define LWIP_NETBUF_TIMESTAMP           1
+
 /**
  * @}
  */

--- a/hal/src/nRF52840/lwip/sys_arch.c
+++ b/hal/src/nRF52840/lwip/sys_arch.c
@@ -39,6 +39,7 @@
 #include "FreeRTOS.h"
 #include "semphr.h"
 #include "task.h"
+#include "timer_hal.h"
 
 /** Set this to 1 if you want the stack size passed to sys_thread_new() to be
  * interpreted as number of stack words (FreeRTOS-like).
@@ -78,7 +79,7 @@
  * Default is 1, where FreeRTOS ticks are used to calculate back to ms.
  */
 #ifndef LWIP_FREERTOS_SYS_NOW_FROM_FREERTOS
-#define LWIP_FREERTOS_SYS_NOW_FROM_FREERTOS           1
+#define LWIP_FREERTOS_SYS_NOW_FROM_FREERTOS           0
 #endif
 
 #if !configSUPPORT_DYNAMIC_ALLOCATION
@@ -134,6 +135,12 @@ u32_t
 sys_now(void)
 {
   return xTaskGetTickCount() * portTICK_PERIOD_MS;
+}
+#else
+u32_t
+sys_now(void)
+{
+  return HAL_Timer_Get_Milli_Seconds();
 }
 #endif
 

--- a/hal/src/rtl872x/lwip/lwiphooks.h
+++ b/hal/src/rtl872x/lwip/lwiphooks.h
@@ -28,6 +28,7 @@ int lwip_hook_ip4_input(struct pbuf *p, struct netif *inp);
 int lwip_hook_ip4_input_post_validation(struct pbuf* p, struct netif* inp);
 struct netif* lwip_hook_ip4_route_src(const ip4_addr_t* src, const ip4_addr_t* dst);
 int lwip_hook_ip4_input_pre_upper_layers(struct pbuf* p, const struct ip_hdr* iphdr, struct netif* inp);
+struct netif* lwip_hook_dns_get_netif_for_server_index(int index);
 #endif /* LWIP_IPV4 */
 
 /* IPv6 hooks */
@@ -47,6 +48,8 @@ void lwip_hook_memp_free(memp_t type, unsigned available, unsigned size);
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */
+
+#define LWIP_HOOK_DNS_GET_NETIF_FOR_SERVER_INDEX(index) lwip_hook_dns_get_netif_for_server_index(index)
 
 /**
  * LWIP_HOOK_TCP_ISN:

--- a/hal/src/rtl872x/lwip/lwipopts.h
+++ b/hal/src/rtl872x/lwip/lwipopts.h
@@ -751,6 +751,11 @@ void sys_unlock_tcpip_core(void);
  * LWIP_NETBUF_RECVINFO==1: append destination addr and port to every netbuf.
  */
 #define LWIP_NETBUF_RECVINFO            0
+
+/**
+ * LWIP_NETBUF_TIMESTAMP==1: append timestamp to netbufs
+ */
+#define LWIP_NETBUF_TIMESTAMP           1
 /**
  * @}
  */

--- a/hal/src/rtl872x/lwip/sys_arch.c
+++ b/hal/src/rtl872x/lwip/sys_arch.c
@@ -39,6 +39,7 @@
 #include "FreeRTOS.h"
 #include "semphr.h"
 #include "task.h"
+#include "timer_hal.h"
 
 /** Set this to 1 if you want the stack size passed to sys_thread_new() to be
  * interpreted as number of stack words (FreeRTOS-like).
@@ -78,7 +79,7 @@
  * Default is 1, where FreeRTOS ticks are used to calculate back to ms.
  */
 #ifndef LWIP_FREERTOS_SYS_NOW_FROM_FREERTOS
-#define LWIP_FREERTOS_SYS_NOW_FROM_FREERTOS           1
+#define LWIP_FREERTOS_SYS_NOW_FROM_FREERTOS           0
 #endif
 
 #if !configSUPPORT_DYNAMIC_ALLOCATION
@@ -134,6 +135,12 @@ u32_t
 sys_now(void)
 {
   return xTaskGetTickCount() * portTICK_PERIOD_MS;
+}
+#else
+u32_t
+sys_now(void)
+{
+  return HAL_Timer_Get_Milli_Seconds();
 }
 #endif
 

--- a/modules/argon/system-part1/makefile
+++ b/modules/argon/system-part1/makefile
@@ -9,6 +9,8 @@ NCP_FIRMWARE_MODULE_VERSION=4
 DEPENDENCIES = newlib_nano modules/argon/user-part modules/argon/system-part1 dynalib services hal platform system wiring communication rt-dynalib crypto proto_defs
 LIB_DEPENDENCIES = services system wiring communication hal platform crypto proto_defs
 
+export LTO_EXTRA_OPTIMIZATIONS=1
+
 # newlib_nano is special in that it's linked automatically by the system, so no need to add it to the library path here
 MAKE_DEPENDENCIES = newlib_nano $(LIB_DEPENDENCIES)
 include ../modular.mk

--- a/modules/b5som/system-part1/makefile
+++ b/modules/b5som/system-part1/makefile
@@ -5,6 +5,8 @@ BUILD_PATH_EXT = $(BUILD_TARGET_PLATFORM)
 HAL_LINK :=
 PLATFORM_DFU = 0x30000
 
+export LTO_EXTRA_OPTIMIZATIONS=1
+
 DEPENDENCIES = newlib_nano modules/b5som/user-part modules/b5som/system-part1 dynalib services hal platform system wiring communication rt-dynalib crypto proto_defs wiring_globals
 LIB_DEPENDENCIES = services system wiring communication hal platform crypto proto_defs wiring_globals
 # newlib_nano is special in that it's linked automatically by the system, so no need to add it to the library path here

--- a/modules/boron/system-part1/makefile
+++ b/modules/boron/system-part1/makefile
@@ -5,6 +5,8 @@ BUILD_PATH_EXT = $(BUILD_TARGET_PLATFORM)
 HAL_LINK :=
 PLATFORM_DFU = 0x30000
 
+export LTO_EXTRA_OPTIMIZATIONS=1
+
 DEPENDENCIES = newlib_nano modules/boron/user-part modules/boron/system-part1 dynalib services hal platform system wiring communication rt-dynalib crypto proto_defs wiring_globals
 LIB_DEPENDENCIES = services system wiring communication hal platform crypto proto_defs wiring_globals
 # newlib_nano is special in that it's linked automatically by the system, so no need to add it to the library path here

--- a/modules/tracker/system-part1/makefile
+++ b/modules/tracker/system-part1/makefile
@@ -5,6 +5,8 @@ BUILD_PATH_EXT = $(BUILD_TARGET_PLATFORM)
 HAL_LINK :=
 PLATFORM_DFU = 0x30000
 
+export LTO_EXTRA_OPTIMIZATIONS=1
+
 DEPENDENCIES = newlib_nano modules/tracker/user-part modules/tracker/system-part1 dynalib services hal platform system wiring communication rt-dynalib crypto proto_defs wiring_globals
 LIB_DEPENDENCIES = services system wiring communication hal platform crypto proto_defs wiring_globals
 # newlib_nano is special in that it's linked automatically by the system, so no need to add it to the library path here

--- a/system/src/system_cloud_connection.h
+++ b/system/src/system_cloud_connection.h
@@ -24,6 +24,9 @@
 #include "ota_flash_hal.h"
 #include "socket_hal.h"
 #include <type_traits>
+#if HAL_PLATFORM_IFAPI
+#include "netdb_hal.h"
+#endif // HAL_PLATFORM_IFAPI
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,6 +35,13 @@ extern "C" {
 typedef enum {
     SYSTEM_CLOUD_DISCONNECT_GRACEFULLY = 1
 } system_cloud_connection_flags_t;
+
+typedef enum CloudServerAddressType {
+    CLOUD_SERVER_ADDRESS_TYPE_NONE            = 0,
+    CLOUD_SERVER_ADDRESS_TYPE_CACHED          = 1,
+    CLOUD_SERVER_ADDRESS_TYPE_CACHED_ADDRINFO = 2,
+    CLOUD_SERVER_ADDRESS_TYPE_NEW_ADDRINFO    = 3
+} CloudServerAddressType;
 
 int system_cloud_connect(int protocol, const ServerAddress* address, sockaddr* saddrCache);
 int system_cloud_disconnect(int flags);
@@ -43,6 +53,10 @@ int system_multicast_announce_presence(void* reserved);
 int system_cloud_set_inet_family_keepalive(int af, unsigned int value, int flags);
 int system_cloud_get_inet_family_keepalive(int af, unsigned int* value);
 sock_handle_t system_cloud_get_socket_handle();
+
+#if HAL_PLATFORM_IFAPI
+int system_cloud_resolv_address(int protocol, const ServerAddress* address, sockaddr* saddrCache, addrinfo** info, CloudServerAddressType* type, bool useCachedAddrInfo);
+#endif // HAL_PLATFORM_IFAPI
 
 #ifdef __cplusplus
 }

--- a/system/src/system_cloud_connection_posix.cpp
+++ b/system/src/system_cloud_connection_posix.cpp
@@ -363,7 +363,6 @@ int system_cloud_recv(uint8_t* buf, size_t buflen, int flags)
 
 int system_internet_test(void* reserved)
 {
-    LOG(INFO, "internet test system.cm");
     return particle::system::ConnectionManager::instance()->testConnections();
 }
 

--- a/system/src/system_cloud_connection_posix.cpp
+++ b/system/src/system_cloud_connection_posix.cpp
@@ -35,13 +35,6 @@
 
 namespace {
 
-enum CloudServerAddressType {
-    CLOUD_SERVER_ADDRESS_TYPE_NONE            = 0,
-    CLOUD_SERVER_ADDRESS_TYPE_CACHED          = 1,
-    CLOUD_SERVER_ADDRESS_TYPE_CACHED_ADDRINFO = 2,
-    CLOUD_SERVER_ADDRESS_TYPE_NEW_ADDRINFO    = 3
-};
-
 struct SystemCloudState {
     int socket = -1;
     struct addrinfo* addr = nullptr;
@@ -54,11 +47,10 @@ const unsigned CLOUD_SOCKET_HALF_CLOSED_WAIT_TIMEOUT = 5000;
 
 } /* anonymous */
 
-int system_cloud_connect(int protocol, const ServerAddress* address, sockaddr* saddrCache)
-{
-    struct addrinfo* info = nullptr;
-    CloudServerAddressType type = CLOUD_SERVER_ADDRESS_TYPE_NONE;
-    bool clean = true;
+int system_cloud_resolv_address(int protocol, const ServerAddress* address, sockaddr* saddrCache, addrinfo** info, CloudServerAddressType* type, bool useCachedAddrInfo) {
+    CHECK_TRUE(info, SYSTEM_ERROR_INVALID_ARGUMENT);
+
+    *type = CLOUD_SERVER_ADDRESS_TYPE_NONE;
 
     if (saddrCache && /* protocol == IPPROTO_UDP && */ saddrCache->sa_family != AF_UNSPEC) {
         char tmphost[INET6_ADDRSTRLEN] = {};
@@ -73,21 +65,21 @@ int system_cloud_connect(int protocol, const ServerAddress* address, sockaddr* s
             /* FIXME: */
             hints.ai_socktype = hints.ai_protocol == IPPROTO_UDP ? SOCK_DGRAM : SOCK_STREAM;
 
-            if (!netdb_getaddrinfo(tmphost, tmpserv, &hints, &info)) {
-                type = CLOUD_SERVER_ADDRESS_TYPE_CACHED;
+            if (!netdb_getaddrinfo(tmphost, tmpserv, &hints, info)) {
+                *type = CLOUD_SERVER_ADDRESS_TYPE_CACHED;
             }
         }
     }
 
-    if (type == CLOUD_SERVER_ADDRESS_TYPE_NONE) {
+    if (*type == CLOUD_SERVER_ADDRESS_TYPE_NONE && useCachedAddrInfo) {
         /* Check if we have another address to try from the cached addrinfo list */
         if (s_state.addr && s_state.next) {
-            info = s_state.next;
-            type = CLOUD_SERVER_ADDRESS_TYPE_CACHED_ADDRINFO;
+            *info = s_state.next;
+            *type = CLOUD_SERVER_ADDRESS_TYPE_CACHED_ADDRINFO;
         }
     }
 
-    if ((type == CLOUD_SERVER_ADDRESS_TYPE_NONE) && address) {
+    if ((*type == CLOUD_SERVER_ADDRESS_TYPE_NONE) && address) {
         /* Use passed ServerAddress */
         switch (address->addr_type) {
             case IP_ADDRESS: {
@@ -107,8 +99,8 @@ int system_cloud_connect(int protocol, const ServerAddress* address, sockaddr* s
                 if (inet_inet_ntop(AF_INET, &in, tmphost, sizeof(tmphost))) {
                     snprintf(tmpserv, sizeof(tmpserv), "%u", address->port);
 
-                    netdb_getaddrinfo(tmphost, tmpserv, &hints, &info);
-                    type = CLOUD_SERVER_ADDRESS_TYPE_NEW_ADDRINFO;
+                    netdb_getaddrinfo(tmphost, tmpserv, &hints, info);
+                    *type = CLOUD_SERVER_ADDRESS_TYPE_NEW_ADDRINFO;
                 }
                 break;
             }
@@ -126,18 +118,30 @@ int system_cloud_connect(int protocol, const ServerAddress* address, sockaddr* s
                 system_string_interpolate(address->domain, tmphost, sizeof(tmphost), system_interpolate_cloud_server_hostname);
                 snprintf(tmpserv, sizeof(tmpserv), "%u", address->port);
                 LOG(TRACE, "Resolving %s#%s", tmphost, tmpserv);
-                netdb_getaddrinfo(tmphost, tmpserv, &hints, &info);
-                type = CLOUD_SERVER_ADDRESS_TYPE_NEW_ADDRINFO;
+                netdb_getaddrinfo(tmphost, tmpserv, &hints, info);
+                *type = CLOUD_SERVER_ADDRESS_TYPE_NEW_ADDRINFO;
                 break;
             }
         }
     }
 
-    int r = SYSTEM_ERROR_NETWORK;
-
-    if (info == nullptr) {
+    if (*info == nullptr) {
         LOG(ERROR, "Failed to determine server address");
+        return SYSTEM_ERROR_NOT_FOUND;
     }
+
+    return 0;
+}
+
+int system_cloud_connect(int protocol, const ServerAddress* address, sockaddr* saddrCache)
+{
+    struct addrinfo* info = nullptr;
+    CloudServerAddressType type = CLOUD_SERVER_ADDRESS_TYPE_NONE;
+    bool clean = true;
+
+    system_cloud_resolv_address(protocol, address, saddrCache, &info, &type, true /* useCachedAddrInfo */);
+
+    int r = SYSTEM_ERROR_NETWORK;
 
     LOG(TRACE, "Address type: %d", type);
 
@@ -359,6 +363,7 @@ int system_cloud_recv(uint8_t* buf, size_t buflen, int flags)
 
 int system_internet_test(void* reserved)
 {
+    LOG(INFO, "internet test system.cm");
     return particle::system::ConnectionManager::instance()->testConnections();
 }
 

--- a/system/src/system_connection_manager.cpp
+++ b/system/src/system_connection_manager.cpp
@@ -153,6 +153,7 @@ network_handle_t ConnectionManager::selectCloudConnectionNetwork() {
         LOG_DEBUG(TRACE, "Using best network: %s", netifToName(bestNetwork));
         return bestNetwork;
     } else {
+        nextPeriodicCheck_ = 0;
         LOG_DEBUG(TRACE, "Using preferred network: %s", netifToName(preferredNetwork_));
         return preferredNetwork_;
     }

--- a/system/src/system_connection_manager.cpp
+++ b/system/src/system_connection_manager.cpp
@@ -95,10 +95,9 @@ void ConnectionManager::setPreferredNetwork(network_handle_t network, bool prefe
         if (network != NETWORK_INTERFACE_ALL) {
             preferredNetwork_ = network;
 
-            // If cloud is already connected, and a preferred network is set, and it is up, move cloud connection to it immediately
+            // If cloud is already connected, and a preferred network is set, and it is up, attempt to move cloud connection to it immediately
             if (spark_cloud_flag_connected() && network_ready(preferredNetwork_, 0, nullptr)) {
-                auto options = CloudDisconnectOptions().graceful(true).reconnect(true).toSystemOptions();
-                spark_cloud_disconnect(&options, nullptr);
+                scheduleCloudConnectionNetworkCheck();
             }
         }
     } else {

--- a/system/src/system_connection_manager.cpp
+++ b/system/src/system_connection_manager.cpp
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, see <http://www.gnu.org/licenses/>.
  */
+#define DEBUG_BUILD
 #include "logging.h"
 LOG_SOURCE_CATEGORY("system.cm")
 
@@ -38,13 +39,15 @@ LOG_SOURCE_CATEGORY("system.cm")
 
 namespace particle { namespace system {
 
-typedef struct {
+typedef struct DTLSPlaintext_t {
     uint8_t type;
     uint8_t version[2];
     uint16_t epoch;
     uint8_t sequence_number[6];
     uint16_t length;
 } __attribute__((__packed__)) DTLSPlaintext_t;
+
+constexpr uint16_t EPOCH_BASE = 0x8000;
 
 static const char* netifToName(uint8_t interfaceNumber) {
     switch(interfaceNumber) {
@@ -56,32 +59,22 @@ static const char* netifToName(uint8_t interfaceNumber) {
 #endif
 #if HAL_PLATFORM_WIFI
         case NETWORK_INTERFACE_WIFI_STA:
-            return "WiFi    ";
+            return "WiFi";
 #endif
         default:
             return "";
     }
 }
 
-static int getCloudHostnameAndPort(uint16_t * port, char * hostname, int hostnameLength) {
+static int getCloudHostnameAndPort(addrinfo** info, CloudServerAddressType* type, bool allowCached = false) {
     ServerAddress server_addr = {};
-    char tmphost[sizeof(server_addr.domain) + 32] = {};
-    if (hostnameLength < (int)(sizeof(tmphost)+1)) {
-        return SYSTEM_ERROR_TOO_LARGE;
-    }
-
     HAL_FLASH_Read_ServerAddress(&server_addr);
     if (server_addr.port == 0 || server_addr.port == 0xFFFF) {
         server_addr.port = spark_cloud_udp_port_get();
     }
 
-    system_string_interpolate(server_addr.domain, tmphost, sizeof(tmphost), system_interpolate_cloud_server_hostname);
-    strcpy(hostname, tmphost);
-    *port = server_addr.port;
-
-    LOG_DEBUG(TRACE, "Cloud hostname#port %s#%d", hostname, *port);
-    return 0;
-};
+    return system_cloud_resolv_address(IPPROTO_UDP, &server_addr, allowCached ? (sockaddr*)&g_system_cloud_session_data.address : nullptr, info, type, false /* useCachedAddrInfo */);
+}
 
 ConnectionManager::ConnectionManager()
     : preferredNetwork_(NETWORK_INTERFACE_ALL) {
@@ -131,7 +124,7 @@ network_handle_t ConnectionManager::selectCloudConnectionNetwork() {
     network_handle_t bestNetwork = NETWORK_INTERFACE_ALL;
 
     if (preferredNetwork_ != NETWORK_INTERFACE_ALL && network_ready(preferredNetwork_, 0, nullptr)) {
-        LOG_DEBUG(TRACE, "Using preferred network: %lu", preferredNetwork_);
+        LOG_DEBUG(TRACE, "Using preferred network: %s", netifToName(preferredNetwork_));
         return preferredNetwork_;
     }
 
@@ -140,7 +133,7 @@ network_handle_t ConnectionManager::selectCloudConnectionNetwork() {
     // Network has best criteria based on network tester results
     for (auto& i: bestNetworks_) {
         if (network_ready(i, 0, nullptr)) {
-            LOG_DEBUG(TRACE, "Using best network: %lu", i);
+            LOG_DEBUG(TRACE, "Using best network: %s", netifToName(i));
             return i;
         }
     }
@@ -151,22 +144,61 @@ network_handle_t ConnectionManager::selectCloudConnectionNetwork() {
     return bestNetwork;
 }
 
-int ConnectionManager::testConnections(bool cache) {
-    if (cache) {
-        testResultsActual_ = true;
-    } else if (!cache && testResultsActual_) {
+int ConnectionManager::testConnections(bool background) {
+    if (!background) {
+        LOG(INFO, "testConnections full");
+    }
+    if (!background && testResultsActual_) {
         // Skip the test once
         testResultsActual_ = false;
         LOG_DEBUG(TRACE, "Skipping connection test as there are valid cached results");
         return 0;
     }
-    ConnectionTester tester;
-    int r = tester.testConnections();
+
+    int r = SYSTEM_ERROR_NETWORK;
+    Vector<ConnectionMetrics> metrics;
+
+    if (!background) {
+        if (backgroundTestInProgress_) {
+            LOG(WARN, "Background reachability test aborted");
+        }
+        backgroundTestInProgress_ = false;
+        backgroundTester_.reset();
+        testResultsActual_ = false;
+
+        LOG(INFO, "Full reachability test started");
+        ConnectionTester tester;
+        CHECK(tester.prepare(true /* full test */));
+        // Blocking call
+        r = tester.runTest();
+        LOG(INFO, "Full reachability test finished (%d)", r);
+        metrics = tester.getConnectionMetrics();
+    } else {
+        // Background test
+        testResultsActual_ = false;
+        if (!backgroundTestInProgress_) {
+            LOG(INFO, "Background reachability test started");
+            backgroundTester_ = std::make_unique<ConnectionTester>();
+            CHECK_TRUE(backgroundTester_, SYSTEM_ERROR_NO_MEMORY);
+            CHECK(backgroundTester_->prepare(false /* full test*/));
+            backgroundTestInProgress_ = true;
+        }
+        r = backgroundTester_->runTest(0 /* non blocking */);
+        if (!r || r != SYSTEM_ERROR_BUSY) {
+            LOG(INFO, "Background reachability test finished (%d)", r);
+            backgroundTestInProgress_ = false;
+            metrics = backgroundTester_->getConnectionMetrics();
+            backgroundTester_.reset();
+        }
+    }
     if (r == 0) {
-        auto metrics = tester.getConnectionMetrics();
         bestNetworks_.clear();
         for (auto& i: metrics) {
             bestNetworks_.append(i.interface);
+        }
+        if (background) {
+            // Disable this for now
+            // testResultsActual_ = true;
         }
     }
     return r;
@@ -174,49 +206,84 @@ int ConnectionManager::testConnections(bool cache) {
 
 int ConnectionManager::scheduleCloudConnectionNetworkCheck() {
     testResultsActual_ = false;
-    const auto task = new(std::nothrow) ISRTaskQueue::Task();
-    if (!task) {
-        return SYSTEM_ERROR_NO_MEMORY;
-    }
-    task->func = [](ISRTaskQueue::Task* task) {
-        delete task;
-        ConnectionManager::instance()->checkCloudConnectionNetwork();
-    };
-    SystemISRTaskQueue.enqueue(task);
+    LOG(INFO, "schedule currently scheduled=%d", checkScheduled_);
+    checkScheduled_ = true;
     return 0;
 }
 
 int ConnectionManager::checkCloudConnectionNetwork() {
-    if (!spark_cloud_flag_connected()) {
+    bool finishedBackgroundTest = false;
+    if (backgroundTestInProgress_) {
+        int r = testConnections(true /* background */);
+        if (checkScheduled_) {
+            // Invalidate results
+            r = SYSTEM_ERROR_ABORTED;
+        }
+        if (!r) {
+            // Finished without errors
+            finishedBackgroundTest = true;
+        } else if (r == SYSTEM_ERROR_BUSY) {
+            // Wait to complete
+            return 0;
+        } else if (r != SYSTEM_ERROR_ABORTED) {
+            // Finished with an error, reschedule a check, if aborted - do nothing
+            return scheduleCloudConnectionNetworkCheck();
+        }
+    }
+
+    if (!checkScheduled_ && !finishedBackgroundTest) {
+        return 0;
+    }
+
+    uint8_t resetPending = 0;
+    system_get_flag(SYSTEM_FLAG_RESET_PENDING, &resetPending, nullptr);
+
+    if (!spark_cloud_flag_connected() || resetPending || SPARK_FLASH_UPDATE) {
+        // Postpone until cloud connection is established or while in OTA
         return SYSTEM_ERROR_INVALID_STATE;
     }
+
+    checkScheduled_ = false;
+
     unsigned countReady = 0;
     bool matchesCurrent = false;
+    network_handle_t best = NETWORK_INTERFACE_ALL;
     for (const auto& i: bestNetworks_) {
+        LOG_DEBUG(TRACE, "%s - ready=%d (getCloudConnectionNetwork()=%s)", netifToName(i), network_ready(i, 0, nullptr), netifToName(getCloudConnectionNetwork()));
         if (network_ready(i, 0, nullptr)) {
             countReady++;
             if (i == getCloudConnectionNetwork()) {
                 matchesCurrent = true;
             }
+            best = i;
         }
     }
+    if (countReady == 0) {
+        return SYSTEM_ERROR_INVALID_STATE;
+    }
     // Simple case, just perform a cloud ping
-    if (countReady == 1 && matchesCurrent) {
+    if (matchesCurrent && (countReady == 1 || getCloudConnectionNetwork() == getPreferredNetwork())) {
         spark_protocol_command(system_cloud_protocol_instance(), ProtocolCommands::PING, 0, nullptr);
-        LOG_DEBUG(TRACE, "Still using the same network interface for the cloud connection - perform a cloud ping");
+        LOG_DEBUG(TRACE, "Still using the same network interface (%s) for the cloud connection - perform a cloud ping", netifToName(getCloudConnectionNetwork()));
         return 0;
     }
-    // Re-test connections
-    CHECK(testConnections(true /* cache */));
-    auto best = selectCloudConnectionNetwork();
-    // If matches current again just perform a ping
-    if (best == getCloudConnectionNetwork()) {
-        spark_protocol_command(system_cloud_protocol_instance(), ProtocolCommands::PING, 0, nullptr);
-        LOG_DEBUG(TRACE, "Best network interface candidate for the cloud connection is still the same - perform a cloud ping");
-        return 0;
+    if (countReady > 1) {
+        if (!finishedBackgroundTest) {
+            // Re-test connections
+            backgroundTestInProgress_ = false;
+            return testConnections(true /* background */);
+        } else {
+            best = selectCloudConnectionNetwork();
+            // If matches current again just perform a ping
+            if (best == getCloudConnectionNetwork()) {
+                spark_protocol_command(system_cloud_protocol_instance(), ProtocolCommands::PING, 0, nullptr);
+                LOG_DEBUG(TRACE, "Best network interface candidate for the cloud connection is still the same (%s) - perform a cloud ping", netifToName(best));
+                return 0;
+            }
+        }
     }
     // If best candidate doesn't match current network interface - reconnect
-    LOG_DEBUG(TRACE, "Best network interface for cloud connection changed - move the cloud session");
+    LOG_DEBUG(TRACE, "Best network interface for cloud connection changed (to %s) - move the cloud session", netifToName(best));
     auto options = CloudDisconnectOptions().reconnect(true);
     auto systemOptions = options.toSystemOptions();
     spark_cloud_disconnect(&systemOptions, nullptr);
@@ -243,7 +310,7 @@ ConnectionTester::~ConnectionTester() {
             free(i.rxBuffer);
         }
     }
-};
+}
 
 ConnectionMetrics* ConnectionTester::metricsFromSocketDescriptor(int socketDescriptor) {
     for (auto& i : metrics_) {
@@ -252,16 +319,16 @@ ConnectionMetrics* ConnectionTester::metricsFromSocketDescriptor(int socketDescr
         }
     }
     return nullptr;
-};
+}
 
 bool ConnectionTester::testPacketsOutstanding() {
     for (auto& i : metrics_) {
-        if (i.txPacketCount > i.rxPacketCount) {
+        if (i.txPacketCount != REACHABILITY_TEST_MAX_TX_PACKET_COUNT && i.txPacketCount != i.rxPacketCount) {
             return true;
         }
     }
     return false;
-};
+}
 
 int ConnectionTester::allocateTestPacketBuffers(ConnectionMetrics* metrics) {
     int maxMessageLength = REACHABILITY_MAX_PAYLOAD_SIZE + sizeof(DTLSPlaintext_t);
@@ -282,54 +349,92 @@ int ConnectionTester::allocateTestPacketBuffers(ConnectionMetrics* metrics) {
     metrics->txBuffer = txBuffer;
     metrics->rxBuffer = rxBuffer;
     return 0;
-};
+}
 
 int ConnectionTester::sendTestPacket(ConnectionMetrics* metrics) {
     int r = 0;
-    // Only send a new packet if we have received the previous one, or we timeout waiting for a response
-    if (metrics->txPacketCount == metrics->rxPacketCount || 
-        (millis() > metrics->txPacketStartMillis + REACHABILITY_TEST_PACKET_TIMEOUT_MS)) {
+    // Only send a new packet every REACHABILITY_TEST_PACKET_TX_TIMEOUT_MS milliseconds
+    if (HAL_Timer_Get_Milli_Seconds() >= (metrics->txPacketStartMillis + REACHABILITY_TEST_PACKET_TX_TIMEOUT_MS) && metrics->txPacketCount < REACHABILITY_TEST_MAX_TX_PACKET_COUNT) {
+        size_t testPacketSize = CHECK(generateTestPacket(metrics));
 
-        generateTestPacket(metrics);
-
-        int r = sock_send(metrics->socketDescriptor, metrics->txBuffer, metrics->testPacketSize, 0);
+        int r = sock_send(metrics->socketDescriptor, metrics->txBuffer, testPacketSize, 0);
+        // Take TX errors into account too
+        metrics->txPacketStartMillis = HAL_Timer_Get_Milli_Seconds();
+        metrics->txPacketCount++;
+        metrics->testPacketSequenceNumber++;
         if (r > 0) {
-            metrics->txPacketStartMillis = millis();
-            metrics->txPacketCount++;
-            metrics->testPacketSequenceNumber++;
-            metrics->txBytes += metrics->testPacketSize;
+            metrics->txBytes += testPacketSize;
         } else {
+            metrics->txPacketErrors++;
             LOG_DEBUG(WARN, "Test sock_send failed %d errno %d interface %d", r, errno, metrics->interface);
             return SYSTEM_ERROR_NETWORK;
         }
         
-        LOG_DEBUG(TRACE, "Sock %d packet # %d tx > %d", metrics->socketDescriptor, metrics->txPacketCount, r);
+        // LOG_DEBUG(TRACE, "Sock %d packet # %d tx > %d", metrics->socketDescriptor, metrics->txPacketCount, r);
     }
     return r;
-};
+}
 
 int ConnectionTester::receiveTestPacket(ConnectionMetrics* metrics) {
-    int r = sock_recv(metrics->socketDescriptor, metrics->rxBuffer, metrics->testPacketSize, MSG_DONTWAIT);
-    if (r > 0) {
-        metrics->totalPacketWaitMillis += (millis() - metrics->txPacketStartMillis);
-        metrics->rxPacketCount++;
-        metrics->rxBytes += metrics->testPacketSize;
+    msghdr msg = {};
+    iovec iov = {};
+    msg.msg_iov = &iov;
+    msg.msg_iovlen = 1;
+    iov.iov_base = metrics->rxBuffer;
+    iov.iov_len = REACHABILITY_MAX_PAYLOAD_SIZE + sizeof(DTLSPlaintext_t);
+    char controlBuf[CMSG_SPACE(sizeof(timespec))] = {};
+    msg.msg_control = controlBuf;
+    msg.msg_controllen = sizeof(controlBuf);
 
-        CHECK_TRUE((uint32_t)r == metrics->testPacketSize, SYSTEM_ERROR_BAD_DATA);
-
-        if (memcmp(metrics->rxBuffer, metrics->txBuffer, r)) {
-            LOG(WARN, "Socket %d Interface %d did not receive the same echo data: %d", metrics->socketDescriptor, metrics->interface, r);
-            return SYSTEM_ERROR_BAD_DATA;
+    int r = sock_recvmsg(metrics->socketDescriptor, &msg, MSG_DONTWAIT);
+    if (r >= (int)sizeof(DTLSPlaintext_t)) {
+        system_tick_t rxTimestamp = 0;
+        for (cmsghdr* cm = CMSG_FIRSTHDR(&msg); cm != nullptr; cm = CMSG_NXTHDR(&msg, cm)) {
+            if (cm->cmsg_level == SOL_SOCKET && cm->cmsg_type == SO_TIMESTAMPING) {
+                auto ts = (timespec*)CMSG_DATA(cm);
+                rxTimestamp = (ts->tv_sec * 1000 + ts->tv_nsec / 1000000);
+            }
         }
-
+        if (!rxTimestamp) {
+            // Just in case
+            LOG(WARN, "No RX timestamp from SO_TIMESTAMPING");
+            rxTimestamp = HAL_Timer_Get_Milli_Seconds();
+        }
+        // Parse packet
+        auto header = (DTLSPlaintext_t*)metrics->rxBuffer;
+        header->epoch = bigEndianToNative(header->epoch);
+        // LOG(TRACE, "epoch=%04x", header->epoch);
+        CHECK_TRUE(header->epoch >= EPOCH_BASE, SYSTEM_ERROR_BAD_DATA);
+        CHECK_TRUE((header->epoch & ~(EPOCH_BASE)) == metrics->interface, SYSTEM_ERROR_BAD_DATA);
+        header->length = bigEndianToNative(header->length);
+        // LOG(TRACE, "length=%u (r=%d)", header->length, r);
+        CHECK_TRUE(header->length == (r - sizeof(DTLSPlaintext_t)), SYSTEM_ERROR_BAD_DATA);
+        uint32_t sentTimestamp = 0;
+        uint16_t seqNum = 0;
+        memcpy(&sentTimestamp, header->sequence_number, sizeof(sentTimestamp));
+        memcpy(&seqNum, header->sequence_number + sizeof(uint32_t), sizeof(uint16_t));
+        seqNum = bigEndianToNative(seqNum);
+        sentTimestamp = bigEndianToNative(sentTimestamp);
+        // LOG(TRACE, "seqNum=%u testSeqNum=%u sentTimestamp=%u now=%u", seqNum, metrics->testPacketSequenceNumber, sentTimestamp, HAL_Timer_Get_Milli_Seconds());
+        CHECK_TRUE(seqNum <= metrics->testPacketSequenceNumber, SYSTEM_ERROR_BAD_DATA);
+        CHECK_TRUE(sentTimestamp < HAL_Timer_Get_Milli_Seconds(), SYSTEM_ERROR_BAD_DATA);
+        if (metrics->rxPacketMask & (1 << seqNum)) {
+            LOG(TRACE, "Duplicate packet seq=%u mask=%04x", seqNum, metrics->rxPacketMask);
+            // Already seen this seq num
+            return 0;
+        }
+        metrics->rxPacketMask |= (1 << seqNum);
+        metrics->totalPacketWaitMillis += (rxTimestamp - sentTimestamp);
+        metrics->rxPacketCount++;
+        metrics->rxBytes += header->length;
+        // LOG_DEBUG(TRACE, "Sock %d packet # %u rx < %d", metrics->socketDescriptor, seqNum, r);
     } else {
         LOG_DEBUG(WARN, "Test sock_recv failed %d errno %d interface %d", r, errno, metrics->interface);
         return SYSTEM_ERROR_NETWORK;
     }
     
-    LOG_DEBUG(TRACE, "Sock %d packet # %d rx < %d", metrics->socketDescriptor, metrics->rxPacketCount, r);
     return r;
-};
+}
 
 int ConnectionTester::generateTestPacket(ConnectionMetrics* metrics) {
     unsigned packetDataLength = random(1, REACHABILITY_MAX_PAYLOAD_SIZE);
@@ -337,7 +442,7 @@ int ConnectionTester::generateTestPacket(ConnectionMetrics* metrics) {
     DTLSPlaintext_t msg = {
         REACHABILITY_TEST_MSG, // DTLS Message Type
         {0xfe, 0xfd},          // DTLS type 1.2
-        0x8000,                // Differentiate interfaces by epoch field
+        EPOCH_BASE,            // Differentiate interfaces by epoch field
         {},                    // Sequence number
         0                      // Payload length
     };
@@ -347,21 +452,22 @@ int ConnectionTester::generateTestPacket(ConnectionMetrics* metrics) {
 
     msg.epoch |= metrics->interface;
     msg.length = packetDataLength;
-    uint32_t sequenceNumber = nativeToBigEndian(metrics->testPacketSequenceNumber);
+    uint16_t sequenceNumber = nativeToBigEndian((uint16_t)metrics->testPacketSequenceNumber);
 
     msg.epoch = nativeToBigEndian(msg.epoch);
     msg.length = nativeToBigEndian(msg.length);
-    memcpy(&msg.sequence_number, &sequenceNumber, sizeof(sequenceNumber));
+    uint32_t ts = nativeToBigEndian(HAL_Timer_Get_Milli_Seconds());
+    memcpy(msg.sequence_number, &ts, sizeof(ts));
+    memcpy(msg.sequence_number + sizeof(ts), &sequenceNumber, sizeof(sequenceNumber));
 
     Random rand;
     rand.gen((char*)metrics->txBuffer + sizeof(msg), packetDataLength);    
     memcpy(metrics->txBuffer, &msg, headerLength);
-    metrics->testPacketSize = totalMessageLength;
-    return 0;
-};
+    return totalMessageLength;
+}
 
 int ConnectionTester::pollSockets(struct pollfd* pfds, int socketCount) {
-    int pollCount = sock_poll(pfds, socketCount, 0);
+    int pollCount = sock_poll(pfds, socketCount, 1 /* ms */);
 
     if (pollCount < 0) {
         LOG(ERROR, "Connection test poll error %d", pollCount);
@@ -375,15 +481,18 @@ int ConnectionTester::pollSockets(struct pollfd* pfds, int socketCount) {
             return SYSTEM_ERROR_BAD_DATA;
         }
 
+        // Ignore errors
+        sendTestPacket(connection);
+
         if (pfds[i].revents & POLLIN) {
-            receiveTestPacket(connection);
-        }
-        if (pfds[i].revents & POLLOUT) {
-            CHECK(sendTestPacket(connection));
+            int r = receiveTestPacket(connection);
+            if (r == SYSTEM_ERROR_BAD_DATA) {
+                LOG(WARN, "Reachability packet failed validation");
+            }
         }
     }
     return 0;
-};
+}
 
 // GOAL: To maintain a list of which network interface is "best" at any given time
 // 1) Retrieve the server hostname and port. Resolve the hostname to an addrinfo list (ie IP addresses of server)
@@ -391,40 +500,26 @@ int ConnectionTester::pollSockets(struct pollfd* pfds, int socketCount) {
 // 3) Add these created+connected sockets to a pollfd structure. Allocate buffers for the reachability test messages.
 // 4) Poll all the sockets. Polling sends a reachability test message and waits for the response. The test continues for the test duration
 // 5) After polling completes, free the allocated buffers, reset diagnostics and calculate updated metrics. 
-int ConnectionTester::testConnections() {
-    // Step 1: resolve server hostname to IP address
+int ConnectionTester::prepare(bool fullTest) {
     struct addrinfo* info = nullptr;
-    struct addrinfo hints = {};
-    hints.ai_flags = AI_NUMERICSERV | AI_ADDRCONFIG;
-    hints.ai_protocol = IPPROTO_UDP;
-    hints.ai_socktype = SOCK_DGRAM;
+    CloudServerAddressType type = CLOUD_SERVER_ADDRESS_TYPE_NONE;
 
-    char tmphost[128] = {}; // TODO: better size ie sizeof(address->domain)
-    char tmpserv[8] = {};
-    uint16_t tmpport = 0;
-
-    int r = SYSTEM_ERROR_NETWORK;
-
-    getCloudHostnameAndPort(&tmpport, tmphost, sizeof(tmphost));
-    snprintf(tmpserv, sizeof(tmpserv), "%u", tmpport);
-    LOG(TRACE, "Resolving %s#%s", tmphost, tmpserv);
-    // FIXME: get addrinfo/server IP from DNS lookup using the specific interfaces DNS server 
-    r = netdb_getaddrinfo(tmphost, tmpserv, &hints, &info); 
-    if (r) {
-        LOG(ERROR, "No addrinfo for %s#%s", tmphost, tmpserv);
-        return SYSTEM_ERROR_NETWORK;
-    }
+    // Step 1: Retrieve the server hostname and port. Resolve the hostname to an addrinfo list (ie IP addresses of server)
+    CHECK(getCloudHostnameAndPort(&info, &type, !fullTest));
 
     SCOPE_GUARD({
         netdb_freeaddrinfo(info);
     });
 
     int socketCount = 0;
-    auto pfds = std::make_unique<pollfd[]>(metrics_.size());;
+    auto pfds = std::make_unique<pollfd[]>(metrics_.size());
     CHECK_TRUE(pfds, SYSTEM_ERROR_NO_MEMORY);
+
+    int r = SYSTEM_ERROR_NETWORK;
     
     // Step 2: Create, bind, and connect sockets for each network interface to test
     for (struct addrinfo* a = info; a != nullptr; a = a->ai_next) {
+        bool ok = true;
         // For each network interface to test, create + open a socket with the retrieved server address
         // If any of the sockets fail to be created + opened with this server address, return an error
         for (auto& connectionMetrics: metrics_) {
@@ -436,6 +531,7 @@ int ConnectionTester::testConnections() {
             int s = sock_socket(a->ai_family, a->ai_socktype, a->ai_protocol);
             NAMED_SCOPE_GUARD(guard, {
                 sock_close(s);
+                ok = false;
             });
 
             if (s < 0) {
@@ -467,6 +563,14 @@ int ConnectionTester::testConnections() {
                 return SYSTEM_ERROR_NETWORK;
             }
 
+            // Enable timestamps on recvd packets
+            int dummy = 1;
+            r = sock_setsockopt(s, SOL_SOCKET, SO_TIMESTAMPING, &dummy, sizeof(dummy));
+            if (r) {
+                LOG(WARN, "test socket=%d, failed to enable timestamping");
+                // Not a critical error
+            }
+
             connectionMetrics.socketConnAttempts++;
             r = sock_connect(s, a->ai_addr, a->ai_addrlen);
             if (r) {
@@ -479,53 +583,87 @@ int ConnectionTester::testConnections() {
             // Step 3: Use the socket descriptor for the polling structure, allocate our test buffers
             connectionMetrics.socketDescriptor = s;
             pfds[socketCount].fd = connectionMetrics.socketDescriptor;
-            pfds[socketCount].events = (POLLIN | POLLOUT);
+            pfds[socketCount].events = (POLLIN);
             socketCount++;
 
             guard.dismiss();
             CHECK(allocateTestPacketBuffers(&connectionMetrics));
         }
-    }
-    
-    // Step 4: Send/Receive data on the sockets for the duration of the test time
-    auto endTime = HAL_Timer_Get_Milli_Seconds() + REACHABILITY_TEST_DURATION_MS;
-    while (HAL_Timer_Get_Milli_Seconds() < endTime) {
-        CHECK(pollSockets(pfds.get(), socketCount));
-        SystemISRTaskQueue.process();
-    }
-
-    // Only read from sockets to receive any final outstanding packets
-    for (int i = 0; i < socketCount; i++) {
-        pfds[i].events = (POLLIN);
-    }
-
-    endTime = HAL_Timer_Get_Milli_Seconds() + REACHABILITY_TEST_DURATION_MS;
-    while(testPacketsOutstanding() && HAL_Timer_Get_Milli_Seconds() < endTime) {
-        pollSockets(pfds.get(), socketCount);
-        SystemISRTaskQueue.process();
-    }
-
-    // Step 5: calculate updated metrics
-    for (auto& i: metrics_) {
-        if (i.rxPacketCount > 0) {
-            i.avgPacketRoundTripTime = (i.totalPacketWaitMillis / i.rxPacketCount);
-
-            LOG(INFO,"%s: %d/%d packets %d/%d bytes received, avg rtt: %d", 
-                netifToName(i.interface), 
-                i.rxPacketCount,
-                i.txPacketCount, 
-                i.rxBytes,
-                i.txBytes,
-                i.avgPacketRoundTripTime);
+        if (ok) {
+            r = SYSTEM_ERROR_NONE;
+            break;
         }
     }
 
-    // Sort list by packet latency in ascending order, ie fastest to slowest
-    std::sort(metrics_.begin(), metrics_.end(), [](const ConnectionMetrics& dg1, const ConnectionMetrics& dg2) {
-        return (dg1.avgPacketRoundTripTime < dg2.avgPacketRoundTripTime); 
-    });
+    if (!r) {
+        socketCount_ = socketCount;
+        pfds_ = std::move(pfds);
+    }
 
-    return 0;
+    endTime_ = HAL_Timer_Get_Milli_Seconds() + REACHABILITY_TEST_DURATION_MS;
+
+    return r;
+}
+
+int ConnectionTester::runTest(system_tick_t maxBlockTime) {
+    if (finished_) {
+        return 0;
+    }
+
+    auto start = HAL_Timer_Get_Milli_Seconds();
+
+    // Step 4: Send/Receive data on the sockets for the duration of the test time
+    while(testPacketsOutstanding() || HAL_Timer_Get_Milli_Seconds() < endTime_) {
+        pollSockets(pfds_.get(), socketCount_);
+        SystemISRTaskQueue.process();
+        if (HAL_Timer_Get_Milli_Seconds() - start >= maxBlockTime) {
+            break;
+        }
+    }
+
+    finished_ = !testPacketsOutstanding() || HAL_Timer_Get_Milli_Seconds() >= endTime_;
+    if (finished_) {
+        // Step 5: calculate updated metrics
+        for (auto& i: metrics_) {
+            if (i.rxPacketCount > 0) {
+                i.avgPacketRoundTripTime = (i.totalPacketWaitMillis / i.rxPacketCount);
+                i.resultingScore = i.totalPacketWaitMillis;
+                unsigned penalty = 0;
+                unsigned consecutive = 0;
+                for (unsigned j = 0; j < i.txPacketCount; j++) {
+                    if (i.rxPacketMask & (1 << j)) {
+                        // Received
+                        penalty = 0;
+                        consecutive = 0;
+                    } else {
+                        penalty = i.avgPacketRoundTripTime * (2 << consecutive++) /* 2^(conscutive++) */;
+                        LOG(TRACE, "%d: total=%u consecutive=%u penalty=%u resultingScore=%u new=%u", i.interface, i.totalPacketWaitMillis, consecutive, penalty, i.resultingScore, i.resultingScore + penalty);
+                        i.resultingScore += penalty;
+                    }
+                }
+                i.resultingScore /= i.rxPacketCount;
+            } else {
+                i.avgPacketRoundTripTime = 0;
+                i.resultingScore = std::numeric_limits<decltype(i.resultingScore)>::max();
+            }
+            LOG(INFO,"%s: %lu/%lu packets (%lu tx errors) %lu/%lu bytes received, avg rtt: %lu, mask=%04x, score=%lu",
+                    netifToName(i.interface), 
+                    i.rxPacketCount,
+                    i.txPacketCount, 
+                    i.txPacketErrors,
+                    i.rxBytes,
+                    i.txBytes,
+                    i.avgPacketRoundTripTime,
+                    i.rxPacketMask,
+                    i.resultingScore);
+        }
+        // Sort list by packet latency in ascending order, ie fastest to slowest
+        std::sort(metrics_.begin(), metrics_.end(), [](const ConnectionMetrics& dg1, const ConnectionMetrics& dg2) {
+            return (dg1.resultingScore < dg2.resultingScore); 
+        });
+        return 0;
+    }
+    return SYSTEM_ERROR_BUSY;
 }
 
 const Vector<ConnectionMetrics> ConnectionTester::getConnectionMetrics(){

--- a/system/src/system_connection_manager.cpp
+++ b/system/src/system_connection_manager.cpp
@@ -358,8 +358,12 @@ ConnectionMetrics* ConnectionTester::metricsFromSocketDescriptor(int socketDescr
 
 bool ConnectionTester::testPacketsOutstanding() {
     for (auto& i : metrics_) {
-        if (i.txPacketCount != REACHABILITY_TEST_MAX_TX_PACKET_COUNT && i.txPacketCount != i.rxPacketCount) {
+        if (i.txPacketCount != REACHABILITY_TEST_MAX_TX_PACKET_COUNT) {
             return true;
+        } else {
+            if (i.txPacketCount != i.rxPacketCount) {
+                return true;
+            }
         }
     }
     return false;
@@ -648,7 +652,7 @@ int ConnectionTester::runTest(system_tick_t maxBlockTime) {
     auto start = HAL_Timer_Get_Milli_Seconds();
 
     // Step 4: Send/Receive data on the sockets for the duration of the test time
-    while(testPacketsOutstanding() || HAL_Timer_Get_Milli_Seconds() < endTime_) {
+    while(testPacketsOutstanding() && HAL_Timer_Get_Milli_Seconds() < endTime_) {
         pollSockets(pfds_.get(), socketCount_);
         SystemISRTaskQueue.process();
         if (HAL_Timer_Get_Milli_Seconds() - start >= maxBlockTime) {

--- a/system/src/system_connection_manager.cpp
+++ b/system/src/system_connection_manager.cpp
@@ -149,6 +149,7 @@ network_handle_t ConnectionManager::selectCloudConnectionNetwork() {
     if (!canUsePreferred) {
         if (preferredNetwork_ != NETWORK_INTERFACE_ALL && network_ready(preferredNetwork_, 0, nullptr)) {
             nextPeriodicCheck_ = HAL_Timer_Get_Milli_Seconds() + PERIODIC_CHECK_PERIOD_MS;
+            LOG(TRACE, "Scheduled a periodic check @ %lu ms", nextPeriodicCheck_);
         }
         LOG_DEBUG(TRACE, "Using best network: %s", netifToName(bestNetwork));
         return bestNetwork;
@@ -229,11 +230,14 @@ int ConnectionManager::scheduleCloudConnectionNetworkCheck() {
 void ConnectionManager::handlePeriodicCheck() {
     if (nextPeriodicCheck_ != 0 && HAL_Timer_Get_Milli_Seconds() >= nextPeriodicCheck_) {
         if (!testIsAllowed()) {
+            LOG(ERROR, "Periodic check not allowed");
             return;
         }
         if (preferredNetwork_ != NETWORK_INTERFACE_ALL && getCloudConnectionNetwork() != preferredNetwork_) {
             LOG(TRACE, "Periodic check because preferred interface was not picked during last run");
             scheduleCloudConnectionNetworkCheck();
+        } else {
+            LOG(INFO, "Periodic check not run preferred=%d cloud=%d", preferredNetwork_, getCloudConnectionNetwork());
         }
         nextPeriodicCheck_ = 0;
     }

--- a/system/src/system_connection_manager.h
+++ b/system/src/system_connection_manager.h
@@ -24,6 +24,7 @@
 
 #include "system_network.h"
 #include "spark_wiring_vector.h"
+#include <memory>
 
 namespace particle { namespace system {
 
@@ -32,11 +33,11 @@ struct ConnectionMetrics {
     int socketDescriptor;
     uint8_t *txBuffer;
     uint8_t *rxBuffer;
-    uint32_t testPacketSize;
     uint32_t testPacketSequenceNumber;
-    uint32_t testPacketTxMillis;
     uint32_t txPacketCount;
+    uint32_t txPacketErrors;
     uint32_t rxPacketCount;
+    uint32_t rxPacketMask;
     uint32_t txPacketStartMillis;
     uint32_t totalPacketWaitMillis;
 
@@ -47,7 +48,10 @@ struct ConnectionMetrics {
     uint32_t txBytes;
     uint32_t rxBytes;
     uint32_t avgPacketRoundTripTime;
+    uint32_t resultingScore;
 };
+
+class ConnectionTester;
 
 class ConnectionManager {
 public:
@@ -61,7 +65,7 @@ public:
     network_handle_t getCloudConnectionNetwork();
     network_handle_t selectCloudConnectionNetwork();
 
-    int testConnections(bool cache = false);
+    int testConnections(bool background = false);
     int scheduleCloudConnectionNetworkCheck();
     int checkCloudConnectionNetwork();
 
@@ -69,6 +73,9 @@ private:
     network_handle_t preferredNetwork_;
     Vector<network_handle_t> bestNetworks_;
     volatile bool testResultsActual_ = false;
+    volatile bool checkScheduled_ = false;
+    bool backgroundTestInProgress_ = false;
+    std::unique_ptr<ConnectionTester> backgroundTester_;
 };
 
 class ConnectionTester {
@@ -76,7 +83,8 @@ public:
     ConnectionTester();
     ~ConnectionTester();
 
-    int testConnections();
+    int prepare(bool fullTest = true);
+    int runTest(system_tick_t maxBlockTime = 0xffffffff);
 
     const Vector<ConnectionMetrics> getConnectionMetrics();
     static const Vector<network_interface_t> getSupportedInterfaces();
@@ -91,11 +99,16 @@ private:
     bool testPacketsOutstanding();
 
     const uint8_t REACHABILITY_TEST_MSG = 252;
-    const unsigned REACHABILITY_MAX_PAYLOAD_SIZE = 256;
-    const unsigned REACHABILITY_TEST_DURATION_MS = 2500;
-    const unsigned REACHABILITY_TEST_PACKET_TIMEOUT_MS = 500;
+    const system_tick_t REACHABILITY_MAX_PAYLOAD_SIZE = 512; // FIXME: get some constant from cloud layer
+    const system_tick_t REACHABILITY_TEST_DURATION_MS = 5000;
+    const system_tick_t REACHABILITY_TEST_PACKET_TX_TIMEOUT_MS = 250;
+    const unsigned REACHABILITY_TEST_MAX_TX_PACKET_COUNT = 10;
 
     Vector<ConnectionMetrics> metrics_;
+    std::unique_ptr<pollfd[]> pfds_;
+    system_tick_t endTime_ = 0;
+    bool finished_ = false;
+    size_t socketCount_ = 0;
 };
 
 } } /* particle::system */

--- a/system/src/system_connection_manager.h
+++ b/system/src/system_connection_manager.h
@@ -70,12 +70,18 @@ public:
     int checkCloudConnectionNetwork();
 
 private:
+    void handlePeriodicCheck();
+    bool testIsAllowed() const;
+
+private:
     network_handle_t preferredNetwork_;
     Vector<network_handle_t> bestNetworks_;
     volatile bool testResultsActual_ = false;
     volatile bool checkScheduled_ = false;
     bool backgroundTestInProgress_ = false;
     std::unique_ptr<ConnectionTester> backgroundTester_;
+    static constexpr system_tick_t PERIODIC_CHECK_PERIOD_MS = 5 * 60 * 100;
+    system_tick_t nextPeriodicCheck_ = 0;
 };
 
 class ConnectionTester {

--- a/system/src/system_connection_manager.h
+++ b/system/src/system_connection_manager.h
@@ -61,11 +61,14 @@ public:
     network_handle_t getCloudConnectionNetwork();
     network_handle_t selectCloudConnectionNetwork();
 
-    int testConnections();
+    int testConnections(bool cache = false);
+    int scheduleCloudConnectionNetworkCheck();
+    int checkCloudConnectionNetwork();
 
 private:
     network_handle_t preferredNetwork_;
     Vector<network_handle_t> bestNetworks_;
+    volatile bool testResultsActual_ = false;
 };
 
 class ConnectionTester {

--- a/system/src/system_connection_manager.h
+++ b/system/src/system_connection_manager.h
@@ -75,12 +75,12 @@ private:
 
 private:
     network_handle_t preferredNetwork_;
-    Vector<network_handle_t> bestNetworks_;
+    Vector<std::pair<network_handle_t, uint32_t>> bestNetworks_;
     volatile bool testResultsActual_ = false;
     volatile bool checkScheduled_ = false;
     bool backgroundTestInProgress_ = false;
     std::unique_ptr<ConnectionTester> backgroundTester_;
-    static constexpr system_tick_t PERIODIC_CHECK_PERIOD_MS = 5 * 60 * 100;
+    static constexpr system_tick_t PERIODIC_CHECK_PERIOD_MS = 5 * 60 * 1000;
     system_tick_t nextPeriodicCheck_ = 0;
 };
 
@@ -93,7 +93,7 @@ public:
     int runTest(system_tick_t maxBlockTime = 0xffffffff);
 
     const Vector<ConnectionMetrics> getConnectionMetrics();
-    static const Vector<network_interface_t> getSupportedInterfaces();
+    static const Vector<std::pair<network_interface_t, uint32_t>> getSupportedInterfaces();
 
 private:
     int allocateTestPacketBuffers(ConnectionMetrics* metrics);

--- a/system/src/system_network_manager.cpp
+++ b/system/src/system_network_manager.cpp
@@ -96,18 +96,8 @@ int for_each_iface(F&& f) {
     return 0;
 }
 
-void forceCloudPingIfConnected() {
-    const auto task = new(std::nothrow) ISRTaskQueue::Task();
-    if (!task) {
-        return;
-    }
-    task->func = [](ISRTaskQueue::Task* task) {
-        delete task;
-        if (spark_cloud_flag_connected()) {
-            spark_protocol_command(system_cloud_protocol_instance(), ProtocolCommands::PING, 0, nullptr);
-        }
-    };
-    SystemISRTaskQueue.enqueue(task);
+void forceCloudPingOrTest() {
+    ConnectionManager::instance()->scheduleCloudConnectionNetworkCheck();
 }
 
 const char NETWORK_CONFIG_FILE[] = "/sys/network.dat";
@@ -538,11 +528,6 @@ void NetworkManager::handleIfState(if_t iface, const struct if_event* ev) {
 }
 
 void NetworkManager::handleIfLink(if_t iface, const struct if_event* ev) {
-    uint8_t netIfIndex = 0;
-    if_get_index(iface, &netIfIndex);
-    bool disconnectCloud = false;
-    auto options = CloudDisconnectOptions().reconnect(true);
-
     if (ev->ev_if_link->state) {
         /* Interface link state changed to UP */
         NetworkInterfaceConfig conf;
@@ -616,14 +601,6 @@ void NetworkManager::handleIfLink(if_t iface, const struct if_event* ev) {
         } else if (state_ == State::IP_CONFIGURED || state_ == State::IFACE_LINK_UP) {
             refreshIpState();
         }
-
-        // If the cloud is connected, and the preferred network becomes available, move to that network
-        if (spark_cloud_flag_connected() && ConnectionManager::instance()->getPreferredNetwork() == netIfIndex && !SPARK_FLASH_UPDATE) {
-            LOG(INFO, "Preferred network %u available, moving cloud connection", netIfIndex);
-            options.graceful(true);
-            disconnectCloud = true;
-        }
-
     } else {
         // Disable by default
         if_clear_xflags(iface, IFXF_DHCP);
@@ -638,20 +615,9 @@ void NetworkManager::handleIfLink(if_t iface, const struct if_event* ev) {
                 refreshIpState();
             }
         }
-        
-        // If the current cloud connection network interfaces goes down, and there are other configured interfaces, close the cloud and connect to them
-        if (ConnectionManager::instance()->getCloudConnectionNetwork() == netIfIndex && state_ == State::IP_CONFIGURED) {
-            LOG(WARN, "Cloud connection interface %d link state down, switching interfaces", netIfIndex);
-            disconnectCloud = true;
-        }
     }
 
-    if (spark_cloud_flag_connected() && disconnectCloud) {
-        auto systemOptions = options.toSystemOptions();
-        spark_cloud_disconnect(&systemOptions, nullptr);
-    }
-
-    forceCloudPingIfConnected();
+    forceCloudPingOrTest();
 }
 
 void NetworkManager::clearDnsConfiguration(if_t iface) {
@@ -664,7 +630,7 @@ void NetworkManager::handleIfAddr(if_t iface, const struct if_event* ev) {
     if (state_ == State::IP_CONFIGURED || state_ == State::IFACE_LINK_UP) {
         refreshIpState();
     }
-    forceCloudPingIfConnected();
+    forceCloudPingOrTest();
 }
 
 void NetworkManager::handleIfLinkLayerAddr(if_t iface, const struct if_event* ev) {
@@ -868,7 +834,7 @@ void NetworkManager::resolvEventHandler(const void* data) {
     refreshIpState();
     // NOTE: we could potentially force a cloud ping on DNS change, but
     // this seems excessive, and it's better to rely on IP state only instead
-    // forceCloudPingIfConnected();
+    // forceCloudPingOrTest();
 }
 
 const char* NetworkManager::stateToName(State state) const {

--- a/system/src/system_network_manager.cpp
+++ b/system/src/system_network_manager.cpp
@@ -616,7 +616,7 @@ void NetworkManager::handleIfLink(if_t iface, const struct if_event* ev) {
             }
         }
     }
-
+    LOG(INFO, "handleIfLink system.cm");
     forceCloudPingOrTest();
 }
 
@@ -630,6 +630,7 @@ void NetworkManager::handleIfAddr(if_t iface, const struct if_event* ev) {
     if (state_ == State::IP_CONFIGURED || state_ == State::IFACE_LINK_UP) {
         refreshIpState();
     }
+    LOG(INFO, "handleIfAddr system.cm");
     forceCloudPingOrTest();
 }
 

--- a/system/src/system_network_manager.cpp
+++ b/system/src/system_network_manager.cpp
@@ -601,7 +601,12 @@ void NetworkManager::handleIfLink(if_t iface, const struct if_event* ev) {
         } else if (state_ == State::IP_CONFIGURED || state_ == State::IFACE_LINK_UP) {
             refreshIpState();
         }
+
+        if (getInterfaceIp4State(iface) == ProtocolState::CONFIGURED || getInterfaceIp6State(iface) == ProtocolState::CONFIGURED) {
+            forceCloudPingOrTest();
+        }
     } else {
+        auto state = getInterfaceRuntimeState(iface);
         // Disable by default
         if_clear_xflags(iface, IFXF_DHCP);
         resetInterfaceProtocolState(iface);
@@ -615,8 +620,11 @@ void NetworkManager::handleIfLink(if_t iface, const struct if_event* ev) {
                 refreshIpState();
             }
         }
+
+        if (state && (state->ip4State == ProtocolState::CONFIGURED || state->ip6State == ProtocolState::CONFIGURED)) {
+            forceCloudPingOrTest();
+        }
     }
-    forceCloudPingOrTest();
 }
 
 void NetworkManager::clearDnsConfiguration(if_t iface) {

--- a/system/src/system_network_manager.cpp
+++ b/system/src/system_network_manager.cpp
@@ -616,7 +616,6 @@ void NetworkManager::handleIfLink(if_t iface, const struct if_event* ev) {
             }
         }
     }
-    LOG(INFO, "handleIfLink system.cm");
     forceCloudPingOrTest();
 }
 
@@ -630,7 +629,6 @@ void NetworkManager::handleIfAddr(if_t iface, const struct if_event* ev) {
     if (state_ == State::IP_CONFIGURED || state_ == State::IFACE_LINK_UP) {
         refreshIpState();
     }
-    LOG(INFO, "handleIfAddr system.cm");
     forceCloudPingOrTest();
 }
 

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -428,7 +428,7 @@ void handle_cloud_connection(bool force_events)
                 }
                 const auto diag = CloudDiagnostics::instance();
                 diag->lastError(err);
-                cloud_disconnect();
+                cloud_disconnect(HAL_PLATFORM_MAY_LEAK_SOCKETS ? CLOUD_DISCONNECT_DONT_CLOSE : 0, CLOUD_DISCONNECT_REASON_ERROR);
             } else {
                 cfod_count = 0;
             }

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -57,6 +57,7 @@
 #include "spark_wiring_led.h"
 #if HAL_PLATFORM_IFAPI
 #include "system_listening_mode.h"
+#include "system_connection_manager.h"
 #endif
 
 #if HAL_PLATFORM_BLE_SETUP
@@ -447,6 +448,10 @@ void manage_cloud_connection(bool force_events)
     }
     else // cloud connection is wanted
     {
+#if HAL_PLATFORM_IFAPI
+        ConnectionManager::instance()->checkCloudConnectionNetwork();
+#endif // HAL_PLATFORM_IFAPI
+
         establish_cloud_connection();
 
         handle_cloud_connection(force_events);


### PR DESCRIPTION
### Description

1. On network state changes re-evaluation is performed once the cloud connection is fully established (i.e. postponed during handshake). Also postponed during OTA and pending reset post-OTA. Happens now outside of network manager and solely in connection manager
2. Re-evalution happens in the background now without blocking the system (normal internet test is performed in a blocking fashion)
3. I've refactored/fixed rtt and (added) score calculations taking into account packet losses/reordering/duplicates
4. Final score is penalized on losses and exponentially on sequential losses (this is not ideal yet, but should be good enough for now; a better approach would be to do something similar to TCP with congestion window, bursting, miss indication blah blah, but again this is a dumber variant of that to some extent)
5. Changed some timings/constants (5s total test, fixed 250ms gap between tx packets, 10 tx packets)
6. DNS resolutions are not performed during background check if possible, instead using previously resolved cloud IP (again, if available) -> DNS resolutions are blocking and take a while sometimes (TODO to fix DNS stuff later)
7. ACM calls into system_cloud layer to get cloud address for the most part (just removed a bunch of similar code for flash space savings purposes)
8. Outgoing DNS packets go through the network interface DNS servers have been provisioned for (e.g. ones from DHCP on WiFi will use WiFi as outgoing interface, cellular ones provisioned through PPP will use cellular etc)
9. Periodic preferred network check is scheduled every 5 minutes if last ACM evaluation did not choose it for some reason (e.g. cloud is not reachable due to no internet connectivity)
10. Fixed a bug with session resumption not triggering reachability (internet) test
11. Preferred network is not chosen if it fails reachability test
12. `X.prefer()` API will not trigger immediate cloud connection migration, instead a check will be performed and if cloud is reachable through X - migration will happen

### Dependencies

Depends on https://github.com/particle-iot/lwip/pull/16

### Minimal test app

```c++
#include "application.h"

SerialLogHandler dbg(LOG_LEVEL_ALL);
SYSTEM_THREAD(ENABLED);
SYSTEM_MODE(SEMI_AUTOMATIC);

/* executes once at startup */
void setup() {
    //WiFi.prefer();
    //Cellular.prefer();
    waitUntil(Serial.isConnected);
    Particle.connect();
}

/* executes continuously after setup() runs */
void loop() {
    if (Serial.available() > 0) {
        char c = Serial.read();
        switch (c) {
            case 'w': {
                WiFi.disconnect();
                delay(1);
                WiFi.connect();
                break;
            }
            case 'c': {
                Cellular.disconnect();
                delay(1);
                Cellular.connect();
                break;
            }
            case 'W': {
                WiFi.prefer();
                break;
            }
            case 'C': {
                Cellular.prefer();
                break;
            }
            case 'N': {
                Network.prefer();
                break;
            }
        }
    }
}
```

### Poor connectivity results (see score)
```
0000024174 [system.cm] TRACE: 5: total=2884 consecutive=1 penalty=2884 resultingScore=2884 new=5768
0000024220 [system.cm] TRACE: 5: total=2884 consecutive=2 penalty=5768 resultingScore=5768 new=11536
0000024268 [system.cm] TRACE: 5: total=2884 consecutive=3 penalty=11536 resultingScore=11536 new=23072
0000024322 [system.cm] TRACE: 5: total=2884 consecutive=4 penalty=23072 resultingScore=23072 new=46144
0000024378 [system.cm] TRACE: 5: total=2884 consecutive=5 penalty=46144 resultingScore=46144 new=92288
0000024429 [system.cm] TRACE: 5: total=2884 consecutive=6 penalty=92288 resultingScore=92288 new=184576
0000024481 [system.cm] TRACE: 5: total=2884 consecutive=7 penalty=184576 resultingScore=184576 new=369152
0000024537 [system.cm] TRACE: 5: total=2884 consecutive=8 penalty=369152 resultingScore=369152 new=738304
0000024598 [system.cm] INFO: WiFi: 2/10 packets (0 tx errors) 385/1847 bytes received, avg rtt: 1442, mask=0003, score=369152
0000024661 [system.cm] TRACE: 4: total=2809 consecutive=1 penalty=624 resultingScore=2809 new=3433
0000024710 [system.cm] INFO: Cellular: 9/10 packets (0 tx errors) 2301/2590 bytes received, avg rtt: 312, mask=01ff, score=381
```