### PR TITLE
[gen4] wifi: use BSSID from scan result, always perform scans before connect

### DIFF
--- a/hal/src/rtl872x/i2c_hal.cpp
+++ b/hal/src/rtl872x/i2c_hal.cpp
@@ -346,7 +346,7 @@ public:
                 goto ret;
             }
             if(checkAbrt()) {
-                LOG(TRACE, "Abort: %08X", i2cDev_->IC_TX_ABRT_SOURCE);
+                LOG_DEBUG(TRACE, "Abort: %08X", i2cDev_->IC_TX_ABRT_SOURCE);
                 I2C_ClearAllINT(i2cDev_);
                 goto ret;
             }
@@ -478,7 +478,7 @@ public:
                 return SYSTEM_ERROR_I2C_TX_DATA_TIMEOUT;
             }
             if(checkAbrt()) {
-                LOG(TRACE, "Abort: %08X", i2cDev_->IC_TX_ABRT_SOURCE);
+                LOG_DEBUG(TRACE, "Abort: %08X", i2cDev_->IC_TX_ABRT_SOURCE);
                 I2C_ClearAllINT(i2cDev_);
                 return SYSTEM_ERROR_CANCELLED;
             }


### PR DESCRIPTION
### Description

Default connect sequence in RTL872x SDK doesn't seem to work well with single SSID/multiple BSSIDs, apply the same workaround as for ESP32-based platforms to always perform a scan and use the best access point (BSSID) based on signal strength to connect to, instead of just blindly letting the SDK to connect by SSID name.

(I2C log change is unrelated, just fixing an annoying log line that can occur with flaky I2C buses or devices that like to NACK a lot)

### Steps to Test

Which unit/integration/application tests are applicable to this code change? (At minimum a test of some kind should be provided)

### Example App

N/A

### References

N/A
---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
