### PR TITLE
[test] Fixes for `wiring/serial_loopback2`

### DIFF
--- a/user/tests/wiring/serial_loopback2/loopback.cpp
+++ b/user/tests/wiring/serial_loopback2/loopback.cpp
@@ -159,6 +159,7 @@ test(SERIAL_02_LoopbackReceivedDataShouldRetainAfterSleepWakeup) {
 }
 
 #if HAL_PLATFORM_USART_9BIT_SUPPORTED
+
 test(SERIAL_03_Loopback9BitNoDataLossAndAvailableIsCorrect) {
     const size_t TEST_BUFFER_SIZE_MIN = 8;
     const size_t TEST_BUFFER_SIZE_MAX = USE_BUFFER_SIZE / 2;
@@ -209,8 +210,8 @@ test(SERIAL_05_Loopback9BitReceivedDataShouldRetainAfterSleepWakeup) {
     }
 }
 
+#endif // HAL_PLATFORM_USART_9BIT_SUPPORTED
+
 test(SERIAL_ZZZ_Cleanup) {
     pinMode(A2, INPUT); // PULL-UP HIGH
 }
-
-#endif // HAL_PLATFORM_USART_9BIT_SUPPORTED


### PR DESCRIPTION
### Problem

- p2 devices can have an issue booting when a load is put on the RX pin.  The test `wiring/serial_loopback2` attempts to fix this with the use of a buffer between TX and RX for the test.  However, the `SERIAL_ZZZ_Cleanup` task that tri-stated the buffer was located within the `HAL_PLATFORM_USART_9BIT_SUPPORTED` block, which p2 does not support.
- This leaves the device not reachable over USB for future tests

### Solution

- Move the `SERIAL_ZZZ_Cleanup` out of the block so it always runs.

### Steps to Test

- Should be able to run `device-os-test run p2 wiring/serial_loopback2` multiple times without resetting the device under test.