### PR TITLE
Implement cellular env var tests for BG95-S5

### DIFF
--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -1047,17 +1047,23 @@ int QuectelNcpClient::setupBands() {
     char qbandGsmStr[4+1] = {};
     char qbandLteStr[32+1] = {};
     char qbandCatNbStr[32+1] = {};
-    // BG95_M5: +QCFG: "band",0xf,0x100002000000000f0e189f,0x10004200000000090e189f <GSM>,<CAT-M1-1-128>,<CAT-NB-1-128>
-    auto retBand = CHECK_PARSER(respBand.scanf("+QCFG: \"band\",0x%4[^,],0x%32[^,],0x%32[^,]", qbandGsmStr, qbandLteStr, qbandCatNbStr));
+    char qbandNtnStr[3+1] = {};
+    // BG95_M5: +QCFG: "band",0xf,0x100002000000000f0e189f,0x10004200000000090e189f     <GSM>,<CAT-M1-1-128>,<CAT-NB-1-128>
+    // BG95_S5: +QCFG: "band",0xf,0x100002000000000f0e189f,0x10004200000000090e189f,0x7 <GSM>,<CAT-M1-1-128>,<CAT-NB-1-128>,<NTN_NB-IoT_bandval>
+    auto retBand = CHECK_PARSER(respBand.scanf("+QCFG: \"band\",0x%4[^,],0x%32[^,],0x%32[^,],%s", qbandGsmStr, qbandLteStr, qbandCatNbStr, qbandNtnStr));
     CHECK_PARSER_OK(respBand.readResult());
-
-    if (retBand == 3) {
+    if (retBand == 3 || retBand == 4) {
         CellularBandMask bandsCurrent(qbandLteStr);
 
         if (bandsCurrent != envPreferredBands) {
             // Apply band changes immediately, no reboot required.
             CHECK_PARSER_OK(setModuleFunctionality(CellularFunctionality::AIRPLANE, true /* check */));
-            CHECK_PARSER_OK(parser_.execCommand("AT+QCFG=\"band\",%s,%s,%s,1", qbandGsmStr, (const char*)envPreferredBands.toString(), qbandCatNbStr));
+            if (retBand == 3) {
+                CHECK_PARSER_OK(parser_.execCommand("AT+QCFG=\"band\",%s,%s,%s,1", qbandGsmStr, (const char*)envPreferredBands.toString(), qbandCatNbStr));    
+            } else if (retBand == 4) {
+                CHECK_PARSER_OK(parser_.execCommand("AT+QCFG=\"band\",%s,%s,%s,%s,1", qbandGsmStr, (const char*)envPreferredBands.toString(), qbandCatNbStr, qbandNtnStr));
+            }
+            
             CHECK_PARSER_OK(setModuleFunctionality(CellularFunctionality::FULL, false /* check */));
         }
     }
@@ -1226,6 +1232,7 @@ int QuectelNcpClient::configurePlmn() {
 
     auto ncp_id = ncpId();
     if (ncp_id != PLATFORM_NCP_QUECTEL_BG95_M5 &&
+            ncp_id != PLATFORM_NCP_QUECTEL_BG95_S5 &&
             ncp_id != PLATFORM_NCP_QUECTEL_EG91_NAX &&
             ncp_id != PLATFORM_NCP_QUECTEL_EG91_EX &&
             ncp_id != PLATFORM_NCP_QUECTEL_EG91_E) {
@@ -1424,6 +1431,7 @@ int QuectelNcpClient::initReady(ModemState state) {
 
     configuredPlmn_ = false;
     if (ncpId() == PLATFORM_NCP_QUECTEL_BG95_M5 ||
+            ncpId() == PLATFORM_NCP_QUECTEL_BG95_S5 ||
             ncpId() == PLATFORM_NCP_QUECTEL_BG96 ||
             ncpId() == PLATFORM_NCP_QUECTEL_EG91_NAX ||
             ncpId() == PLATFORM_NCP_QUECTEL_EG91_E ||

--- a/hal/shared/ncp_band_mask.h
+++ b/hal/shared/ncp_band_mask.h
@@ -71,6 +71,7 @@ const uint64_t QUECTEL_NCP_BANDMASK_CATM1_65_128_BG95 = 0x100002;     // Band 66
 // BG95-S5
 const uint64_t QUECTEL_NCP_BANDMASK_CATM1_1_64_BG95_S5 = 0xF0E189F;   // Bands 1,2,3,4,5,8,12,13,18,19,20,25,26,27,28 [all default enabled]
 const uint64_t QUECTEL_NCP_BANDMASK_CATM1_65_128_BG95_S5 = 0x100002;  // Band 66,85 enabled
+//const uint64_t QUECTEL_NCP_BANDMASK_NTN_1_64_BG95_S5 = 0x07; // NTN Band 23, 255, 256 enabled
 
 // BG96-MC
 const uint64_t QUECTEL_NCP_BANDMASK_CATM1_1_64_BG96_MC = 0x40090E189F;  // Bands 1,2,3,4,5,8,12,13,17(shows up in mask, but not listed in datasheet),

--- a/hal/shared/ncp_band_mask.h
+++ b/hal/shared/ncp_band_mask.h
@@ -68,6 +68,10 @@ const uint64_t QUECTEL_NCP_BANDMASK_CATM1_65_128_BG95 = 0x100002;     // Band 66
 // const uint64_t QUECTEL_NCP_BANDMASK_CATNB_1_64_BG95 = 0x90E189F;      // Bands 1,2,3,4,5,8,12,13,18,19,20,25,26,27,28 [all default enabled]
 // const uint64_t QUECTEL_NCP_BANDMASK_CATNB_65_128_BG95 = 0x100002;     // Band 66,85 enabled
 
+// BG95-S5
+const uint64_t QUECTEL_NCP_BANDMASK_CATM1_1_64_BG95_S5 = 0xF0E189F;   // Bands 1,2,3,4,5,8,12,13,18,19,20,25,26,27,28 [all default enabled]
+const uint64_t QUECTEL_NCP_BANDMASK_CATM1_65_128_BG95_S5 = 0x100002;  // Band 66,85 enabled
+
 // BG96-MC
 const uint64_t QUECTEL_NCP_BANDMASK_CATM1_1_64_BG96_MC = 0x40090E189F;  // Bands 1,2,3,4,5,8,12,13,17(shows up in mask, but not listed in datasheet),
                                                                         //       18,19,20,25,26(v1.2 hardware),28,39
@@ -91,6 +95,8 @@ inline uint64_t getBandMaskByNcpIdForRAT(int ncpid, CellularAccessTechnology rat
                 return upper ? UBLOX_NCP_BANDMASK_65_128_R410 : (legacy ? UBLOX_NCP_BANDMASK_1_64_R410_LEGACY : UBLOX_NCP_BANDMASK_1_64_R410);
             case PLATFORM_NCP_QUECTEL_BG95_M5:
                 return upper ? QUECTEL_NCP_BANDMASK_CATM1_65_128_BG95 : QUECTEL_NCP_BANDMASK_CATM1_1_64_BG95;
+            case PLATFORM_NCP_QUECTEL_BG95_S5:
+                return upper ? QUECTEL_NCP_BANDMASK_CATM1_65_128_BG95_S5 : QUECTEL_NCP_BANDMASK_CATM1_1_64_BG95_S5;
             case PLATFORM_NCP_QUECTEL_BG96:
                 return upper ? 0 : QUECTEL_NCP_BANDMASK_CATM1_1_64_BG96_MC;
             case PLATFORM_NCP_QUECTEL_EG91_E:

--- a/user/tests/integration/system/cellular_env/cellular_env.cpp
+++ b/user/tests/integration/system/cellular_env/cellular_env.cpp
@@ -68,6 +68,7 @@ ModemType getModemType() {
 
     switch (getNcpId()) {
         case PLATFORM_NCP_QUECTEL_BG95_M5:
+        case PLATFORM_NCP_QUECTEL_BG95_S5:
         case PLATFORM_NCP_QUECTEL_BG96:
         case PLATFORM_NCP_QUECTEL_EG91_NAX:
         case PLATFORM_NCP_QUECTEL_EG91_E:
@@ -266,8 +267,9 @@ void completeFirmwareUpdate(bool expectSafeMode = false) {
 #if HAL_PLATFORM_CELLULAR
 
 test(1_particle_cellular_preferred_bands_init) {
-    if (TestSuite::instance()->network() != NETWORK_INTERFACE_ALL &&
-            TestSuite::instance()->network() != NETWORK_INTERFACE_CELLULAR) {
+    if (getModemType() == ModemType::UNSUPPORTED ||
+        (TestSuite::instance()->network() != NETWORK_INTERFACE_ALL &&
+         TestSuite::instance()->network() != NETWORK_INTERFACE_CELLULAR)) {
         g_SkipTests = true;
     } else {
         g_SkipTests = false;


### PR DESCRIPTION
### Problem

BG95-S5 with modem firmware A03 is not supported in cellular env vars

### Solution

The modem supports the necessary AT commands to do band masking, preferred operator support, update ncp client and tests to support it. 

### Steps to Test
Use a M635 with Kore esim profile loaded to enable cellular communication

```device-os-test --device-os-dir=/Users/scottbrust/develop/device-os run msom  system/cellular_env  -- -fixture```

Also tested with stock M404 msom and tests passed still. (ie didnt break parsing for non NTN bandmasks)

### Example passing log

```
device-os-test --device-os-dir=/Users/scottbrust/develop/device-os run msom system/cellular_env  -- -fixture


  Cellular env vars
    msom
      systemThread=disabled
PARTICLE_CELLULAR_PREFERRED_BANDS=100000000000000f0e189c
        ✓ 1_particle_cellular_preferred_bands_init (8.7s)
Default LTE band mask (QUECTEL): 100002000000000f0e189f
        ✓ 2_particle_cellular_preferred_bands_default (5.7s)
LTE band mask after PREFERRED_BANDS env var (QUECTEL): 100000000000000f0e189c
        ✓ 3_particle_cellular_preferred_bands_set (2s)
PARTICLE_CELLULAR_FORBIDDEN_BANDS=ffffffffffeffffffffffffff0f1e763
        ✓ 4_particle_cellular_forbidden_bands_init (4.6s)
Default LTE band mask (QUECTEL): 100002000000000f0e189f
        ✓ 5_particle_cellular_forbidden_bands_default (5.9s)
LTE band mask after FORBIDDEN_BANDS env var (QUECTEL): 100000000000000f0e189c
        ✓ 6_particle_cellular_forbidden_bands_set (1.9s)
        ✓ 7_particle_cellular_preferred_plmn_init (4s)
Default CPOL response: empty
        ✓ 8_particle_cellular_preferred_plmn_default (5.4s)
AT+CPOL response after PREFERRED_PLMN env var:
+CPOL: 1,2,"310410",0,0,0,1

+CPOL: 2,2,"310260",0,0,0,1

+CPOL: 3,2,"311480",0,0,0,1

        ✓ 9_particle_cellular_preferred_plmn_set (5.9s)
        ✓ 10_particle_cellular_preferred_plmn_cleanup (4.1s)
Band mask after env clear: 100002000000000f0e189f
AT+CPOL response after env clear: empty
        ✓ 11_particle_cellular_env_vars_cleared_verify_defaults (10.5s)
        ✓ 97_cleanup (3.7s)
spark/flash/status started
spark/flash/status success
        ✓ 98_cleanup (11.4s)
        ✓ 99_cleanup_1 (3.7s)
        ✓ 99_cleanup_2 (8.7s)
      systemThread=enabled
PARTICLE_CELLULAR_PREFERRED_BANDS=100000000000000f0e189c
        ✓ 1_particle_cellular_preferred_bands_init (8.7s)
Default LTE band mask (QUECTEL): 100002000000000f0e189f
        ✓ 2_particle_cellular_preferred_bands_default (5.8s)
LTE band mask after PREFERRED_BANDS env var (QUECTEL): 100000000000000f0e189c
        ✓ 3_particle_cellular_preferred_bands_set (1.9s)
PARTICLE_CELLULAR_FORBIDDEN_BANDS=ffffffffffeffffffffffffff0f1e763
        ✓ 4_particle_cellular_forbidden_bands_init (4.5s)
Default LTE band mask (QUECTEL): 100002000000000f0e189f
        ✓ 5_particle_cellular_forbidden_bands_default (5.3s)
LTE band mask after FORBIDDEN_BANDS env var (QUECTEL): 100000000000000f0e189c
        ✓ 6_particle_cellular_forbidden_bands_set (1.9s)
        ✓ 7_particle_cellular_preferred_plmn_init (4s)
Default CPOL response: empty
        ✓ 8_particle_cellular_preferred_plmn_default (6.1s)
AT+CPOL response after PREFERRED_PLMN env var:
+CPOL: 1,2,"310410",0,0,0,1

+CPOL: 2,2,"310260",0,0,0,1

+CPOL: 3,2,"311480",0,0,0,1

        ✓ 9_particle_cellular_preferred_plmn_set (5s)
        ✓ 10_particle_cellular_preferred_plmn_cleanup (4s)
Band mask after env clear: 100002000000000f0e189f
AT+CPOL response after env clear: empty
        ✓ 11_particle_cellular_env_vars_cleared_verify_defaults (9.2s)
        ✓ 97_cleanup (3.8s)
spark/flash/status started
spark/flash/status success
        ✓ 98_cleanup (13.5s)
        ✓ 99_cleanup_1 (4.2s)
        ✓ 99_cleanup_2 (8.7s)


  30 passing (4m)
```


