### PR TITLE
Fixes I2C hal issues

### DIFF
--- a/hal/src/nRF52840/i2c_hal.cpp
+++ b/hal/src/nRF52840/i2c_hal.cpp
@@ -170,6 +170,7 @@ static void twisHandler(hal_i2c_interface_t i2c, nrfx_twis_evt_t const * p_event
             break;
         }
         case NRFX_TWIS_EVT_WRITE_REQ: {
+            i2cMap[i2c].rx_index_head = i2cMap[i2c].rx_index_tail = 0;
             if (p_event->data.buf_req) {
                 nrfx_twis_rx_prepare(i2cMap[i2c].slave, (void *)i2cMap[i2c].rx_buf, i2cMap[i2c].rx_buf_size);
             }
@@ -185,6 +186,8 @@ static void twisHandler(hal_i2c_interface_t i2c, nrfx_twis_evt_t const * p_event
         case NRFX_TWIS_EVT_WRITE_ERROR:
         case NRFX_TWIS_EVT_GENERAL_ERROR: {
             LOG_DEBUG(TRACE, "TWIS ERROR");
+            i2cMap[i2c].tx_index_tail = i2cMap[i2c].tx_index_head = 0;
+            i2cMap[i2c].rx_index_head = i2cMap[i2c].rx_index_tail = 0;
             break;
         }
         default: {


### PR DESCRIPTION
### Problem
1. Gen3: I2C slave RX buffer may have stale data if the last rx operation failed.
2. Gen4: I2C master may fail to re-enable due to I2C FSM(Realtek's concept: Finite State Machine) state never changes to idle

### Solution
1. Reset buffer state on write-request received or error encountered
2. Abort master operation before disabling the I2C module and checks the `IC_ENABLE_STATUS` flag, instead of the activity flag. If we don't abort master operation and only switch to check the `IC_ENABLE_STATUS` flag, the following I2C master operation will fail with abort source `ABRT_MASTER_DIS`.

### Steps to Test
Run the `i2c_master_slave` fixture test

### Example App
`user/tests/wiring/i2c_master_slave`

### References
N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
