### PR TITLE
Fix DNS server change lockup

### DIFF
--- a/system/src/system_cloud_connection_posix.cpp
+++ b/system/src/system_cloud_connection_posix.cpp
@@ -48,6 +48,7 @@ const unsigned CLOUD_SOCKET_HALF_CLOSED_WAIT_TIMEOUT = 5000;
 } /* anonymous */
 
 int system_cloud_resolv_address(int protocol, const ServerAddress* address, sockaddr* saddrCache, addrinfo** info, CloudServerAddressType* type, bool useCachedAddrInfo, network_handle_t interface, bool flushDnsCache) {
+    int r = 0;
     CHECK_TRUE(info, SYSTEM_ERROR_INVALID_ARGUMENT);
 
     *type = CLOUD_SERVER_ADDRESS_TYPE_NONE;
@@ -125,7 +126,7 @@ int system_cloud_resolv_address(int protocol, const ServerAddress* address, sock
                     if_get_by_index(interface, &iface);
                 }
                 LOG(TRACE, "Resolving %s#%s cache=%d iface=%d", tmphost, tmpserv, !flushDnsCache, interface);
-                netdb_getaddrinfo_ex(tmphost, tmpserv, &hints, info, iface);
+                r = netdb_getaddrinfo_ex(tmphost, tmpserv, &hints, info, iface);
                 *type = CLOUD_SERVER_ADDRESS_TYPE_NEW_ADDRINFO;
                 break;
             }
@@ -133,7 +134,7 @@ int system_cloud_resolv_address(int protocol, const ServerAddress* address, sock
     }
 
     if (*info == nullptr) {
-        LOG(ERROR, "Failed to determine server address");
+        LOG(ERROR, "Failed to determine server address: %d", r);
         return SYSTEM_ERROR_NOT_FOUND;
     }
 

