### PR TITLE
[wiring] implement WiFi/Cellular/Ethernet/Network.ping() for Gen 3 and Gen 4 platforms

### DIFF
--- a/build/gcc-tools.mk
+++ b/build/gcc-tools.mk
@@ -14,8 +14,10 @@ endif
 
 # C compiler flags
 CFLAGS +=  -g3 -m64 -O$(GCC_OPTIMIZE) -gdwarf-2
-CFLAGS += -Wno-unused-local-typedefs -Wno-pragmas -Wno-overloaded-virtual
+CFLAGS += -Wno-unused-local-typedefs -Wno-pragmass
 ASFLAGS +=  -g3
+
+CPPFLAGS += -Wno-overloaded-virtual
 
 
 ifeq ("$(MAKE_OS)", "LINUX")

--- a/services/inc/icmp_echo.h
+++ b/services/inc/icmp_echo.h
@@ -42,7 +42,7 @@ namespace detail {
 /*
  * RFC 1071 - http://tools.ietf.org/html/rfc1071
  */
-static uint16_t ipChecksum(const uint8_t *buf, size_t size) {
+inline uint16_t ipChecksum(const uint8_t *buf, size_t size) {
     size_t i;
     uint64_t sum = 0;
 
@@ -77,7 +77,7 @@ inline bool validatePingData(const uint8_t* buffer, size_t bufferSize) {
     return true;
 }
 
-int createIcmpPacket(int af, uint16_t id, uint16_t seq, uint8_t* buffer, size_t bufferSize) {
+inline int createIcmpPacket(int af, uint16_t id, uint16_t seq, uint8_t* buffer, size_t bufferSize) {
     if (af == AF_INET) {
         CHECK_TRUE(bufferSize >= sizeof(icmp_echo_hdr), SYSTEM_ERROR_INVALID_ARGUMENT);
         auto hdr = reinterpret_cast<icmp_echo_hdr*>(buffer);
@@ -106,7 +106,7 @@ int createIcmpPacket(int af, uint16_t id, uint16_t seq, uint8_t* buffer, size_t 
     return SYSTEM_ERROR_INVALID_ARGUMENT;
 }
 
-bool validateIcmpPacket(int af, uint16_t id, uint16_t seq, const uint8_t* buffer, int bufferSize, size_t expected,
+inline bool validateIcmpPacket(int af, uint16_t id, uint16_t seq, const uint8_t* buffer, int bufferSize, size_t expected,
         const char* host, const struct sockaddr* from, system_tick_t elapsed) {
 
     char fromAddress[INET6_ADDRSTRLEN] = {};
@@ -149,7 +149,7 @@ bool validateIcmpPacket(int af, uint16_t id, uint16_t seq, const uint8_t* buffer
 
 } // detail
 
-int ping(const char* host, unsigned count = 1, system_tick_t timeoutMs = 1000, network_interface_t pingIface = NETWORK_INTERFACE_ALL, int addressFamily = AF_UNSPEC) {
+inline int ping(const char* host, unsigned count = 1, system_tick_t timeoutMs = 1000, network_interface_t pingIface = NETWORK_INTERFACE_ALL, int addressFamily = AF_UNSPEC) {
     static const constexpr size_t packetSize = 64;
 
     struct addrinfo* ais = nullptr;

--- a/services/inc/icmp_echo.h
+++ b/services/inc/icmp_echo.h
@@ -15,6 +15,8 @@
  * License along with this library; if not, see <http://www.gnu.org/licenses/>.
  */
 
+#pragma once
+
 #include "socket_hal_posix.h"
 #include "netdb_hal.h"
 #include "inet_hal_posix.h"

--- a/user/tests/wiring/api/cellular.cpp
+++ b/user/tests/wiring/api/cellular.cpp
@@ -154,4 +154,15 @@ test(api_cellular_registration_timeout_set) {
     API_COMPILE(cellular_registration_timeout_set(60 * 60 * 1000, nullptr)); // 60 minutes
 }
 
+test(api_cellular_ping) {
+    String hostname;
+    IPAddress addr;
+    API_COMPILE(Cellular.ping(addr));
+    API_COMPILE(Cellular.ping(hostname));
+    API_COMPILE(Cellular.ping(addr, 10));
+    API_COMPILE(Cellular.ping(hostname, 10));
+    API_COMPILE(Cellular.ping(addr, 10s, 10));
+    API_COMPILE(Cellular.ping(hostname, 10s, 10));
+}
+
 #endif

--- a/user/tests/wiring/api/ethernet.cpp
+++ b/user/tests/wiring/api/ethernet.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "testapi.h"
+
+#if Wiring_Ethernet
+
+test(api_ethernet_ping) {
+    String hostname;
+    IPAddress addr;
+    API_COMPILE(Ethernet.ping(addr));
+    API_COMPILE(Ethernet.ping(hostname));
+    API_COMPILE(Ethernet.ping(addr, 10));
+    API_COMPILE(Ethernet.ping(hostname, 10));
+    API_COMPILE(Ethernet.ping(addr, 10s, 10));
+    API_COMPILE(Ethernet.ping(hostname, 10s, 10));
+}
+
+#endif // Wiring_Ethernet

--- a/user/tests/wiring/api/wifi.cpp
+++ b/user/tests/wiring/api/wifi.cpp
@@ -256,4 +256,15 @@ test(api_wifi_hostname)
 #endif // !HAL_PLATFORM_NCP
 #endif // !HAL_PLATFORM_WIFI_SCAN_ONLY
 
+test(api_wifi_ping) {
+    String hostname;
+    IPAddress addr;
+    API_COMPILE(WiFi.ping(addr));
+    API_COMPILE(WiFi.ping(hostname));
+    API_COMPILE(WiFi.ping(addr, 10));
+    API_COMPILE(WiFi.ping(hostname, 10));
+    API_COMPILE(WiFi.ping(addr, 10s, 10));
+    API_COMPILE(WiFi.ping(hostname, 10s, 10));
+}
+
 #endif

--- a/user/tests/wiring/network_config/network_config.cpp
+++ b/user/tests/wiring/network_config/network_config.cpp
@@ -588,7 +588,7 @@ test(NETWORK_CONFIG_ETH_09_dhcp_with_no_gw) {
     assertEqual(addr.profile, ethConfig.profile);
 }
 
-test(NETWORK_CONFIG_ETH_94_restore) {
+test(NETWORK_CONFIG_ETH_93_restore) {
     if (!isEthernetPresent()) {
         skip();
         return;
@@ -603,7 +603,7 @@ test(NETWORK_CONFIG_ETH_94_restore) {
     assertTrue(networkInterfaceConfigMatches(conf, storedConf));
 }
 
-test(NETWORK_CONFIG_ETH_95_connect) {
+test(NETWORK_CONFIG_ETH_94_connect) {
     if (!isEthernetPresent()) {
         skip();
         return;
@@ -616,7 +616,7 @@ test(NETWORK_CONFIG_ETH_95_connect) {
     assertTrue(waitFor(Particle.connected, 60000));
 }
 
-test(NETWORK_CONFIG_ETH_96_ping_gw_latency) {
+test(NETWORK_CONFIG_ETH_95_ping_gw_latency) {
     if (!isEthernetPresent()) {
         skip();
         return;
@@ -643,6 +643,25 @@ test(NETWORK_CONFIG_ETH_96_ping_gw_latency) {
     latency /= goodCount;
     assertMoreOrEqual(goodCount, 1);
     assertLessOrEqual(latency, 10);
+}
+
+test(NETWORK_CONFIG_ETH_96_ping) {
+    if (!isEthernetPresent()) {
+        skip();
+        return;
+    }
+
+    assertTrue(Ethernet.ready());
+    IPAddress addr;
+    for (int i = 0; i < 5; i++) {
+        addr = Ethernet.resolve("dns.google");
+        if (addr) {
+            break;
+        }
+    }
+    assertTrue((bool)addr);
+    assertMoreOrEqual(Ethernet.ping(addr, 5), 2);
+    assertMoreOrEqual(Ethernet.ping("dns.google", 5), 2);
 }
 
 test(NETWORK_CONFIG_ETH_97_reset_cache) {

--- a/user/tests/wiring/no_fixture_cellular/cellular.cpp
+++ b/user/tests/wiring/no_fixture_cellular/cellular.cpp
@@ -96,6 +96,20 @@ test(CELLULAR_03_resolve) {
     assertEqual(addr, 0);
 }
 
+test(CELLULAR_04_ping) {
+    assertTrue(Cellular.ready());
+    IPAddress addr;
+    for (int i = 0; i < 5; i++) {
+        addr = Cellular.resolve("dns.google");
+        if (addr) {
+            break;
+        }
+    }
+    assertTrue((bool)addr);
+    assertMoreOrEqual(Cellular.ping(addr, 5), 2);
+    assertMoreOrEqual(Cellular.ping("dns.google", 5), 2);
+}
+
 // Collects cellular signal strength and quality and validates Accesstechnology (RAT)
 test(CELLULAR_05_sigstr_is_valid) {
     connect_to_cloud(HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME);

--- a/user/tests/wiring/no_fixture_wifi/wifi.cpp
+++ b/user/tests/wiring/no_fixture_wifi/wifi.cpp
@@ -67,6 +67,20 @@ test(WIFI_03_resolve) {
     assertEqual(addr, 0);
 }
 
+test(WIFI_04_ping) {
+    assertTrue(WiFi.ready());
+    IPAddress addr;
+    for (int i = 0; i < 5; i++) {
+        addr = WiFi.resolve("dns.google");
+        if (addr) {
+            break;
+        }
+    }
+    assertTrue((bool)addr);
+    assertMoreOrEqual(WiFi.ping(addr, 5), 2);
+    assertMoreOrEqual(WiFi.ping("dns.google", 5), 2);
+}
+
 namespace {
 void checkIPAddress(const char* name, const IPAddress& address)
 {
@@ -90,7 +104,7 @@ void checkEtherAddress(const uint8_t* address)
     assertNotEqual(sum, 0);
 }
 
-test(WIFI_04_config)
+test(WIFI_05_config)
 {
     checkIPAddress("local", WiFi.localIP());
     checkIPAddress("gateway", WiFi.gatewayIP());
@@ -118,7 +132,7 @@ test(WIFI_04_config)
 
 #endif // !HAL_PLATFORM_WIFI_SCAN_ONLY
 
-test(WIFI_05_scan)
+test(WIFI_06_scan)
 {
     if (!WiFi.isOn()) {
         WiFi.on();
@@ -131,7 +145,7 @@ test(WIFI_05_scan)
 
 #if !HAL_PLATFORM_WIFI_SCAN_ONLY
 
-test(WIFI_06_restore_connection)
+test(WIFI_07_restore_connection)
 {
     set_system_mode(AUTOMATIC);
     if (!Particle.connected())
@@ -143,32 +157,32 @@ test(WIFI_06_restore_connection)
 #endif // !HAL_PLATFORM_WIFI_SCAN_ONLY
 
 #if !HAL_PLATFORM_NCP
-test(WIFI_07_reset_hostname)
+test(WIFI_08_reset_hostname)
 {
     assertEqual(WiFi.setHostname(NULL), 0);
 }
 
-test(WIFI_08_default_hostname_equals_device_id)
+test(WIFI_09_default_hostname_equals_device_id)
 {
     String hostname = WiFi.hostname();
     String devId = System.deviceID();
     assertEqual(hostname, devId);
 }
 
-test(WIFI_09_custom_hostname_can_be_set)
+test(WIFI_10_custom_hostname_can_be_set)
 {
     String hostname("testhostname");
     assertEqual(WiFi.setHostname(hostname), 0);
     assertEqual(WiFi.hostname(), hostname);
 }
 
-test(WIFI_10_restore_default_hostname)
+test(WIFI_11_restore_default_hostname)
 {
     assertEqual(WiFi.setHostname(NULL), 0);
 }
 #endif //!HAL_PLATFORM_NCP
 
-test(WIFI_11_scan_returns_zero_result_or_error_when_wifi_is_off)
+test(WIFI_12_scan_returns_zero_result_or_error_when_wifi_is_off)
 {
     WiFiAccessPoint results[5];
     WiFi.off();
@@ -185,7 +199,7 @@ test(WIFI_11_scan_returns_zero_result_or_error_when_wifi_is_off)
 
 #if !HAL_PLATFORM_WIFI_SCAN_ONLY
 
-test(WIFI_12_restore_connection)
+test(WIFI_13_restore_connection)
 {
     if (!Particle.connected())
     {
@@ -193,7 +207,7 @@ test(WIFI_12_restore_connection)
     }
 }
 
-test(WIFI_13_wifi_class_methods_work_correctly_when_wifi_interface_is_off) {
+test(WIFI_14_wifi_class_methods_work_correctly_when_wifi_interface_is_off) {
     Particle.disconnect();
     WiFi.disconnect();
     WiFi.off();

--- a/wiring/inc/spark_wiring_network.h
+++ b/wiring/inc/spark_wiring_network.h
@@ -28,6 +28,7 @@
 
 #include "spark_wiring_ipaddress.h"
 #include "system_network.h"
+#include <chrono>
 
 namespace spark {
 
@@ -71,8 +72,13 @@ public:
     IPAddress gatewayIP() __attribute__((deprecated("Please use WiFi.gatewayIP() instead")));
     char* SSID() __attribute__((deprecated("Please use WiFi.SSID() instead")));
     int8_t RSSI() __attribute__((deprecated("Please use WiFi.RSSI() instead")));
-    uint32_t ping(IPAddress remoteIP) __attribute__((deprecated("Please use WiFi.ping() instead")));
-    uint32_t ping(IPAddress remoteIP, uint8_t nTries) __attribute__((deprecated("Please use WiFi.ping() instead")));
+
+    static constexpr auto DEFAULT_PING_TIMEOUT = 4000;
+
+    int ping(IPAddress remoteIP, unsigned nTries = 1, unsigned timeoutMs = DEFAULT_PING_TIMEOUT);
+    int ping(String hostname, unsigned nTries = 1, unsigned timeoutMs = DEFAULT_PING_TIMEOUT);
+    int ping(IPAddress remoteIP, std::chrono::milliseconds timeout, unsigned nTries = 1);
+    int ping(String hostname, std::chrono::milliseconds timeout, unsigned nTries = 1);
 
     virtual void connect(unsigned flags = 0);
     virtual void disconnect();

--- a/wiring/inc/spark_wiring_wifi.h
+++ b/wiring/inc/spark_wiring_wifi.h
@@ -175,13 +175,6 @@ public:
     }
 
     WiFiSignal RSSI();
-    uint32_t ping(IPAddress remoteIP) {
-        return ping(remoteIP, 5);
-    }
-
-    uint32_t ping(IPAddress remoteIP, uint8_t nTries) {
-        return inet_ping(&remoteIP.raw(), *this, nTries, NULL);
-    }
 
     void connect(unsigned flags=0) {
         network_connect(*this, flags, 0, NULL);

--- a/wiring/src/spark_wiring_network.cpp
+++ b/wiring/src/spark_wiring_network.cpp
@@ -24,9 +24,9 @@
 #include "hal_platform.h"
 #if HAL_USE_INET_HAL_POSIX
 #include <netdb.h>
+#include "icmp_echo.h"
 #endif // HAL_USE_INET_HAL_POSIX
 #include "check.h"
-#include "icmp_echo.h"
 
 using namespace particle;
 

--- a/wiring/src/spark_wiring_network.cpp
+++ b/wiring/src/spark_wiring_network.cpp
@@ -26,6 +26,7 @@
 #include <netdb.h>
 #endif // HAL_USE_INET_HAL_POSIX
 #include "check.h"
+#include "icmp_echo.h"
 
 using namespace particle;
 
@@ -172,6 +173,31 @@ IPAddress NetworkClass::resolve(const char* name) {
 }
 
 #if HAL_USE_SOCKET_HAL_POSIX
+
+int NetworkClass::ping(IPAddress remoteIP, unsigned nTries, unsigned timeoutMs) {
+    return services::ping(remoteIP.toString().c_str(), nTries, timeoutMs, iface_);
+}
+
+int NetworkClass::ping(String hostname, unsigned nTries, unsigned timeoutMs) {
+    auto addr = this->resolve(hostname.c_str());
+    if (addr) {
+        return ping(addr, nTries, timeoutMs);
+    }
+    return SYSTEM_ERROR_NOT_FOUND;
+}
+
+int NetworkClass::ping(IPAddress remoteIP, std::chrono::milliseconds timeout, unsigned nTries) {
+    return ping(remoteIP, nTries, timeout.count());
+}
+
+int NetworkClass::ping(String hostname, std::chrono::milliseconds timeout, unsigned nTries) {
+    auto addr = this->resolve(hostname.c_str());
+    if (addr) {
+        return ping(addr, timeout, nTries);
+    }
+    return SYSTEM_ERROR_NOT_FOUND;
+}
+
 int NetworkClass::setConfig(const NetworkInterfaceConfig& conf) {
     network_configuration_t c = {};
     c.size = sizeof(c);


### PR DESCRIPTION
### Problem

`WiFi`/`Cellular`/`Ethernet`/`Network``.ping()` is not implement for Gen 3 and Gen 4 platforms.

### Steps to Test

- wiring/api
- wiring/no_fixture_wifi
- wiring/no_fixture_cellular
- wiring/network_config (for Ethernet)

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
