### PR TITLE
[gen4] usb: fix an issue with USB re-attach after sleep

### DIFF
--- a/hal/src/rtl872x/usbd_cdc.cpp
+++ b/hal/src/rtl872x/usbd_cdc.cpp
@@ -84,6 +84,9 @@ int CdcClassDriver::deinit(unsigned cfgIdx) {
         if (txState_) {
             dev_->flushEndpoint(epInData_);
         }
+        if (rxState_) {
+            dev_->flushEndpoint(epOutData_);
+        }
     }
 #if !HAL_PLATFORM_USB_SOF
     stopTxTimeoutTimer();

--- a/hal/src/rtl872x/usbd_device.cpp
+++ b/hal/src/rtl872x/usbd_device.cpp
@@ -139,6 +139,7 @@ int Device::attach() {
 
 int Device::detach() {
     CHECK_TRUE(driver_, SYSTEM_ERROR_INVALID_STATE);
+    clearConfig(0); // config index shouldn't matter here
     CHECK(driver_->detach());
     return 0;
 }

--- a/hal/src/rtl872x/usbd_driver.cpp
+++ b/hal/src/rtl872x/usbd_driver.cpp
@@ -189,7 +189,9 @@ int RtlUsbDriver::detach() {
     std::lock_guard<RtlUsbDriver> lk(*this);
     needsReset_ = false;
     initialized_ = false;
+#if MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
     HAL_Delay_Milliseconds(10);
+#endif // MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
 
     usb_hal_disable_global_interrupt();
     usbd_unregister_class();

--- a/hal/src/rtl872x/usbd_driver.cpp
+++ b/hal/src/rtl872x/usbd_driver.cpp
@@ -98,6 +98,7 @@ uint8_t usb_hal_flush_tx_fifo(uint32_t num);
 uint8_t usb_hal_flush_rx_fifo();
 uint8_t usb_hal_write_packet(uint8_t *src, uint8_t ep_ch_num, uint16_t len);
 void usb_hal_disable_global_interrupt(void);
+void usb_hal_enable_global_interrupt(void);
 void usbd_pcd_set_address(void* pcd, uint8_t addr);
 void usbd_pcd_stop(void* pcd);
 void usbd_pcd_start(void* pcd);
@@ -185,11 +186,15 @@ int RtlUsbDriver::attach() {
 }
 
 int RtlUsbDriver::detach() {
-    usb_hal_disable_global_interrupt();
     std::lock_guard<RtlUsbDriver> lk(*this);
+    needsReset_ = false;
+    initialized_ = false;
+    HAL_Delay_Milliseconds(10);
+
+    usb_hal_disable_global_interrupt();
     usbd_unregister_class();
     usbd_deinit();
-    initialized_ = false;
+    needsReset_ = true;
     resetCount_ = 0;
     return 0;
 }
@@ -224,6 +229,7 @@ void RtlUsbDriver::loop(void* ctx) {
 #endif // MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
         if (!self->initialized_ && !error) {
 #if MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
+            HAL_Delay_Milliseconds(period / 10);
             continue;
 #else
             return;


### PR DESCRIPTION
### Description

Supersedes #2817 

### Steps to Test

Use the app below: should sleep, wake-up and correctly re-attach on Windows/Linux/Mac. Main issue was seen on Linux.

### Example App

```c++
#include "application.h"

SerialLogHandler dbg1(LOG_LEVEL_ALL);
Serial1LogHandler dbg(115200, LOG_LEVEL_ALL);
SYSTEM_THREAD(ENABLED);
SYSTEM_MODE(SEMI_AUTOMATIC);

void setup() {

}

SystemSleepResult result;
system_tick_t start = 0, end = 0;

void loop() {
    waitUntil(Serial.isConnected);
    delay(1000);
    Log.info("Start sleep test slept=%u result=%d", end - start, (int)result.wakeupReason());

    SystemSleepConfiguration config;

    config.mode(SystemSleepMode::ULTRA_LOW_POWER)
        .gpio(A7, FALLING)
        .duration(30s);

    Log.info("going to ULP");
    delay(10);

    start = millis();
    result = System.sleep(config);
    end = millis();
}
```

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
