### PR TITLE
[gen4] core: fix PSRAM heap size while in safe mode

### DIFF
--- a/build/arm/linker/rtl872x/platform_ram.ld
+++ b/build/arm/linker/rtl872x/platform_ram.ld
@@ -192,6 +192,7 @@ platform_bootloader_secure_ram_end   = platform_bootloader_secure_ram_start + pl
 
 
 /* The heap size after linkage should meet the minimum heap requirement. */
-platform_heap_min_size = 32K;
+/* This is PSRAM heap, 128K is well enough */
+platform_heap_min_size = 128K;
 
 INCLUDE platform_ram_shared.ld

--- a/hal/shared/filesystem.cpp
+++ b/hal/shared/filesystem.cpp
@@ -428,6 +428,10 @@ int filesystem_dump_info(filesystem_t* fs) {
 }
 
 int filesystem_to_system_error(int error) {
+    // Just in case
+    if (error >= 0) {
+        return error;
+    }
     switch (error) {
     case LFS_ERR_OK: return SYSTEM_ERROR_NONE;
     case LFS_ERR_IO: return SYSTEM_ERROR_FILESYSTEM_IO;

--- a/hal/src/rtl872x/core_hal.c
+++ b/hal/src/rtl872x/core_hal.c
@@ -76,6 +76,7 @@ extern uintptr_t platform_system_backup_ram_start;
 
 extern uintptr_t link_heap_location, link_heap_location_end;
 extern uintptr_t link_heap_location_alt, link_heap_location_end_alt;
+extern uintptr_t platform_psram_end;
 
 extern int hal_exflash_disable_xip(void);
 
@@ -356,6 +357,8 @@ void HAL_Core_Config(void) {
             malloc_heap_regions[HAL_PLATFORM_HEAP_REGION_PSRAM].end = (void*)dyn->dynalib_start_address;
         } else {
             module_ota.end_address = module_ota.start_address + module_ota.maximum_size;
+            // Expand PSRAM heap, let the system use full PSRAM in safe mode
+            malloc_heap_regions[HAL_PLATFORM_HEAP_REGION_PSRAM].end = (void*)&platform_psram_end;
         }
     }
 #endif

--- a/services/inc/dct_file.h
+++ b/services/inc/dct_file.h
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 #include <mutex>
+#include "check.h"
 
 namespace particle {
 namespace dct {
@@ -42,27 +43,23 @@ public:
 
     ssize_t read(size_t offset, uint8_t* buffer, size_t size) {
         FsLock lk(fs_);
-        open(LFS_O_RDONLY);
-        ssize_t r = seek(offset);
-        if (r < 0) {
+        CHECK_FS(open(LFS_O_RDONLY));
+        SCOPE_GUARD({
             close();
-            return r;
-        }
-        r = lfs_file_read(lfs(), &file_, buffer, size);
-        close();
-        return r;
+        });
+        CHECK_FS(seek(offset));
+        return lfs_file_read(lfs(), &file_, buffer, size);
     }
 
     ssize_t write(size_t offset, const uint8_t* buffer, size_t size) {
         FsLock lk(fs_);
 
-        open(LFS_O_WRONLY);
-
-        ssize_t r = seek(offset);
-        if (r < 0) {
+        CHECK_FS(open(LFS_O_WRONLY));
+        SCOPE_GUARD({
             close();
-            return r;
-        }
+        });
+
+        ssize_t r = CHECK_FS(seek(offset));
 
         r = lfs_file_write(lfs(), &file_, buffer, size);
         if (r < 0) {
@@ -70,14 +67,12 @@ public:
             LOG_DEBUG(ERROR, "Failed to write to DCT: %d", r);
         }
 
-        close();
-
         return r;
     }
 
     bool clear() {
         FsLock lk(fs_);
-        if (!open(LFS_O_WRONLY)) {
+        if (open(LFS_O_WRONLY) < 0) {
             return false;
         }
         SCOPE_GUARD({
@@ -104,17 +99,18 @@ public:
 
 private:
 
-    bool open(int flags) {
-        open_ = lfs_file_open(lfs(), &file_, path_, flags) == 0;
-        return open_;
+    int open(int flags) {
+        int r = lfs_file_open(lfs(), &file_, path_, flags);
+        open_ = (r == 0);
+        return r;
     }
 
-    bool close() {
+    int close() {
         if (!open_) {
             return false;
         }
         open_ = false;
-        return lfs_file_close(lfs(), &file_) == 0;
+        return lfs_file_close(lfs(), &file_);
     }
 
     ssize_t seek(size_t offset) {
@@ -144,7 +140,7 @@ private:
             flags |= LFS_O_CREAT;
         }
 
-        SPARK_ASSERT(open(flags));
+        SPARK_ASSERT(open(flags) == 0);
 
         if (flags & LFS_O_CREAT) {
             LOG_DEBUG(INFO, "Initializing empty DCT");
@@ -157,7 +153,7 @@ private:
             }
         }
 
-        SPARK_ASSERT(close());
+        SPARK_ASSERT(close() == 0);
     }
 
     void deinit() {


### PR DESCRIPTION
### Problem

While in safe mode Gen 4 devices only use 32KB of PSRAM for heap. This is not enough. 

### Solution

Set the minimum PSRAM heap size to 128KB and additionally while in safe mode expand the PSRAM heap to full PSRAM size.

This PR additionally fixes a couple of issues in DCT implementation which doesn't expect e.g. open() calls to fail which leads to RAM and/or flash corruption in case of unexpected issues like being low on heap.

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
