### PR TITLE
[fuelgauge] fixes access when i2c unintentionally disabled [sc-137389]

### DIFF
--- a/hal/src/nRF52840/i2c_hal.cpp
+++ b/hal/src/nRF52840/i2c_hal.cpp
@@ -317,11 +317,19 @@ int hal_i2c_init(hal_i2c_interface_t i2c, const hal_i2c_config_t* config) {
     os_thread_scheduling(false, nullptr);
     if (i2cMap[i2c].mutex == nullptr) {
         os_mutex_recursive_create(&i2cMap[i2c].mutex);
-    } 
+    }
 
     // Re-enable threading and capture the mutex
     os_thread_scheduling(true, nullptr);
     I2cLock lk(i2c);
+
+// sc-137389
+#if HAL_PLATFORM_PMIC_BQ24195
+    bool wasEnabled = false;
+    if (i2cMap[i2c].state == HAL_I2C_STATE_ENABLED) {
+        wasEnabled = true;
+    }
+#endif // HAL_PLATFORM_PMIC_BQ24195
 
     if (i2cMap[i2c].configured) {
         // Configured, but new buffers are invalid
@@ -374,6 +382,15 @@ int hal_i2c_init(hal_i2c_interface_t i2c, const hal_i2c_config_t* config) {
     i2cMap[i2c].configured = true;
     memset((void *)i2cMap[i2c].rx_buf, 0, i2cMap[i2c].rx_buf_size);
     memset((void *)i2cMap[i2c].tx_buf, 0, i2cMap[i2c].tx_buf_size);
+
+// sc-137389
+#if HAL_PLATFORM_PMIC_BQ24195
+    if (i2c == HAL_PLATFORM_PMIC_BQ24195_I2C) {
+        if (wasEnabled) {
+            hal_i2c_begin(i2c, I2C_MODE_MASTER, 0x00, nullptr);
+        }
+    }
+#endif // #if HAL_PLATFORM_PMIC_BQ24195
 
     return SYSTEM_ERROR_NONE;
 }

--- a/hal/src/rtl872x/i2c_hal.cpp
+++ b/hal/src/rtl872x/i2c_hal.cpp
@@ -816,7 +816,26 @@ private:
 
 int hal_i2c_init(hal_i2c_interface_t i2c, const hal_i2c_config_t* config) {
     auto instance = CHECK_TRUE_RETURN(I2cClass::getInstance(i2c), SYSTEM_ERROR_NOT_FOUND);
-    return instance->init(config);
+
+// sc-137389
+#if HAL_PLATFORM_PMIC_BQ24195
+    bool wasEnabled = instance->isEnabled();
+#endif // #if HAL_PLATFORM_PMIC_BQ24195
+
+    auto ret = instance->init(config);
+
+// sc-137389
+#if HAL_PLATFORM_PMIC_BQ24195
+    if (ret == SYSTEM_ERROR_NONE) {
+        if (i2c == HAL_PLATFORM_PMIC_BQ24195_I2C) {
+            if (wasEnabled) {
+                ret = instance->begin(I2C_MODE_MASTER, 0x00);
+            }
+        }
+    }
+#endif // #if HAL_PLATFORM_PMIC_BQ24195
+
+    return ret;
 }
 
 void hal_i2c_set_speed(hal_i2c_interface_t i2c, uint32_t speed, void* reserved) {

--- a/user/tests/wiring/no_fixture/i2c.cpp
+++ b/user/tests/wiring/no_fixture/i2c.cpp
@@ -293,8 +293,53 @@ test(I2C_05_Hal_Sleep_API_Test) {
     assertTrue(Wire.isEnabled());
 }
 
+#ifdef PARTICLE_TEST_RUNNER
+// one or more larger than default (32:gen3,512:gen4) will force hal_i2c_init(),
+constexpr size_t I2C_BUFFER_SIZE = HAL_PLATFORM_I2C_BUFFER_SIZE(HAL_PLATFORM_PMIC_BQ24195_I2C) + 1;
+uint8_t _rx_buf[I2C_BUFFER_SIZE];
+uint8_t _tx_buf[I2C_BUFFER_SIZE];
+hal_i2c_config_t acquireWireBuffer()
+{
+    hal_i2c_config_t config = {
+        .size = sizeof(hal_i2c_config_t),
+        .version = HAL_I2C_CONFIG_VERSION_1,
+        .rx_buffer = _rx_buf,
+        .rx_buffer_size = I2C_BUFFER_SIZE,
+        .tx_buffer = _tx_buf,
+        .tx_buffer_size = I2C_BUFFER_SIZE
+    };
+    return config;
+}
+test(I2C_06_I2c_FuelGauge_Works_After_Buffer_Config_Disables_Interface_Reset) {
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
+    System.reset();
+}
+
 #if HAL_PLATFORM_FUELGAUGE_MAX17043
-test(I2C_06_I2c_Sleep_FuelGauge) {
+test(I2C_07_I2c_FuelGauge_Works_After_Buffer_Config_Disables_Interface) {
+    delay(10000); // allow PMIC setup to finish after rebooting from previous step
+
+    FuelGauge fuel(true);
+    // fuel.begin(); // sc-137389 - purposely do not call begin() as in our documentation,
+                     // FuelGauge should call begin() on its own.
+    assertTrue(Wire.isEnabled());
+    fuel.wakeup();
+    auto ver = 0xffff & fuel.getVersion();
+#if HAL_PLATFORM_POWER_MANAGEMENT_OPTIONAL
+    if (ver < 0) {
+        skip();
+        return;
+    }
+#endif // HAL_PLATFORM_POWER_MANAGEMENT_OPTIONAL
+    assertNotEqual(ver, 0xff60); // gen3, if i2c interface not enabled, this is returned
+    assertNotEqual(ver, 0x7400); // gen4
+    assertMoreOrEqual(ver, 0);
+    assertNotEqual(ver, 0x0000);
+    assertNotEqual(ver, 0xffff);
+}
+#endif // PARTICLE_TEST_RUNNER
+
+test(I2C_08_I2c_Sleep_FuelGauge) {
     FuelGauge fuel(true);
     fuel.begin();
     fuel.wakeup();
@@ -321,7 +366,7 @@ test(I2C_06_I2c_Sleep_FuelGauge) {
     assertEqual(ver, ver2);
 }
 
-test(I2C_07_bus_reset_is_not_destructive) {
+test(I2C_09_bus_reset_is_not_destructive) {
     constexpr uint16_t MAX17043_DEFAULT_CONFIG = 0x971c;
 
     FuelGauge fuel;
@@ -379,7 +424,7 @@ test(I2C_07_bus_reset_is_not_destructive) {
 
 #if HAL_PLATFORM_FUELGAUGE_MAX17043 && HAL_PLATFORM_I2C_NUM == 1
 // Uses transactions
-test(I2C_08_can_talk_to_fuelgauge_with_transactions) {
+test(I2C_10_can_talk_to_fuelgauge_with_transactions) {
     FuelGauge fuel;
     fuel.begin();
     fuel.wakeup();
@@ -397,7 +442,7 @@ test(I2C_08_can_talk_to_fuelgauge_with_transactions) {
 #endif // HAL_PLATFORM_FUELGAUGE_MAX17043 && HAL_PLATFORM_I2C_NUM == 1
 
 #if HAL_PLATFORM_PMIC_BQ24195 && HAL_PLATFORM_I2C_NUM == 1
-test(I2C_09_can_talk_to_pmic_with_transactions) {
+test(I2C_11_can_talk_to_pmic_with_transactions) {
     constexpr uint8_t BQ24195_VERSION = 0x23;
     PMIC power;
     power.begin();

--- a/user/tests/wiring/no_fixture/i2c.cpp
+++ b/user/tests/wiring/no_fixture/i2c.cpp
@@ -293,6 +293,8 @@ test(I2C_05_Hal_Sleep_API_Test) {
     assertTrue(Wire.isEnabled());
 }
 
+#if HAL_PLATFORM_FUELGAUGE_MAX17043
+
 #ifdef PARTICLE_TEST_RUNNER
 // one or more larger than default (32:gen3,512:gen4) will force hal_i2c_init(),
 constexpr size_t I2C_BUFFER_SIZE = HAL_PLATFORM_I2C_BUFFER_SIZE(HAL_PLATFORM_PMIC_BQ24195_I2C) + 1;
@@ -315,7 +317,6 @@ test(I2C_06_I2c_FuelGauge_Works_After_Buffer_Config_Disables_Interface_Reset) {
     System.reset();
 }
 
-#if HAL_PLATFORM_FUELGAUGE_MAX17043
 test(I2C_07_I2c_FuelGauge_Works_After_Buffer_Config_Disables_Interface) {
     delay(10000); // allow PMIC setup to finish after rebooting from previous step
 


### PR DESCRIPTION
### Problem

- Calls to `FuelGauge` in certain cases can result in incorrect readings if `FuelGauge::begin()` not called first.
- These cases are typically when using `hal_i2c_config_t acquireWireBuffer()` and setting a buffer size greater than 32.  This ends up re-initialing the I2C bus, and leaving it disabled.  Typically `begin()` would need to be called afterwards, but we do not document it as necessary.
- In addition to the i2c bus being disabled, the `FuelGauge` calls need to occur 5-10s after boot.  The reason for this is the `FuelGauge` i2c bus is shared with the `PMIC`, and if the `PMIC` is still going through it's initial configuration, it will detect the bus has been disabled by the `FuelGauge` call, and call `begin()` again.

### Solution

- Call `hal_i2c_begin()` automatically after `hal_i2c_init()` for `FuelGauge/PMIC`.

### Steps to Test

- Run `device-os-test run bsom wiring/no_fixture -v -- -fixture`

### References

- [sc-137389]
