### PR TITLE
Add serial loopback to test runner

### DIFF
--- a/hal/inc/hal_dynalib_usart.h
+++ b/hal/inc/hal_dynalib_usart.h
@@ -80,6 +80,7 @@ DYNALIB_FN(BASE_IDX2 + 2, hal_usart, hal_usart_send_break, void(hal_usart_interf
 DYNALIB_FN(BASE_IDX2 + 3, hal_usart, hal_usart_break_detected, uint8_t(hal_usart_interface_t))
 DYNALIB_FN(BASE_IDX2 + 4, hal_usart, hal_usart_sleep, int(hal_usart_interface_t serial, bool, void*))
 DYNALIB_FN(BASE_IDX2 + 5, hal_usart, hal_usart_init_ex, int(hal_usart_interface_t, const hal_usart_buffer_config_t*, void*))
+DYNALIB_FN(BASE_IDX2 + 6, hal_usart, hal_usart_get_features, int(hal_usart_interface_t, uint32_t*, void*))
 
 DYNALIB_END(hal_usart)
 

--- a/hal/inc/usart_hal.h
+++ b/hal/inc/usart_hal.h
@@ -167,6 +167,7 @@ ssize_t hal_usart_write_buffer(hal_usart_interface_t serial, const void* buffer,
 ssize_t hal_usart_read_buffer(hal_usart_interface_t serial, void* buffer, size_t size, size_t elementSize);
 ssize_t hal_usart_peek_buffer(hal_usart_interface_t serial, void* buffer, size_t size, size_t elementSize);
 
+int hal_usart_get_features(hal_usart_interface_t serial, uint32_t* features, void* reserved);
 
 #include "usart_hal_compat.h"
 

--- a/hal/src/nRF52840/usart_hal.cpp
+++ b/hal/src/nRF52840/usart_hal.cpp
@@ -261,7 +261,14 @@ public:
         AtomicSection lk;
 
         // Update current available received data
-        data();
+        size_t consumable = 0;
+        {
+            RxLock lk(uarte_);
+            CHECK(data(&consumable));
+            if (consumable > 0) {
+                rxBuffer_.acquireCommit(consumable);
+            }
+        }
         CHECK(disable(false));
 
         state_ = HAL_USART_STATE_SUSPENDED;

--- a/hal/src/nRF52840/usart_hal.cpp
+++ b/hal/src/nRF52840/usart_hal.cpp
@@ -131,6 +131,13 @@ public:
         unsigned int config;
     };
 
+    int getFeatures(uint32_t* features) {
+        *features = 0;
+        *features |= (SERIAL_8N1 | SERIAL_8E1 | SERIAL_8N2 | SERIAL_8E2);
+        *features |= SERIAL_FLOW_CONTROL_RTS_CTS;
+        return SYSTEM_ERROR_NONE;
+    }
+
     int init(const hal_usart_buffer_config_t& conf) {
         if (isEnabled()) {
             CHECK(end());
@@ -827,6 +834,12 @@ void uarte1InterruptHandler(void) {
 
 extern "C" void UARTE1_IRQHandler(void) {
     uarte1InterruptHandler();
+}
+
+int hal_usart_get_features(hal_usart_interface_t serial, uint32_t* features, void* reserved) {
+    CHECK_TRUE(features, SYSTEM_ERROR_INVALID_ARGUMENT);
+    auto usart = CHECK_TRUE_RETURN(getInstance(serial), SYSTEM_ERROR_NOT_FOUND);
+    return usart->getFeatures(features);
 }
 
 int hal_usart_init_ex(hal_usart_interface_t serial, const hal_usart_buffer_config_t* config, void*) {

--- a/hal/src/rtl872x/usart_hal.cpp
+++ b/hal/src/rtl872x/usart_hal.cpp
@@ -128,6 +128,16 @@ public:
         return configured_;
     }
 
+    int getFeatures(uint32_t* features) {
+        *features = 0;
+        *features |= (SERIAL_7E1 | SERIAL_7E2 | SERIAL_7O1 | SERIAL_7O2
+                     |SERIAL_8N1 | SERIAL_8E1 | SERIAL_8N2 | SERIAL_8E2 | SERIAL_8O1 | SERIAL_8O2);
+        if (index_ != 2) {
+            *features |= SERIAL_FLOW_CONTROL_RTS_CTS;
+        }
+        return SYSTEM_ERROR_NONE;
+    }
+
     int init(const hal_usart_buffer_config_t& conf) {
         if (isEnabled()) {
             flush();
@@ -1003,6 +1013,12 @@ private:
 
     EventGroupHandle_t evGroup_;
 };
+
+int hal_usart_get_features(hal_usart_interface_t serial, uint32_t* features, void* reserved) {
+    auto usart = CHECK_TRUE_RETURN(Usart::getInstance(serial), SYSTEM_ERROR_NOT_FOUND);
+    CHECK_TRUE(features, SYSTEM_ERROR_INVALID_ARGUMENT);
+    return usart->getFeatures(features);
+}
 
 int hal_usart_init_ex(hal_usart_interface_t serial, const hal_usart_buffer_config_t* config, void*) {
     auto usart = CHECK_TRUE_RETURN(Usart::getInstance(serial), SYSTEM_ERROR_NOT_FOUND);

--- a/user/tests/integration/wiring/serial_loopback
+++ b/user/tests/integration/wiring/serial_loopback
@@ -1,0 +1,1 @@
+../../wiring/serial_loopback

--- a/user/tests/integration/wiring/serial_loopback2
+++ b/user/tests/integration/wiring/serial_loopback2
@@ -1,0 +1,1 @@
+../../wiring/serial_loopback2

--- a/user/tests/wiring/serial_loopback/application.cpp
+++ b/user/tests/wiring/serial_loopback/application.cpp
@@ -1,6 +1,10 @@
+#ifndef PARTICLE_TEST_RUNNER
+
 #include "application.h"
 #include "unit-test/unit-test.h"
 
 SYSTEM_MODE(MANUAL);
 
 UNIT_TEST_APP();
+
+#endif // PARTICLE_TEST_RUNNER

--- a/user/tests/wiring/serial_loopback/readme.md
+++ b/user/tests/wiring/serial_loopback/readme.md
@@ -1,10 +1,19 @@
 SERIAL testing hardware requirements
 ------------------------------------
 
-Connect a jumper to TX and RX pins i.e. TX-RX lines should be shorted
+Wiring
 
 ```none
-TX <-------> RX
+                        74xx126
+           10k          ___ ____
+  (GND)--/\/\/\--(A2)--|1  u  14|-- (3V3)
+  (TX)-----------------|2       |
+  (RX)-----------------|3       |
+                       |4       |
+                       |5       |
+                       |6       |
+  (GND)----------------|7      8|
+                        ^^^^^^^^
 ```
 
 Flashing the wiring/serial_loopback files

--- a/user/tests/wiring/serial_loopback/serial.cpp
+++ b/user/tests/wiring/serial_loopback/serial.cpp
@@ -57,11 +57,17 @@ hal_usart_buffer_config_t acquireSerial1Buffer()
 #define Serial1_IRQn USART1_IRQn
 #endif
 
-/*
- * Serial1 Test requires TX to be jumpered to RX as follows:
- *           WIRE
- * (TX) --==========-- (RX)
- *
+/* WIRING
+ *                       74xx126
+ *          10k          ___ ____
+ * (GND)--/\/\/\--(A2)--|1  u  14|-- (3V3)
+ * (TX)-----------------|2       |
+ * (RX)-----------------|3       |
+ *                      |4       |
+ *                      |5       |
+ *                      |6       |
+ * (GND)----------------|7      8|
+ *                       ^^^^^^^^
  */
 
 /*
@@ -141,6 +147,11 @@ void commonTestRoutine(uint32_t baudrate, uint32_t mode, uint16_t mask) {
     message[len] = '\0';
     // Compare strings
     assertTrue(strncmp(test, message, 5)==0);
+}
+
+test(SERIAL1_000_Prepare) {
+    pinMode(A2, OUTPUT);
+    digitalWrite(A2, HIGH);
 }
 
 test(SERIAL1_IncorrectConfigurationPassed) {
@@ -513,4 +524,8 @@ test(SERIAL1_LINMasterReadWriteBreakSucceedsInLoopbackWithTxRxShorted) {
     assertTrue(Serial1.breakRx());
 
     Serial1.end();
+}
+
+test(SERIAL1_ZZZ_Cleanup) {
+    pinMode(A2, INPUT);
 }

--- a/user/tests/wiring/serial_loopback/serial.cpp
+++ b/user/tests/wiring/serial_loopback/serial.cpp
@@ -49,6 +49,14 @@ hal_usart_buffer_config_t acquireSerial1Buffer()
 }
 #endif // USE_BUFFER_SIZE
 
+#if HAL_PLATFORM_NRF52840
+#define Serial1_IRQn UARTE0_UART0_IRQn
+#elif HAL_PLATFORM_RTL872X
+#define Serial1_IRQn UART_LOG_IRQ
+#else
+#define Serial1_IRQn USART1_IRQn
+#endif
+
 /*
  * Serial1 Test requires TX to be jumpered to RX as follows:
  *           WIRE
@@ -101,9 +109,38 @@ void consume(Stream& serial)
 void printlnMasked(Stream& serial, char* str, uint16_t mask)
 {
     for (unsigned i = 0; i < strlen(str); i++) {
+#if !HAL_PLATFORM_USART_9BIT_SUPPORTED
+        serial.write(str[i]);
+#else
         serial.write(((uint16_t)str[i]) | mask);
+#endif
     }
     serial.println();
+}
+
+void commonTestRoutine(uint32_t baudrate, uint32_t mode, uint16_t mask) {
+    //The following code will test all the important USART Serial1 routines
+    char test[] = "hello";
+    uint16_t message16[10];
+    char message[10];
+    int len = 0;
+    // when
+    Serial1.begin(baudrate, mode);
+    assertEqual(Serial1.isEnabled(), true);
+    consume(Serial1);
+    printlnMasked(Serial1, test, mask); // Set 9-th bit
+    len = serialReadLine16NoEcho(&Serial1, message16, 9, 1000);//1 sec timeout
+    Serial1.end();
+    // then
+    // Check that MSB is 0 in each uint16_t and copy into char buffer
+    for (int i = 0; i < len; i++) {
+        uint16_t msb = message16[i] & 0xFF00;
+        assertEqual(msb, 0x0000);
+        message[i] = (char)message16[i];
+    }
+    message[len] = '\0';
+    // Compare strings
+    assertTrue(strncmp(test, message, 5)==0);
 }
 
 test(SERIAL1_IncorrectConfigurationPassed) {
@@ -113,281 +150,122 @@ test(SERIAL1_IncorrectConfigurationPassed) {
 }
 
 test(SERIAL1_ReadWriteSucceedsInLoopbackWithTxRxShorted) {
-    //The following code will test all the important USART Serial1 routines
-    char test[] = "hello";
-    uint16_t message16[10];
-    char message[10];
-    int len = 0;
-    // when
-    Serial1.begin(9600);
-    assertEqual(Serial1.isEnabled(), true);
-    consume(Serial1);
-    printlnMasked(Serial1, test, (1 << 8)); // Set 9-th bit
-    len = serialReadLine16NoEcho(&Serial1, message16, 9, 1000);//1 sec timeout
-    Serial1.end();
-    // then
-    // Check that MSB is 0 in each uint16_t and copy into char buffer
-    for (int i = 0; i < len; i++) {
-        uint16_t msb = message16[i] & 0xFF00;
-        assertEqual(msb, 0x0000);
-        message[i] = (char)message16[i];
+    uint32_t features = 0;
+    hal_usart_get_features(HAL_USART_SERIAL1, &features, nullptr);
+    if ((features & SERIAL_8N1) != SERIAL_8N1) {
+        skip();
+        return;
     }
-    message[len] = '\0';
-    // Compare strings
-    assertTrue(strncmp(test, message, 5)==0);
+    commonTestRoutine(9600, SERIAL_8N1, (1 << 8));
 }
 
 test(SERIAL1_ReadWriteParity7E1SucceedsInLoopbackWithTxRxShorted) {
-    //The following code will test all the important USART Serial1 routines
-    char test[] = "hello";
-    uint16_t message16[10];
-    char message[10];
-    int len = 0;
-    // when
-    Serial1.begin(9600, SERIAL_7E1);
-    assertEqual(Serial1.isEnabled(), true);
-    consume(Serial1);
-    printlnMasked(Serial1, test, (1 << 8) | (1 << 7)); // Set 8-th and 9-th bits
-    len = serialReadLine16NoEcho(&Serial1, message16, 9, 1000);//1 sec timeout
-    Serial1.end();
-    // then
-    // Check that upper (16 - 7) bits are 0 in each uint16_t and copy into char buffer
-    for (int i = 0; i < len; i++) {
-        uint16_t msb = message16[i] & 0xFF80;
-        assertEqual(msb, 0x0000);
-        message[i] = (char)message16[i];
+    uint32_t features = 0;
+    hal_usart_get_features(HAL_USART_SERIAL1, &features, nullptr);
+    if ((features & SERIAL_7E1) != SERIAL_7E1) {
+        skip();
+        return;
     }
-    message[len] = '\0';
-    // Compare strings
-    assertTrue(strncmp(test, message, 5)==0);
+    commonTestRoutine(9600, SERIAL_7E1, (1 << 8) | (1 << 7));
 }
 
 test(SERIAL1_ReadWriteParity7E2SucceedsInLoopbackWithTxRxShorted) {
-    //The following code will test all the important USART Serial1 routines
-    char test[] = "hello";
-    uint16_t message16[10];
-    char message[10];
-    int len = 0;
-    // when
-    Serial1.begin(9600, SERIAL_7E2);
-    assertEqual(Serial1.isEnabled(), true);
-    consume(Serial1);
-    printlnMasked(Serial1, test, (1 << 8) | (1 << 7)); // Set 8-th and 9-th bits
-    len = serialReadLine16NoEcho(&Serial1, message16, 9, 1000);//1 sec timeout
-    Serial1.end();
-    // then
-    // Check that upper (16 - 7) bits are 0 in each uint16_t and copy into char buffer
-    for (int i = 0; i < len; i++) {
-        uint16_t msb = message16[i] & 0xFF80;
-        assertEqual(msb, 0x0000);
-        message[i] = (char)message16[i];
+    uint32_t features = 0;
+    hal_usart_get_features(HAL_USART_SERIAL1, &features, nullptr);
+    if ((features & SERIAL_7E2) != SERIAL_7E2) {
+        skip();
+        return;
     }
-    message[len] = '\0';
-    // Compare strings
-    assertTrue(strncmp(test, message, 5)==0);
+    commonTestRoutine(9600, SERIAL_7E2, (1 << 8) | (1 << 7));
 }
 
 test(SERIAL1_ReadWriteParity7O1SucceedsInLoopbackWithTxRxShorted) {
-    //The following code will test all the important USART Serial1 routines
-    char test[] = "hello";
-    uint16_t message16[10];
-    char message[10];
-    int len = 0;
-    // when
-    Serial1.begin(9600, SERIAL_7O1);
-    assertEqual(Serial1.isEnabled(), true);
-    consume(Serial1);
-    printlnMasked(Serial1, test, (1 << 8) | (1 << 7)); // Set 8-th and 9-th bits
-    len = serialReadLine16NoEcho(&Serial1, message16, 9, 1000);//1 sec timeout
-    Serial1.end();
-    // then
-    // Check that upper (16 - 7) bits are 0 in each uint16_t and copy into char buffer
-    for (int i = 0; i < len; i++) {
-        uint16_t msb = message16[i] & 0xFF80;
-        assertEqual(msb, 0x0000);
-        message[i] = (char)message16[i];
+    uint32_t features = 0;
+    hal_usart_get_features(HAL_USART_SERIAL1, &features, nullptr);
+    if ((features & SERIAL_7O1) != SERIAL_7O1) {
+        skip();
+        return;
     }
-    message[len] = '\0';
-    // Compare strings
-    assertTrue(strncmp(test, message, 5)==0);
+    commonTestRoutine(9600, SERIAL_7O1, (1 << 8) | (1 << 7));
 }
 
 test(SERIAL1_ReadWriteParity7O2SucceedsInLoopbackWithTxRxShorted) {
-    //The following code will test all the important USART Serial1 routines
-    char test[] = "hello";
-    uint16_t message16[10];
-    char message[10];
-    int len = 0;
-    // when
-    Serial1.begin(9600, SERIAL_7E1);
-    assertEqual(Serial1.isEnabled(), true);
-    consume(Serial1);
-    printlnMasked(Serial1, test, (1 << 8) | (1 << 7)); // Set 8-th and 9-th bits
-    len = serialReadLine16NoEcho(&Serial1, message16, 9, 1000);//1 sec timeout
-    Serial1.end();
-    // then
-    // Check that upper (16 - 7) bits are 0 in each uint16_t and copy into char buffer
-    for (int i = 0; i < len; i++) {
-        uint16_t msb = message16[i] & 0xFF80;
-        assertEqual(msb, 0x0000);
-        message[i] = (char)message16[i];
+    uint32_t features = 0;
+    hal_usart_get_features(HAL_USART_SERIAL1, &features, nullptr);
+    if ((features & SERIAL_7E1) != SERIAL_7E1) {
+        skip();
+        return;
     }
-    message[len] = '\0';
-    // Compare strings
-    assertTrue(strncmp(test, message, 5)==0);
+    commonTestRoutine(9600, SERIAL_7E1, (1 << 8) | (1 << 7));
 }
 
 test(SERIAL1_ReadWriteParity8N1SucceedsInLoopbackWithTxRxShorted) {
-    //The following code will test all the important USART Serial1 routines
-    char test[] = "hello";
-    uint16_t message16[10];
-    char message[10];
-    int len = 0;
-    // when
-    Serial1.begin(9600, SERIAL_8N1);
-    assertEqual(Serial1.isEnabled(), true);
-    consume(Serial1);
-    printlnMasked(Serial1, test, (1 << 8)); // Set 9-th bit
-    len = serialReadLine16NoEcho(&Serial1, message16, 9, 1000);//1 sec timeout
-    Serial1.end();
-    // then
-    // Check that MSB is 0 in each uint16_t and copy into char buffer
-    for (int i = 0; i < len; i++) {
-        uint16_t msb = message16[i] & 0xFF00;
-        assertEqual(msb, 0x0000);
-        message[i] = (char)message16[i];
+    uint32_t features = 0;
+    hal_usart_get_features(HAL_USART_SERIAL1, &features, nullptr);
+    if ((features & SERIAL_8N1) != SERIAL_8N1) {
+        skip();
+        return;
     }
-    message[len] = '\0';
-    // Compare strings
-    assertTrue(strncmp(test, message, 5)==0);
+    commonTestRoutine(9600, SERIAL_8N1, (1 << 8));
 }
 
 test(SERIAL1_ReadWriteParity8E1SucceedsInLoopbackWithTxRxShorted) {
-    //The following code will test all the important USART Serial1 routines
-    char test[] = "hello";
-    uint16_t message16[10];
-    char message[10];
-    int len = 0;
-    // when
-    Serial1.begin(9600, SERIAL_8E1);
-    assertEqual(Serial1.isEnabled(), true);
-    consume(Serial1);
-    printlnMasked(Serial1, test, (1 << 8)); // Set 9-th bit
-    len = serialReadLine16NoEcho(&Serial1, message16, 9, 1000);//1 sec timeout
-    Serial1.end();
-    // then
-    // Check that MSB is 0 in each uint16_t and copy into char buffer
-    for (int i = 0; i < len; i++) {
-        uint16_t msb = message16[i] & 0xFF00;
-        assertEqual(msb, 0x0000);
-        message[i] = (char)message16[i];
+    uint32_t features = 0;
+    hal_usart_get_features(HAL_USART_SERIAL1, &features, nullptr);
+    if ((features & SERIAL_8E1) != SERIAL_8E1) {
+        skip();
+        return;
     }
-    message[len] = '\0';
-    // Compare strings
-    assertTrue(strncmp(test, message, 5)==0);
+    commonTestRoutine(9600, SERIAL_8E1, (1 << 8));
 }
 
 test(SERIAL1_ReadWriteParity8O1SucceedsInLoopbackWithTxRxShorted) {
-    //The following code will test all the important USART Serial1 routines
-    char test[] = "hello";
-    uint16_t message16[10];
-    char message[10];
-    int len = 0;
-    // when
-    Serial1.begin(9600, SERIAL_8O1);
-    assertEqual(Serial1.isEnabled(), true);
-    consume(Serial1);
-    printlnMasked(Serial1, test, (1 << 8)); // Set 9-th bit
-    len = serialReadLine16NoEcho(&Serial1, message16, 9, 1000);//1 sec timeout
-    Serial1.end();
-    // then
-    // Check that MSB is 0 in each uint16_t and copy into char buffer
-    for (int i = 0; i < len; i++) {
-        uint16_t msb = message16[i] & 0xFF00;
-        assertEqual(msb, 0x0000);
-        message[i] = (char)message16[i];
+    uint32_t features = 0;
+    hal_usart_get_features(HAL_USART_SERIAL1, &features, nullptr);
+    if ((features & SERIAL_8O1) != SERIAL_8O1) {
+        skip();
+        return;
     }
-    message[len] = '\0';
-    // Compare strings
-    assertTrue(strncmp(test, message, 5)==0);
+    commonTestRoutine(9600, SERIAL_8O1, (1 << 8));
 }
 
 test(SERIAL1_ReadWriteParity8N2SucceedsInLoopbackWithTxRxShorted) {
-    //The following code will test all the important USART Serial1 routines
-    char test[] = "hello";
-    uint16_t message16[10];
-    char message[10];
-    int len = 0;
-    // when
-    Serial1.begin(9600, SERIAL_8N2);
-    assertEqual(Serial1.isEnabled(), true);
-    consume(Serial1);
-    printlnMasked(Serial1, test, (1 << 8)); // Set 9-th bit
-    len = serialReadLine16NoEcho(&Serial1, message16, 9, 1000);//1 sec timeout
-    Serial1.end();
-    // then
-    // Check that MSB is 0 in each uint16_t and copy into char buffer
-    for (int i = 0; i < len; i++) {
-        uint16_t msb = message16[i] & 0xFF00;
-        assertEqual(msb, 0x0000);
-        message[i] = (char)message16[i];
+    uint32_t features = 0;
+    hal_usart_get_features(HAL_USART_SERIAL1, &features, nullptr);
+    if ((features & SERIAL_8N2) != SERIAL_8N2) {
+        skip();
+        return;
     }
-    message[len] = '\0';
-    // Compare strings
-    assertTrue(strncmp(test, message, 5)==0);
+    commonTestRoutine(9600, SERIAL_8N2, (1 << 8));
 }
 
 test(SERIAL1_ReadWriteParity8E2SucceedsInLoopbackWithTxRxShorted) {
-    //The following code will test all the important USART Serial1 routines
-    char test[] = "hello";
-    uint16_t message16[10];
-    char message[10];
-    int len = 0;
-    // when
-    Serial1.begin(9600, SERIAL_8E2);
-    assertEqual(Serial1.isEnabled(), true);
-    consume(Serial1);
-    printlnMasked(Serial1, test, (1 << 8)); // Set 9-th bit
-    len = serialReadLine16NoEcho(&Serial1, message16, 9, 1000);//1 sec timeout
-    Serial1.end();
-    // then
-    // Check that MSB is 0 in each uint16_t and copy into char buffer
-    for (int i = 0; i < len; i++) {
-        uint16_t msb = message16[i] & 0xFF00;
-        assertEqual(msb, 0x0000);
-        message[i] = (char)message16[i];
+    uint32_t features = 0;
+    hal_usart_get_features(HAL_USART_SERIAL1, &features, nullptr);
+    if ((features & SERIAL_8E2) != SERIAL_8E2) {
+        skip();
+        return;
     }
-    message[len] = '\0';
-    // Compare strings
-    assertTrue(strncmp(test, message, 5)==0);
+    commonTestRoutine(9600, SERIAL_8E2, (1 << 8));
 }
 
 test(SERIAL1_ReadWriteParity8O2SucceedsInLoopbackWithTxRxShorted) {
-    //The following code will test all the important USART Serial1 routines
-    char test[] = "hello";
-    uint16_t message16[10];
-    char message[10];
-    int len = 0;
-    // when
-    Serial1.begin(9600, SERIAL_8O2);
-    assertEqual(Serial1.isEnabled(), true);
-    consume(Serial1);
-    printlnMasked(Serial1, test, (1 << 8)); // Set 9-th bit
-    len = serialReadLine16NoEcho(&Serial1, message16, 9, 1000);//1 sec timeout
-    Serial1.end();
-    // then
-    // Check that MSB is 0 in each uint16_t and copy into char buffer
-    for (int i = 0; i < len; i++) {
-        uint16_t msb = message16[i] & 0xFF00;
-        assertEqual(msb, 0x0000);
-        message[i] = (char)message16[i];
+    uint32_t features = 0;
+    hal_usart_get_features(HAL_USART_SERIAL1, &features, nullptr);
+    if ((features & SERIAL_8O2) != SERIAL_8O2) {
+        skip();
+        return;
     }
-    message[len] = '\0';
-    // Compare strings
-    assertTrue(strncmp(test, message, 5)==0);
+    commonTestRoutine(9600, SERIAL_8O2, (1 << 8));
 }
 
 test(SERIAL1_ReadWriteParity9N1SucceedsInLoopbackWithTxRxShorted) {
+    uint32_t features = 0;
+    hal_usart_get_features(HAL_USART_SERIAL1, &features, nullptr);
+    if ((features & SERIAL_9N1) != SERIAL_9N1) {
+        skip();
+        return;
+    }
     //The following code will test all the important USART Serial1 routines
     char test[] = "helloworld1234";
     uint16_t test2 = ((uint16_t)'p' << 7) | (uint16_t)'a'; // "pa"
@@ -423,6 +301,12 @@ test(SERIAL1_ReadWriteParity9N1SucceedsInLoopbackWithTxRxShorted) {
 }
 
 test(SERIAL1_ReadWriteParity9N2SucceedsInLoopbackWithTxRxShorted) {
+    uint32_t features = 0;
+    hal_usart_get_features(HAL_USART_SERIAL1, &features, nullptr);
+    if ((features & SERIAL_9N2) != SERIAL_9N2) {
+        skip();
+        return;
+    }
     //The following code will test all the important USART Serial1 routines
     char test[] = "helloworld1234";
     uint16_t test2 = ((uint16_t)'p' << 7) | (uint16_t)'a'; // "pa"
@@ -470,7 +354,7 @@ test(SERIAL1_AvailableForWriteWorksCorrectly) {
     assertEqual(Serial1.availableForWrite(), bufferSize);
 
     // Disable Serial1 IRQ to prevent it from sending data
-    NVIC_DisableIRQ(USART1_IRQn);
+    NVIC_DisableIRQ(Serial1_IRQn);
     // Write (bufferSize / 2) bytes into TX buffer
     for (int i = 0; i < bufferSize / 2; i++) {
         Serial1.write('a');
@@ -485,7 +369,7 @@ test(SERIAL1_AvailableForWriteWorksCorrectly) {
     // There should only be 1 byte available in TX buffer
     assertEqual(Serial1.availableForWrite(), 1);
     // Enable Serial1 IRQ again to send out the data from TX buffer
-    NVIC_EnableIRQ(USART1_IRQn);
+    NVIC_EnableIRQ(Serial1_IRQn);
     Serial1.flush();
 
     // There should be bufferSize available in TX buffer again
@@ -494,15 +378,15 @@ test(SERIAL1_AvailableForWriteWorksCorrectly) {
     // At this point tx_buffer->head = (bufferSize - 1), tx_buffer->tail = (bufferSize - 1)
     // Now test that availableForWrite() returns correct results for cases where tx_buffer->head < tx_buffer->tail
     // Disable Serial1 IRQ again to prevent it from sending data
-    NVIC_DisableIRQ(USART1_IRQn);
+    NVIC_DisableIRQ(Serial1_IRQn);
     // Write (bufferSize / 2 + 1) bytes into TX buffer
     for (int i = 0; i < bufferSize / 2 + 1; i++) {
         Serial1.write('c');
     }
-    // There should be (bufferSize / 2) bytes available in TX buffer
-    assertEqual(Serial1.availableForWrite(), bufferSize / 2);
+    // There should be (bufferSize / 2 - 1) bytes available in TX buffer
+    assertEqual(Serial1.availableForWrite(), bufferSize / 2 - 1);
     // Enable Serial1 IRQ again to send out the data from TX buffer
-    NVIC_EnableIRQ(USART1_IRQn);
+    NVIC_EnableIRQ(Serial1_IRQn);
     Serial1.flush();
 
     // There should be bufferSize available in TX buffer again
@@ -520,7 +404,7 @@ test(SERIAL1_AvailableForWriteIn9BitModeWorksCorrectly) {
     assertEqual(Serial1.availableForWrite(), bufferSize);
 
     // Disable Serial1 IRQ to prevent it from sending data
-    NVIC_DisableIRQ(USART1_IRQn);
+    NVIC_DisableIRQ(Serial1_IRQn);
     // Write (bufferSize / 2) bytes into TX buffer
     for (int i = 0; i < bufferSize / 2; i++) {
         Serial1.write('a');
@@ -535,7 +419,7 @@ test(SERIAL1_AvailableForWriteIn9BitModeWorksCorrectly) {
     // There should only be 1 byte available in TX buffer
     assertEqual(Serial1.availableForWrite(), 1);
     // Enable Serial1 IRQ again to send out the data from TX buffer
-    NVIC_EnableIRQ(USART1_IRQn);
+    NVIC_EnableIRQ(Serial1_IRQn);
     Serial1.flush();
 
     // There should be bufferSize available in TX buffer again
@@ -544,7 +428,7 @@ test(SERIAL1_AvailableForWriteIn9BitModeWorksCorrectly) {
     // At this point tx_buffer->head = (bufferSize - 1), tx_buffer->tail = (bufferSize - 1)
     // Now test that availableForWrite() returns correct results for cases where tx_buffer->head < tx_buffer->tail
     // Disable Serial1 IRQ again to prevent it from sending data
-    NVIC_DisableIRQ(USART1_IRQn);
+    NVIC_DisableIRQ(Serial1_IRQn);
     // Write (bufferSize / 2 + 1) bytes into TX buffer
     for (int i = 0; i < bufferSize / 2 + 1; i++) {
         Serial1.write('c');
@@ -552,7 +436,7 @@ test(SERIAL1_AvailableForWriteIn9BitModeWorksCorrectly) {
     // There should be (bufferSize / 2) bytes available in TX buffer
     assertEqual(Serial1.availableForWrite(), bufferSize / 2);
     // Enable Serial1 IRQ again to send out the data from TX buffer
-    NVIC_EnableIRQ(USART1_IRQn);
+    NVIC_EnableIRQ(Serial1_IRQn);
     Serial1.flush();
 
     // There should be bufferSize available in TX buffer again
@@ -563,6 +447,13 @@ test(SERIAL1_AvailableForWriteIn9BitModeWorksCorrectly) {
 #endif // HAL_PLATFORM_USART_9BIT_SUPPORTED
 
 test(SERIAL1_LINMasterReadWriteBreakSucceedsInLoopbackWithTxRxShorted) {
+    uint32_t features = 0;
+    uint32_t mode = LIN_MASTER_13B | LIN_BREAK_10B;
+    hal_usart_get_features(HAL_USART_SERIAL1, &features, nullptr);
+    if ((features & mode) != mode) {
+        skip();
+        return;
+    }
     // Test for LIN mode
     // 1. The test will configure Serial1 in LIN Master mode (with 11 bit break detection
     // enabled as in Slave mode)
@@ -578,7 +469,7 @@ test(SERIAL1_LINMasterReadWriteBreakSucceedsInLoopbackWithTxRxShorted) {
     // when
     if (Serial1.isEnabled())
         Serial1.end();
-    Serial1.begin(9600, LIN_MASTER_13B | LIN_BREAK_10B);
+    Serial1.begin(9600, mode);
     assertEqual(Serial1.isEnabled(), true);
     // then
 

--- a/user/tests/wiring/serial_loopback/serial_loopback.config.json
+++ b/user/tests/wiring/serial_loopback/serial_loopback.config.json
@@ -1,0 +1,9 @@
+{
+    "fixtures": [
+        {
+            "name": "serial_loopback",
+            "devices": [
+            ]
+        }
+    ]
+}

--- a/user/tests/wiring/serial_loopback/serial_loopback.spec.js
+++ b/user/tests/wiring/serial_loopback/serial_loopback.spec.js
@@ -1,0 +1,6 @@
+suite('Serial loopback');
+platform('gen3');
+fixture('serial_loopback');
+systemThread('enabled');
+// This tag should be filtered out by default
+tag('fixture');

--- a/user/tests/wiring/serial_loopback/serial_loopback.spec.js
+++ b/user/tests/wiring/serial_loopback/serial_loopback.spec.js
@@ -1,5 +1,5 @@
 suite('Serial loopback');
-platform('gen3');
+platform('gen3', 'gen4');
 fixture('serial_loopback');
 systemThread('enabled');
 // This tag should be filtered out by default

--- a/user/tests/wiring/serial_loopback2/README.md
+++ b/user/tests/wiring/serial_loopback2/README.md
@@ -1,8 +1,18 @@
 ## Serial testing hardware requirements
 
-Connect a jumper to TX and RX pins i.e. TX-RX lines should be shorted.
-```
-TX <-------> RX
+Wiring
+
+```none
+                        74xx126
+           10k          ___ ____
+  (GND)--/\/\/\--(A2)--|1  u  14|-- (3V3)
+  (TX)-----------------|2       |
+  (RX)-----------------|3       |
+                       |4       |
+                       |5       |
+                       |6       |
+  (GND)----------------|7      8|
+                        ^^^^^^^^
 ```
 
 ## Flashing the wiring/serial_loopback2 test application

--- a/user/tests/wiring/serial_loopback2/application.cpp
+++ b/user/tests/wiring/serial_loopback2/application.cpp
@@ -15,9 +15,13 @@
  * License along with this library; if not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef PARTICLE_TEST_RUNNER
+
 #include "application.h"
 #include "unit-test/unit-test.h"
 
 SYSTEM_MODE(MANUAL);
 
 UNIT_TEST_APP();
+
+#endif // PARTICLE_TEST_RUNNER

--- a/user/tests/wiring/serial_loopback2/loopback.cpp
+++ b/user/tests/wiring/serial_loopback2/loopback.cpp
@@ -19,6 +19,19 @@
 #include "unit-test/unit-test.h"
 #include "random.h"
 
+/* WIRING
+ *                       74xx126
+ *          10k          ___ ____
+ * (GND)--/\/\/\--(A2)--|1  u  14|-- (3V3)
+ * (TX)-----------------|2       |
+ * (RX)-----------------|3       |
+ *                      |4       |
+ *                      |5       |
+ *                      |6       |
+ * (GND)----------------|7      8|
+ *                       ^^^^^^^^
+ */
+
 #ifndef USE_BUFFER_SIZE
 #warning "Using default 64 byte buffer"
 #define USE_BUFFER_SIZE (SERIAL_BUFFER_SIZE)
@@ -87,6 +100,11 @@ void runLoopback(size_t buffer_size_min, size_t buffer_size_max, bool sleep, boo
     } while (++pos <= bufferSize);
 
     assertTrue(!strncmp(txBuf, rxBuf, bufferSize));
+}
+
+test(SERIAL_000_Prepare) {
+    pinMode(A2, OUTPUT);
+    digitalWrite(A2, HIGH);
 }
 
 test(SERIAL_00_LoopbackNoDataLossAndAvailableIsCorrect) {
@@ -188,6 +206,10 @@ test(SERIAL_05_Loopback9BitReceivedDataShouldRetainAfterSleepWakeup) {
     for (unsigned i = 0; i < ITERATIONS; ++i) {
         runLoopback(TEST_BUFFER_SIZE_MIN, TEST_BUFFER_SIZE_MAX, true);
     }
+}
+
+test(SERIAL_ZZZ_Cleanup) {
+    pinMode(A2, INPUT);
 }
 
 #endif // HAL_PLATFORM_USART_9BIT_SUPPORTED

--- a/user/tests/wiring/serial_loopback2/serial_loopback2.config.json
+++ b/user/tests/wiring/serial_loopback2/serial_loopback2.config.json
@@ -1,0 +1,9 @@
+{
+    "fixtures": [
+        {
+            "name": "serial_loopback2",
+            "devices": [
+            ]
+        }
+    ]
+}

--- a/user/tests/wiring/serial_loopback2/serial_loopback2.spec.js
+++ b/user/tests/wiring/serial_loopback2/serial_loopback2.spec.js
@@ -1,5 +1,5 @@
 suite('Serial loopback2');
-platform('gen3');
+platform('gen3', 'gen4');
 fixture('serial_loopback2');
 systemThread('enabled');
 // This tag should be filtered out by default

--- a/user/tests/wiring/serial_loopback2/serial_loopback2.spec.js
+++ b/user/tests/wiring/serial_loopback2/serial_loopback2.spec.js
@@ -1,0 +1,6 @@
+suite('Serial loopback2');
+platform('gen3');
+fixture('serial_loopback2');
+systemThread('enabled');
+// This tag should be filtered out by default
+tag('fixture');


### PR DESCRIPTION
- fixes USART::available() after waking from sleep
- adds serial loopback/loopback2 tests

### Steps to Test
`user/tests/wiring/serial_loopback` and `user/tests/wiring/serial_loopback2`

### References
N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
