### PR TITLE
Adds support for I2C::setSpeed() from 10kHz to 99kHz in 1kHz increments

### DIFF
--- a/hal/inc/i2c_hal.h
+++ b/hal/inc/i2c_hal.h
@@ -84,6 +84,7 @@ typedef enum hal_i2c_state_t {
 } hal_i2c_state_t;
 
 /* Exported macros -----------------------------------------------------------*/
+#define CLOCK_SPEED_10KHZ          (uint32_t)10000
 #define CLOCK_SPEED_100KHZ         (uint32_t)100000
 #define CLOCK_SPEED_400KHZ         (uint32_t)400000
 #define HAL_I2C_DEFAULT_TIMEOUT_MS (100)

--- a/hal/src/nRF52840/i2c_hal.cpp
+++ b/hal/src/nRF52840/i2c_hal.cpp
@@ -57,6 +57,13 @@
 // [219] TWIM: I2C timing spec is violated at 400 kHz
 const nrf_twim_frequency_t NRF_TWIM_FREQ_390K = (nrf_twim_frequency_t)(0x06200000UL);
 
+#define CEIL_DIV(A, B)      (((A) + (B) - 1) / (B))
+
+// Calculate TWIM frequency register value
+#define CALC_TWIM_FREQ_HZ(freq_hz) \
+    (CEIL_DIV(((uint64_t)(freq_hz) << 32) / 16000000UL, 4096UL) << 12)
+
+
 class I2cLock {
 public:
     I2cLock() = delete;
@@ -252,13 +259,19 @@ static int twiUninit(hal_i2c_interface_t i2c, bool reset_pin_configuration = tru
 
 static int twiInit(hal_i2c_interface_t i2c) {
     ret_code_t ret;
-    // NOTE:
-    // [219] TWIM: I2C timing spec is violated at 400 kHz
-    // If communication does not work at 400 kHz with an I2C compatible device
-    // that requires the SCL clock to have a minimum low period of 1.3 µs,
-    // use 390 kHz instead of 400kHz by writing 0x06200000 to the FREQUENCY register.
-    // With this setting, the SCL low period is greater than 1.3 µs.
-    nrf_twim_frequency_t nrfFrequency = (i2cMap[i2c].speed == CLOCK_SPEED_400KHZ) ? NRF_TWIM_FREQ_390K : NRF_TWIM_FREQ_100K;
+
+    nrf_twim_frequency_t nrfFrequency = NRF_TWIM_FREQ_100K;
+    if (i2cMap[i2c].speed == CLOCK_SPEED_400KHZ) {
+        // NOTE:
+        // [219] TWIM: I2C timing spec is violated at 400 kHz
+        // If communication does not work at 400 kHz with an I2C compatible device
+        // that requires the SCL clock to have a minimum low period of 1.3 µs,
+        // use 390 kHz instead of 400kHz by writing 0x06200000 to the FREQUENCY register.
+        // With this setting, the SCL low period is greater than 1.3 µs.
+        nrfFrequency = NRF_TWIM_FREQ_390K;
+    } else if (i2cMap[i2c].speed < CLOCK_SPEED_100KHZ && i2cMap[i2c].speed >= CLOCK_SPEED_10KHZ) {
+        nrfFrequency = (nrf_twim_frequency_t)CALC_TWIM_FREQ_HZ(i2cMap[i2c].speed);
+    }
 
     hal_pin_info_t* PIN_MAP = hal_pin_map();
 

--- a/hal/src/rtl872x/i2c_hal.cpp
+++ b/hal/src/rtl872x/i2c_hal.cpp
@@ -78,6 +78,8 @@ extern "C" {
     res;                                                                        \
 })
 
+#define CEIL_DIV(A, B)      (((A) + (B) - 1) / (B))
+
 class I2cClass {
 public:
     bool isConfigured() const {
@@ -284,8 +286,9 @@ public:
             I2C_Cmd(i2cDev_, DISABLE);
             state_ = HAL_I2C_STATE_DISABLED;
         }
-        i2cInitStruct_.I2CSpdMod = ((speed == CLOCK_SPEED_100KHZ) ? I2C_SS_MODE : I2C_FS_MODE);
-        i2cInitStruct_.I2CClk    = ((speed == CLOCK_SPEED_100KHZ) ? 100 : 400);
+        i2cInitStruct_.I2CSpdMod = ((speed == CLOCK_SPEED_400KHZ) ? I2C_FS_MODE : I2C_SS_MODE );
+        i2cInitStruct_.I2CClk    = ((speed == CLOCK_SPEED_100KHZ) ? 100 :
+                                    (speed < CLOCK_SPEED_100KHZ && speed >= CLOCK_SPEED_10KHZ) ? CEIL_DIV(speed, 1000) : 400);
         if (enabled) {
             I2C_Init(i2cDev_, &i2cInitStruct_);
             I2C_Cmd(i2cDev_, ENABLE);

--- a/user/tests/wiring/api/wiring.cpp
+++ b/user/tests/wiring/api/wiring.cpp
@@ -48,7 +48,9 @@ test(api_wiring_analogGetReference) {
 
 test(api_wiring_wire_setSpeed)
 {
+    API_COMPILE(Wire.setSpeed(CLOCK_SPEED_10KHZ));
     API_COMPILE(Wire.setSpeed(CLOCK_SPEED_100KHZ));
+    API_COMPILE(Wire.setSpeed(CLOCK_SPEED_400KHZ));
 }
 void D0_callback()
 {

--- a/user/tests/wiring/no_fixture/i2c.cpp
+++ b/user/tests/wiring/no_fixture/i2c.cpp
@@ -340,7 +340,43 @@ test(I2C_07_I2c_FuelGauge_Works_After_Buffer_Config_Disables_Interface) {
 }
 #endif // PARTICLE_TEST_RUNNER
 
-test(I2C_08_I2c_Sleep_FuelGauge) {
+test(I2C_08_I2c_FuelGauge_Works_Across_Entire_Frequency_Range) {
+    uint32_t freq = CLOCK_SPEED_400KHZ;
+    uint32_t s = millis();
+    while (true) {
+        FuelGauge fuel(true);
+        Wire.setSpeed(freq);
+        Wire.begin();
+        if (freq == CLOCK_SPEED_400KHZ) {
+            freq -= 300000;
+        } else if (freq <= CLOCK_SPEED_100KHZ) {
+            freq -= 1000; // will drop to 9kHz which is not supported, so will default to 100kHz
+        }
+        assertTrue(Wire.isEnabled());
+        fuel.wakeup();
+        auto ver = 0xffff & fuel.getVersion();
+#if HAL_PLATFORM_POWER_MANAGEMENT_OPTIONAL
+        if (ver < 0) {
+            skip();
+            return;
+        }
+#endif // HAL_PLATFORM_POWER_MANAGEMENT_OPTIONAL
+        assertNotEqual(ver, 0xff60); // gen3, if i2c interface not enabled, this is returned
+        assertNotEqual(ver, 0x7400); // gen4
+        assertMoreOrEqual(ver, 0);
+        assertNotEqual(ver, 0x0000);
+        assertNotEqual(ver, 0xffff);
+
+        // kick out on 8kHz, or 2 minutes
+        if (freq <= CLOCK_SPEED_10KHZ - 2000 || millis() - s > 120000) {
+            break;
+        }
+
+        delay(100);
+    }
+}
+
+test(I2C_09_I2c_Sleep_FuelGauge) {
     FuelGauge fuel(true);
     fuel.begin();
     fuel.wakeup();
@@ -367,7 +403,7 @@ test(I2C_08_I2c_Sleep_FuelGauge) {
     assertEqual(ver, ver2);
 }
 
-test(I2C_09_bus_reset_is_not_destructive) {
+test(I2C_10_bus_reset_is_not_destructive) {
     constexpr uint16_t MAX17043_DEFAULT_CONFIG = 0x971c;
 
     FuelGauge fuel;
@@ -425,7 +461,7 @@ test(I2C_09_bus_reset_is_not_destructive) {
 
 #if HAL_PLATFORM_FUELGAUGE_MAX17043 && HAL_PLATFORM_I2C_NUM == 1
 // Uses transactions
-test(I2C_10_can_talk_to_fuelgauge_with_transactions) {
+test(I2C_11_can_talk_to_fuelgauge_with_transactions) {
     FuelGauge fuel;
     fuel.begin();
     fuel.wakeup();
@@ -443,7 +479,7 @@ test(I2C_10_can_talk_to_fuelgauge_with_transactions) {
 #endif // HAL_PLATFORM_FUELGAUGE_MAX17043 && HAL_PLATFORM_I2C_NUM == 1
 
 #if HAL_PLATFORM_PMIC_BQ24195 && HAL_PLATFORM_I2C_NUM == 1
-test(I2C_11_can_talk_to_pmic_with_transactions) {
+test(I2C_12_can_talk_to_pmic_with_transactions) {
     constexpr uint8_t BQ24195_VERSION = 0x23;
     PMIC power;
     power.begin();


### PR DESCRIPTION
### Feature

- Adds support for `I2C::setSpeed()` from 10kHz to 99kHz in 1kHz increments for Gen 3 and Gen 4 devices

### Steps to Test

- Run `device-os-test run bsom wiring/no_fixture -v -- -fixture` on SoM eval board with FuelGauge
- Run `device-os-test run msom wiring/no_fixture -v -- -fixture` on SoM eval board with FuelGauge