### PR TITLE
[r510] ensures LTE Cat-M1 band 71 is disabled

### DIFF
--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -106,6 +106,9 @@ const auto UBLOX_NCP_KEEPALIVE_PERIOD_DISABLED = 0; // disables muxer keep alive
 const auto UBLOX_NCP_KEEPALIVE_PERIOD_R510 = UBLOX_NCP_KEEPALIVE_PERIOD_DISABLED;
 const auto UBLOX_NCP_KEEPALIVE_MAX_MISSED = 5;
 
+// const uint32_t UBLOX_NCP_BANDMASK_01_64_R510 = 0x0B0E189F;  // Bands 1,2,3,4,5,8,12,13,18,19,20,25,26,28 [all default enabled]
+const uint8_t UBLOX_NCP_BANDMASK_65_128_R510 = 0x40;        // Band 66,85 enabled, 71 disabled [used as a mask]
+
 // FIXME: for now using a very large buffer
 const auto UBLOX_NCP_AT_CHANNEL_RX_BUFFER_SIZE = 4096;
 const auto UBLOX_NCP_PPP_CHANNEL_RX_BUFFER_SIZE = 256;
@@ -1202,22 +1205,43 @@ int SaraNcpClient::selectNetworkProf(ModemState& state) {
             disableLowPowerModes = true;
         } else if (r == 1 && (static_cast<UbloxSaraUmnoprof>(curProf) == UbloxSaraUmnoprof::STANDARD_EUROPE ||
                 static_cast<UbloxSaraUmnoprof>(curProf) == UbloxSaraUmnoprof::STANDARD_GLOBAL)) {
-            // Log bandmask, and change bandmask for R410 if necessary
+            // Log bandmask, and change bandmask if necessary
             auto respBand = parser_.sendCommand(UBLOX_UBANDMASK_TIMEOUT, "AT+UBANDMASK?");
-            uint64_t ubandUint64 = 0;
-            char ubandStr[24] = {};
-            auto retBand = CHECK_PARSER(respBand.scanf("+UBANDMASK: 0,%23[^,]", ubandStr));
+            uint64_t uint64Uband01_64Current = 0;
+            uint64_t uint64Uband65_128Current = 0;
+            // uint64_t uint64Uband01_64Desired = 0;
+            uint64_t uint64Uband65_128Desired = 0;
+            char uband01_64Str[24] = {};
+            char uband65_128Str[24] = {};
+            // R510: +UBANDMASK: 0,185473183,1048642 <RAT>,<CAT-M1-1-64>,<CAT-M1-65-128>
+            // R410: +UBANDMASK: 0,524420,1,524420 <RAT>,<CAT-M1>,<RAT>,<CAT-NB> ... CAT-NB not supported by SARA-R410M-01B
+            // Technically the following scanf is only correct for R510, but since we ignore uband65_128Str for R410 it works fine
+            auto retBand = CHECK_PARSER(respBand.scanf("+UBANDMASK: 0,%23[^,],%23[^,]", uband01_64Str,uband65_128Str));
             CHECK_PARSER_OK(respBand.readResult());
-            if (retBand == 1 && netConf_.netProv() == CellularNetworkProvider::TWILIO && ncpId() == PLATFORM_NCP_SARA_R410) {
-                char* pEnd = &ubandStr[0];
-                ubandUint64 = strtoull(ubandStr, &pEnd, 10);
-                // Only update if Twilio Super SIM and not set to correct bands
-                if (pEnd - ubandStr > 0 && ubandUint64 != 6170) {
-                    // Enable Cat-M1 bands 2,4,5,12 (AT&T), 13 (VZW) = 6170
-                    parser_.execCommand(UBLOX_UBANDMASK_TIMEOUT, "AT+UBANDMASK=0,6170");
-                    // Not checking for error since we will reset either way
-                    reset = true;
-                    disableLowPowerModes = false;
+            char* pEnd1 = &uband01_64Str[0];
+            char* pEnd2 = &uband65_128Str[0];
+            uint64Uband01_64Current = strtoull(uband01_64Str, &pEnd1, 10);
+            uint64Uband65_128Current = strtoull(uband65_128Str, &pEnd2, 10);
+            if (netConf_.netProv() == CellularNetworkProvider::TWILIO && retBand == 2) {
+                // Enable Cat-M1 bands 2,4,5,12 (AT&T), 13 (VZW) = 6170
+                if (ncpId() == PLATFORM_NCP_SARA_R410) {
+                    if (pEnd1 - uband01_64Str > 0 && uint64Uband01_64Current != 6170) {
+                        parser_.execCommand(UBLOX_UBANDMASK_TIMEOUT, "AT+UBANDMASK=0,6170");
+                        // Not checking for error since we will reset either way
+                        reset = true;
+                        disableLowPowerModes = false;
+                    }
+                }
+                // When modem is initially set to UMNOPROF=90, all bands will be enabled
+                // Allow any combination of Cat-M1 bands, but disable band 71
+                else if (ncpId() == PLATFORM_NCP_SARA_R510) {
+                    uint64Uband65_128Desired = uint64Uband65_128Current & ~UBLOX_NCP_BANDMASK_65_128_R510;
+                    if (pEnd2 - uband65_128Str > 0 && uint64Uband65_128Current != uint64Uband65_128Desired) {
+                        parser_.execCommand(UBLOX_UBANDMASK_TIMEOUT, "AT+UBANDMASK=0,%lu,%lu",(uint32_t)uint64Uband01_64Current,(uint32_t)uint64Uband65_128Desired);
+                        // Not checking for error since we will reset either way
+                        reset = true;
+                        disableLowPowerModes = false;
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Problem

- Device OS 6.2.0 unmasked all bands on R510, however band 71 should be disabled.

### Solution

- Ensure LTE Cat-M1 band 71 is disabled on R510, while still allowing custom band masking if desired.

### Steps to Test

- Reset bands to default on R410 and R510 With 8988**** SIM prefix.  Ensure R410 is masked to 6170 (Bands 2,4,5,12,13), and R510 is unmasked except for band 71.

### Example AT command logs

#### R510

```
0000030260 [ncp.at] TRACE: > AT+UMNOPROF?
0000030265 [ncp.at] TRACE: < +UMNOPROF: 100
0000030270 [ncp.at] TRACE: < OK
0000030272 [ncp.at] TRACE: > AT+CFUN?
0000030276 [ncp.at] TRACE: < +CFUN: 1,7
0000030277 [ncp.at] TRACE: < OK
0000030281 [ncp.at] TRACE: > AT+CFUN=0
0000030289 [ncp.at] TRACE: < OK
0000030289 [ncp.at] TRACE: > AT+UMNOPROF=90
0000030294 [ncp.at] TRACE: < OK
0000030294 [ncp.at] TRACE: > AT+CFUN=16
0000034113 [ncp.at] TRACE: < OK
0000045114 [ncp.at] TRACE: > AT
0000045119 [ncp.at] TRACE: < OK
0000045119 [ncp.at] TRACE: > AT+CPIN?
0000045122 [ncp.at] TRACE: < +CPIN: READY
0000045126 [ncp.at] TRACE: < OK
0000045127 [ncp.at] TRACE: > AT+CCID
0000045178 [ncp.at] TRACE: < +CCID: 8988****************
0000045178 [ncp.at] TRACE: < OK
0000045181 [ncp.at] TRACE: > AT+IFC?
0000045185 [ncp.at] TRACE: < +IFC: 2,2
0000045190 [ncp.at] TRACE: < OK
0000045190 [ncp.at] TRACE: > AT+CPSMS?
0000045196 [ncp.at] TRACE: < +CPSMS: 0,,,"00010011","00000011"
0000045201 [ncp.at] TRACE: < OK
0000045203 [ncp.at] TRACE: > AT+CEDRXS?
0000045207 [ncp.at] TRACE: < +CEDRXS:
0000045209 [ncp.at] TRACE: < OK
0000045213 [ncp.at] TRACE: > AT+UMNOPROF?
0000045218 [ncp.at] TRACE: < +UMNOPROF: 90
0000045220 [ncp.at] TRACE: < OK
0000045224 [ncp.at] TRACE: > AT+UBANDMASK?
0000045229 [ncp.at] TRACE: < +UBANDMASK: 0,185473183,1048642
0000045235 [ncp.at] TRACE: < OK
0000045235 [ncp.at] TRACE: > AT+UBANDMASK=0,185473183,1048578 // Band 71 excluded
0000045240 [ncp.at] TRACE: < OK
0000045246 [ncp.at] TRACE: > AT+CFUN=16
0000047294 [ncp.at] TRACE: < OK
```

#### R410

```
0000030480 [ncp.at] TRACE: > AT+UMNOPROF?
0000030486 [ncp.at] TRACE: < +UMNOPROF: 0
0000030488 [ncp.at] TRACE: < OK
0000030492 [ncp.at] TRACE: > AT+CFUN?
0000030497 [ncp.at] TRACE: < +CFUN: 1
0000030498 [ncp.at] TRACE: < OK
0000030503 [ncp.at] TRACE: > AT+CFUN=0,0
0000030718 [ncp.at] TRACE: < OK
0000030719 [ncp.at] TRACE: > AT+UMNOPROF=100
0000030866 [ncp.at] TRACE: < OK
0000030866 [ncp.at] TRACE: > AT+CFUN=15
0000030869 [ncp.at] TRACE: < OK
0000041872 [ncp.at] TRACE: > AT
0000041875 [ncp.at] TRACE: < OK
0000041875 [ncp.at] TRACE: > AT+CPIN?
0000041878 [ncp.at] TRACE: < +CPIN: READY
0000041882 [ncp.at] TRACE: < OK
0000041884 [ncp.at] TRACE: > AT+CCID
0000041887 [ncp.at] TRACE: < +CCID: 8988****************
0000041893 [ncp.at] TRACE: < OK
0000041895 [ncp.at] TRACE: > AT+IFC?
0000041899 [ncp.at] TRACE: < +IFC: 2,2
0000041901 [ncp.at] TRACE: < OK
0000041904 [ncp.at] TRACE: > AT+CPSMS?
0000041910 [ncp.at] TRACE: < +CPSMS:1,,,"00010011","00000011"
0000041915 [ncp.at] TRACE: < OK
0000041916 [ncp.at] TRACE: > AT+CPSMS=0
0000041926 [ncp.at] TRACE: < OK
0000041926 [ncp.at] TRACE: > AT+CEDRXS?
0000041929 [ncp.at] TRACE: < +CEDRXS: 2,"0010"
0000041933 [ncp.at] TRACE: < +CEDRXS: 4,"0010"
0000041937 [ncp.at] TRACE: < +CEDRXS: 5,"0010"
0000041942 [ncp.at] TRACE: < OK
0000041944 [ncp.at] TRACE: > AT+CEDRXS=3,2
0000041948 [ncp.at] TRACE: < OK
0000041950 [ncp.at] TRACE: > AT+CEDRXS=3,4
0000041953 [ncp.at] TRACE: < OK
0000041959 [ncp.at] TRACE: > AT+CEDRXS=3,5
0000041961 [ncp.at] TRACE: < OK
0000041964 [ncp.at] TRACE: > AT+UMNOPROF?
0000041970 [ncp.at] TRACE: < +UMNOPROF: 100
0000041972 [ncp.at] TRACE: < OK
0000041975 [ncp.at] TRACE: > AT+UBANDMASK?
0000041979 [ncp.at] TRACE: < +UBANDMASK: 0,524420,1,524420
0000041983 [ncp.at] TRACE: < OK
0000041987 [ncp.at] TRACE: > AT+UBANDMASK=0,6170
0000041992 [ncp.at] TRACE: < OK
0000041994 [ncp.at] TRACE: > AT+CFUN=15
0000041998 [ncp.at] TRACE: < OK
0000053001 [ncp.at] TRACE: > AT
0000053005 [ncp.at] TRACE: < OK
0000053005 [ncp.at] TRACE: > AT+CPIN?
0000053008 [ncp.at] TRACE: < +CPIN: READY
0000053011 [ncp.at] TRACE: < OK
0000053017 [ncp.at] TRACE: > AT+CCID
0000053020 [ncp.at] TRACE: < +CCID: 8988****************
0000053021 [ncp.at] TRACE: < OK
0000053027 [ncp.at] TRACE: > AT+IFC?
0000053029 [ncp.at] TRACE: < +IFC: 2,2
0000053032 [ncp.at] TRACE: < OK
0000053034 [ncp.at] TRACE: > AT+UMNOPROF?
0000053041 [ncp.at] TRACE: < +UMNOPROF: 100
0000053042 [ncp.at] TRACE: < OK
0000053046 [ncp.at] TRACE: > AT+UBANDMASK?
0000053051 [ncp.at] TRACE: < +UBANDMASK: 0,6170,1,524420 // Bands 2,4,5,12,13 only
0000053053 [ncp.at] TRACE: < OK
```