### PR TITLE
Optimize Gen4 boot time

### DIFF
--- a/bootloader/src/rtl872x/linker.ld
+++ b/bootloader/src/rtl872x/linker.ld
@@ -89,6 +89,13 @@ SECTIONS
         link_global_data_end = .;
     } > SRAM AT> APP_FLASH
 
+    .igot.plt :
+    {
+        *(.igot.plt)
+        FILL(0xff)
+        . = ALIGN(16);
+    } > SRAM AT> APP_FLASH
+
     .sram.text :
     {
         . = ALIGN(4);

--- a/build/arm/startup/startup_rtl872x.S
+++ b/build/arm/startup/startup_rtl872x.S
@@ -134,52 +134,18 @@ Reset_Handler:
 .L_loop3_done:
 #endif /* __STARTUP_CLEAR_BSS */
 
-/* Load PSRAM code */
-    ldr r1, =link_psram_code_flash_start
-    ldr r2, =link_psram_code_start
-    ldr r3, =link_psram_code_end
+    bl SystemInit
+    ldr r0, =Jump_To_Main
+    bx r0
 
-    subs r3, r2
-    ble .L_loop4_done
-
-.L_loop4:
-    subs r3, #4
-    ldr r0, [r1,r3]
-    str r0, [r2,r3]
-    bgt .L_loop4
-
-.L_loop4_done:
-/* Load dynalib into PSRAM */
-    ldr r1, =link_dynalib_flash_start
-    ldr r2, =link_dynalib_start
-    ldr r3, =link_dynalib_end
-
-    subs r3, r2
-    ble .L_loop5_done
-
-.L_loop5:
-    subs r3, #4
-    ldr r0, [r1,r3]
-    str r0, [r2,r3]
-    bgt .L_loop5
-
-.L_loop5_done:
-    ldr r0, =Jump_To_Psram
-    blx r0
-
-/* Jump to psram */
     .text
     .thumb
     .thumb_func
     .align 1
     .section .text,"a",%progbits
-    .globl Jump_To_Psram
-    .type Jump_To_Psram, %function
-Jump_To_Psram:
-
-/* Execute SystemInit function. */
-    bl SystemInit
-
+    .globl Jump_To_Main
+    .type Jump_To_Main, %function
+Jump_To_Main:
 /* Call _start function provided by libraries.
  * If those libraries are not accessible, define __START as your entry point.
  */

--- a/hal/src/rtl872x/ble_hal.cpp
+++ b/hal/src/rtl872x/ble_hal.cpp
@@ -3699,7 +3699,6 @@ int hal_ble_cancel_callback_on_adv_events(hal_ble_on_adv_evt_cb_t callback, void
 int hal_ble_set_callback_on_periph_link_events(hal_ble_on_link_evt_cb_t callback, void* context, void* reserved) {
     BleLock lk;
     LOG_DEBUG(TRACE, "hal_ble_set_callback_on_periph_link_events().");
-    CHECK_TRUE(BleGap::getInstance().initialized(), SYSTEM_ERROR_INVALID_STATE);
     return BleGap::getInstance().onPeripheralLinkEventCallback(callback, context);
 }
 
@@ -4027,14 +4026,12 @@ bool hal_ble_gap_is_paired(hal_ble_conn_handle_t conn_handle, void* reserved) {
 int hal_ble_gatt_server_add_service(uint8_t type, const hal_ble_uuid_t* uuid, hal_ble_attr_handle_t* handle, void* reserved) {
     BleLock lk;
     LOG_DEBUG(TRACE, "hal_ble_gatt_server_add_service().");
-    CHECK_TRUE(BleGap::getInstance().initialized(), SYSTEM_ERROR_INVALID_STATE);
     return BleGatt::getInstance().addService(type, uuid, handle);;
 }
 
 int hal_ble_gatt_server_add_characteristic(const hal_ble_char_init_t* char_init, hal_ble_char_handles_t* char_handles, void* reserved) {
     BleLock lk;
     LOG_DEBUG(TRACE, "hal_ble_gatt_server_add_characteristic().");
-    CHECK_TRUE(BleGap::getInstance().initialized(), SYSTEM_ERROR_INVALID_STATE);
     return BleGatt::getInstance().addCharacteristic(char_init, char_handles);
 }
 
@@ -4047,7 +4044,6 @@ int hal_ble_gatt_server_add_descriptor(const hal_ble_desc_init_t* desc_init, hal
 ssize_t hal_ble_gatt_server_set_characteristic_value(hal_ble_attr_handle_t value_handle, const uint8_t* buf, size_t len, void* reserved) {
     BleLock lk;
     LOG_DEBUG(TRACE, "hal_ble_gatt_server_set_characteristic_value().");
-    CHECK_TRUE(BleGap::getInstance().initialized(), SYSTEM_ERROR_INVALID_STATE);
     return BleGatt::getInstance().setValue(value_handle, buf, len);
 }
 

--- a/hal/src/rtl872x/core_hal.c
+++ b/hal/src/rtl872x/core_hal.c
@@ -454,7 +454,8 @@ bool HAL_Core_Validate_Modules(uint32_t flags, void* reserved)
     do {
         bounds = find_module_bounds(MODULE_FUNCTION_SYSTEM_PART, i++, HAL_PLATFORM_MCU_DEFAULT);
         if (bounds) {
-            module_fetched = fetch_module(&mod, bounds, false, MODULE_VALIDATION_INTEGRITY);
+            // Bootloader has done integrity check
+            module_fetched = fetch_module(&mod, bounds, false, 0);
             valid = module_fetched && (mod.validity_checked == mod.validity_result);
         }
         if (flags & 1) {

--- a/hal/src/rtl872x/usb_hal.cpp
+++ b/hal/src/rtl872x/usb_hal.cpp
@@ -81,7 +81,10 @@ void HAL_USB_Init(void) {
 
         ControlInterfaceClassDriver::instance()->enable(true);
         // Only enabled if HAL_USB_USART_Init() was called to configure buffers
-        // getCdcClassDriver().enable(true);
+#if defined (START_DFU_FLASHER_SERIAL_SPEED)
+        HAL_USB_USART_Init(HAL_USB_USART_SERIAL, nullptr);
+        getCdcClassDriver().enable(true);
+#endif
         HAL_USB_Attach();
     });
 }

--- a/platform/MCU/rtl872x/src/hw_config.c
+++ b/platform/MCU/rtl872x/src/hw_config.c
@@ -340,6 +340,8 @@ void Set_System(void)
     // irq_table_init(RTL_DEFAULT_MSP_S);
     // __set_MSP(RTL_DEFAULT_MSP_S);
 
+    Cache_Enable(1);
+
 #if MODULE_FUNCTION == MOD_FUNC_BOOTLOADER
     __NVIC_SetVector(HardFault_IRQn, (u32)(void*)HardFault_Handler);
     __NVIC_SetVector(MemoryManagement_IRQn, (u32)(void*)MemManage_Handler);

--- a/system/src/ble_control_request_channel.cpp
+++ b/system/src/ble_control_request_channel.cpp
@@ -1039,21 +1039,17 @@ int BleControlRequestChannel::cccdChanged(const hal_ble_char_evt_t& event) {
 }
 
 int BleControlRequestChannel::initProfile() {
+#if HAL_PLATFORM_NRF52840
     bool btStackInitialized = hal_ble_is_initialized(nullptr);
     if (!btStackInitialized) {
         SPARK_ASSERT(hal_ble_stack_init(nullptr) == SYSTEM_ERROR_NONE);
     }
+#endif
     if (initialized_) {
         LOG_DEBUG(TRACE, "BLE profile already initialized");
         return SYSTEM_ERROR_INVALID_STATE;
     }
-#if HAL_PLATFORM_RTL872X
-    SCOPE_GUARD ({
-        if (!btStackInitialized) {
-            hal_ble_stack_deinit(nullptr);
-        }
-    });
-#endif
+    
     hal_ble_attr_handle_t serviceHandle;
     hal_ble_char_init_t char_init;
     hal_ble_char_handles_t attrHandles;


### PR DESCRIPTION
### Problem

Gen4 takes too much time to boot into user app.

### Solution

- Current state:
```
#      <- On reset
[+3060] set wlan slot random fail! coex mechanism is off!
[+ 985] Blank app started on MSOM
```

- Enable cache in `Set_System()`
```
#
[+2640] set wlan slot random fail! coex mechanism is off!
[+ 985] Blank app started on MSOM
```

- Enable cache before copying code/data from external flash to PSRAM
```
#
[+2068] set wlan slot random fail! coex mechanism is off!
[+ 986] Blank app started on MSOM
```

- Do not init BLE stack when initialize BLE control request channel
```
#
[+2510] Blank app started on MSOM
```

- Avoid re-attaching USB
```
#
[+2191] Blank app started on MSOM
```

- Do not check System part integrity
```
#
[+1862] Blank app started on MSOM
```

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
