### PR TITLE
[Gen4] fixes a BLE lockup circumstance

### DIFF
--- a/hal/src/rtl872x/ble_hal.cpp
+++ b/hal/src/rtl872x/ble_hal.cpp
@@ -2329,6 +2329,10 @@ void BleGap::handleConnectionStateChanged(uint8_t connHandle, T_GAP_CONN_STATE n
             if (!connection || (connection && addressEqual(connectingAddr_, connection->info.address))) {
                 if (connecting_) {
                     connecting_ = false;
+                }
+                hal_ble_addr_t dummyAddr = {};
+                if (!addressEqual(connectingAddr_, dummyAddr)) {
+                    // connecting_ might have been set to false on GAP_CONN_STATE_CONNECTED event, but the ATT MTU callback is not invoked
                     // Central failed to connect
                     os_semaphore_give(connectSemaphore_, false);
                 }

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -2816,7 +2816,9 @@ int BleLocalDevice::disconnectAll() const {
 
 BlePeerDevice BleLocalDevice::peerCentral() const {
     WiringBleLock lk;
-    for (auto& p : impl()->peers()) {
+    Vector<BlePeerDevice> peers = impl()->peers();
+    lk.unlock();
+    for (auto& p : peers) {
         hal_ble_conn_info_t connInfo = {};
         connInfo.version = BLE_API_VERSION;
         connInfo.size = sizeof(hal_ble_conn_info_t);


### PR DESCRIPTION
### Problem
There is deadlock happening among multi-threads.
1. Custom thread acquired the `HAL BLE lock` when calling `BLE.connect()`, relying on BLE event thread to release the lock, thus, suspended.
2. User thread acquired the `wiring BLE lock` when calling `BLE.peerCentral()`, followed by trying acquiring the `HAL BLE lock`, thus, suspended.
3. BLE event thread tries acquiring the `wiring BLE lock` when invoking callback, thus, suspended.

### Solution
Try acquiring BLE hal lock for query APIs.

### Steps to Test
More info can be found [here](https://app.shortcut.com/particle/story/130253/panic-resets-when-using-ble-group-library-on-photon-2#activity-130929)

### References
N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
