### PR TITLE
Fix section size calc for some filenames

### DIFF
--- a/build/macros.mk
+++ b/build/macros.mk
@@ -54,6 +54,6 @@ check_modular = $(if $(PLATFORM_DYNALIB_MODULES),,$(error "Platform '$(PLATFORM)
 get_module_start_address = 0x$(word 1,$(shell $(OBJDUMP) --syms $(TARGET_BASE).elf | grep 'link_module_start'))
 
 # FIXME: Cygwin gawk is weird, current awk script seems to work, adding -1 within it breaks everything for some reason
-get_section_size_with_alignment = $(shell echo $$(($(shell $(OBJDUMP) -h --section=$1 $2 | grep -E '$1' | $(AWK) '{ print "0x"$$3" + "$$7}') - 1)))
+get_section_size_with_alignment = $(shell echo $$(($(shell $(OBJDUMP) -h --section=$1 $2 | grep -F '$1' | tail -n 1 | $(AWK) '{ print "0x"$$3" + "$$7}') - 1)))
 
 get_symbol_address = 0x$(shell $(READELF) -W -s $1 | grep -E '$2$$' | $(AWK) '{ print $$2 }')


### PR DESCRIPTION
### Problem

Commit 38ced0de0a2f04bd2fae597338d0eb8583bbc1f1 introduced alignment into section size calculations, but failed on file paths that contain strings "data", "bss", etc.

### Solution

Apply a small fix to the Makefile macro.

### Steps to Test

Create a project or file path containing the string "data".

### Example App

N/A

### References

Bug report:
https://community.particle.io/t/section-bss-will-not-fit-in-region-sram/66641

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
