### PR TITLE
Fix delay() introducing an unwanted delay when processing app events

### DIFF
--- a/system/inc/active_object.h
+++ b/system/inc/active_object.h
@@ -301,7 +301,7 @@ public:
             started(false) {
     }
 
-    bool process();
+    bool process(int timeout = -1);
 
     bool isCurrentThread() {
         return os_thread_is_current(_thread);
@@ -394,11 +394,6 @@ public:
         createQueue();
         setCurrentThread();
         run();
-    }
-
-    bool process()
-    {
-        return ActiveObjectQueue::process();
     }
 };
 

--- a/system/inc/active_object.h
+++ b/system/inc/active_object.h
@@ -53,10 +53,10 @@ struct ActiveObjectConfiguration
     size_t stack_size;
 
     /**
-     * Time to wait for a message in the queue. This governs how often the
+     * Default Time to wait for a message in the queue. This governs how often the
      * background task is executed.
      */
-    unsigned take_wait;
+    unsigned default_take_wait;
 
     /**
      * How long to wait to put items in the queue before giving up.
@@ -80,12 +80,12 @@ struct ActiveObjectConfiguration
     static constexpr const char DEFAULT_TASK_NAME[] = "active_object";
 
 public:
-    ActiveObjectConfiguration(background_task_t task, unsigned take_wait_, unsigned put_wait_, uint16_t queue_size_,
+    ActiveObjectConfiguration(background_task_t task, unsigned default_take_wait, unsigned put_wait_, uint16_t queue_size_,
             size_t stack_size_ = OS_THREAD_STACK_SIZE_DEFAULT, os_thread_prio_t priority = OS_THREAD_PRIORITY_DEFAULT,
             const char* name = nullptr) :
             background_task(task),
             stack_size(stack_size_),
-            take_wait(take_wait_),
+            default_take_wait(default_take_wait),
             put_wait(put_wait_),
             queue_size(queue_size_),
             priority(priority) {
@@ -282,8 +282,8 @@ protected:
 
 
     // todo - concurrent queue should be a strategy so it's pluggable without requiring inheritance
-    virtual bool take(Item& item)=0;
-    virtual bool put(Item& item, bool dontBlock = false)=0;
+    virtual bool take(Item& item, int timeout = -1) = 0;
+    virtual bool put(Item& item, bool dontBlock = false) = 0;
 
     /**
      * Static thread entrypoint to run this active object loop.
@@ -352,12 +352,12 @@ protected:
 
     os_queue_t  queue;
 
-    virtual bool take(Item& result)
+    bool take(Item& result, int timeout) override
     {
-        return !os_queue_take(queue, &result, configuration.take_wait, nullptr);
+        return !os_queue_take(queue, &result, (timeout < 0) ? configuration.default_take_wait : (unsigned)timeout, nullptr);
     }
 
-    virtual bool put(Item& item, bool dontBlock)
+    bool put(Item& item, bool dontBlock) override
     {
         return !os_queue_put(queue, &item, dontBlock ? 0 : configuration.put_wait, nullptr);
     }
@@ -416,9 +416,9 @@ public:
 
 // FIXME: some other feature flag?
 #if HAL_PLATFORM_SOCKET_IOCTL_NOTIFY
-    virtual bool take(Item& result) override
+    virtual bool take(Item& result, int timeout) override
     {
-        auto r = os_thread_wait(configuration.take_wait, nullptr);
+        auto r = os_thread_wait((timeout < 0) ? configuration.default_take_wait : (unsigned)timeout, nullptr);
         if (!os_queue_take(queue, &result, 0, nullptr)) {
             return true;
         }

--- a/system/src/active_object.cpp
+++ b/system/src/active_object.cpp
@@ -75,11 +75,11 @@ void ActiveObjectBase::run()
 #endif // !HAL_PLATFORM_SOCKET_IOCTL_NOTIFY
 }
 
-bool ActiveObjectBase::process()
+bool ActiveObjectBase::process(int timeout)
 {
     bool result = false;
     Item item = nullptr;
-    if (take(item) && item)
+    if (take(item, timeout) && item)
     {
         Message& msg = *item;
         msg();

--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -537,7 +537,7 @@ namespace particle {
 // timeout after attempting to put calls into the application queue, so the system thread does not deadlock  (since the application may also
 // be trying to put events in the system queue.)
 ActiveObjectCurrentThreadQueue ApplicationThread(ActiveObjectConfiguration(app_thread_idle,
-		0, /* take time */
+		0, /* default take time */
 		5000, /* put time */
 		20 /* queue size */));
 

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -648,16 +648,12 @@ void system_delay_pump(unsigned long ms, bool force_no_background_loop)
         return;
     }
 
