### PR TITLE
A couple of 6.3.0 fixes

### DIFF
--- a/hal/network/lwip/wiznet/wiznetif.cpp
+++ b/hal/network/lwip/wiznet/wiznetif.cpp
@@ -324,13 +324,16 @@ int WizNetif::init(const WizNetifConfigData& config) {
 }
 
 bool WizNetif::isPresent(bool retry) {
-    uint8_t retries = retry ? 10 : 1;
+    const auto RETRY_DELAY = 10;
+    // It takes about 250ms for W5500 to startup usually
+    const auto MAX_STARTUP_TIME = 300;
+    uint8_t retries = retry ? MAX_STARTUP_TIME / RETRY_DELAY : 1;
     uint8_t cv = 0;
     for (uint8_t i = 0; i < retries; i++) {
         cv = getVERSIONR();
         /* VERSIONR always indicates the W5500 version as 0x04 */
         if (cv != 0x04 && retry) {
-            HAL_Delay_Milliseconds(10);
+            HAL_Delay_Milliseconds(RETRY_DELAY);
             continue;
         }
         break;

--- a/user/tests/wiring/no_fixture_long_running/network.cpp
+++ b/user/tests/wiring/no_fixture_long_running/network.cpp
@@ -51,9 +51,18 @@ bool udpEchoTest(UDP* udp, const IPAddress& ip, uint16_t port, const uint8_t* se
     while (retries-- > 0) {
         auto snd = udp->sendPacket(sendBuf, len, ip, port);
         if (snd == (int)len) {
-            auto recvd = udp->parsePacket(timeout);
-            if (recvd == (int)len) {
-                return !memcmp(udp->buffer(), sendBuf, len);
+            while (true) {
+                auto recvd = udp->parsePacket(timeout);
+                if (recvd == (int)len) {
+                    auto same = !memcmp(udp->buffer(), sendBuf, len);
+                    if (same) {
+                        return true;
+                    }
+                }
+                if (recvd == 0 && timeout == 0) {
+                    break;
+                }
+                timeout = 0;
             }
             // Failed to receive reply, retry
         } else {
@@ -190,6 +199,40 @@ test(NETWORK_01_LargePacketsDontCauseIssues_ResolveMtu) {
         assertMoreOrEqual((mtu - IPV4_PLUS_UDP_HEADER_LENGTH), MBEDTLS_SSL_MAX_CONTENT_LEN);
     }
 #endif // PLATFORM_ID != PLATFORM_BORON && PLATFORM_ID != PLATFORM_BSOM && PLATFORM_ID != PLATFORM_ELECTRON2
+
+    int replies = 0;
+    for (int i = 0; i < 100; i++) {
+        const size_t payloadSize = mtu - IPV4_PLUS_UDP_HEADER_LENGTH;
+        rand.gen((char*)sendBuffer.get(), payloadSize);
+        int sent = 0;
+        int recvd = 0;
+        for (int j = 0; j < 10; j++) {
+            // Burst of 10 packets
+            if (udp->sendPacket(sendBuffer.get(), payloadSize, udpEchoIp, UDP_ECHO_PORT) == payloadSize) {
+                sent++;
+            }
+        }
+        assertMoreOrEqual(sent, 1);
+        if (sent > 0) {
+            for (auto start = millis(); millis() - start <= 5000;) {
+                auto len = udp->parsePacket(10);
+                if (len == payloadSize) {
+                    if (!memcmp(udp->buffer(), sendBuffer.get(), payloadSize)) {
+                        recvd++;
+                        replies++;
+                    }
+                }
+                if (recvd >= sent) {
+                    break;
+                }
+            }
+        }
+    }
+
+    Serial.printlnf("Recvd %d replies", replies);
+
+    assertMoreOrEqual(replies, 100 * 10 / 2);
+    assertFalse((bool)networkState.disconnected);
 }
 
 #if HAL_PLATFORM_NCP_AT || HAL_PLATFORM_CELLULAR

--- a/wiring/inc/spark_wiring_eeprom.h
+++ b/wiring/inc/spark_wiring_eeprom.h
@@ -31,6 +31,8 @@
 
 /* Includes ------------------------------------------------------------------*/
 #include "eeprom_hal.h"
+#include <type_traits>
+#include "spark_wiring_string.h"
 
 /***
     EERef class.
@@ -142,12 +144,14 @@ struct EEPROMClass{
     //Functionality to 'get' and 'put' objects to and from EEPROM.
     template <typename T> T &get( int idx, T &t )
     {
+        static_assert(!std::is_base_of_v<String, T>, "String class cannot be used with EEPROM, use char[] array");
         HAL_EEPROM_Get(idx, &t, sizeof(T));
         return t;
     }
 
     template <typename T> const T &put( int idx, const T &t )
     {
+        static_assert(!std::is_base_of_v<String, T>, "String class cannot be used with EEPROM, use char[] array");
         HAL_EEPROM_Put(idx, &t, sizeof(T));
         return t;
     }


### PR DESCRIPTION
### Description

1. Wiznet W5500 usual start up time is up to 250ms, so need to retry for longer. (this was broken in #2847 and was not in any public release)
2. EEPROM.get/set cannot be used with `String` objects, generate assertion failure when doing so
3. Update network tests to stress test large packets up to MTU size once max MTU is figured out


### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
