### PR TITLE
[tests] Support integration tests on gen4 after device-constants update

### DIFF
--- a/user/tests/integration/communication/events/events.spec.js
+++ b/user/tests/integration/communication/events/events.spec.js
@@ -1,6 +1,6 @@
 suite('Cloud events');
 
-platform('gen3');
+platform('gen3', 'gen4');
 
 let maxEventDataSize = 0;
 

--- a/user/tests/integration/communication/functions/functions.spec.js
+++ b/user/tests/integration/communication/functions/functions.spec.js
@@ -1,6 +1,6 @@
 suite('Cloud functions')
 
-platform('gen3');
+platform('gen3', 'gen4');
 
 let api = null;
 let auth = null;

--- a/user/tests/integration/communication/ledger/ledger.spec.js
+++ b/user/tests/integration/communication/ledger/ledger.spec.js
@@ -1,6 +1,6 @@
 suite('Ledger')
 
-platform('gen3');
+platform('gen3', 'gen4');
 
 const Particle = require('particle-api-js');
 

--- a/user/tests/integration/communication/variables/variables.spec.js
+++ b/user/tests/integration/communication/variables/variables.spec.js
@@ -1,6 +1,6 @@
 suite('Cloud variables')
 
-platform('gen3');
+platform('gen3', 'gen4');
 
 let api = null;
 let auth = null;

--- a/user/tests/integration/ota/assets/assets.spec.js
+++ b/user/tests/integration/ota/assets/assets.spec.js
@@ -1,6 +1,6 @@
 suite('Assets OTA')
 
-platform('gen3');
+platform('gen3', 'gen4');
 
 // Some platforms have pretty slow connectivity
 timeout(30 * 60 * 1000);

--- a/user/tests/integration/ota/min_max_app_size/min_max_app_size.spec.js
+++ b/user/tests/integration/ota/min_max_app_size/min_max_app_size.spec.js
@@ -1,6 +1,6 @@
 suite('Minimum and maximum app size OTA');
 
-platform('gen3');
+platform('gen3', 'gen4');
 systemThread('enabled');
 
 const { HalModuleParser, ModuleInfo, compressModule, updateModuleCrc32, updateModulePrefix, updateModuleSuffix, updateModuleSha256 } = require('binary-version-reader');

--- a/user/tests/integration/ota/multiple_ota_no_reset/multiple_ota_no_reset.spec.js
+++ b/user/tests/integration/ota/multiple_ota_no_reset/multiple_ota_no_reset.spec.js
@@ -1,6 +1,6 @@
 suite('Multiple OTA updates with disabled resets');
 
-platform('gen3');
+platform('gen3', 'gen4');
 systemThread('enabled');
 
 const { HalModuleParser, ModuleInfo, updateModulePrefix, updateModuleSuffix, updateModuleCrc32 } = require('binary-version-reader');

--- a/user/tests/integration/package-lock.json
+++ b/user/tests/integration/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@particle/device-constants": "^3.3.1",
+        "@particle/device-constants": "^3.5.0",
         "binary-version-reader": "^2.4.0",
         "chai-exclude": "^2.1.0",
         "particle-api-js": "^10.4.2",
@@ -45,9 +45,9 @@
       }
     },
     "node_modules/@particle/device-constants": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.3.1.tgz",
-      "integrity": "sha512-wnGqj6QHtH9RfeWYyiYTAWAD9G5w51gZG3EDHc3Gp45az+C2uIxZs82MukZFS0BgM3boeCBRpPwCQjAGZy6rwg==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.5.0.tgz",
+      "integrity": "sha512-dJ85XvE+TrWHCkFP3pOkHloWuSdMSnCMzPdNrdEfXqs/ejwGUEi6G3w5DE0p4saT1KDD7VtRMpn1FHzFW4K5vA==",
       "engines": {
         "node": ">=12.x",
         "npm": "8.x"
@@ -1510,9 +1510,9 @@
       }
     },
     "@particle/device-constants": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.3.1.tgz",
