### PR TITLE
[gen4] hal: get rid of unnecessary constant delay(1) in HAL_USB_USART_Send_Data()

### DIFF
--- a/hal/src/rtl872x/usb_hal.cpp
+++ b/hal/src/rtl872x/usb_hal.cpp
@@ -24,6 +24,9 @@
 #include <mutex>
 #include "usb_settings.h"
 #include "usbd_hid.h"
+// FIXME: not ideal, directly using freertos task APIs
+#include "FreeRTOS.h"
+#include "task.h"
 
 using namespace particle::usbd;
 
@@ -220,16 +223,24 @@ int32_t HAL_USB_USART_Send_Data(HAL_USB_USART_Serial serial, uint8_t data) {
     if ((__get_PRIMASK() & 1) || (__get_BASEPRI() != 0)) {
         return -1;
     }
-    int32_t available = -1;
-    do {
-        available = HAL_USB_USART_Available_Data_For_Write(serial);
-        if (available > 0) {
-            break;
+    int32_t available = HAL_USB_USART_Available_Data_For_Write(serial);
+    if (available == 0) {
+        bool needToYield = false;
+        auto prio = uxTaskPriorityGet(nullptr);
+        if (prio >= rtl::RTL_USBD_ISR_PROCESSING_THREAD_PRIORITY) {
+            needToYield = true;
         }
-        // TODO: check thread priorities here and delay only conditionally?
-        HAL_Delay_Milliseconds(1);
-    } while (available < 1 && available != -1);
-    if (HAL_USB_USART_Is_Connected(serial) && available > 0) {
+        while (true) {
+            available = HAL_USB_USART_Available_Data_For_Write(serial);
+            if (available > 0 || available < 0) {
+                break;
+            }
+            if (needToYield) {
+                HAL_Delay_Milliseconds(1);
+            }
+        }
+    }
+    if (available > 0 && HAL_USB_USART_Is_Connected(serial)) {
         return getCdcClassDriver().write(&data, sizeof(data));
     }
     return -1;

--- a/hal/src/rtl872x/usbd_driver.cpp
+++ b/hal/src/rtl872x/usbd_driver.cpp
@@ -170,7 +170,7 @@ int RtlUsbDriver::attach() {
 #if MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
     SCOPE_GUARD({
         if (!thread_) {
-            os_thread_create(&thread_, "usbd_watch", RTL_USBD_ISR_PRIORITY, &RtlUsbDriver::loop, this, OS_THREAD_STACK_SIZE_DEFAULT);
+            os_thread_create(&thread_, "usbd_watch", rtl::RTL_USBD_ISR_PROCESSING_THREAD_PRIORITY, &RtlUsbDriver::loop, this, OS_THREAD_STACK_SIZE_DEFAULT);
             SPARK_ASSERT(thread_);
         }
     });

--- a/hal/src/rtl872x/usbd_driver.h
+++ b/hal/src/rtl872x/usbd_driver.h
@@ -35,6 +35,11 @@ namespace particle { namespace usbd {
 namespace rtl {
 
 const size_t TEMP_BUFFER_SIZE = 512;
+#if MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
+const uint8_t RTL_USBD_ISR_PROCESSING_THREAD_PRIORITY = OS_THREAD_PRIORITY_NETWORK - 1;
+#else
+const uint8_t RTL_USBD_ISR_PROCESSING_THREAD_PRIORITY = 7; // Does not matter, no RTOS
+#endif // MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
 
 } // rtl
 
@@ -99,11 +104,6 @@ private:
     usb_dev_t* rtlDev_ = nullptr;
     bool setupError_ = false;
 
-#if MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
-    const uint8_t RTL_USBD_ISR_PRIORITY = OS_THREAD_PRIORITY_NETWORK - 1;
-#else
-    const uint8_t RTL_USBD_ISR_PRIORITY = 7; // Does not matter, no RTOS
-#endif // MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
     __attribute__((aligned(4))) uint8_t tempBuffer_[rtl::TEMP_BUFFER_SIZE];
 
     // TODO: Validate whether these are required to be present at all times
@@ -116,7 +116,7 @@ private:
         .speed = USB_SPEED_HIGH_IN_FULL,
         .dma_enable = 0, // ?
         .self_powered = 1,
-        .isr_priority = RTL_USBD_ISR_PRIORITY,
+        .isr_priority = rtl::RTL_USBD_ISR_PROCESSING_THREAD_PRIORITY,
     };
 
     usbd_class_driver_t classDrv_ = {


### PR DESCRIPTION
### Problem

We are always unnecessarily delaying 1ms on each byte sent over USB serial.

Moreover this happens even if there is no host connected, as `_blocking = true` by default and `Serial::write()` is implemented as following and always goes down to `HAL_USB_USART_Send_Data()`:

```c++
size_t USBSerial::write(uint8_t byte)
{
  if (HAL_USB_USART_Available_Data_For_Write(_serial) > 0 || _blocking) {
    return std::max(0, (int)HAL_USB_USART_Send_Data(_serial, byte));
  }
  return 0;
}
```

### Solution

Get rid of it. In addition to that fixes the FIXME about thread priorities. Don't need to delay(1) if we are below USB ISR processing task.

### Steps to Test
N/A

### Example App

N/A

### References

- [SC133780]

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
