### PR TITLE
[network] fixes Ethernet default config/validation, minor optimizations

### DIFF
--- a/hal/network/lwip/wiznet/wiznetif.cpp
+++ b/hal/network/lwip/wiznet/wiznetif.cpp
@@ -551,10 +551,11 @@ int WizNetif::input() {
 
         if (pktSize >= 1522 /* IEEE 802.3ac max size */) {
             // Attempt to recover
+            LOG_DEBUG(WARN, "invalid packet size %u, attempting to recover the RX buffer", pktSize);
             wiz_recv_ignore(0, pktSize + 2);
             closeRaw();
             openRaw();
-            return r;
+            break;
         }
 
 #if ETH_PAD_SIZE
@@ -580,11 +581,12 @@ int WizNetif::input() {
             /* reclaim the padding word */
             pbuf_add_header(p, ETH_PAD_SIZE);
 #endif /* ETH_PAD_SIZE */
-
-            LwipTcpIpCoreLock lk;
-            if (netif_.input(p, &netif_) != ERR_OK) {
-                LOG(ERROR, "Error inputing packet");
-                pbuf_free(p);
+            {
+                LwipTcpIpCoreLock lk;
+                if (netif_.input(p, &netif_) != ERR_OK) {
+                    LOG(ERROR, "Error inputing packet");
+                    pbuf_free(p);
+                }
             }
         } else {
             LOG(ERROR, "Failed to allocate pbuf");
@@ -601,9 +603,14 @@ int WizNetif::input() {
         ++count;
     }
 
-    if (getSn_RX_RSR(0) == 0 || getSn_RX_RSR(0) == 0xffff) {
+    auto rxr = getSn_RX_RSR(0);
+
+    if (rxr == 0 || rxr == 0xffff) {
         inRecv_ = false;
         setSn_IR(0, Sn_IR_RECV);
+    } else {
+        // back-off
+        r = 1;
     }
 
     return r;
@@ -621,7 +628,7 @@ err_t WizNetif::linkOutput(pbuf* p) {
     }
 
     if (os_queue_put(queue_, &q, 0, nullptr)) {
-        LOG(ERROR, "Dropping packet %x, not enough space in event queue", q);
+        LOG_DEBUG(ERROR, "Dropping packet %x, not enough space in event queue", q);
         pbuf_free(q);
         return ERR_MEM;
     }

--- a/hal/network/lwip/wiznet/wiznetif_config.cpp
+++ b/hal/network/lwip/wiznet/wiznetif_config.cpp
@@ -15,10 +15,10 @@
  * License along with this library; if not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "wiznetif_config.h"
-
 #include "logging.h"
 #define WIZNETIF_CONFIG_LOG_CATEGORY "net.en.cfg"
+
+#include "wiznetif_config.h"
 
 #include "system_error.h"
 #include <algorithm>
@@ -67,9 +67,9 @@ int WizNetifConfig::initializeWizNetifConfigData(WizNetifConfigData& configData)
     memset(&configData, 0, sizeof(wizNetifConfigData_));
     configData.size = sizeof(WizNetifConfigData);
     configData.version = WIZNETIF_CONFIG_DATA_VERSION;
-    configData.cs_pin = PIN_INVALID;
-    configData.reset_pin = PIN_INVALID;
-    configData.int_pin = PIN_INVALID;
+    configData.cs_pin = HAL_PLATFORM_ETHERNET_WIZNETIF_CS_PIN_DEFAULT;
+    configData.reset_pin = HAL_PLATFORM_ETHERNET_WIZNETIF_RESET_PIN_DEFAULT;
+    configData.int_pin = HAL_PLATFORM_ETHERNET_WIZNETIF_INT_PIN_DEFAULT;
 
     return SYSTEM_ERROR_NONE;
 }
@@ -138,30 +138,23 @@ int WizNetifConfig::getConfigData(WizNetifConfigData* configData) {
     CHECK_TRUE(configData, SYSTEM_ERROR_INVALID_ARGUMENT);
     CHECK_TRUE(configData->size != 0, SYSTEM_ERROR_INVALID_ARGUMENT);
 
-    recallWizNetifConfigData();
+    // If we are already initialized we should already have a valid config in wizNetifConfigData_
 
     memcpy(configData, &wizNetifConfigData_, std::min(configData->size, wizNetifConfigData_.size));
-    if (configData->cs_pin == PIN_INVALID) {
-        configData->cs_pin = HAL_PLATFORM_ETHERNET_WIZNETIF_CS_PIN_DEFAULT;
-    }
     logWizNetifConfigData(wizNetifConfigData_);
 
     return SYSTEM_ERROR_NONE;
 }
 
 bool WizNetifConfig::isPinValid(uint16_t pin) {
-    if (pin >= TOTAL_PINS && pin != PIN_INVALID) {
-        return false;
-    }
-
-    return true;
+    return pin < TOTAL_PINS;
 }
 
 int WizNetifConfig::validateWizNetifConfigData(const WizNetifConfigData* configData) {
     // XXX: If we add a new version in the future this will need to handle that
     if (configData->size != sizeof(WizNetifConfigData) ||
             configData->version != WIZNETIF_CONFIG_DATA_VERSION ||
-            !isPinValid(configData->cs_pin)) {
+            !isPinValid(configData->cs_pin)) { // CS pin must not be PIN_INVALID!
         LOG(ERROR, "configData not valid! size:%u ver:%u cs_pin:%u reset_pin:%u int_pin:%u",
                 configData->size,
                 configData->version,

--- a/user/tests/app/connection-manager/application.cpp
+++ b/user/tests/app/connection-manager/application.cpp
@@ -131,9 +131,9 @@ void setup() {
         if_wiznet_pin_remap remap = {};
         remap.base.type = IF_WIZNET_DRIVER_SPECIFIC_PIN_REMAP;
 
-        remap.cs_pin = PIN_INVALID; // default
-        remap.reset_pin = PIN_INVALID; // default
-        remap.int_pin = PIN_INVALID; // default
+        remap.cs_pin = HAL_PLATFORM_ETHERNET_WIZNETIF_CS_PIN_DEFAULT; // default
+        remap.reset_pin = HAL_PLATFORM_ETHERNET_WIZNETIF_RESET_PIN_DEFAULT; // default
+        remap.int_pin = HAL_PLATFORM_ETHERNET_WIZNETIF_INT_PIN_DEFAULT; // default
 
         // remap.cs_pin = D8; // MSoM Eval Board
         // remap.reset_pin = A7;

--- a/user/tests/app/ethernet/ethernet.cpp
+++ b/user/tests/app/ethernet/ethernet.cpp
@@ -51,9 +51,9 @@ void setup() {
         if_wiznet_pin_remap remap = {};
         remap.base.type = IF_WIZNET_DRIVER_SPECIFIC_PIN_REMAP;
 
-        remap.cs_pin = PIN_INVALID; // default
-        remap.reset_pin = PIN_INVALID; // default
-        remap.int_pin = PIN_INVALID; // default
+        remap.cs_pin = HAL_PLATFORM_ETHERNET_WIZNETIF_CS_PIN_DEFAULT; // default
+        remap.reset_pin = HAL_PLATFORM_ETHERNET_WIZNETIF_RESET_PIN_DEFAULT; // default
+        remap.int_pin = HAL_PLATFORM_ETHERNET_WIZNETIF_INT_PIN_DEFAULT; // default
 
         // remap.cs_pin = D8; // MSoM Eval Board
         // remap.reset_pin = A7;

--- a/user/tests/wiring/network_config/network_config.cpp
+++ b/user/tests/wiring/network_config/network_config.cpp
@@ -588,7 +588,7 @@ test(NETWORK_CONFIG_ETH_09_dhcp_with_no_gw) {
     assertEqual(addr.profile, ethConfig.profile);
 }
 
-test(NETWORK_CONFIG_ETH_96_restore) {
+test(NETWORK_CONFIG_ETH_94_restore) {
     if (!isEthernetPresent()) {
         skip();
         return;
@@ -603,7 +603,7 @@ test(NETWORK_CONFIG_ETH_96_restore) {
     assertTrue(networkInterfaceConfigMatches(conf, storedConf));
 }
 
-test(NETWORK_CONFIG_ETH_97_connect) {
+test(NETWORK_CONFIG_ETH_95_connect) {
     if (!isEthernetPresent()) {
         skip();
         return;
@@ -616,7 +616,7 @@ test(NETWORK_CONFIG_ETH_97_connect) {
     assertTrue(waitFor(Particle.connected, 60000));
 }
 
-test(NETWORK_CONFIG_ETH_98_ping_gw_latency) {
+test(NETWORK_CONFIG_ETH_96_ping_gw_latency) {
     if (!isEthernetPresent()) {
         skip();
         return;
@@ -634,6 +634,52 @@ test(NETWORK_CONFIG_ETH_98_ping_gw_latency) {
     for (int i = 0; i < 10; i++) {
         auto t0 = millis();
         int r = services::ping(Ethernet.gatewayIP().toString().c_str(), 1, 1000, Ethernet, AF_INET);
+        auto t1 = millis();
+        if (r == 1) {
+            latency += t1 - t0;
+            goodCount++;
+        }
+    }
+    latency /= goodCount;
+    assertMoreOrEqual(goodCount, 1);
+    assertLessOrEqual(latency, 10);
+}
+
+test(NETWORK_CONFIG_ETH_97_reset_cache) {
+    if (!isEthernetPresent()) {
+        skip();
+        return;
+    }
+
+    // This will reset ethernet pin config to default settings if any were there before
+    unlink("/sys/cache.dat");
+
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 5000));
+    System.reset();
+}
+
+test(NETWORK_CONFIG_ETH_98_ping_gw_latency_default_config) {
+    if (!isEthernetPresent()) {
+        skip();
+        return;
+    }
+
+    Ethernet.on();
+    Ethernet.connect();
+    assertTrue(waitFor(Ethernet.ready, 60000));
+
+    // Tests for poor SPI/Wiznet network driver performance
+    // ICMP echo to the gateway should normally be 2ms roundtrip
+    // If performance is affected this will be over 10ms
+    assertTrue(Ethernet.ready());
+    assertTrue((bool)Ethernet.localIP());
+    assertTrue((bool)Ethernet.gatewayIP());
+
+    system_tick_t latency = 0;
+    size_t goodCount = 0;
+    for (int i = 0; i < 100; i++) {
+        auto t0 = millis();
+        int r = services::ping(Ethernet.gatewayIP().toString().c_str(), 1, 20, Ethernet, AF_INET);
         auto t1 = millis();
         if (r == 1) {
             latency += t1 - t0;


### PR DESCRIPTION
### Problem

`PIN_INVALID` should not be used as a default pin setting for wiznet config. It's very easy to put ethernet driver into a not so performant mode due to lack of interrupt pin configuration.

### Solution

`PIN_INVALID` should not be used to reset the settings, as currently calling
```c++
        if_wiznet_pin_remap remap = {};
        remap.base.type = IF_WIZNET_DRIVER_SPECIFIC_PIN_REMAP;

        remap.cs_pin = PIN_INVALID; // default
        remap.reset_pin = PIN_INVALID; // default
        remap.int_pin = PIN_INVALID; // default

        auto ret = if_request(nullptr, IF_REQ_DRIVER_SPECIFIC, &remap, sizeof(remap), nullptr);
```

will result in `cs_pin` being properly overridden to defaults, but not RESET or INT. This is not in public docs, but a couple of test apps are using this.

Reset to defaults should be:
```c++
        if_wiznet_pin_remap remap = {};
        remap.base.type = IF_WIZNET_DRIVER_SPECIFIC_PIN_REMAP;

        remap.cs_pin = HAL_PLATFORM_ETHERNET_WIZNETIF_CS_PIN_DEFAULT; // default
        remap.reset_pin = HAL_PLATFORM_ETHERNET_WIZNETIF_RESET_PIN_DEFAULT; // default
        remap.int_pin = HAL_PLATFORM_ETHERNET_WIZNETIF_INT_PIN_DEFAULT; // default

        auto ret = if_request(nullptr, IF_REQ_DRIVER_SPECIFIC, &remap, sizeof(remap), nullptr);
```

until we introduce a nicer API.

When loading the config from filesystem, if we see `cs_pin = PIN_INVALID` - invalidate the whole config to the defaults. This is NOT a valid configuration and it's better to just revert to defaults.

Setting `reset_pin` or `int_pin` to `PIN_INVALID` is still allowed.

This PR also includes some minor optimizations to ethernet driver itself.

### Steps to Test

N/A

### Example App

N/A

### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
