### PR TITLE
[tests] fixes for device-os-test-runner 0.11.0 changes

### DIFF
--- a/user/tests/integration/communication/events/events.spec.js
+++ b/user/tests/integration/communication/events/events.spec.js
@@ -1,6 +1,6 @@
 suite('Cloud events');
 
-platform('gen3');
+platform('gen3', 'gen4');
 
 let maxEventDataSize = 0;
 

--- a/user/tests/integration/communication/functions/functions.spec.js
+++ b/user/tests/integration/communication/functions/functions.spec.js
@@ -1,6 +1,6 @@
 suite('Cloud functions')
 
-platform('gen3');
+platform('gen3', 'gen4');
 
 let api = null;
 let auth = null;

--- a/user/tests/integration/communication/ledger/ledger.spec.js
+++ b/user/tests/integration/communication/ledger/ledger.spec.js
@@ -1,6 +1,6 @@
 suite('Ledger')
 
-platform('gen3');
+platform('gen3', 'gen4');
 
 const Particle = require('particle-api-js');
 

--- a/user/tests/integration/communication/variables/variables.spec.js
+++ b/user/tests/integration/communication/variables/variables.spec.js
@@ -1,6 +1,6 @@
 suite('Cloud variables')
 
-platform('gen3');
+platform('gen3', 'gen4');
 
 let api = null;
 let auth = null;

--- a/user/tests/integration/ota/assets/assets.spec.js
+++ b/user/tests/integration/ota/assets/assets.spec.js
@@ -1,6 +1,6 @@
 suite('Assets OTA')
 
-platform('gen3');
+platform('gen3', 'gen4');
 
 // Some platforms have pretty slow connectivity
 timeout(30 * 60 * 1000);

--- a/user/tests/integration/ota/min_max_app_size/min_max_app_size.spec.js
+++ b/user/tests/integration/ota/min_max_app_size/min_max_app_size.spec.js
@@ -1,6 +1,6 @@
 suite('Minimum and maximum app size OTA');
 
-platform('gen3');
+platform('gen3', 'gen4');
 systemThread('enabled');
 
 const { HalModuleParser, ModuleInfo, compressModule, updateModuleCrc32, updateModulePrefix, updateModuleSuffix, updateModuleSha256 } = require('binary-version-reader');

--- a/user/tests/integration/ota/multiple_ota_no_reset/multiple_ota_no_reset.spec.js
+++ b/user/tests/integration/ota/multiple_ota_no_reset/multiple_ota_no_reset.spec.js
@@ -1,6 +1,6 @@
 suite('Multiple OTA updates with disabled resets');
 
-platform('gen3');
+platform('gen3', 'gen4');
 systemThread('enabled');
 
 const { HalModuleParser, ModuleInfo, updateModulePrefix, updateModuleSuffix, updateModuleCrc32 } = require('binary-version-reader');

--- a/user/tests/integration/runner/mailbox/mailbox.spec.js
+++ b/user/tests/integration/runner/mailbox/mailbox.spec.js
@@ -1,6 +1,6 @@
 suite('Test runner mailbox');
 
-platform('gen3');
+platform('gen3', 'gen4');
 systemThread('enabled');
 
 let device = null;

--- a/user/tests/integration/slo/application_max_size/application_max_size.spec.js
+++ b/user/tests/integration/slo/application_max_size/application_max_size.spec.js
@@ -1,4 +1,4 @@
 suite('Application max size');
 
-platform('gen3');
+platform('gen3', 'gen4');
 systemThread('enabled');

--- a/user/tests/integration/slo/connect_time/connect_time.spec.js
+++ b/user/tests/integration/slo/connect_time/connect_time.spec.js
@@ -7,7 +7,7 @@
 //   and less than 30 seconds when starting from a warm boot
 suite('Network/cloud connection time SLOs');
 
-platform('gen3');
+platform('gen3', 'gen4');
 systemThread('enabled');
 
 // Parameters validated by this test

--- a/user/tests/integration/slo/startup/startup-slos.spec.js
+++ b/user/tests/integration/slo/startup/startup-slos.spec.js
@@ -9,7 +9,7 @@
 
 suite('Device startup service level objectives (SLOs)');
 
-platform('gen3');
+platform('gen3', 'gen4');
 // Enabling system thread, in order to account for its overhead in the measurements
 systemThread('enabled');
 

--- a/user/tests/wiring/ble_central_peripheral/ble_central_peripheral.spec.js
+++ b/user/tests/wiring/ble_central_peripheral/ble_central_peripheral.spec.js
@@ -1,5 +1,5 @@
 suite('BLE central peripheral');
-platform('gen3');
+platform('gen3', 'gen4');
 fixture('ble_central', 'ble_peripheral');
 systemThread('enabled');
 // This tag should be filtered out by default

--- a/user/tests/wiring/ble_scanner_broadcaster/ble_scanner_broadcaster.spec.js
+++ b/user/tests/wiring/ble_scanner_broadcaster/ble_scanner_broadcaster.spec.js
@@ -1,5 +1,5 @@
 suite('BLE scanner broadcaster');
