### PR TITLE
Support detecting/configuring M-HAT in Tinker

### DIFF
--- a/user/applications/tinker/src/board_config.cpp
+++ b/user/applications/tinker/src/board_config.cpp
@@ -81,8 +81,9 @@ void BoardConfig::detectBaseBoard() {
         {ATSHA204A, 0x64},
         {LORA, 0x61},
     };
-    constexpr uint16_t muonI2cDevices = STUSB4500 | AM1805 | TMP112A | BQ24195 | MAX17043 | LORA;
-    constexpr uint16_t mhatI2cDevices = STUSB4500 | AM1805 | TMP112A | BQ24195 | MAX17043 | ATSHA204A;
+    constexpr uint16_t essentialI2cDevices = STUSB4500 | AM1805 | TMP112A | BQ24195 | MAX17043;
+    constexpr uint16_t muonI2cDevices = essentialI2cDevices | LORA;
+    constexpr uint16_t mhatI2cDevices = essentialI2cDevices | ATSHA204A;
 
     Wire.lock();
     Wire.begin();
@@ -91,6 +92,20 @@ void BoardConfig::detectBaseBoard() {
         Wire.beginTransmission(addrs[i].second);
         if (Wire.endTransmission() == 0) {
             i2cDeviceMask |= addrs[i].first;
+        }
+    }
+    // If swapping from "none" to "muon", auxiliary power is not enabled by default.
+    // Thus, the LoRa chip is not detected in the first scan.
+    if (i2cDeviceMask == essentialI2cDevices) {
+        PinMode mode = getPinMode(D7);
+        pinMode(D7, OUTPUT);
+        digitalWrite(D7, HIGH); // It's active HIGH on Muon
+        delay(350); // Wait for the LoRa chip to power on, 200ms is estimated to be not sufficient
+        Wire.beginTransmission(0x61); // Lora I2C address
+        if (Wire.endTransmission() == 0) {
+            i2cDeviceMask |= LORA;
+        } else {
+            pinMode(D7, mode);
         }
     }
     Wire.unlock();
