### PR TITLE
[Gen4] ble: clear connecting flag on connected for peripheral role

### DIFF
--- a/hal/src/rtl872x/ble_hal.cpp
+++ b/hal/src/rtl872x/ble_hal.cpp
@@ -2436,6 +2436,7 @@ void BleGap::handleConnectionStateChanged(uint8_t connHandle, T_GAP_CONN_STATE n
                 LOG_DEBUG(TRACE, "Connected as Central");
             } else {
                 connection.info.role = BLE_ROLE_PERIPHERAL;
+                connecting_ = false;
                 LOG_DEBUG(TRACE, "Connected as Peripheral");
             }
             connection.info.conn_handle = connHandle;


### PR DESCRIPTION
### Problem
When a device is connected as BLE peripheral, it cannot connect to a BLE periperhal device.

### Solution
Reset the `connecting_` flag on connected as BLE peripheral.

### References
https://community.particle.io/t/ble-fails-to-connect-to-peripheral-as-central-after-connecting-as-a-peripheral-to-iphone/68477?u=ielec

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