--- a/system/src/system_connection_manager.cpp
+++ b/system/src/system_connection_manager.cpp
@@ -197,23 +197,27 @@ int ConnectionManager::testConnections(bool background) {
     } else {
         // Background test
         testResultsActual_ = false;
+        auto backgroundTestPrepared = true;
         if (!backgroundTestInProgress_) {
             LOG_DEBUG(INFO, "Background reachability test started");
             backgroundTester_ = std::make_unique<ConnectionTester>();
             CHECK_TRUE(backgroundTester_, SYSTEM_ERROR_NO_MEMORY);
-            r = backgroundTester_->prepare(false /* full test*/);
+            r = backgroundTester_->prepare(false /* full test*/, lastTestFailed_);
             if (r == 0) {
                 backgroundTestInProgress_ = true;
-                r = backgroundTester_->runTest(0 /* non blocking */);
             } else {
                 lastTestFailed_ = true;
+                backgroundTestPrepared = false;
             }
         }
-        if (!r || r != SYSTEM_ERROR_BUSY) {
-            LOG_DEBUG(INFO, "Background reachability test finished (%d)", r);
-            backgroundTestInProgress_ = false;
-            metrics = backgroundTester_->getConnectionMetrics();
-            backgroundTester_.reset();
+        if (backgroundTestPrepared) {
+            r = backgroundTester_->runTest(0 /* non blocking */);
+            if (!r || r != SYSTEM_ERROR_BUSY) {
+                LOG_DEBUG(INFO, "Background reachability test finished (%d)", r);
+                backgroundTestInProgress_ = false;
+                metrics = backgroundTester_->getConnectionMetrics();
+                backgroundTester_.reset();
+            }
         }
     }
 

--- a/system/src/system_connection_manager.cpp
+++ b/system/src/system_connection_manager.cpp
@@ -204,11 +204,11 @@ int ConnectionManager::testConnections(bool background) {
             r = backgroundTester_->prepare(false /* full test*/);
             if (r == 0) {
                 backgroundTestInProgress_ = true;
+                r = backgroundTester_->runTest(0 /* non blocking */);
             } else {
                 lastTestFailed_ = true;
             }
         }
-        r = backgroundTester_->runTest(0 /* non blocking */);
         if (!r || r != SYSTEM_ERROR_BUSY) {
             LOG_DEBUG(INFO, "Background reachability test finished (%d)", r);
             backgroundTestInProgress_ = false;
@@ -216,6 +216,7 @@ int ConnectionManager::testConnections(bool background) {
             backgroundTester_.reset();
         }
     }
+
     if (r == 0) {
         bestNetworks_.clear();
         bool hasValidScore = false;

--- a/system/src/system_connection_manager.cpp
+++ b/system/src/system_connection_manager.cpp
@@ -183,13 +183,17 @@ int ConnectionManager::testConnections(bool background) {
         backgroundTester_.reset();
         testResultsActual_ = false;
 
-        LOG_DEBUG(INFO, "Full reachability test started");
+        LOG_DEBUG(INFO, "Full reachability test started: %d", lastTestFailed_);
         ConnectionTester tester;
-        CHECK(tester.prepare(true /* full test */, lastTestFailed_));
-        // Blocking call
-        r = tester.runTest();
-        LOG_DEBUG(INFO, "Full reachability test finished (%d)", r);
-        metrics = tester.getConnectionMetrics();
+        r = tester.prepare(true /* full test */, lastTestFailed_);
+        if (r == 0) {
+            // Blocking call
+            r = tester.runTest();
+            LOG_DEBUG(INFO, "Full reachability test finished (%d)", r);
+            metrics = tester.getConnectionMetrics();
+        } else {
+            lastTestFailed_ = true;
+        }
     } else {
         // Background test
         testResultsActual_ = false;
@@ -197,8 +201,12 @@ int ConnectionManager::testConnections(bool background) {
             LOG_DEBUG(INFO, "Background reachability test started");
             backgroundTester_ = std::make_unique<ConnectionTester>();
             CHECK_TRUE(backgroundTester_, SYSTEM_ERROR_NO_MEMORY);
-            CHECK(backgroundTester_->prepare(false /* full test*/));
-            backgroundTestInProgress_ = true;
+            r = backgroundTester_->prepare(false /* full test*/);
+            if (r == 0) {
+                backgroundTestInProgress_ = true;
+            } else {
+                lastTestFailed_ = true;
+            }
         }
         r = backgroundTester_->runTest(0 /* non blocking */);
         if (!r || r != SYSTEM_ERROR_BUSY) {


### PR DESCRIPTION
### Problem
See [LWIP issue](https://github.com/particle-iot/lwip/pull/18) for detailed summary of DNS issues.
Another problem is that the connection tester logic to explicitly rotate network interfaces/their associated DNS servers fails if the DNS resolution step fails. 

### Solution
If we cant resolve DNS on an interface, treat that as a failure and dont return due to the `CHECK()` macro. 

### Steps to Test
1. Connect on wifi
2. Connect on Ethernet
3. Whichever connection is used for the cloud connection, disable the DNS server for that connection. If using ethernet, unplug the upstream router. If using wifi, block traffic from the device on your router but leave it still assigned an IP
4. Cloud communication and DNS resolution should start failing
5. The device should fail over to the working interface and explicitly use that devices DNS server

### Example App
Enable LWIP debugging via 
```
#define DNS_DEBUG                       LWIP_DBG_ON
```
in `lwipopts.h`

Use this app to connect/disconnect interfaces as needed
```c

#include "Particle.h"

// Let Device OS manage the connection to the Particle Cloud
SYSTEM_MODE(AUTOMATIC);

Serial1LogHandler logHandler(115200, LOG_LEVEL_ALL, 
{
    { "app", LOG_LEVEL_ALL }, 
    //{ "sys.power", LOG_LEVEL_TRACE },
    { "comm.protocol", LOG_LEVEL_TRACE },
    { "system", LOG_LEVEL_TRACE },
    { "network", LOG_LEVEL_TRACE },
    { "ncp.at", LOG_LEVEL_TRACE },
    { "system.nm", LOG_LEVEL_TRACE },
    { "system.cm", LOG_LEVEL_TRACE },
    { "system.nd", LOG_LEVEL_TRACE },
    { "ncp.client", LOG_LEVEL_TRACE },
    { "net.rltkncp", LOG_LEVEL_TRACE },
    { "net.ifapi", LOG_LEVEL_TRACE },
    { "net.ppp.client", LOG_LEVEL_WARN },
    { "net.en", LOG_LEVEL_TRACE },
    { "service.ntp", LOG_LEVEL_TRACE },
    { "net.en", LOG_LEVEL_TRACE },
    { "mux", LOG_LEVEL_ERROR },
    { "net.ppp.ipcp", LOG_LEVEL_ERROR },
    { "comm.cloud.posix", LOG_LEVEL_TRACE },
}   
);

STARTUP(System.enableFeature(FEATURE_DISABLE_LISTENING_MODE));

void setup()
{
    // For Muon
    // Enable 3V3_AUX
    SystemPowerConfiguration powerConfig = System.getPowerConfiguration();
    powerConfig.auxiliaryPowerControlPin(D7).interruptPin(A7);
    System.setPowerConfiguration(powerConfig);

    // Enable Ethernet
    if_wiznet_pin_remap remap = {};
    remap.base.type = IF_WIZNET_DRIVER_SPECIFIC_PIN_REMAP;

    System.enableFeature(FEATURE_ETHERNET_DETECTION);
    remap.cs_pin = A3;
    remap.reset_pin = PIN_INVALID;
    remap.int_pin = A4;
    auto ret = if_request(nullptr, IF_REQ_DRIVER_SPECIFIC, &remap, sizeof(remap), nullptr);
}

WiFiAccessPoint ap[5];

void logNetworkStates() {
    int wifiReady, cellReady = -1;
#if HAL_PLATFORM_CELLULAR
    cellReady = Cellular.ready();
#endif
#if HAL_PLATFORM_WIFI
    wifiReady = WiFi.ready();
#endif

    auto activeNetwork = Particle.connectionInterface();
    Log.info("Ethernet Ready: %d WiFi ready: %d Cellular ready: %d Cloud conn: %lu", 
        Ethernet.ready(), 
        wifiReady, 
        cellReady,
        static_cast<network_interface_t>(activeNetwork));
}

static void printCellularInfo() {
    CellularDevice device = {};
    device.size = sizeof(device);
    cellular_device_info(&device, NULL);
    Log.info("HAL    ICCID %s IMEI %s dev %d FW %s", device.iccid, device.imei, device.dev, device.radiofw);
};

void loop() {
    if (!Serial1.available()) {
        return;
    }

    while (Serial1.available()) {
        char c = Serial1.read();
        logNetworkStates();

        if (c == 'p') {
            Log.info("Particle.publishVitals");
            Particle.publishVitals(particle::NOW);
        }
        else if(c == '2') {
            // Print DNS servers
            system_internal(4, nullptr);
        }
#if HAL_PLATFORM_WIFI
        else if (c == 'w') {
            static bool wifiState = true;
            Log.info("Wifi state: %d", wifiState);

            if(wifiState){
                WiFi.connect();
            } else {
                WiFi.disconnect();
            }
            wifiState = !wifiState;
        }
        else if (c == 'l') {
            int found = WiFi.getCredentials(ap, 5);
            Log.info("Found %d wifi creds", found);
            for (int i = 0; i < found; i++) {
                Log.info("ssid: %s", ap[i].ssid);
                Log.info("security: %d", (int) ap[i].security);
                Log.info("cipher: %d", (int) ap[i].cipher);
            }
        }
#endif
#if HAL_PLATFORM_CELLULAR
        else if (c == 'c') {
            static bool cellState = true;
            Log.info("Cell state: %d", cellState);
            
            if(cellState){
                Cellular.connect();
            } else {
                Cellular.disconnect();
            }
            cellState = !cellState;
        }
        else if(c == '9') {
            printCellularInfo();
        } 
#endif
        else if (c == 'e') {
            static bool ethernet = true;
            Log.info("Ethernet state: %d", ethernet);
            
            if(ethernet){
                System.enableFeature(FEATURE_ETHERNET_DETECTION);
            } else {
                System.disableFeature(FEATURE_ETHERNET_DETECTION);
            }
            ethernet = !ethernet;
        } else if (c == 'f') {
            auto conf = Ethernet.getConfig();

            uint8_t ethernet_mac[6] = {};
            Ethernet.macAddress(ethernet_mac);
            Log.info("MAC: %02X:%02X:%02X:%02X:%02X:%02X",
                ethernet_mac[0],ethernet_mac[1],ethernet_mac[2],
                ethernet_mac[3],ethernet_mac[4],ethernet_mac[5]);
            Log.info("localIP: %s", Ethernet.localIP().toString().c_str());
            Log.info("DHCP: %s", Ethernet.dhcpServerIP().toString().c_str());
            Log.info("Gateway IP: %s", Ethernet.gatewayIP().toString().c_str());
            Log.info("Subnet Mask: %s", Ethernet.subnetMask().toString().c_str());

            for (const auto& addr: conf.addresses()) {
                Log.info("Addr: %s/%u (%s) - family = %d", addr.address().address().toString().c_str(), (unsigned)addr.prefixLength(), addr.mask().address().toString().c_str(), addr.family());
            }
            for (const auto& addr: conf.dns()) {
                Log.info("DNS: %s", addr.toString().c_str());
            }
            Log.info("Gateway: %s", conf.gateway().toString().c_str());
            Log.info("Source: %d/%d", (int)conf.source(AF_INET), (int)conf.source(AF_INET6));
        }
        else if (c == 'g') {
            static bool ethernetConnect = true;
            Log.info("ethernetConnect: %d", ethernetConnect);
            
            if(ethernetConnect){
                Ethernet.connect();
            } else {
                Ethernet.disconnect();
            }
            ethernetConnect = !ethernetConnect;
        } else if (c == 'h') {
            auto r = network_clear_credentials(0, 0, NULL, NULL);
            Log.info("network_clear_credentials: %d", r);
        } else if (c == 'd') {
            static bool particleConnect = true;
            Log.info("Particle connect: %d", particleConnect);
            
            if(particleConnect){
                Particle.connect();
            } else {
                Particle.disconnect();
            }
            particleConnect = !particleConnect;
        }
    }
}
```

I patched system_task to print DNS servers on demand as well
```c
void list_dns_servers(void) {
    const ip_addr_t *dns_ip;
    
    LOG(INFO, "Configured DNS servers:");
    
    for (u8_t i = 0; i < DNS_MAX_SERVERS; i++) {
        dns_ip = dns_getserver(i);
        
        if (dns_ip != NULL && !ip_addr_isany(dns_ip)) {
            #if LWIP_IPV4 && LWIP_IPV6
            // Dual stack - check which IP version
            if (IP_IS_V4(dns_ip)) {
                LOG(INFO, "  DNS[%d]: %s (IPv4)", i, ip4addr_ntoa(ip_2_ip4(dns_ip)));
            } else if (IP_IS_V6(dns_ip)) {
                LOG(INFO, "  DNS[%d]: %s (IPv6)", i, ip6addr_ntoa(ip_2_ip6(dns_ip)));
            }
            #elif LWIP_IPV4
            // IPv4 only
            LOG(INFO, "  DNS[%d]: %s", i, ip4addr_ntoa(ip_2_ip4(dns_ip)));
            #elif LWIP_IPV6
            // IPv6 only
            LOG(INFO, "  DNS[%d]: %s", i, ip6addr_ntoa(ip_2_ip6(dns_ip)));
            #endif
        } else {
            // LOG(INFO, "  DNS[%d]: Not configured", i);
        }
    }
}

void* system_internal(int item, void* reserved)
{
    switch (item) {
#if PLATFORM_THREADING
    case 0: {
        return &ApplicationThread;
    }
    case 1: {
        return &SystemThread;
    }
    case 2: {
        return mutex_usb_serial();
    }
#endif
    case 3: {
        return reinterpret_cast<void*>(system_cloud_get_socket_handle());
    }
    case 4: {
        list_dns_servers();
        return nullptr;
    }
    default:
        return nullptr;
    }
}
```