-      "integrity": "sha512-wnGqj6QHtH9RfeWYyiYTAWAD9G5w51gZG3EDHc3Gp45az+C2uIxZs82MukZFS0BgM3boeCBRpPwCQjAGZy6rwg=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.5.0.tgz",
+      "integrity": "sha512-dJ85XvE+TrWHCkFP3pOkHloWuSdMSnCMzPdNrdEfXqs/ejwGUEi6G3w5DE0p4saT1KDD7VtRMpn1FHzFW4K5vA=="
     },
     "aggregate-error": {
       "version": "3.1.0",

--- a/user/tests/integration/package.json
+++ b/user/tests/integration/package.json
@@ -2,7 +2,7 @@
   "description": "Device OS Integration Tests",
   "private": true,
   "dependencies": {
-    "@particle/device-constants": "^3.3.1",
+    "@particle/device-constants": "^3.5.0",
     "binary-version-reader": "^2.4.0",
     "chai-exclude": "^2.1.0",
     "particle-api-js": "^10.4.2",

--- a/user/tests/integration/runner/mailbox/mailbox.spec.js
+++ b/user/tests/integration/runner/mailbox/mailbox.spec.js
@@ -1,6 +1,6 @@
 suite('Test runner mailbox');
 
-platform('gen3');
+platform('gen3', 'gen4');
 systemThread('enabled');
 
 let device = null;

--- a/user/tests/integration/slo/application_max_size/application_max_size.spec.js
+++ b/user/tests/integration/slo/application_max_size/application_max_size.spec.js
@@ -1,4 +1,4 @@
 suite('Application max size');
 
-platform('gen3');
+platform('gen3', 'gen4');
 systemThread('enabled');

--- a/user/tests/integration/slo/connect_time/connect_time.spec.js
+++ b/user/tests/integration/slo/connect_time/connect_time.spec.js
@@ -7,7 +7,7 @@
 //   and less than 30 seconds when starting from a warm boot
 suite('Network/cloud connection time SLOs');
 
-platform('gen3');
+platform('gen3', 'gen4');
 systemThread('enabled');
 
 // Parameters validated by this test

--- a/user/tests/integration/slo/startup/startup-slos.spec.js
+++ b/user/tests/integration/slo/startup/startup-slos.spec.js
@@ -9,7 +9,7 @@
 
 suite('Device startup service level objectives (SLOs)');
 
-platform('gen3');
+platform('gen3', 'gen4');
 // Enabling system thread, in order to account for its overhead in the measurements
 systemThread('enabled');
 

--- a/user/tests/wiring/ble_central_peripheral/ble_central_peripheral.spec.js
+++ b/user/tests/wiring/ble_central_peripheral/ble_central_peripheral.spec.js
@@ -1,5 +1,5 @@
 suite('BLE central peripheral');
-platform('gen3');
+platform('gen3', 'gen4');
 fixture('ble_central', 'ble_peripheral');
 systemThread('enabled');
 // This tag should be filtered out by default

--- a/user/tests/wiring/ble_scanner_broadcaster/ble_scanner_broadcaster.spec.js
+++ b/user/tests/wiring/ble_scanner_broadcaster/ble_scanner_broadcaster.spec.js
@@ -1,5 +1,5 @@
 suite('BLE scanner broadcaster');
-platform('gen3');
+platform('gen3', 'gen4');
 fixture('ble_scanner', 'ble_broadcaster');
 systemThread('enabled');
 // This tag should be filtered out by default

--- a/user/tests/wiring/filesystem/filesystem.spec.js
+++ b/user/tests/wiring/filesystem/filesystem.spec.js
@@ -1,3 +1,3 @@
 suite('POSIX filesystem API');
 
-platform('gen3');
+platform('gen3', 'gen4');

--- a/user/tests/wiring/gen3_invalid_compat_user_app/gen3_invalid_compat_user_app.spec.js
+++ b/user/tests/wiring/gen3_invalid_compat_user_app/gen3_invalid_compat_user_app.spec.js
@@ -1,3 +1,3 @@
 suite('Gen 3 invalid compat user app');
 
-platform('gen3');
+platform('gen3', 'gen4');

--- a/user/tests/wiring/ledger/ledger.spec.js
+++ b/user/tests/wiring/ledger/ledger.spec.js
@@ -1,3 +1,3 @@
 suite('Ledger API');
 
-platform('gen3');
+platform('gen3', 'gen4');

--- a/user/tests/wiring/network_config/network_config.spec.js
+++ b/user/tests/wiring/network_config/network_config.spec.js
@@ -1,3 +1,3 @@
 suite('Network config');
 
-platform('gen3');
+platform('gen3', 'gen4');

--- a/user/tests/wiring/no_fixture/no_fixture.spec.js
+++ b/user/tests/wiring/no_fixture/no_fixture.spec.js
@@ -1,4 +1,4 @@
 suite('No fixture');
 
-platform('gen3');
+platform('gen3', 'gen4');
 timeout(17 * 60 * 1000);

--- a/user/tests/wiring/no_fixture_ble/no_fixture_ble.spec.js
+++ b/user/tests/wiring/no_fixture_ble/no_fixture_ble.spec.js
@@ -1,3 +1,3 @@
 suite('No fixture BLE');
 
-platform('gen3');
+platform('gen3', 'gen4');

--- a/user/tests/wiring/no_fixture_i2c/no_fixture_i2c.spec.js
+++ b/user/tests/wiring/no_fixture_i2c/no_fixture_i2c.spec.js
@@ -1,3 +1,3 @@
 suite('No fixture I2C');
 
-platform('gen3');
+platform('gen3', 'gen4');

--- a/user/tests/wiring/no_fixture_long_running/no_fixture_long_running.spec.js
+++ b/user/tests/wiring/no_fixture_long_running/no_fixture_long_running.spec.js
@@ -1,4 +1,4 @@
 suite('No fixture long running');
 
-platform('gen3');
+platform('gen3', 'gen4');
 timeout(32 * 60 * 1000);

--- a/user/tests/wiring/no_fixture_spi/no_fixture_spi.spec.js
+++ b/user/tests/wiring/no_fixture_spi/no_fixture_spi.spec.js
@@ -1,3 +1,3 @@
 suite('No fixture SPI');
 
-platform('gen3');
+platform('gen3', 'gen4');

--- a/user/tests/wiring/no_fixture_stress/no_fixture_stress.spec.js
+++ b/user/tests/wiring/no_fixture_stress/no_fixture_stress.spec.js
@@ -1,3 +1,3 @@
 suite('No fixture stress');
 
-platform('gen3');
+platform('gen3', 'gen4');

--- a/user/tests/wiring/strformat/strformat.spec.js
+++ b/user/tests/wiring/strformat/strformat.spec.js
@@ -1,3 +1,3 @@
 suite('String format');
 
-platform('gen3');
+platform('gen3', 'gen4');

--- a/user/tests/wiring/time_compat/time_compat.spec.js
+++ b/user/tests/wiring/time_compat/time_compat.spec.js
@@ -1,3 +1,3 @@
 suite('time_t 32/64-bit compatibility');
 
-platform('gen3');
+platform('gen3', 'gen4');

--- a/user/tests/wiring/watchdog/watchdog.spec.js
+++ b/user/tests/wiring/watchdog/watchdog.spec.js
@@ -1,4 +1,4 @@
 suite('Watchdog');
 
-platform('gen3');
+platform('gen3', 'gen4');
 timeout(5 * 60 * 1000);


### PR DESCRIPTION
- Device-constants is updated and now differentiates gen3 and gen4.
- Device-constants - https://github.com/particle-iot-inc/device-constants/commit/bec3c86ab0c908e39a22cb33230e155f38c1d4e8
- Device-os-test-runner - https://github.com/particle-iot/device-os-test-runner/commit/118bfe3ac051f2446c0081c486cf93a3e4c54b96

