### PR TITLE
add 20 KHz and 50 KHz I2C speeds for the gen3 Nordic-based modules

### DIFF
--- a/hal/inc/i2c_hal.h
+++ b/hal/inc/i2c_hal.h
@@ -84,6 +84,8 @@ typedef enum hal_i2c_state_t {
 } hal_i2c_state_t;
 
 /* Exported macros -----------------------------------------------------------*/
+#define CLOCK_SPEED_20KHZ          (uint32_t)20000
+#define CLOCK_SPEED_50KHZ          (uint32_t)50000
 #define CLOCK_SPEED_100KHZ         (uint32_t)100000
 #define CLOCK_SPEED_400KHZ         (uint32_t)400000
 #define HAL_I2C_DEFAULT_TIMEOUT_MS (100)

--- a/hal/src/nRF52840/i2c_hal.cpp
+++ b/hal/src/nRF52840/i2c_hal.cpp
@@ -56,6 +56,8 @@
 
 // [219] TWIM: I2C timing spec is violated at 400 kHz
 const nrf_twim_frequency_t NRF_TWIM_FREQ_390K = (nrf_twim_frequency_t)(0x06200000UL);
+const nrf_twim_frequency_t NRF_TWIM_FREQ_50K  = (nrf_twim_frequency_t)(0x00CC0000UL);
+const nrf_twim_frequency_t NRF_TWIM_FREQ_20K  = (nrf_twim_frequency_t)(0x00530000UL);
 
 class I2cLock {
 public:
@@ -258,7 +260,20 @@ static int twiInit(hal_i2c_interface_t i2c) {
     // that requires the SCL clock to have a minimum low period of 1.3 µs,
     // use 390 kHz instead of 400kHz by writing 0x06200000 to the FREQUENCY register.
     // With this setting, the SCL low period is greater than 1.3 µs.
-    nrf_twim_frequency_t nrfFrequency = (i2cMap[i2c].speed == CLOCK_SPEED_400KHZ) ? NRF_TWIM_FREQ_390K : NRF_TWIM_FREQ_100K;
+    nrf_twim_frequency_t nrfFrequency = NRF_TWIM_FREQ_100K;
+    if (i2cMap[i2c].speed == CLOCK_SPEED_20KHZ) {
+        nrfFrequency = NRF_TWIM_FREQ_20K;
+    } else if (i2cMap[i2c].speed == CLOCK_SPEED_50KHZ) {
+        nrfFrequency = NRF_TWIM_FREQ_50K;
+    } else if (i2cMap[i2c].speed == CLOCK_SPEED_400KHZ) {
+        // NOTE:
+        // [219] TWIM: I2C timing spec is violated at 400 kHz
+        // If communication does not work at 400 kHz with an I2C compatible device
+        // that requires the SCL clock to have a minimum low period of 1.3 µs,
+        // use 390 kHz instead of 400kHz by writing 0x06200000 to the FREQUENCY register.
+        // With this setting, the SCL low period is greater than 1.3 µs.
+        nrfFrequency = NRF_TWIM_FREQ_390K;
+    }
 
     hal_pin_info_t* PIN_MAP = hal_pin_map();
 

--- a/hal/src/nRF52840/i2c_hal.cpp
+++ b/hal/src/nRF52840/i2c_hal.cpp
@@ -254,12 +254,7 @@ static int twiUninit(hal_i2c_interface_t i2c, bool reset_pin_configuration = tru
 
 static int twiInit(hal_i2c_interface_t i2c) {
     ret_code_t ret;
-    // NOTE:
-    // [219] TWIM: I2C timing spec is violated at 400 kHz
-    // If communication does not work at 400 kHz with an I2C compatible device
-    // that requires the SCL clock to have a minimum low period of 1.3 µs,
-    // use 390 kHz instead of 400kHz by writing 0x06200000 to the FREQUENCY register.
-    // With this setting, the SCL low period is greater than 1.3 µs.
+    
     nrf_twim_frequency_t nrfFrequency = NRF_TWIM_FREQ_100K;
     if (i2cMap[i2c].speed == CLOCK_SPEED_20KHZ) {
         nrfFrequency = NRF_TWIM_FREQ_20K;


### PR DESCRIPTION
### Problem

We need lower I2C speeds to support longer cable distances on our Gen3 devices. Right now we are limited to 100 KHz or 400 KHz only.

### Solution

This solution adds two more I2C speeds: 20 KHz and 50 KHz and adds support for them to the Nordic HAL.

### Steps to Test

Using `Wire.setSpeed(20000)` and `Wire.setSpeed(50000)` before calling `Wire.begin()` and using a logic analyzer to view the I2C clock during communication. This was tested on the new speeds and the existing 100 KHz and 400 KHz speeds and confirmed to work both with working I2C communication and a logic analyzer on the I2C line.

### Example App

```c
void setup() {
  Wire.setSpeed(20000);
  Wire.begin();
}

void loop() {

}
```

### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
