### PR TITLE
5.9.0 fixes

### DIFF
--- a/system/src/system_power_manager.cpp
+++ b/system/src/system_power_manager.cpp
@@ -172,6 +172,9 @@ void PowerManager::init() {
   if (config_.version >= HAL_POWER_CONFIG_VERSION_1 && config_.aux_pwr_ctrl_pin != PIN_INVALID) {
     hal_gpio_mode(config_.aux_pwr_ctrl_pin, OUTPUT);
     hal_gpio_write(config_.aux_pwr_ctrl_pin, !config_.aux_pwr_ctrl_pin_level); // Turn off auxiliary power by default
+  } else {
+    // No aux power control
+    system_notify_event(aux_power_state, 0);
   }
 
 #if HAL_PLATFORM_POWER_MANAGEMENT_OPTIONAL

--- a/user/tests/integration/slo/startup/startup-slos.spec.js
+++ b/user/tests/integration/slo/startup/startup-slos.spec.js
@@ -17,15 +17,15 @@ systemThread('enabled');
 const THRESHOLDS = {
     p2: {
         targetAppFlashSize: 21 * 1024, // 21KB
-        targetFreeRam: 3 * 1024 * 1024 // 3MB
+        targetFreeRam: 3040870         // 2.9MB
     },
     trackerm: {
         targetAppFlashSize: 21 * 1024, // 21KB
-        targetFreeRam: 3 * 1024 * 1024 // 3MB
+        targetFreeRam: 3040870         // 2.9MB
     },
     msom: {
         targetAppFlashSize: 21 * 1024, // 21KB
-        targetFreeRam: 3 * 1024 * 1024 // 3MB
+        targetFreeRam: 3040870         // 2.9MB
     },
     // See rational on this magic number: https://app.clubhouse.io/particle/story/72460/build-device-os-test-runner-integration-test-that-validates-the-minimum-flash-space-and-connects-quickly-slo#activity-72937
     default: {
@@ -39,10 +39,10 @@ test('slo startup stats', async function () {
     const unparsedJson = await this.particle.receiveEvent('startup_stats');
     const startupStats = JSON.parse(unparsedJson);
     console.log("startupStats JSON", startupStats);
-    
+
     // set the device under test to set conditional targets based on platform, etc
     // see device-os-test-runner docs: https://github.com/particle-iot/device-os-test-runner
-    const dut = this.particle.devices[0]; 
+    const dut = this.particle.devices[0];
 
     ///
     // Assertions against the minimum RAM SLO
@@ -51,7 +51,7 @@ test('slo startup stats', async function () {
 
     // show actuals first before assertions
     console.log(`actual_free_mem=${startupStats.free_mem} target_free_mem=${thresh.targetFreeRam} platform=${dut.platform.name}`);
-    
+
     // make free ram assertion
     expect(startupStats.free_mem).to.be.at.least(thresh.targetFreeRam);
 

--- a/user/tests/wiring/no_fixture/i2c.cpp
+++ b/user/tests/wiring/no_fixture/i2c.cpp
@@ -377,8 +377,6 @@ test(I2C_07_bus_reset_is_not_destructive) {
 }
 #endif // HAL_PLATFORM_FUELGAUGE_MAX17043
 
-Serial1LogHandler dbg(115200, LOG_LEVEL_ALL);
-
 #if HAL_PLATFORM_FUELGAUGE_MAX17043 && HAL_PLATFORM_I2C_NUM == 1
 // Uses transactions
 test(I2C_08_can_talk_to_fuelgauge_with_transactions) {


### PR DESCRIPTION
- Fixes the issue that if the auxiliary power control pin is specified to be `PIN_INVALID` and the W5500 is not present, the registered "fake" ethernet interface will never be deleted.
- Adjusts slo/startup for gen4 from 3Mi to 2.9Mi
- Removes debug logging in wiring/no_fixture I2C tests