### PR TITLE
[hal] SPI: fixes threading safty issue

### DIFF
--- a/hal/src/nRF52840/spi_hal.cpp
+++ b/hal/src/nRF52840/spi_hal.cpp
@@ -672,8 +672,12 @@ int32_t hal_spi_acquire(hal_spi_interface_t spi, const hal_spi_acquire_config_t*
     if (!hal_interrupt_is_isr()) {
         os_mutex_recursive_t mutex = spiMap[spi].mutex;
         if (mutex) {
-            // FIXME: os_mutex_recursive_lock doesn't take any arguments
-            return os_mutex_recursive_lock(mutex);
+            // FIXME: os_mutex_recursive_lock doesn't take any arguments, using trylock for now
+            if (!conf || conf->timeout != 0) {
+                return os_mutex_recursive_lock(mutex);
+            } else {
+                return os_mutex_recursive_trylock(mutex);
+            }
         }
     }
     return -1;

--- a/hal/src/nRF52840/spi_hal.cpp
+++ b/hal/src/nRF52840/spi_hal.cpp
@@ -672,12 +672,8 @@ int32_t hal_spi_acquire(hal_spi_interface_t spi, const hal_spi_acquire_config_t*
     if (!hal_interrupt_is_isr()) {
         os_mutex_recursive_t mutex = spiMap[spi].mutex;
         if (mutex) {
-            // FIXME: os_mutex_recursive_lock doesn't take any arguments, using trylock for now
-            if (!conf || conf->timeout != 0) {
-                return os_mutex_recursive_lock(mutex);
-            } else {
-                return os_mutex_recursive_trylock(mutex);
-            }
+            // FIXME: os_mutex_recursive_lock doesn't take any arguments
+            return os_mutex_recursive_lock(mutex);
         }
     }
     return -1;

--- a/hal/src/rtl872x/spi_hal.cpp
+++ b/hal/src/rtl872x/spi_hal.cpp
@@ -456,12 +456,8 @@ public:
 
     int lock(system_tick_t timeout = 0) {
         CHECK_TRUE(hal_interrupt_is_isr() == false, SYSTEM_ERROR_INVALID_STATE);
-        // FIXME: os_mutex_recursive_lock doesn't take any arguments, using trylock for now
-        if (timeout) {
-            return os_mutex_recursive_lock(mutex_);
-        }
-
-        return os_mutex_recursive_trylock(mutex_);
+        // FIXME: os_mutex_recursive_lock doesn't take any arguments
+        return os_mutex_recursive_lock(mutex_);
     }
 
     int unlock() {

--- a/hal/src/rtl872x/spi_hal.cpp
+++ b/hal/src/rtl872x/spi_hal.cpp
@@ -454,10 +454,13 @@ public:
         return SYSTEM_ERROR_NONE;
     }
 
-    int lock(system_tick_t timeout = 0) {
+    int lock(system_tick_t timeout = 1) {
         CHECK_TRUE(hal_interrupt_is_isr() == false, SYSTEM_ERROR_INVALID_STATE);
-        // FIXME: os_mutex_recursive_lock doesn't take any arguments
-        return os_mutex_recursive_lock(mutex_);
+        // FIXME: os_mutex_recursive_lock doesn't take any arguments, using trylock for now
+        if (timeout != 0) {
+            return os_mutex_recursive_lock(mutex_);
+        }
+        return os_mutex_recursive_trylock(mutex_);
     }
 
     int unlock() {
@@ -1215,6 +1218,9 @@ int hal_spi_sleep(hal_spi_interface_t spi, bool sleep, void* reserved) {
 
 int32_t hal_spi_acquire(hal_spi_interface_t spi, const hal_spi_acquire_config_t* conf) {
     auto spiInstance = CHECK_TRUE_RETURN(getInstance(spi), SYSTEM_ERROR_NOT_FOUND);
+    if (conf && conf->timeout == 0) {
+        return spiInstance->lock(0);
+    }
     return spiInstance->lock();
 }
 


### PR DESCRIPTION
### Problem
`hal_spi_acquire()` may fail to acquire mutex and when the caller doesn't check the result, it may corrupt stack.

### Solution
Use `os_mutex_recursive_lock()` in `hal_spi_acquire()` when timeout is not specified or is non-zero.

### Steps to Test
1. Install MSoM on Muon
2. Connect to the Particle cloud over Etehrnet only while keeping accessing the Lora module (or the Muon's on-board IO expander).

### Example
```c++
#include "Particle.h"
#include "mcp23s17.h"

SYSTEM_MODE(SEMI_AUTOMATIC);

Serial1LogHandler logHandler(115200, LOG_LEVEL_ALL);

STARTUP (
    System.setPowerConfiguration(SystemPowerConfiguration()
        .powerSourceMinVoltage(3880)
        .powerSourceMaxCurrent(3000)
        .batteryChargeVoltage(4200)
        .batteryChargeCurrent(900)
        .auxiliaryPowerControlPin(D7)
        .interruptPin(A7)
        .feature(SystemPowerFeature::PMIC_DETECTION));

    System.enableFeature(FEATURE_ETHERNET_DETECTION);

    if_wiznet_pin_remap remap = {};
    remap.base.type = IF_WIZNET_DRIVER_SPECIFIC_PIN_REMAP;
    remap.cs_pin = A3;
    remap.reset_pin = PIN_INVALID;
    remap.int_pin = A4;
    if_request(nullptr, IF_REQ_DRIVER_SPECIFIC, &remap, sizeof(remap), nullptr);
);

void setup() {
    Ethernet.on();
    Ethernet.connect();
    waitUntil(Ethernet.ready);
    Log.info("Local IP: %s", Ethernet.localIP().toString().c_str());
    Particle.connect();
    waitUntil(Particle.connected);
    Log.info("Cloud connected");
}

void loop() {
    delay(1000);
    Log.info("Local IP: %s", Ethernet.localIP().toString().c_str());
    uint8_t temp;
    Mcp23s17::getInstance().readRegister(0x00, &temp);
}

```

### References
N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
