### PR TITLE
Add a long running publish test

### DIFF
--- a/user/tests/integration/communication/long_publish/long_publish.cpp
+++ b/user/tests/integration/communication/long_publish/long_publish.cpp
@@ -1,0 +1,95 @@
+#include <cstring>
+
+#include "application.h"
+#include "test.h"
+
+namespace {
+
+/*
+Serial1LogHandler logHandler(115200, LOG_LEVEL_WARN, {
+    { "comm.coap", LOG_LEVEL_ALL },
+    { "app", LOG_LEVEL_ALL }
+});
+*/
+
+const size_t EVENT_DATA_SIZE = 1024;
+
+char inEventData[EVENT_DATA_SIZE + 1] = {};
+char outEventData[EVENT_DATA_SIZE + 1] = {};
+
+void oldEventHandler(const char* name, const char* data) {
+    if (!data) {
+        Log.error("Unexpected event size");
+        return;
+    }
+    auto d = std::strchr(data, ' ');
+    if (!d) {
+        Log.error("Invalid event format");
+        return;
+    }
+    size_t prefixLen = d - data;
+    size_t dataLen = std::strlen(d) + prefixLen;
+    if (dataLen != EVENT_DATA_SIZE) {
+        Log.error("Unexpected event size");
+        return;
+    }
+    Log.trace("recv %.*s", (int)prefixLen, data);
+    std::memcpy(outEventData, data, prefixLen + 1);
+    bool ok = Particle.publish("devout1", outEventData);
+    std::memset(outEventData, 'b', prefixLen + 1); // Restore the fill bytes
+    if (!ok) {
+        Log.error("Failed to publish event");
+        return;
+    }
+    Log.trace("send %.*s", (int)prefixLen, data);
+}
+
+void newEventHandler(CloudEvent ev) {
+    if (ev.size() != EVENT_DATA_SIZE) {
+        Log.error("Unexpected event size");
+        return;
+    }
+    int r = ev.read(inEventData, EVENT_DATA_SIZE);
+    if (r != (int)EVENT_DATA_SIZE) {
+        Log.error("Failed to read event");
+    }
+    auto d = std::strchr(inEventData, ' ');
+    if (!d) {
+        Log.error("Invalid event format");
+        return;
+    }
+    size_t prefixLen = d - inEventData;
+    Log.trace("recv %.*s", (int)prefixLen, inEventData);
+    CloudEvent ev2 = CloudEvent().name("devout2");
+    ev2.write(inEventData, prefixLen + 1); // Write the prefix
+    ev2.write(outEventData, EVENT_DATA_SIZE - prefixLen - 1); // Write the fill bytes
+    Particle.publish(ev2);
+    if (!ev2.isOk()) {
+        Log.error("Failed to publish event");
+        return;
+    }
+    Log.trace("send %.*s", (int)prefixLen, inEventData);
+}
+
+inline String scopedEventName(const char* name) {
+    return System.deviceID() + '/' + name;
+}
+
+} // namespace
+
+test(01_connect_and_subscribe) {
+    std::memset(outEventData, 'b', EVENT_DATA_SIZE);
+
+    // Prefix the names of events sent towards the device with the device ID. This way, the tests
+    // can run simultaneously on multiple devices under the same user account
+    Particle.subscribe(scopedEventName("devin1"), oldEventHandler);
+    Particle.subscribe(scopedEventName("devin2"), newEventHandler);
+    Particle.connect();
+    assertTrue(waitFor(Particle.connected, 60000));
+}
+
+test(02_ping_pong_old_api) {
+}
+
+test(03_ping_pong_new_api) {
+}

--- a/user/tests/integration/communication/long_publish/long_publish.spec.js
+++ b/user/tests/integration/communication/long_publish/long_publish.spec.js
@@ -1,0 +1,61 @@
+suite('Cloud events (long running)');
+
+platform('gen3', 'gen4');
+
+const TEST_DURATION = 2 * 60000;
+const EVENT_TIMEOUT = 30000;
+const EVENT_DATA_SIZE = 1024;
+
+let deviceId;
+
+async function runPingPongTest(ctx, inEvent, outEvent) {
+  const t1 = Date.now();
+  let count = 0;
+  do {
+    // Publish an event
+    const outNum = ++count;
+    const data = (outNum.toString() + ' ' + 'a'.repeat(EVENT_DATA_SIZE)).slice(0, EVENT_DATA_SIZE);
+    await ctx.apiClient.instance.publishEvent({
+      name: `${deviceId}/${outEvent}`,
+      data,
+      auth: ctx.apiClient.token
+    });
+    // Receive back an event with the same number
+    let inNum;
+    do {
+      const timeout = Math.min(EVENT_TIMEOUT, Math.max(TEST_DURATION - (Date.now() - t1), 0));
+      const data = await ctx.receiveEvent(inEvent, { timeout });
+      if (!data || data.length != EVENT_DATA_SIZE) {
+        throw new Error('Unexpected event size');
+      }
+      const pos = data.indexOf(' ');
+      if (pos <= 0) {
+        throw new Error('Unexpected event format');
+      }
+      inNum = Number(data.slice(0, pos));
+    } while (inNum !== outNum);
+  } while (Date.now() - t1 < TEST_DURATION);
+  return count;
+}
+
+before(function() {
+  const dev = this.particle.devices[0];
+  deviceId = dev.id;
+});
+
+test('01_connect_and_subscribe', async function() {
+});
+
+test('02_ping_pong_old_api', async function() {
+  this.timeout(TEST_DURATION + EVENT_TIMEOUT);
+  const count = await runPingPongTest(this.particle, 'devout1', 'devin1');
+  expect(count).to.be.at.least(10);
+  console.log('Sent/received events:', count);
+});
+
+test('03_ping_pong_new_api', async function() {
+  this.timeout(TEST_DURATION + EVENT_TIMEOUT);
+  const count = await runPingPongTest(this.particle, 'devout2', 'devin2');
+  expect(count).to.be.at.least(10);
+  console.log('Sent/received events:', count);
+});


### PR DESCRIPTION
### Problem

Add a test for catching network/protocol issues that may occur when sending data back and forth between the device and the cloud over a prolonged period of time.
