### PR TITLE
[msom] Ignore CIMI errors on bg95s5 with no esim profile loaded

### DIFF
--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -1007,7 +1007,8 @@ int QuectelNcpClient::checkNetConfForImsi() {
             // if max retries are exhausted
             return SYSTEM_ERROR_AT_RESPONSE_UNEXPECTED;
         } else if (r != AtResponse::OK && ncpId() == PLATFORM_NCP_QUECTEL_BG95_S5) {
-            // Ignore CIMI errors on BG95_S5, this means eSIM profile is not loaded
+            // Ignore CIMI errors on BG95_S5, this likely means eSIM profile is not loaded
+            // TODO: remove platform check when eSIM management is implemented
             return SYSTEM_ERROR_NONE;
         }
         ++imsiCount;

--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -1006,6 +1006,9 @@ int QuectelNcpClient::checkNetConfForImsi() {
         } else if (imsiCount >= IMSI_MAX_RETRY_CNT) {
             // if max retries are exhausted
             return SYSTEM_ERROR_AT_RESPONSE_UNEXPECTED;
+        } else if (r != AtResponse::OK && ncpId() == PLATFORM_NCP_QUECTEL_BG95_S5) {
+            // Ignore CIMI errors on BG95_S5, this means eSIM profile is not loaded
+            return SYSTEM_ERROR_NONE;
         }
         ++imsiCount;
         HAL_Delay_Milliseconds(100*imsiCount);


### PR DESCRIPTION
### Problem

`QuectelNcpClient::connect()` for bg95-s5 fails when no esim profile is loaded due to IMSI AT command failing.
DVOS will reset the modem continually each time `connect()` fails. This is causing problems at the factory as they require a stable modem USB connection for testing. 

### Solution

Ignore `AT+CIMI` errors for BG95S5 modems. We will assume it has no profile loaded

### Steps to Test

Run DVOS on M635E device, it should idle and not reset modem

### Example App
Tinker

### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
