### PR TITLE
system_event network_credentials_added passes NetworkCredentials object

### DIFF
--- a/hal/inc/wlan_hal.h
+++ b/hal/inc/wlan_hal.h
@@ -33,6 +33,7 @@
 #include "socket_hal.h"
 #include "timer_hal.h"
 #include "net_hal.h"
+#include "wlan_hal_shared.h"
 
 
 #ifdef	__cplusplus
@@ -183,16 +184,6 @@ int wlan_has_credentials();
 #undef WLAN_SEC_WPA_ENTERPRISE
 #undef WLAN_SEC_WPA2_ENTERPRISE
 #endif
-typedef enum {
-    WLAN_SEC_UNSEC = 0,
-    WLAN_SEC_WEP,
-    WLAN_SEC_WPA,
-    WLAN_SEC_WPA2,
-    WLAN_SEC_WPA_ENTERPRISE,
-    WLAN_SEC_WPA2_ENTERPRISE,
-    WLAN_SEC_WPA3,
-    WLAN_SEC_NOT_SET = 0xFF
-} WLanSecurityType;
 
 
 typedef enum {

--- a/hal/inc/wlan_hal_shared.h
+++ b/hal/inc/wlan_hal_shared.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2025 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+typedef enum {
+    WLAN_SEC_UNSEC = 0,
+    WLAN_SEC_WEP,
+    WLAN_SEC_WPA,
+    WLAN_SEC_WPA2,
+    WLAN_SEC_WPA_ENTERPRISE,
+    WLAN_SEC_WPA2_ENTERPRISE,
+    WLAN_SEC_WPA3,
+    WLAN_SEC_NOT_SET = 0xFF
+} WLanSecurityType;
+
+namespace particle {
+
+enum class WifiSecurity {
+    NONE = 0,
+    WEP = 1,
+    WPA_PSK = 2,
+    WPA2_PSK = 3,
+    WPA_WPA2_PSK = 4,
+    WPA3_PSK = 5,
+    WPA2_WPA3_PSK = 6
+};
+
+inline WLanSecurityType fromWifiSecurity(WifiSecurity sec) {
+    switch (sec) {
+    case WifiSecurity::NONE:
+        return WLanSecurityType::WLAN_SEC_UNSEC;
+    case WifiSecurity::WEP:
+        return WLanSecurityType::WLAN_SEC_WEP;
+    case WifiSecurity::WPA_PSK:
+        return WLanSecurityType::WLAN_SEC_WPA;
+    case WifiSecurity::WPA2_PSK:
+    case WifiSecurity::WPA_WPA2_PSK:
+        return WLanSecurityType::WLAN_SEC_WPA2;
+    case WifiSecurity::WPA3_PSK:
+    case WifiSecurity::WPA2_WPA3_PSK:
+        return WLanSecurityType::WLAN_SEC_WPA3;
+    default:
+        return WLanSecurityType::WLAN_SEC_UNSEC;
+    }
+}
+
+} // namespace particle

--- a/hal/network/ncp/wifi/wifi_network_manager.h
+++ b/hal/network/ncp/wifi/wifi_network_manager.h
@@ -23,6 +23,8 @@
 #include <cstdint>
 #include "enumflags.h"
 
+#include "wlan_hal_shared.h"
+
 namespace particle {
 
 class WifiNcpClient;
@@ -35,16 +37,6 @@ const size_t MAX_SSID_SIZE = 32;
 
 // Maximum length of a WPA/WPA2 key
 const size_t MAX_WPA_WPA2_PSK_SIZE = 64;
-
-enum class WifiSecurity {
-    NONE = 0,
-    WEP = 1,
-    WPA_PSK = 2,
-    WPA2_PSK = 3,
-    WPA_WPA2_PSK = 4,
-    WPA3_PSK = 5,
-    WPA2_WPA3_PSK = 6
-};
 
 enum class WifiNetworkConfigFlag {
     NONE = 0x00,

--- a/hal/network/ncp/wifi/wlan_hal.cpp
+++ b/hal/network/ncp/wifi/wlan_hal.cpp
@@ -71,25 +71,6 @@ WifiSecurity toWifiSecurity(WLanSecurityType type) {
     }
 }
 
-WLanSecurityType fromWifiSecurity(WifiSecurity sec) {
-    switch (sec) {
-    case WifiSecurity::NONE:
-        return WLanSecurityType::WLAN_SEC_UNSEC;
-    case WifiSecurity::WEP:
-        return WLanSecurityType::WLAN_SEC_WEP;
-    case WifiSecurity::WPA_PSK:
-        return WLanSecurityType::WLAN_SEC_WPA;
-    case WifiSecurity::WPA2_PSK:
-    case WifiSecurity::WPA_WPA2_PSK:
-        return WLanSecurityType::WLAN_SEC_WPA2;
-    case WifiSecurity::WPA3_PSK:
-    case WifiSecurity::WPA2_WPA3_PSK:
-        return WLanSecurityType::WLAN_SEC_WPA3;
-    default:
-        return WLanSecurityType::WLAN_SEC_UNSEC;
-    }
-}
-
 } // unnamed
 
 int wlan_connect_init() {

--- a/system/src/control/wifi_new.cpp
+++ b/system/src/control/wifi_new.cpp
@@ -64,6 +64,49 @@ void bssidFromPb(MacAddress* bssid, const T& pbBssid) {
     }
 }
 
+void network_credentials_cleanup(void* ptr) {
+    auto creds = static_cast<NetworkCredentials*>(ptr);
+    free(creds);
+}
+
+NetworkCredentials* alloc_network_credentials_deep_copy(WifiNetworkConfig conf)
+{
+    const size_t ssid_bytes = conf.ssid() ? (strlen(conf.ssid()) + 1) : 0;
+    const size_t pass_bytes = conf.credentials().password() ? (strlen(conf.credentials().password()) + 1) : 0;
+    const size_t total = sizeof(NetworkCredentials) + ssid_bytes + pass_bytes;
+
+    unsigned char* mem = static_cast<unsigned char*>(malloc(total));
+    if (!mem) {
+        return nullptr;
+    }
+
+    auto creds = reinterpret_cast<NetworkCredentials*>(mem);
+    memset(creds, 0, sizeof(*creds));
+
+    unsigned char* p = mem + sizeof(NetworkCredentials);
+
+    if (ssid_bytes) {
+        char* ssid_buf = reinterpret_cast<char*>(p);
+        memcpy(ssid_buf, conf.ssid(), ssid_bytes);
+        creds->ssid = ssid_buf;
+        creds->ssid_len = static_cast<unsigned>(ssid_bytes - 1);
+        p += ssid_bytes;
+    }
+
+    if (pass_bytes) {
+        char* pass_buf = reinterpret_cast<char*>(p);
+        memcpy(pass_buf, conf.credentials().password(), pass_bytes);
+        creds->password = pass_buf;
+        creds->password_len = static_cast<unsigned>(pass_bytes - 1);
+        p += pass_bytes;
+    }
+
+    creds->security = fromWifiSecurity(conf.security());
+    creds->size = sizeof(NetworkCredentials);
+
+    return creds;
+}
+
 } // unnamed
 
 int joinNewNetwork(ctrl_request* req) {
@@ -136,8 +179,18 @@ int joinNewNetwork(ctrl_request* req) {
     CHECK(ncpClient->on());
     // Set new configuration
     CHECK(wifiMgr->setNetworkConfig(conf, WifiNetworkConfigFlag::VALIDATE));
-    // TODO: Not adding NetworkCredentials for now as this object needs to be allocated on heap and then cleaned up
-    system_notify_event(network_credentials, network_credentials_added);
+    // Deep copy credentials and pass object to system_notify_event with a cleanup function
+    auto creds = alloc_network_credentials_deep_copy(conf);
+
+    if (creds) {
+        system_notify_event(
+            network_credentials,
+            network_credentials_added,
+            creds,
+            network_credentials_cleanup,
+            creds
+        );
+    }
 
     network_connect(NETWORK_INTERFACE_WIFI_STA, NETWORK_CONNECT_FLAG_FORCE, 0, nullptr);
     NAMED_SCOPE_GUARD(networkDisconnectGuard, {
@@ -307,7 +360,18 @@ int setNetworkCredentials(ctrl_request* req) {
     const auto wifiMgr = wifiNetworkManager();
     CHECK_TRUE(wifiMgr, SYSTEM_ERROR_UNKNOWN);
     CHECK(wifiMgr->setNetworkConfig(conf, WifiNetworkConfigFlag::NONE));
-    system_notify_event(network_credentials, network_credentials_added);
+    // Deep copy credentials and pass object to system_notify_event with a cleanup function
+    auto creds = alloc_network_credentials_deep_copy(conf);
+
+    if (creds) {
+        system_notify_event(
+            network_credentials,
+            network_credentials_added,
+            creds,
+            network_credentials_cleanup,
+            creds
+        );
+    }
 
     return 0;
 }


### PR DESCRIPTION
### Problem

- When setting Wi-Fi network credentials over USB/BLE, NetworkCredentials object is not passed to system event network_credentials_added as it is when calling WiFi.setCredentials() directly.

### Solution

- Pass NetworkCredentials as required

### Steps to Test

- @jlovinger-particle to test via BLE setup process