### PR TITLE
[Gen4] clear I2C tx buffer per transmission

### DIFF
--- a/hal/src/rtl872x/i2c_hal.cpp
+++ b/hal/src/rtl872x/i2c_hal.cpp
@@ -36,6 +36,7 @@
 #include <memory>
 #include "check.h"
 #include "service_debug.h"
+#include "scope_guard.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -401,7 +402,16 @@ public:
         return 1;
     }
 
+    int beginTransmission(uint8_t address, const hal_i2c_transmission_config_t* config) {
+        setConfigOrDefault(config, address);
+        txBuffer_.reset();
+        return SYSTEM_ERROR_NONE;
+    }
+
     int endTransmission(uint8_t stop) {
+        SCOPE_GUARD({
+            txBuffer_.reset();
+        });
         if (i2cInitStruct_.I2CMaster != I2C_MASTER_MODE) {
             return SYSTEM_ERROR_INVALID_STATE;
         }
@@ -828,7 +838,7 @@ void hal_i2c_begin_transmission(hal_i2c_interface_t i2c, uint8_t address, const 
     if (!hal_i2c_is_enabled(i2c, nullptr)) {
         return;
     }
-    instance->setConfigOrDefault(config, address);
+    instance->beginTransmission(address, config);
 }
 
 uint8_t hal_i2c_end_transmission(hal_i2c_interface_t i2c, uint8_t stop, void* reserved) {


### PR DESCRIPTION
### Problem
I2C TX buffer may contain staled data that will be sent to other slave devices, causing unexpected behavior.

### Solution
Clear the TX buffer when `beginTransmission()` or `endTransmission()` is called, making it consistent with Gen3.

### Steps to Test
Run the i2c_master_slave fixture test

### Example App
`user/tests/wiring/i2c_master_slave`


### References
N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