-platform('gen3');
+platform('gen3', 'gen4');
 fixture('ble_scanner', 'ble_broadcaster');
 systemThread('enabled');
 // This tag should be filtered out by default

--- a/user/tests/wiring/filesystem/filesystem.spec.js
+++ b/user/tests/wiring/filesystem/filesystem.spec.js
@@ -1,3 +1,3 @@
 suite('POSIX filesystem API');
 
-platform('gen3');
+platform('gen3', 'gen4');

--- a/user/tests/wiring/gen3_invalid_compat_user_app/gen3_invalid_compat_user_app.spec.js
+++ b/user/tests/wiring/gen3_invalid_compat_user_app/gen3_invalid_compat_user_app.spec.js
@@ -1,3 +1,3 @@
 suite('Gen 3 invalid compat user app');
 
-platform('gen3');
+platform('gen3', 'gen4');

--- a/user/tests/wiring/ledger/ledger.spec.js
+++ b/user/tests/wiring/ledger/ledger.spec.js
@@ -1,3 +1,3 @@
 suite('Ledger API');
 
-platform('gen3');
+platform('gen3', 'gen4');

--- a/user/tests/wiring/network_config/network_config.spec.js
+++ b/user/tests/wiring/network_config/network_config.spec.js
@@ -1,3 +1,3 @@
 suite('Network config');
 
-platform('gen3');
+platform('gen3', 'gen4');

--- a/user/tests/wiring/no_fixture/no_fixture.spec.js
+++ b/user/tests/wiring/no_fixture/no_fixture.spec.js
@@ -1,4 +1,4 @@
 suite('No fixture');
 
-platform('gen3');
+platform('gen3', 'gen4');
 timeout(17 * 60 * 1000);

--- a/user/tests/wiring/no_fixture/system.cpp
+++ b/user/tests/wiring/no_fixture/system.cpp
@@ -488,7 +488,9 @@ test(SYSTEM_10_system_ticks_delay) {
     assertMoreOrEqual(duration, expected_low);
 }
 
+#ifdef PARTICLE_TEST_RUNNER
 test(SYSTEM_11_system_reset) {
     assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
     System.reset();
 }
+#endif // PARTICLE_TEST_RUNNER

--- a/user/tests/wiring/no_fixture_ble/no_fixture_ble.spec.js
+++ b/user/tests/wiring/no_fixture_ble/no_fixture_ble.spec.js
@@ -1,3 +1,3 @@
 suite('No fixture BLE');
 
-platform('gen3');
+platform('gen3', 'gen4');

--- a/user/tests/wiring/no_fixture_i2c/no_fixture_i2c.spec.js
+++ b/user/tests/wiring/no_fixture_i2c/no_fixture_i2c.spec.js
@@ -1,3 +1,3 @@
 suite('No fixture I2C');
 
-platform('gen3');
+platform('gen3', 'gen4');

--- a/user/tests/wiring/no_fixture_long_running/no_fixture_long_running.spec.js
+++ b/user/tests/wiring/no_fixture_long_running/no_fixture_long_running.spec.js
@@ -1,4 +1,4 @@
 suite('No fixture long running');
 
-platform('gen3');
+platform('gen3', 'gen4');
 timeout(32 * 60 * 1000);

--- a/user/tests/wiring/no_fixture_spi/no_fixture_spi.spec.js
+++ b/user/tests/wiring/no_fixture_spi/no_fixture_spi.spec.js
@@ -1,3 +1,3 @@
 suite('No fixture SPI');
 
-platform('gen3');
+platform('gen3', 'gen4');

--- a/user/tests/wiring/no_fixture_stress/no_fixture_stress.spec.js
+++ b/user/tests/wiring/no_fixture_stress/no_fixture_stress.spec.js
@@ -1,3 +1,3 @@
 suite('No fixture stress');
 
-platform('gen3');
+platform('gen3', 'gen4');

--- a/user/tests/wiring/strformat/strformat.spec.js
+++ b/user/tests/wiring/strformat/strformat.spec.js
@@ -1,3 +1,3 @@
 suite('String format');
 
-platform('gen3');
+platform('gen3', 'gen4');

--- a/user/tests/wiring/time_compat/time_compat.spec.js
+++ b/user/tests/wiring/time_compat/time_compat.spec.js
@@ -1,3 +1,3 @@
 suite('time_t 32/64-bit compatibility');
 
-platform('gen3');
+platform('gen3', 'gen4');

--- a/user/tests/wiring/watchdog/watchdog.spec.js
+++ b/user/tests/wiring/watchdog/watchdog.spec.js
@@ -1,4 +1,4 @@
 suite('Watchdog');
 
-platform('gen3');
+platform('gen3', 'gen4');
 timeout(5 * 60 * 1000);


### PR DESCRIPTION
- HIL job `prepare-binaries-platforms` pulls in the latest `device-os-test-runner`, and a tag change not present in `*.spec.js` was preventing tests from building.