### PR TITLE
Add lock around reading logical efuse

### DIFF
--- a/hal/src/rtl872x/deviceid_hal.cpp
+++ b/hal/src/rtl872x/deviceid_hal.cpp
@@ -46,52 +46,6 @@ const uint8_t DEVICE_ID_PREFIX[] = {0x0a, 0x10, 0xac, 0xed, 0x20, 0x21};
 
 } // Anonymous
 
-int readLogicalEfuse(uint32_t offset, uint8_t* buf, size_t size) {
-#if MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
-    std::unique_ptr<uint8_t[]> efuseData(new uint8_t[LOGICAL_EFUSE_SIZE]);
-    CHECK_TRUE(efuseData, SYSTEM_ERROR_NO_MEMORY);
-    uint8_t* efuseBuf = efuseData.get();
-#else
-    // No heap in bootloader
-    static uint8_t efuseBuf[LOGICAL_EFUSE_SIZE];
-#endif // MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
-
-    memset(efuseBuf, 0xff, LOGICAL_EFUSE_SIZE);
-
-    bool dataConsistent = false;
-    for (int i = 0; i < 5 && !dataConsistent; i++) {
-        // There are places in ambd_sdk where efuses might be read as well (e.g. BLE stack)
-        // This is not a thread safe operation, so now those places are guarded with a lock in the SDK
-        // Use the same lock here as well.
-#if MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
-        device_mutex_lock(RT_DEV_LOCK_EFUSE);
-#endif
-        EFUSE_LMAP_READ(efuseBuf);
-#if MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
-        device_mutex_unlock(RT_DEV_LOCK_EFUSE);
-#endif
-        uint32_t crc1 = HAL_Core_Compute_CRC32(efuseBuf, LOGICAL_EFUSE_SIZE);
-
-#if MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
-        device_mutex_lock(RT_DEV_LOCK_EFUSE);
-#endif
-        EFUSE_LMAP_READ(efuseBuf);
-#if MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
-        device_mutex_unlock(RT_DEV_LOCK_EFUSE);
-#endif
-        uint32_t crc2 = HAL_Core_Compute_CRC32(efuseBuf, LOGICAL_EFUSE_SIZE);
-
-        dataConsistent = (crc1 == crc2);
-    }
-
-    if (!dataConsistent) {
-        return SYSTEM_ERROR_INTERNAL;
-    }
-    memcpy(buf, efuseBuf + offset, size);
-
-    return SYSTEM_ERROR_NONE;
-}
-
 unsigned hal_get_device_id(uint8_t* dest, unsigned destLen) {
     // Device ID is composed of prefix and MAC address
     uint8_t id[HAL_DEVICE_ID_SIZE] = {};

--- a/hal/src/rtl872x/deviceid_hal_impl.h
+++ b/hal/src/rtl872x/deviceid_hal_impl.h
@@ -29,10 +29,6 @@
                                          (type) == HAL_DEVICE_MAC_WIFI_AP || \
                                          (type) == HAL_DEVICE_MAC_ETHERNET)
 
-#define LOGICAL_EFUSE_SIZE      1024
-#define EFUSE_SUCCESS           1
-#define EFUSE_FAILURE           0
-
 #define BLE_MAC_OFFSET          0x190
 #define WIFI_MAC_OFFSET         0x11A
 #define MOBILE_SECRET_OFFSET    0x160

--- a/hal/src/rtl872x/efuse.cpp
+++ b/hal/src/rtl872x/efuse.cpp
@@ -24,6 +24,7 @@
 #include "check.h"
 
 extern "C" {
+#include "device_lock.h"
 #include "rtl8721d.h"
 #include "rtl8721d_efuse.h"
 }
@@ -42,10 +43,16 @@ int efuse_read_logical(uint32_t offset, uint8_t* buf, size_t size) {
 
     bool dataConsistent = false;
     for (int i = 0; i < 5 && !dataConsistent; i++) {
+#if MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
+        device_mutex_lock(RT_DEV_LOCK_EFUSE);
+#endif
         EFUSE_LMAP_READ(efuseBuf);
         uint32_t crc1 = HAL_Core_Compute_CRC32(efuseBuf, EFUSE_LOGICAL_SIZE);
 
         EFUSE_LMAP_READ(efuseBuf);
+#if MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
+        device_mutex_unlock(RT_DEV_LOCK_EFUSE);
+#endif
         uint32_t crc2 = HAL_Core_Compute_CRC32(efuseBuf, EFUSE_LOGICAL_SIZE);
 
         dataConsistent = (crc1 == crc2);

--- a/hal/src/rtl872x/efuse.cpp
+++ b/hal/src/rtl872x/efuse.cpp
@@ -43,12 +43,21 @@ int efuse_read_logical(uint32_t offset, uint8_t* buf, size_t size) {
 
     bool dataConsistent = false;
     for (int i = 0; i < 5 && !dataConsistent; i++) {
+        // There are places in ambd_sdk where efuses might be read as well (e.g. BLE stack)
+        // This is not a thread safe operation, so now those places are guarded with a lock in the SDK
+        // Use the same lock here as well.
 #if MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
         device_mutex_lock(RT_DEV_LOCK_EFUSE);
 #endif
         EFUSE_LMAP_READ(efuseBuf);
+#if MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
+        device_mutex_unlock(RT_DEV_LOCK_EFUSE);
+#endif
         uint32_t crc1 = HAL_Core_Compute_CRC32(efuseBuf, EFUSE_LOGICAL_SIZE);
 
+#if MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
+        device_mutex_lock(RT_DEV_LOCK_EFUSE);
+#endif
         EFUSE_LMAP_READ(efuseBuf);
 #if MODULE_FUNCTION != MOD_FUNC_BOOTLOADER
         device_mutex_unlock(RT_DEV_LOCK_EFUSE);


### PR DESCRIPTION
### Problem
Reading logical efuse sometimes failed even after retries, which results failed to get device ID, mobile secrect and serial number.

### Solution
Acquire `RT_DEV_LOCK_EFUSE` during reading logical efuse. 

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
