### PR TITLE
[Gen4] fixes deadlock in USB hal

### DIFF
--- a/hal/src/rtl872x/usbd_driver.cpp
+++ b/hal/src/rtl872x/usbd_driver.cpp
@@ -224,6 +224,7 @@ void RtlUsbDriver::loop(void* ctx) {
 #endif // MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
         if (!self->initialized_ && !error) {
 #if MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
+            HAL_Delay_Milliseconds(5);
             continue;
 #else
             return;


### PR DESCRIPTION
### Problem
Device may reside in blocked state after reset or waking up from hibernate mode.
1. `HAL_USB_Init()` in main.cpp sets `initialized_` to `true` and usb thread starts to run with `OS_THREAD_PRIORITY_NETWORK - 1` priority
2. `USB_USART_LineCoding_BitRate_Handler()` in main.cpp or `Serial.begin()` in app thread with lower priority -> `HAL_USB_USART_Begin()` -> `HAL_USB_Detach()` set `initialized_` to `false`
3. usb thread continues to run and keeps waiting for `initialized_` to be `true` in a busy loop
4. app thread is blocked and `HAL_USB_Attach()` won’t be executed and `initialized_` won’t be set `true`
goto #3

### Solution
Add a minimum delay within the usb busy loop to allow other threads to call into `HAL_USB_Attach()`

### Steps to Test
Device running the attached app should behave as expected for a long mount of time

### Example App

```cpp
#include "application.h"

SYSTEM_MODE(SEMI_AUTOMATIC);
SYSTEM_THREAD(ENABLED);

SerialLogHandler l(115200, LOG_LEVEL_ALL);

void setup() {
}

void loop() {
    Particle.connect();
    waitFor(Particle.connected, 60000);

    Log.info("Start sleep test");

    SystemSleepConfiguration config;

    config.mode(SystemSleepMode::HIBERNATE)
        .gpio(D8, FALLING)
        .duration(10s);

    Log.info("going to sleep");
    delay(10);

    System.sleep(config);
}
```

### References
N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
