### PR TITLE
Gen4 BLE fixes

### DIFF
--- a/user/tests/wiring/ble_central_peripheral/ble_peripheral/peripheral.cpp
+++ b/user/tests/wiring/ble_central_peripheral/ble_peripheral/peripheral.cpp
@@ -363,8 +363,8 @@ static void pairingTestRoutine(bool request, BlePairingAlgorithm algorithm,
     assertTrue(waitFor(BLE.connected, 20000));
     {
         SCOPE_GUARD ({
-            Particle.publish("disconnect");
-            assertTrue(waitFor([]{ return !BLE.connected(); }, 5000));
+            Particle.publish("BLE disconnect", nullptr, WITH_ACK);
+            assertTrue(waitFor([]{ return !BLE.connected(); }, 60000));
             assertFalse(BLE.connected());
         });
 

--- a/user/tests/wiring/ble_central_peripheral/ble_peripheral/peripheral.cpp
+++ b/user/tests/wiring/ble_central_peripheral/ble_peripheral/peripheral.cpp
@@ -363,6 +363,7 @@ static void pairingTestRoutine(bool request, BlePairingAlgorithm algorithm,
     assertTrue(waitFor(BLE.connected, 20000));
     {
         SCOPE_GUARD ({
+            Particle.publish("disconnect");
             assertTrue(waitFor([]{ return !BLE.connected(); }, 5000));
             assertFalse(BLE.connected());
         });
@@ -374,8 +375,10 @@ static void pairingTestRoutine(bool request, BlePairingAlgorithm algorithm,
         } else {
             assertTrue(waitFor([&]{ return pairingRequested; }, 20000));
         }
-        assertTrue(BLE.isPairing(peer));
-        assertTrue(waitFor([&]{ return !BLE.isPairing(peer); }, 60000));
+        // It may be paired in real quick if pairing uses JUST_WORK
+        if (BLE.isPairing(peer)) {
+            assertTrue(waitFor([&]{ return !BLE.isPairing(peer); }, 60000));
+        }
         assertTrue(BLE.isPaired(peer));
         assertEqual(pairingStatus, (int)SYSTEM_ERROR_NONE);
         if (algorithm != BlePairingAlgorithm::LEGACY_ONLY) {
@@ -569,6 +572,7 @@ test(BLE_37_Central_Can_Connect_While_Peripheral_Is_Scanning_And_Stops_Scanning_
         }, nullptr);
     }, nullptr);
     assertTrue((bool)scanThread);
+    waitFor([]{ return BLE.scanning(); }, 5000);
 }
 
 test(BLE_38_Central_Can_Connect_While_Peripheral_Is_Scanning_And_Stops_Scanning) {


### PR DESCRIPTION
### Problem
1. `connectionsMutex_ ` may block the application thread for prolonged amount of time. For example:
      - onBLEPairingEvent()hold the `connectionsMutex_`
      - waiting for some cloud data in the BLE pairing event handler
      - received data from cloud and the subscription handler is scheduled from application thread
      - application thread calls `waitFor(][(return BLE.isPaired))`, which is blocked by `connectionsMutex_`
      - cloud data cannot be handled
2. `assertTrue(results[i].scanResponse().length() > 0);` may fail in `ble_central_peripheral/ble_central `test

### Solution
1. Do not acquire `connectionsMutex_ ` in `notifyLinkEvent()` and acquire it where necessary.
2. To be consistent with Gen3, BLE HAL doesn't notify the pending scanned adv data

### Example App
`user/tests/wiring/ble_central_peripheral`

### References
N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