@@ -118,7 +133,7 @@ int BoardConfig::configure(String baseBoard) {
     Log.info("Set system power configuration");
     SystemPowerConfiguration powerConfig = System.getPowerConfiguration();
     if (baseBoard == "muon" || baseBoard == "m-hat") {
-        powerConfig.auxiliaryPowerControlPin(D7).interruptPin(A7).feature(SystemPowerFeature::PMIC_DETECTION);
+        powerConfig.auxiliaryPowerControlPin(D7, HIGH).interruptPin(A7).feature(SystemPowerFeature::PMIC_DETECTION);
     } else {
         powerConfig.auxiliaryPowerControlPin(PIN_INVALID).interruptPin(LOW_BAT_UC);
     }

--- a/user/applications/tinker/src/board_config.cpp
+++ b/user/applications/tinker/src/board_config.cpp
@@ -72,10 +72,34 @@ size_t BoardConfig::replySize() {
 }
 
 void BoardConfig::detectBaseBoard() {
-    bool isMuon = detectI2cSlaves();
+    constexpr std::pair<I2cDevice, uint8_t> addrs[] = {
+        {STUSB4500, 0x28},
+        {AM1805, 0x69},
+        {TMP112A, 0x48},
+        {BQ24195, 0x6B},
+        {MAX17043, 0x36},
+        {ATSHA204A, 0x64},
+        {LORA, 0x61},
+    };
+    constexpr uint16_t muonI2cDevices = STUSB4500 | AM1805 | TMP112A | BQ24195 | MAX17043 | LORA;
+    constexpr uint16_t mhatI2cDevices = STUSB4500 | AM1805 | TMP112A | BQ24195 | MAX17043 | ATSHA204A;
+
+    Wire.lock();
+    Wire.begin();
+    uint16_t i2cDeviceMask = 0;
+    for (uint8_t i = 0; i < sizeof(addrs) / sizeof(addrs[0]); i++) {
+        Wire.beginTransmission(addrs[i].second);
+        if (Wire.endTransmission() == 0) {
+            i2cDeviceMask |= addrs[i].first;
+        }
+    }
+    Wire.unlock();
+
     replyWriter_.beginObject();
-    if (isMuon) {
+    if (i2cDeviceMask == muonI2cDevices) {
         replyWriter_.name("board").value("muon");
+    } else if (i2cDeviceMask == mhatI2cDevices) {
+        replyWriter_.name("board").value("m-hat");
     } else {
         replyWriter_.name("board").value("none");
     }
@@ -84,39 +108,17 @@ void BoardConfig::detectBaseBoard() {
 
 void BoardConfig::configureBaseBoard(JSONValue value) {
     int ret = SYSTEM_ERROR_INVALID_ARGUMENT;
-    if (value.toString() == "muon") {
-        ret = configure(true);
-    } else if (value.toString() == "none") {
-        ret = configure(false);
-    }
+    ret = configure(static_cast<String>(value.toString()));
     replyWriter_.beginObject();
     replyWriter_.name("status").value(ret);
     replyWriter_.endObject();
 }
 
-bool BoardConfig::detectI2cSlaves() {
-    constexpr uint8_t addrs[] = {
-        0x28,   // STUSB4500 USB PD chip
-        0x69,   // AM18x5 RTC
-        0x48,   // TMP112A temperature sensor
-        0x6B,   // BQ24195 PMIC
-        0x36    // MAX17043 fuel gauge
-    };
-    Wire.begin();
-    for (uint8_t i = 0; i < sizeof(addrs); i++) {
-        Wire.beginTransmission(addrs[i]);
-        if (Wire.endTransmission() != 0) {
-            return false;
-        }
-    }
-    return true;
-}
-
-int BoardConfig::configure(bool muon) {
+int BoardConfig::configure(String baseBoard) {
     Log.info("Set system power configuration");
     SystemPowerConfiguration powerConfig = System.getPowerConfiguration();
-    if (muon) {
-        powerConfig.auxiliaryPowerControlPin(D7).interruptPin(A7);
+    if (baseBoard == "muon" || baseBoard == "m-hat") {
+        powerConfig.auxiliaryPowerControlPin(D7).interruptPin(A7).feature(SystemPowerFeature::PMIC_DETECTION);
     } else {
         powerConfig.auxiliaryPowerControlPin(PIN_INVALID).interruptPin(LOW_BAT_UC);
     }
@@ -125,7 +127,7 @@ int BoardConfig::configure(bool muon) {
     Log.info("Set Ethernet configuration");
     if_wiznet_pin_remap remap = {};
     remap.base.type = IF_WIZNET_DRIVER_SPECIFIC_PIN_REMAP;
-    if (muon) {
+    if (baseBoard == "muon") {
         System.enableFeature(FEATURE_ETHERNET_DETECTION);
         remap.cs_pin = A3;
         remap.reset_pin = PIN_INVALID;

--- a/user/applications/tinker/src/board_config.cpp
+++ b/user/applications/tinker/src/board_config.cpp
@@ -79,7 +79,6 @@ void BoardConfig::detectBaseBoard() {
         {BQ24195, 0x6B},
         {MAX17043, 0x36},
         {ATSHA204A, 0x64},
-        {LORA, 0x61},  // Not used for now
     };
     constexpr uint16_t essentialI2cDevices = STUSB4500 | AM1805 | TMP112A | BQ24195 | MAX17043;
     constexpr uint16_t muonI2cDevices = essentialI2cDevices;

--- a/user/applications/tinker/src/board_config.cpp
+++ b/user/applications/tinker/src/board_config.cpp
@@ -79,10 +79,10 @@ void BoardConfig::detectBaseBoard() {
         {BQ24195, 0x6B},
         {MAX17043, 0x36},
         {ATSHA204A, 0x64},
-        {LORA, 0x61},
+        {LORA, 0x61},  // Not used for now
     };
     constexpr uint16_t essentialI2cDevices = STUSB4500 | AM1805 | TMP112A | BQ24195 | MAX17043;
-    constexpr uint16_t muonI2cDevices = essentialI2cDevices | LORA;
+    constexpr uint16_t muonI2cDevices = essentialI2cDevices;
     constexpr uint16_t mhatI2cDevices = essentialI2cDevices | ATSHA204A;
 
     Wire.lock();
@@ -92,20 +92,6 @@ void BoardConfig::detectBaseBoard() {
         Wire.beginTransmission(addrs[i].second);
         if (Wire.endTransmission() == 0) {
             i2cDeviceMask |= addrs[i].first;
-        }
-    }
-    // If swapping from "none" to "muon", auxiliary power is not enabled by default.
-    // Thus, the LoRa chip is not detected in the first scan.
-    if (i2cDeviceMask == essentialI2cDevices) {
-        PinMode mode = getPinMode(D7);
-        pinMode(D7, OUTPUT);
-        digitalWrite(D7, HIGH); // It's active HIGH on Muon
-        delay(350); // Wait for the LoRa chip to power on, 200ms is estimated to be not sufficient
-        Wire.beginTransmission(0x61); // Lora I2C address
-        if (Wire.endTransmission() == 0) {
-            i2cDeviceMask |= LORA;
-        } else {
-            pinMode(D7, mode);
         }
     }
     Wire.unlock();

--- a/user/applications/tinker/src/board_config.h
+++ b/user/applications/tinker/src/board_config.h
@@ -35,13 +35,23 @@ public:
     size_t replySize();
     
 private:
+    enum __attribute__((packed)) I2cDevice {
+        STUSB4500 = 0x01,
+        AM1805 = 0x02,
+        TMP112A = 0x04,
+        BQ24195 = 0x08,
+        MAX17043 = 0x10,
+        ATSHA204A = 0x20,
+        LORA = 0x40,
+        RESERVED = 0xFFFF
+    };
+
     JSONBufferWriter replyWriter_;
     char replyBuffer_[64];
 
     void detectBaseBoard();
     void configureBaseBoard(JSONValue value);
-    bool detectI2cSlaves();
-    int configure(bool muon);
+    int configure(String baseBoard);
 };
 
 } // particle

--- a/user/applications/tinker/src/board_config.h
+++ b/user/applications/tinker/src/board_config.h
@@ -35,7 +35,7 @@ public:
     size_t replySize();
     
 private:
-    enum __attribute__((packed)) I2cDevice {
+    enum I2cDevice {
         STUSB4500 = 0x01,
         AM1805 = 0x02,
         TMP112A = 0x04,


### PR DESCRIPTION
### Problem
The factory default user app, i.e. the Tinker firmware, running on Particle M.2 SoMs that is installed on M-HAT may not work as expected, since some of the pins for controlling the power module are not correct.

### Steps to Test
1. Build and flash the tinker app to a Particle M.2 SoM
2. Update the `DVOS/user/tests/app/usb_ctrl_request/test/test.js` with the following content
3. Follow the `DVOS/user/tests/app/usb_ctrl_request/README.md` to run the test
```js
import * as control from './support/control';
import * as proto from './support/proto';
import * as usb from './support/usb';
import './support/init';

import * as semver from 'semver';
import * as randomstring from 'randomstring';

import { expect } from 'chai';

describe('USB requests', function() {
  let dev = null;
  let detectedBoard = null;
  const supportedBoards = ['none', 'muon', 'm-hat'];

  before('find a Particle USB device', function() {
    return usb.enumDevices().then((devs) => {
      if (devs.length == 0) {
        throw new Error('No Particle USB devices found');
      }
      dev = devs[0]; // Use the first device in the list
    });
  });

  before('open device', function() {
    return dev.open();
  });

  after('close device', function() {
    if (dev) {
      return dev.close();
    }
  });

  describe('application control requests', function() {
    this.slow(2000); // Test application replies with a random delay

    it('identify base board should succeed', function() {
      const reqData = '{"BASE_BOARD_DETECT":null}';
      console.log(reqData);
      return control.sendRequest(dev, control.RequestType.APP_CUSTOM, reqData).then((rep) => {
        expect(rep.result).to.equal(control.Result.OK);
        const data = JSON.parse(rep.data);
        console.log(data);
        expect(data).to.have.property('board');
        expect(data.board).to.be.oneOf(supportedBoards);
        detectedBoard = data.board;
      });
    });

    it('configure base board should succeed', function() {
        expect(detectedBoard).to.be.oneOf(supportedBoards);
        const reqData = JSON.stringify({ CONFIGURE_MODULE_BOARD: detectedBoard });
        console.log(reqData);
        return control.sendRequest(dev, control.RequestType.APP_CUSTOM, reqData).should.become({
          result: control.Result.OK,
          data: '{"status":0}'
        });
      });
  });
});

```

### Example App
`make PLATFORM=msom all APP=tinker`

### References
N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
