### PR TITLE
Add API to set advertising scheme on disconnected

### DIFF
--- a/hal/src/nRF52840/ble_hal.cpp
+++ b/hal/src/nRF52840/ble_hal.cpp
@@ -4154,7 +4154,7 @@ int hal_ble_gap_set_auto_advertise(hal_ble_auto_adv_cfg_t config, void* reserved
 int hal_ble_gap_get_auto_advertise(hal_ble_auto_adv_cfg_t* cfg, void* reserved) {
     BleLock lk;
     LOG_DEBUG(TRACE, "hal_ble_gap_get_auto_advertise().");
-    CHECK_TRUE(BleObject::getInstance().initialized(), BLE_AUTO_ADV_FORBIDDEN);
+    CHECK_TRUE(BleObject::getInstance().initialized(), SYSTEM_ERROR_INVALID_STATE);
     return BleObject::getInstance().broadcaster()->getAutoAdvertiseScheme(cfg);
 }
 

--- a/hal/src/rtl872x/ble_hal.cpp
+++ b/hal/src/rtl872x/ble_hal.cpp
@@ -2384,17 +2384,18 @@ void BleGap::handleConnectionStateChanged(uint8_t connHandle, T_GAP_CONN_STATE n
             removeConnection(connHandle);
             BleGatt::getInstance().removeSubscriber(connHandle);
             if (role == BLE_ROLE_PERIPHERAL) {
+                SCOPE_GUARD ({
+                    if (autoAdvCfg_ == BLE_AUTO_ADV_SINCE_NEXT_CONN) {
+                        autoAdvCfg_ = BLE_AUTO_ADV_ALWAYS;
+                    }
+                });
                 // FIXME: check whether it's enabled?
                 if (isAdvertising()) {
                     enqueue(BLE_CMD_STOP_ADV);
                     enqueue(BLE_CMD_START_ADV);
                     return;
                 }
-                if (autoAdvCfg_ == BLE_AUTO_ADV_FORBIDDEN) {
-                    return;
-                }
-                if (autoAdvCfg_ == BLE_AUTO_ADV_SINCE_NEXT_CONN) {
-                    autoAdvCfg_ = BLE_AUTO_ADV_ALWAYS;
+                if (autoAdvCfg_ == BLE_AUTO_ADV_FORBIDDEN || autoAdvCfg_ == BLE_AUTO_ADV_SINCE_NEXT_CONN) {
                     return;
                 }
                 enqueue(BLE_CMD_START_ADV);

--- a/hal/src/rtl872x/ble_hal.cpp
+++ b/hal/src/rtl872x/ble_hal.cpp
@@ -387,6 +387,8 @@ public:
     int startAdvertising(bool wait = true); // TODO: always wait, now we have command thread to execute asynchronously
     int stopAdvertising(bool wait = true); // TODO: always wait, now we have command thread to execute asynchronously
     int notifyAdvStop();
+    int setAutoAdvertiseScheme(hal_ble_auto_adv_cfg_t config);
+    int getAutoAdvertiseScheme(hal_ble_auto_adv_cfg_t* cfg);
 
     bool isAdvertising() const {
         return isAdvertising_;
@@ -521,6 +523,7 @@ private:
               addr_{},
               advParams_{},
               advTimeoutTimer_(nullptr),
+              autoAdvCfg_(BLE_AUTO_ADV_ALWAYS),
               isScanning_(false),
               notifyScanResult_(false),
               scanParams_{},
@@ -655,6 +658,7 @@ private:
     hal_ble_addr_t addr_;
     hal_ble_adv_params_t advParams_;
     os_timer_t advTimeoutTimer_;                    /**< Timer for advertising timeout.  */
+    volatile hal_ble_auto_adv_cfg_t autoAdvCfg_;    /**< Automatic advertising configuration. */
     volatile bool isScanning_;                      /**< If it is scanning or not. */
     volatile bool notifyScanResult_;
     hal_ble_scan_params_t scanParams_;              /**< BLE scanning parameters. */
@@ -1636,6 +1640,28 @@ int BleGap::notifyAdvStop() {
     return SYSTEM_ERROR_NONE;
 }
 
+int BleGap::setAutoAdvertiseScheme(hal_ble_auto_adv_cfg_t config) {
+    autoAdvCfg_ = config;
+    bool connectedAsPeripheral = false;
+    std::lock_guard<RecursiveMutex> lk(connectionsMutex_);
+    for (auto& connection : connections_) {
+        if (connection.info.role == BLE_ROLE_PERIPHERAL) {
+            connectedAsPeripheral = true;
+            break;
+        }
+    }
+    if (!connectedAsPeripheral && autoAdvCfg_ == BLE_AUTO_ADV_SINCE_NEXT_CONN) {
+        // If it is not connected as Peripheral currently.
+        autoAdvCfg_ = BLE_AUTO_ADV_ALWAYS;
+    }
+    return SYSTEM_ERROR_NONE;
+}
+
+int BleGap::getAutoAdvertiseScheme(hal_ble_auto_adv_cfg_t* cfg) {
+    *cfg = autoAdvCfg_;
+    return SYSTEM_ERROR_NONE;
+}
+
 void BleGap::onAdvTimeoutTimerExpired(os_timer_t timer) {
     BleGap* gap;
     os_timer_get_id(timer, (void**)&gap);
@@ -2361,6 +2387,15 @@ void BleGap::handleConnectionStateChanged(uint8_t connHandle, T_GAP_CONN_STATE n
                 // FIXME: check whether it's enabled?
                 if (isAdvertising()) {
                     enqueue(BLE_CMD_STOP_ADV);
+                    enqueue(BLE_CMD_START_ADV);
+                    return;
+                }
+                if (autoAdvCfg_ == BLE_AUTO_ADV_FORBIDDEN) {
+                    return;
+                }
+                if (autoAdvCfg_ == BLE_AUTO_ADV_SINCE_NEXT_CONN) {
+                    autoAdvCfg_ = BLE_AUTO_ADV_ALWAYS;
+                    return;
                 }
                 enqueue(BLE_CMD_START_ADV);
             }
@@ -3757,14 +3792,16 @@ int hal_ble_gap_start_advertising(void* reserved) {
 int hal_ble_gap_set_auto_advertise(hal_ble_auto_adv_cfg_t config, void* reserved) {
     BleLock lk;
     LOG_DEBUG(TRACE, "hal_ble_gap_set_auto_advertise().");
+    CHECK_TRUE(BleGap::getInstance().initialized(), SYSTEM_ERROR_INVALID_STATE);
     CHECK_FALSE(BleGap::getInstance().lockMode(), SYSTEM_ERROR_INVALID_STATE);
-    return SYSTEM_ERROR_NONE;
+    return BleGap::getInstance().setAutoAdvertiseScheme(config);
 }
 
 int hal_ble_gap_get_auto_advertise(hal_ble_auto_adv_cfg_t* cfg, void* reserved) {
     BleLock lk;
     LOG_DEBUG(TRACE, "hal_ble_gap_get_auto_advertise().");
-    return SYSTEM_ERROR_NONE;
+    CHECK_TRUE(BleGap::getInstance().initialized(), SYSTEM_ERROR_INVALID_STATE);
+    return BleGap::getInstance().getAutoAdvertiseScheme(cfg);
 }
 
 int hal_ble_gap_stop_advertising(void* reserved) {

--- a/user/tests/wiring/api/ble.cpp
+++ b/user/tests/wiring/api/ble.cpp
@@ -206,9 +206,9 @@ test(ble_pairing_event_type) {
 
 test(ble_advertising_scheme) {
     BleAdvertisingScheme scheme;
-    API_COMPILE({ scheme = BleAdvertisingScheme::STOP_ADV_ON_DISCONNECTED; });
-    API_COMPILE({ scheme = BleAdvertisingScheme::STOP_ADV_ON_DISCONNECTED_ONCE; });
-    API_COMPILE({ scheme = BleAdvertisingScheme::RESTART_ADV_ON_DISCONNECTED; });
+    API_COMPILE({ scheme = BleAdvertisingScheme::AUTO_ADV_FORBIDDEN; });
+    API_COMPILE({ scheme = BleAdvertisingScheme::AUTO_ADV_SINCE_NEXT_CONN; });
+    API_COMPILE({ scheme = BleAdvertisingScheme::AUTO_ADV_ALWAYS; });
     (void)scheme;
 }
 
@@ -688,7 +688,7 @@ test(ble_local_device_class) {
     BleUuid charUuid;
     BleUuid svcUuid;
     BlePeerDevice peer;
-    BleAdvertisingScheme scheme = BleAdvertisingScheme::RESTART_ADV_ON_DISCONNECTED;
+    BleAdvertisingScheme scheme = BleAdvertisingScheme::AUTO_ADV_ALWAYS;
 
     API_COMPILE({ int ret = BleLocalDevice::getInstance().on(); (void)ret; });
 
@@ -737,6 +737,7 @@ test(ble_local_device_class) {
     API_COMPILE({ size_t ret = BLE.getScanResponseData(srData); (void)ret; });
     API_COMPILE({ size_t ret = BLE.setAdvertisingScheme(scheme); (void)ret; });
     API_COMPILE({ size_t ret = BLE.getAdvertisingScheme(&scheme); (void)ret; });
+    API_COMPILE({ size_t ret = BLE.getAdvertisingScheme(scheme); (void)ret; });
 
     API_COMPILE({ int ret = BLE.advertise(); (void)ret; });
     API_COMPILE({ int ret = BLE.advertise(&advData); (void)ret; });

--- a/user/tests/wiring/api/ble.cpp
+++ b/user/tests/wiring/api/ble.cpp
@@ -204,6 +204,14 @@ test(ble_pairing_event_type) {
     (void)type;
 }
 
+test(ble_advertising_scheme) {
+    BleAdvertisingScheme scheme;
+    API_COMPILE({ scheme = BleAdvertisingScheme::STOP_ADV_ON_DISCONNECTED; });
+    API_COMPILE({ scheme = BleAdvertisingScheme::STOP_ADV_ON_DISCONNECTED_ONCE; });
+    API_COMPILE({ scheme = BleAdvertisingScheme::RESTART_ADV_ON_DISCONNECTED; });
+    (void)scheme;
+}
+
 test(ble_phys_type) {
     BlePhy phy;
     API_COMPILE({ phy = BlePhy::BLE_PHYS_AUTO; });
@@ -680,6 +688,7 @@ test(ble_local_device_class) {
     BleUuid charUuid;
     BleUuid svcUuid;
     BlePeerDevice peer;
+    BleAdvertisingScheme scheme = BleAdvertisingScheme::RESTART_ADV_ON_DISCONNECTED;
 
     API_COMPILE({ int ret = BleLocalDevice::getInstance().on(); (void)ret; });
 
@@ -726,6 +735,8 @@ test(ble_local_device_class) {
     API_COMPILE({ size_t ret = BLE.getAdvertisingData(advData); (void)ret; });
     API_COMPILE({ size_t ret = BLE.getScanResponseData(&srData); (void)ret; });
     API_COMPILE({ size_t ret = BLE.getScanResponseData(srData); (void)ret; });
+    API_COMPILE({ size_t ret = BLE.setAdvertisingScheme(scheme); (void)ret; });
+    API_COMPILE({ size_t ret = BLE.getAdvertisingScheme(&scheme); (void)ret; });
 
     API_COMPILE({ int ret = BLE.advertise(); (void)ret; });
     API_COMPILE({ int ret = BLE.advertise(&advData); (void)ret; });

--- a/user/tests/wiring/ble_central_peripheral/ble_central/central.cpp
+++ b/user/tests/wiring/ble_central_peripheral/ble_central/central.cpp
@@ -710,5 +710,45 @@ test(BLE_38_Central_Can_Connect_While_Peripheral_Is_Scanning_And_Stops_Scanning)
     }
 }
 
+test(BLE_39_Advertising_Scheme_Auto_Adv_After_Disconnect) {
+    tryConnecting(false);
+    assertTrue(peer.connected());
+    delay(3000);
+    assertEqual(BLE.disconnect(peer), (int)SYSTEM_ERROR_NONE);
+    assertFalse(BLE.connected());
+    delay(5000);
+}
+
+test(BLE_40_Advertising_Scheme_Stop_Adv_After_Current_Connection_Disconnect) {
+    for (uint8_t i = 0; i < 4; i++) {
+        tryConnecting(false);
+        assertTrue(peer.connected());
+        delay(3000);
+        assertEqual(BLE.disconnect(peer), (int)SYSTEM_ERROR_NONE);
+        assertFalse(BLE.connected());
+        delay(5000);
+    }
+}
+
+test(BLE_41_Advertising_Scheme_Stop_Adv_After_Disconnect) {
+    for (uint8_t i = 0; i < 4; i++) {
+        tryConnecting(false);
+        assertTrue(peer.connected());
+        delay(3000);
+        assertEqual(BLE.disconnect(peer), (int)SYSTEM_ERROR_NONE);
+        assertFalse(BLE.connected());
+        delay(5000);
+    }
+}
+
+test(BLE_42_Advertising_Scheme_Ignored_After_Disconnect_If_Advertising_While_Connected) {
+    tryConnecting(false);
+    assertTrue(peer.connected());
+    delay(3000);
+    assertEqual(BLE.disconnect(peer), (int)SYSTEM_ERROR_NONE);
+    assertFalse(BLE.connected());
+    delay(5000);
+}
+
 #endif // #if Wiring_BLE == 1
 

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -180,9 +180,9 @@ enum class BlePairingEventType : uint8_t {
 };
 
 enum class BleAdvertisingScheme : uint8_t {
-    STOP_ADV_ON_DISCONNECTED = BLE_AUTO_ADV_FORBIDDEN,
-    STOP_ADV_ON_DISCONNECTED_ONCE = BLE_AUTO_ADV_SINCE_NEXT_CONN,
-    RESTART_ADV_ON_DISCONNECTED = BLE_AUTO_ADV_ALWAYS,
+    AUTO_ADV_FORBIDDEN = BLE_AUTO_ADV_FORBIDDEN,
+    AUTO_ADV_SINCE_NEXT_CONN = BLE_AUTO_ADV_SINCE_NEXT_CONN,
+    AUTO_ADV_ALWAYS = BLE_AUTO_ADV_ALWAYS,
 };
 
 struct BlePairingStatus {
@@ -1018,6 +1018,7 @@ public:
 
     int setAdvertisingScheme(BleAdvertisingScheme scheme) const;
     int getAdvertisingScheme(BleAdvertisingScheme* scheme) const;
+    int getAdvertisingScheme(BleAdvertisingScheme& scheme) const;
 
     // Advertising control
     int advertise() const;

--- a/wiring/inc/spark_wiring_ble.h
+++ b/wiring/inc/spark_wiring_ble.h
@@ -179,6 +179,12 @@ enum class BlePairingEventType : uint8_t {
     NUMERIC_COMPARISON = BLE_EVT_PAIRING_NUMERIC_COMPARISON
 };
 
+enum class BleAdvertisingScheme : uint8_t {
+    STOP_ADV_ON_DISCONNECTED = BLE_AUTO_ADV_FORBIDDEN,
+    STOP_ADV_ON_DISCONNECTED_ONCE = BLE_AUTO_ADV_SINCE_NEXT_CONN,
+    RESTART_ADV_ON_DISCONNECTED = BLE_AUTO_ADV_ALWAYS,
+};
+
 struct BlePairingStatus {
     int status;
     bool bonded;
@@ -1009,6 +1015,9 @@ public:
     ssize_t getAdvertisingData(BleAdvertisingData& advertisingData) const;
     ssize_t getScanResponseData(BleAdvertisingData* scanResponse) const;
     ssize_t getScanResponseData(BleAdvertisingData& scanResponse) const;
+
+    int setAdvertisingScheme(BleAdvertisingScheme scheme) const;
+    int getAdvertisingScheme(BleAdvertisingScheme* scheme) const;
 
     // Advertising control
     int advertise() const;

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -2266,6 +2266,10 @@ int BleLocalDevice::getAdvertisingScheme(BleAdvertisingScheme* scheme) const {
     return ret;
 }
 
+int BleLocalDevice::getAdvertisingScheme(BleAdvertisingScheme& scheme) const {
+    return getAdvertisingScheme(&scheme);
+}
+
 int BleLocalDevice::advertise() const {
     return hal_ble_gap_start_advertising(nullptr);
 }

--- a/wiring/src/spark_wiring_ble.cpp
+++ b/wiring/src/spark_wiring_ble.cpp
@@ -2255,6 +2255,17 @@ ssize_t BleLocalDevice::getScanResponseData(BleAdvertisingData& scanResponse) co
     return getScanResponseData(&scanResponse);
 }
 
+int BleLocalDevice::setAdvertisingScheme(BleAdvertisingScheme scheme) const {
+    return hal_ble_gap_set_auto_advertise((hal_ble_auto_adv_cfg_t)scheme, nullptr);
+}
+
+int BleLocalDevice::getAdvertisingScheme(BleAdvertisingScheme* scheme) const {
+    hal_ble_auto_adv_cfg_t config;
+    int ret = hal_ble_gap_get_auto_advertise(&config, nullptr);
+    *scheme = (BleAdvertisingScheme)config;
+    return ret;
+}
+
 int BleLocalDevice::advertise() const {
     return hal_ble_gap_start_advertising(nullptr);
 }


### PR DESCRIPTION
### Problem
Currently when device acting as BLE peripheral is disconnected from peer device, it will re-start advertising automatically. In some use cases, user may wants to stop advertising on disconnected, unless otherwise user manually calls `BLE.advertise()` to start advertising.

### Solution
Add wiring API to set advertising scheme for which after disconnected from peer deivce.

### Example App

```cpp
#include "application.h"

SYSTEM_MODE(MANUAL);

SerialLogHandler logHandler(LOG_LEVEL_ALL);

system_tick_t disconTime = 0;
bool restartAdv = false;

/* executes once at startup */
void setup() {
    // BLE.setAdvertisingScheme(BleAdvertisingScheme::RESTART_ADV_ON_DISCONNECTED);
    // BLE.setAdvertisingScheme(BleAdvertisingScheme::STOP_ADV_ON_DISCONNECTED);
    BLE.setAdvertisingScheme(BleAdvertisingScheme::STOP_ADV_ON_DISCONNECTED_ONCE);
    BLE.advertise();
    BLE.onDisconnected([&](const BlePeerDevice& peer) {
        disconTime = millis();
        restartAdv = true;
    });
}

/* executes continuously after setup() runs */
void loop() {
    if (restartAdv && (millis() - disconTime > 15000)) {
        restartAdv = false;
        if (!BLE.advertising()) {
            Log.info("Restarting advertising");
            BLE.advertise();
        }
    }
}
```

### References
https://community.particle.io/t/ble-disconnect-works-but-then-reconnects/68469

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
