### PR TITLE
Fix retransmissions when blockwise transfer is used

### DIFF
--- a/communication/inc/v2/coap_channel.h
+++ b/communication/inc/v2/coap_channel.h
@@ -175,7 +175,7 @@ private:
     int handleResponse(CoapMessageDecoder& d);
     int handleAck(CoapMessageDecoder& d);
 
-    int prepareMessage(const RefCountPtr<Message>& msg);
+    int prepareMessage(const RefCountPtr<Message>& msg, bool retransmit = false);
     int updateMessage(const RefCountPtr<Message>& msg);
     int sendMessage(RefCountPtr<Message> msg, bool retransmit = false, bool passthrough = false);
     int sendPayloadBlock(const RefCountPtr<Message>& msg, bool retransmit = false);

--- a/communication/src/v2/coap_channel.cpp
+++ b/communication/src/v2/coap_channel.cpp
@@ -1531,10 +1531,10 @@ int CoapChannel::handleAck(CoapMessageDecoder& d) {
     return Result::HANDLED;
 }
 
-int CoapChannel::prepareMessage(const RefCountPtr<Message>& msg) {
+int CoapChannel::prepareMessage(const RefCountPtr<Message>& msg, bool retransmit) {
     assert(!curMsgId_);
     CHECK_PROTOCOL(protocol_->get_channel().create(msgBuf_));
-    if (msg->type == MessageType::REQUEST || msg->type == MessageType::BLOCK_REQUEST) {
+    if (!retransmit && (msg->type == MessageType::REQUEST || msg->type == MessageType::BLOCK_REQUEST)) {
         msg->token = tokenFrom(protocol_->get_next_token()); // TODO: Use longer tokens with outgoing requests
     }
     msg->prefixSize = 0;
@@ -1643,7 +1643,7 @@ int CoapChannel::sendPayloadBlock(const RefCountPtr<Message>& msg, bool retransm
         msg->blockIndex = msg->payloadPos / COAP_BLOCK_SIZE;
         msg->hasMore = msg->payloadPos + bytesToSend < msg->payload->size();
     }
-    CHECK(prepareMessage(msg));
+    CHECK(prepareMessage(msg, retransmit));
     if (bytesToSend > 0) {
         *msg->pos++ = 0xff; // Payload marker
         msg->pos += CHECK(msg->payload->read(msg->pos, bytesToSend, msg->payloadPos));


### PR DESCRIPTION
### Problem

There's a bug in https://github.com/particle-iot/device-os/pull/2840 that causes the new CoAP implementation to generate a new token when an individual block of a blockwise request is retransmitted.

### Steps to Test

Run the tests in `communication/events_new`.