-    system_tick_t endMillis = startMillis + ms;
-
-    for (;;) {
-        system_tick_t d = endMillis - HAL_Timer_Get_Milli_Seconds();
-        static_assert(std::is_unsigned_v<system_tick_t>);
-        if (d == 0 || d > std::numeric_limits<system_tick_t>::max() / 2) {
-            break;
-        }
-        ApplicationThread.process(d);
-    }
+    system_tick_t timeout;
+    do {
+        system_tick_t elapsed = HAL_Timer_Get_Milli_Seconds() - startMillis;
+        timeout = (ms > elapsed) ? (ms - elapsed) : 0;
+        ApplicationThread.process(timeout);
+    } while (timeout > 0);
 #endif // PLATFORM_THREADING
 }
 

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -557,7 +557,7 @@ void Spark_Idle_Events(bool force_events/*=false*/)
 
 namespace {
 
-// Old implementation for non-threaded applications
+// Old implementation for a non-threaded system configuration
 void system_delay_pump_no_threading_impl(unsigned long ms, system_tick_t start_millis, bool force_no_background_loop = false)
 {
     if (ms==0) return;

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -637,11 +637,12 @@ void system_delay_pump(unsigned long ms, bool force_no_background_loop)
 {
     system_tick_t startMillis = HAL_Timer_Get_Milli_Seconds();
 
-    if (!system_thread_get_state(nullptr) || !APPLICATION_THREAD_CURRENT()) {
+    if (!PLATFORM_THREADING || !system_thread_get_state(nullptr) || !APPLICATION_THREAD_CURRENT()) {
         system_delay_pump_no_threading_impl(ms, startMillis, force_no_background_loop);
         return;
     }
 
+#if PLATFORM_THREADING
     if (!ms || force_no_background_loop) {
         HAL_Delay_Milliseconds(ms);
         return;
@@ -657,6 +658,7 @@ void system_delay_pump(unsigned long ms, bool force_no_background_loop)
         }
         ApplicationThread.process(d);
     }
+#endif // PLATFORM_THREADING
 }
 
 /**

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -555,17 +555,16 @@ void Spark_Idle_Events(bool force_events/*=false*/)
     system_shutdown_if_needed();
 }
 
-/*
- * @brief This should block for a certain number of milliseconds and also execute spark_wlan_loop
- */
-void system_delay_pump(unsigned long ms, bool force_no_background_loop=false)
+namespace {
+
+// Old implementation for non-threaded applications
+void system_delay_pump_no_threading_impl(unsigned long ms, system_tick_t start_millis, bool force_no_background_loop = false)
 {
     if (ms==0) return;
 
     system_tick_t spark_loop_elapsed_millis = SPARK_LOOP_DELAY_MILLIS;
     spark_loop_total_millis += ms;
 
-    system_tick_t start_millis = HAL_Timer_Get_Milli_Seconds();
     system_tick_t end_micros = HAL_Timer_Get_Micro_Seconds() + (1000*ms);
 
     // Ensure that RTOS vTaskDelay(0) is called to force a reschedule to avoid task starvation in tight delay(1) loops
@@ -626,6 +625,37 @@ void system_delay_pump(unsigned long ms, bool force_no_background_loop=false)
     {
         // Always pump the system thread at least once
         spark_process();
+    }
+}
+
+} // namespace
+
+/*
+ * @brief This should block for a certain number of milliseconds and also execute spark_wlan_loop
+ */
+void system_delay_pump(unsigned long ms, bool force_no_background_loop)
+{
+    system_tick_t startMillis = HAL_Timer_Get_Milli_Seconds();
+
+    if (!system_thread_get_state(nullptr) || !APPLICATION_THREAD_CURRENT()) {
+        system_delay_pump_no_threading_impl(ms, startMillis, force_no_background_loop);
+        return;
+    }
+
+    if (!ms || force_no_background_loop) {
+        HAL_Delay_Milliseconds(ms);
+        return;
+    }
+
+    system_tick_t endMillis = startMillis + ms;
+
+    for (;;) {
+        system_tick_t d = endMillis - HAL_Timer_Get_Milli_Seconds();
+        static_assert(std::is_unsigned_v<system_tick_t>);
+        if (d == 0 || d > std::numeric_limits<system_tick_t>::max() / 2) {
+            break;
+        }
+        ApplicationThread.process(d);
     }
 }
 

