### PR TITLE
[b5som][eg91nax][quectel] fixes policyman/svc_mode setting preventing IMSI switching [sc-137388]

### DIFF
--- a/hal/network/ncp/cellular/cellular_ncp_client.h
+++ b/hal/network/ncp/cellular/cellular_ncp_client.h
@@ -111,6 +111,12 @@ enum class CellularFunctionality {
 
 PARTICLE_DEFINE_ENUM_COMPARISON_OPERATORS(CellularFunctionality);
 
+enum class CellularPolicymanServiceMode {
+    NONE = -1,
+    NO_SERVICE = 0,
+    FULL_SERVICE = 2,
+};
+
 enum class CellularStrengthUnits {
     NONE = 0,
     RXLEV = 1,

--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -113,6 +113,8 @@ const unsigned REGISTRATION_TIMEOUT = 10 * 60 * 1000;
 const unsigned REGISTRATION_INTERVENTION_TIMEOUT = 15 * 1000;
 const unsigned REGISTRATION_TWILIO_HOLDOFF_TIMEOUT = 5 * 60 * 1000;
 
+const unsigned QUECTEL_POLICYMAN_SRV_MODE_CHECK_INTERVAL = 60 * 1000;
+
 const system_tick_t QUECTEL_COPS_TIMEOUT = 3 * 60 * 1000;
 const system_tick_t QUECTEL_CFUN_TIMEOUT = 3 * 60 * 1000;
 
@@ -177,6 +179,7 @@ int QuectelNcpClient::init(const NcpClientConfig& conf) {
     connState_ = NcpConnectionState::DISCONNECTED;
     regStartTime_ = 0;
     regCheckTime_ = 0;
+    policymanSrvModeCheckTime_ = 0;
     parserError_ = 0;
     ready_ = false;
     registrationTimeout_ = REGISTRATION_TIMEOUT;
@@ -1139,6 +1142,10 @@ int QuectelNcpClient::initReady(ModemState state) {
         CHECK_PARSER(parser_.execCommand("AT+QCFG=\"urc/ri/other\",\"off\""));
     }
 
+    if (ncpId() == PLATFORM_NCP_QUECTEL_EG91_NAX) {
+        setPolicymanServiceMode(CellularPolicymanServiceMode::FULL_SERVICE, true /* check */);
+    }
+
     if (state != ModemState::MuxerAtChannel) {
         // Cold Boot only, Warm Boot will skip the following block...
 
@@ -1397,6 +1404,43 @@ int QuectelNcpClient::setModuleFunctionality(CellularFunctionality cfun, bool ch
     return r;
 }
 
+int QuectelNcpClient::getPolicymanServiceMode() {
+    auto resp = parser_.sendCommand(QUECTEL_CFUN_TIMEOUT, "AT+QNVFR=\"policyman/svc_mode\"");
+    int curVal = (int)CellularPolicymanServiceMode::NONE;
+    auto r = resp.scanf("+QNVFR: %d", &curVal);
+    // Soft response on ERROR
+    const int result = CHECK_PARSER(resp.readResult());
+    if (result != AtResponse::OK) {
+        return (int)CellularPolicymanServiceMode::NONE;
+    }
+    CHECK_TRUE(r == 1, (int)CellularPolicymanServiceMode::NONE);
+    return curVal;
+}
+
+int QuectelNcpClient::setPolicymanServiceMode(CellularPolicymanServiceMode mode, bool check) {
+    int curVal = (int)CellularPolicymanServiceMode::NONE;
+    if (check) {
+        curVal = getPolicymanServiceMode();
+        if ((int)mode == curVal || curVal == (int)CellularPolicymanServiceMode::NONE) {
+            // Already in required state, or command error'd/not supported.
+            return 0;
+        }
+    }
+
+    int r = SYSTEM_ERROR_UNKNOWN;
+
+    if (mode == CellularPolicymanServiceMode::FULL_SERVICE) {
+        r = parser_.execCommand(10000, "AT+QNVFW=\"policyman/svc_mode\",02");
+    } else if (mode == CellularPolicymanServiceMode::NO_SERVICE) {
+        r = parser_.execCommand(10000, "AT+QNVFW=\"policyman/svc_mode\",00");
+    }
+
+    CHECK_PARSER(r);
+
+    // AtResponse::Result!
+    return r;
+}
+
 int QuectelNcpClient::configureApn(const CellularNetworkConfig& conf) {
     // IMPORTANT: Set modem full functionality!
     // Otherwise we won't be able to query ICCID/IMSI
@@ -1549,6 +1593,7 @@ int QuectelNcpClient::registerNet() {
 
     regStartTime_ = millis();
     regCheckTime_ = regStartTime_;
+    policymanSrvModeCheckTime_ = regStartTime_;
 
     return SYSTEM_ERROR_NONE;
 }
@@ -1857,6 +1902,7 @@ void QuectelNcpClient::resetRegistrationState() {
     eps_.reset();
     regStartTime_ = millis();
     regCheckTime_ = regStartTime_;
+    policymanSrvModeCheckTime_ = regStartTime_;
     registrationInterventions_ = 0;
 }
 
@@ -1974,6 +2020,11 @@ int QuectelNcpClient::processEventsImpl() {
         return SYSTEM_ERROR_NONE;
     }
     SCOPE_GUARD({ regCheckTime_ = millis(); });
+
+    if (ncpId() == PLATFORM_NCP_QUECTEL_EG91_NAX && millis() - policymanSrvModeCheckTime_ >= QUECTEL_POLICYMAN_SRV_MODE_CHECK_INTERVAL) {
+        policymanSrvModeCheckTime_ = millis();
+        setPolicymanServiceMode(CellularPolicymanServiceMode::FULL_SERVICE, true /* check */);
+    }
 
     // Log extended errors for modems that support AT+CEER
     if (isQuecCat1Device()) {

--- a/hal/network/ncp_client/quectel/quectel_ncp_client.h
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.h
@@ -112,6 +112,7 @@ private:
 
     system_tick_t regStartTime_;
     system_tick_t regCheckTime_;
+    system_tick_t policymanSrvModeCheckTime_;
     unsigned registrationTimeout_;
     unsigned registrationInterventions_;
     volatile bool inFlowControl_ = false;
@@ -132,6 +133,8 @@ private:
     int checkSimCard();
     int getModuleFunctionality();
     int setModuleFunctionality(CellularFunctionality cfun, bool check);
+    int getPolicymanServiceMode();
+    int setPolicymanServiceMode(CellularPolicymanServiceMode mode, bool check);
     int configureApn(const CellularNetworkConfig& conf);
     int registerNet();
     int changeBaudRate(unsigned int baud);


### PR DESCRIPTION
### Problem

- A small number of EG91NAX devices have been found to have the `policyman/svc_mode` setting in an incorrect state on first boot, resulting in SIM IMSI switching not occurring.  This can lead to the device not being able to register with the cellular network.
- At this time only EG91NAX is affected.

### Solution

- Quectel has released an updated modem firmware `EG91NAXGAR07A03M1G_A0.002.A0.002` for new devices that automatically checks and fixes this setting. However it may not be practical for all customers to update devices to this firmware, thus we will provide a similar solution in Device OS.
- Check the policyman/svc_mode setting on warm/cold boot and every 60s during the registration process for good measure.

### Steps to Test

- Use a b5som EG91NAX based device with a deactivated SIM and attached antenna
- Run the included test app, and triple click the MODE button to set the policyman/svc_mode to the incorrect setting of "00".  Device should recover automatically to "02" on warm/cold boot, or during registration.

### Example App

```c
#include "Particle.h"
SYSTEM_MODE(SEMI_AUTOMATIC);
SYSTEM_THREAD(ENABLED);
SerialLogHandler logHandler(LOG_LEVEL_ALL);
bool button_clicked_3 = false;

void button_handler(system_event_t event, int clicks)
{
    if (event == button_final_click) {
        if (clicks >= 3) {
            button_clicked_3 = true;
        }
    }
}

void setup() {
    delay(5000);
    System.on(button_final_click, button_handler);
    Particle.connect();
}

void loop() {
    if (button_clicked_3) {
        button_clicked_3 = false;
        Cellular.command(60000, "AT+QNVFW=\"policyman/svc_mode\",00");
    }
}
```

### References

- [sc-137388]