--- a/user/tests/wiring/no_fixture_long_running/thread.cpp
+++ b/user/tests/wiring/no_fixture_long_running/thread.cpp
@@ -50,8 +50,8 @@ test(THREAD_01_delay_does_not_introduce_extra_latency_when_processing_app_events
             d->recvCount = &recvCount;
             now = HAL_Timer_Milliseconds();
             d->sendTime = now;
-            ++sendCount;
             application_thread_invoke(TestData::callback, d.release(), nullptr);
+            ++sendCount;
         } while (now - startTime < 10000);
         stop = true;
     });

--- a/user/tests/wiring/no_fixture_long_running/thread.cpp
+++ b/user/tests/wiring/no_fixture_long_running/thread.cpp
@@ -1,0 +1,70 @@
+#include <atomic>
+
+#include "application.h"
+#include "random.h"
+#include "unit-test/unit-test.h"
+
+test(THREAD_01_delay_does_not_introduce_extra_latency_when_processing_app_events)
+{
+    // This test should only be run with threading enabled
+    if (!system_thread_get_state(nullptr)) {
+        skip();
+        return;
+    }
+
+    struct TestData {
+        system_tick_t sendTime;
+        system_tick_t* maxDelay;
+        int* recvCount;
+
+        static void callback(void* data) {
+            auto recvTime = HAL_Timer_Milliseconds();
+            std::unique_ptr<TestData> d(static_cast<TestData*>(data));
+            auto delay = recvTime - d->sendTime;
+            if (delay > *d->maxDelay) {
+                *d->maxDelay = delay;
+            }
+            ++*d->recvCount;
+        }
+    };
+
+    system_tick_t maxDelay = 0;
+    int sendCount = 0;
+    int recvCount = 0;
+
+    volatile bool stop = false;
+    volatile bool failed = false;
+
+    Thread thread("test", [&]() {
+        auto startTime = HAL_Timer_Milliseconds();
+        system_tick_t now = 0;
+        Random rand;
+        do {
+            HAL_Delay_Milliseconds((rand.gen<unsigned>() % 400) + 100);
+            std::unique_ptr<TestData> d(new(std::nothrow) TestData());
+            if (!d) {
+                failed = true;
+                break;
+            }
+            d->maxDelay = &maxDelay;
+            d->recvCount = &recvCount;
+            now = HAL_Timer_Milliseconds();
+            d->sendTime = now;
+            ++sendCount;
+            application_thread_invoke(TestData::callback, d.release(), nullptr);
+        } while (now - startTime < 10000);
+        stop = true;
+    });
+
+    do {
+        delay((rand() % 2900) + 100);
+    } while (!stop);
+
+    thread.join();
+    Particle.process();
+
+    assertFalse(!!failed);
+    assertLessOrEqual(maxDelay, 2);
+    assertMore(sendCount, 10);
+    assertEqual(recvCount, sendCount);
+}

--- a/user/tests/wiring/no_fixture_long_running/thread.cpp
+++ b/user/tests/wiring/no_fixture_long_running/thread.cpp
@@ -56,8 +56,8 @@ test(THREAD_01_delay_does_not_introduce_extra_latency_when_processing_app_events
         stop = true;
     });
 
-    int delayMillis = 0;
-    int elapsedMillis = 0;
+    unsigned delayMillis = 0;
+    system_tick_t elapsedMillis = 0;
     do {
         auto ms = (rand() % 2900) + 100;
         auto t1 = HAL_Timer_Milliseconds();
@@ -71,7 +71,7 @@ test(THREAD_01_delay_does_not_introduce_extra_latency_when_processing_app_events
 
     assertFalse(!!failed);
     assertMoreOrEqual(elapsedMillis, delayMillis);
-    assertLessOrEqual(elapsedMillis - delayMillis, 2);
+    assertLessOrEqual(elapsedMillis - delayMillis, 5);
     assertLessOrEqual(maxEventDelay, 2);
     assertMore(eventSendCount, 10);
     assertEqual(eventRecvCount, eventSendCount);


### PR DESCRIPTION
Story details: [sc-129892](https://app.shortcut.com/particle/story/129892/events-are-not-processed-on-time-when-delay-is-called-in-app-loop).