### PR TITLE
[test] adds tethering usb/serial1

### DIFF
--- a/user/tests/integration/test/docker.js
+++ b/user/tests/integration/test/docker.js
@@ -1,0 +1,110 @@
+'use strict';
+
+// Generic docker subprocess helpers shared by HIL test fixtures.
+//
+// This module is intentionally test-agnostic: it knows nothing about
+// tethering, any specific image, or the env vars / volumes a particular
+// scenario needs. Callers (e.g. .../wiring/tethering_*/...spec.js) build
+// their own docker-run args and invoke runContainer() / spawnDocker().
+
+const { spawn } = require('child_process');
+
+/**
+ * Spawn `docker <args>` and capture stdout+stderr.
+ *
+ * @param {string[]} args Args to pass to the docker CLI.
+ * @param {object} [opts]
+ * @param {boolean} [opts.stream=false] Mirror child output to process.stdout live.
+ * @param {number} [opts.timeoutMs=0] SIGTERM (then SIGKILL after 5s) if exceeded; 0 disables.
+ * @returns {Promise<{ code: number|null, signal: string|null, output: string, killed: boolean }>}
+ */
+function spawnDocker(args, { stream = false, timeoutMs = 0 } = {}) {
+    return new Promise((resolve) => {
+        const p = spawn('docker', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+        let output = '';
+        const onData = (chunk) => {
+            const s = chunk.toString();
+            output += s;
+            if (stream) {
+                process.stdout.write(s);
+            }
+        };
+        p.stdout.on('data', onData);
+        p.stderr.on('data', onData);
+
+        let killed = false;
+        let timer = null;
+        if (timeoutMs > 0) {
+            timer = setTimeout(() => {
+                killed = true;
+                p.kill('SIGTERM');
+                setTimeout(() => p.kill('SIGKILL'), 5000);
+            }, timeoutMs);
+        }
+
+        p.on('close', (code, signal) => {
+            if (timer) clearTimeout(timer);
+            resolve({ code, signal, output, killed });
+        });
+    });
+}
+
+/**
+ * Ensure an image is locally available; pull it if not.
+ *
+ * @param {string} imageRef Image tag or digest.
+ * @returns {Promise<string>} The same imageRef on success.
+ */
+async function ensureImage(imageRef) {
+    const inspect = await spawnDocker(['image', 'inspect', imageRef]);
+    if (inspect.code === 0) {
+        return imageRef;
+    }
+    console.log(`Pulling docker image ${imageRef} ...`);
+    const pull = await spawnDocker(['pull', imageRef], { stream: true });
+    if (pull.code !== 0) {
+        const tail = pull.output.split('\n').slice(-50).join('\n');
+        throw new Error(`docker pull ${imageRef} failed (exit ${pull.code}):\n${tail}`);
+    }
+    return imageRef;
+}
+
+/**
+ * Best-effort remove of a container by name. Ignores errors, the container
+ * may simply not exist.
+ *
+ * @param {string} name Container name.
+ */
+async function removeContainer(name) {
+    await spawnDocker(['rm', '-f', name]);
+}
+
+/**
+ * Run a container with `--rm`. Cleans up any lingering container with the
+ * same name before starting.
+ *
+ * The caller supplies whatever flags their scenario needs (--privileged, -e,
+ * -v, --network, --tmpfs, etc) via `args`. This function only adds
+ * `run --rm --name <name>`, then the image, then any `cmd`.
+ *
+ * @param {object} opts
+ * @param {string} opts.image Image ref to run.
+ * @param {string} opts.name Container name.
+ * @param {string[]} [opts.args=[]] Flags between `--name` and the image.
+ * @param {string[]} [opts.cmd=[]] Command/args appended after the image.
+ * @param {boolean} [opts.stream=false] Mirror container output live.
+ * @param {number} [opts.timeoutMs=0] SIGTERM the docker run after this many ms.
+ * @returns {Promise<{ code, signal, output, killed }>}
+ */
+async function runContainer({ image, name, args = [], cmd = [], stream = false, timeoutMs = 0 }) {
+    await removeContainer(name);
+    const runArgs = ['run', '--rm', '--name', name, ...args, image, ...cmd];
+    return spawnDocker(runArgs, { stream, timeoutMs });
+}
+
+module.exports = {
+    spawnDocker,
+    ensureImage,
+    removeContainer,
+    runContainer
+};

--- a/user/tests/integration/wiring/tethering_serial1
+++ b/user/tests/integration/wiring/tethering_serial1
@@ -1,0 +1,1 @@
+../../wiring/tethering_serial1/

--- a/user/tests/integration/wiring/tethering_usb
+++ b/user/tests/integration/wiring/tethering_usb
@@ -1,0 +1,1 @@
+../../wiring/tethering_usb/

--- a/user/tests/test
+++ b/user/tests/test
@@ -1,0 +1,1 @@
+integration/test

--- a/user/tests/wiring/tethering_serial1/application.cpp
+++ b/user/tests/wiring/tethering_serial1/application.cpp
@@ -1,0 +1,10 @@
+#ifndef PARTICLE_TEST_RUNNER
+
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+SYSTEM_MODE(SEMI_AUTOMATIC);
+
+UNIT_TEST_APP();
+
+#endif // PARTICLE_TEST_RUNNER

--- a/user/tests/wiring/tethering_serial1/readme.md
+++ b/user/tests/wiring/tethering_serial1/readme.md
@@ -1,0 +1,20 @@
+Tethering Serial1 testing hardware requirements
+-----------------------------------------------
+
+Wiring
+
+- Particle Debugger used as Serial to USB adapter
+- Connect all 5 lines (RX, TX, CTS, RTS, GND)
+- msom (gen 4) - can use som eval board
+- b5som (gen 3) - use m-hat hardware
+
+```
+  Device            Particle Debugger
+
+  (TX)--------------(RX)
+  (RX)--------------(TX)
+  (CTS)-------------(RTS)
+  (RTS)-------------(CTS)
+  (GND)-------------(GND)
+
+```

--- a/user/tests/wiring/tethering_serial1/tethering_serial1.cpp
+++ b/user/tests/wiring/tethering_serial1/tethering_serial1.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+test(01_TETHERING_SERIAL1_setup_and_bind) {
+    // M-HAT: enable channel 2 of the UART switch to route Serial1 (TX/RX/CTS/RTS)
+    // through to the Particle Debugger USB-serial bridge.
+    pinMode(A0, OUTPUT);
+    digitalWrite(A0, HIGH);
+
+    Cellular.on();
+    assertTrue(waitFor(Cellular.isOn, 60000));
+    Cellular.connect();
+    assertTrue(waitFor(Cellular.ready, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
+
+    Tether.bind(TetherSerialConfig().baudrate(921600).serial(Serial1));
+    Tether.on();
+    Tether.connect();
+
+    Particle.connect();
+    assertTrue(waitFor(Particle.connected, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
+}
+
+test(02_TETHERING_SERIAL1_test_download_speeds) {
+    // Host-side: JS fixture spawns the tethering docker container.
+}

--- a/user/tests/wiring/tethering_serial1/tethering_serial1.spec.js
+++ b/user/tests/wiring/tethering_serial1/tethering_serial1.spec.js
@@ -1,0 +1,139 @@
+'use strict';
+/* eslint no-undef: 'off' */
+
+// Tethering-specific glue. The helpers below (constants, rig loader,
+// runTetheringTest) are duplicated in ../tethering_usb/tethering_usb.spec.js
+// because the two scenarios share most of the host-side setup but pass a
+// different `mode` and live in sibling test directories. The only thing
+// hoisted out is generic docker plumbing (integration/test/docker.js).
+// If you change one copy, keep the other in sync.
+//
+// Required environment (Concourse task sets these):
+//   TETHERING_RIG_FILE     — JSON: { devices: [{ id, tethering: { debuggerSerial, budgetSec } }] }
+//   TETHERING_DOCKER_IMAGE — published image tag, e.g. particle/tethering-hil:1.0.0
+//   TETHERING_SCRIPTS_DIR  — absolute path containing tethering-init.sh and
+//                            tethering-tests.sh; bind-mounted as /scripts
+//
+// Optional:
+//   TETHERING_TEST_URL — override the test download URL (default below)
+
+const fs = require('fs');
+const path = require('path');
+const docker = require('../../test/docker');
+
+const DEFAULT_URL = 'http://technobly.com/100/phrack.29.phk';
+const CONTAINER_NAME_PREFIX = 'tethering-hil';
+// Outer cap on the docker-run subprocess. The container's own
+// tethering-tests.sh enforces tighter per-step timeouts.
+const RUN_OVERHEAD_SEC = 300;
+
+function loadRigConfig() {
+    const rigFile = process.env.TETHERING_RIG_FILE;
+    if (!rigFile) {
+        throw new Error('TETHERING_RIG_FILE is not set; the Concourse task must export it');
+    }
+    return JSON.parse(fs.readFileSync(rigFile, 'utf8'));
+}
+
+function rigEntryForDevice(rig, deviceId) {
+    const entry = (rig.devices || []).find((d) => d.id === deviceId);
+    if (!entry) {
+        throw new Error(`No rig entry for device ${deviceId} in ${process.env.TETHERING_RIG_FILE}`);
+    }
+    return entry;
+}
+
+// `ctx` is the Mocha test context (i.e. `this` inside a test function).
+// `mode` is 'usb' or 'serial1'.
+async function runTetheringTest(ctx, mode) {
+    const imageRef = process.env.TETHERING_DOCKER_IMAGE;
+    if (!imageRef) {
+        throw new Error('TETHERING_DOCKER_IMAGE is not set; the Concourse task must export it');
+    }
+    const scriptsDir = process.env.TETHERING_SCRIPTS_DIR;
+    if (!scriptsDir) {
+        throw new Error('TETHERING_SCRIPTS_DIR is not set; the Concourse task must export it');
+    }
+    if (!fs.existsSync(path.join(scriptsDir, 'tethering-init.sh'))) {
+        throw new Error(`TETHERING_SCRIPTS_DIR does not contain tethering-init.sh: ${scriptsDir}`);
+    }
+
+    const devices = ctx.particle && ctx.particle.devices;
+    if (!devices || devices.length === 0) {
+        throw new Error('No devices assigned to this test (expected the device-side counterpart to run first)');
+    }
+    if (devices.length > 1) {
+        throw new Error(`Expected exactly one DUT for tethering test, got ${devices.length}`);
+    }
+    const dutId = devices[0].id;
+
+    const rigEntry = rigEntryForDevice(loadRigConfig(), dutId);
+    const tethering = rigEntry.tethering || {};
+    const debuggerSerial = tethering.debuggerSerial || '';
+    const budgetSec = tethering.budgetSec;
+    if (typeof budgetSec !== 'number') {
+        throw new Error(`Missing tethering.budgetSec for device ${dutId} in rig config`);
+    }
+    if (mode === 'serial1' && !debuggerSerial) {
+        throw new Error(`Missing tethering.debuggerSerial for device ${dutId} (required for Serial1 mode)`);
+    }
+
+    const url = process.env.TETHERING_TEST_URL || DEFAULT_URL;
+    await docker.ensureImage(imageRef);
+
+    const containerName = `${CONTAINER_NAME_PREFIX}-${mode}-${dutId.slice(-8)}-${process.pid}`;
+    const containerArgs = [
+        '--privileged',
+        '--network', 'none',
+        '--dns', '8.8.8.8', '--dns', '8.8.4.4',
+        '-e', `TETHER_MODE=${mode}`,
+        '-e', `DUT_DEVICE_ID=${dutId}`,
+        '-e', `DEBUGGER_USB_SERIAL=${debuggerSerial}`,
+        '-e', `TEST_BUDGET_SEC=${budgetSec}`,
+        '-e', `TEST_URL=${url}`,
+        '-v', `${scriptsDir}:/scripts:ro`,
+        '-v', '/dev/bus/usb:/dev/bus/usb',
+        '--tmpfs', '/run', '--tmpfs', '/run/lock'
+    ];
+    const timeoutMs = (budgetSec + RUN_OVERHEAD_SEC) * 1000;
+
+    console.log(`Running tethering ${mode} test for ${dutId} (budget ${budgetSec}s, image ${imageRef}, container ${containerName})`);
+    const result = await docker.runContainer({
+        image: imageRef,
+        name: containerName,
+        args: containerArgs,
+        stream: true,
+        timeoutMs
+    });
+
+    if (result.killed) {
+        throw new Error(
+            `Tethering ${mode} test TIMED OUT after ${timeoutMs / 1000}s for ${dutId}\n` +
+            'Tail of container output:\n' +
+            result.output.split('\n').slice(-50).join('\n')
+        );
+    }
+    if (result.code !== 0) {
+        const tail = result.output.split('\n').slice(-50).join('\n');
+        throw new Error(
+            `Tethering ${mode} test FAILED (exit ${result.code}) for ${dutId}\n` +
+            `Tail of container output:\n${tail}`
+        );
+    }
+}
+
+suite('Tethering Serial1');
+platform('b5som', 'msom');
+systemThread('enabled');
+tag('fixture');
+
+test('01_TETHERING_SERIAL1_setup_and_bind', async function() {
+    // Device-side handoff: the on-device test brings up cellular and binds
+    // tethering to Serial1 (via the paired Particle Debugger). By the time
+    // we get here, the device is ready.
+});
+
+test('02_TETHERING_SERIAL1_test_download_speeds', async function() {
+    this.timeout(0); // honor the fixture's own timeout (budget + overhead)
+    await runTetheringTest(this, 'serial1');
+});

--- a/user/tests/wiring/tethering_usb/application.cpp
+++ b/user/tests/wiring/tethering_usb/application.cpp
@@ -1,0 +1,10 @@
+#ifndef PARTICLE_TEST_RUNNER
+
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+SYSTEM_MODE(SEMI_AUTOMATIC);
+
+UNIT_TEST_APP();
+
+#endif // PARTICLE_TEST_RUNNER

--- a/user/tests/wiring/tethering_usb/tethering_usb.cpp
+++ b/user/tests/wiring/tethering_usb/tethering_usb.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+test(01_TETHERING_USB_setup_and_bind) {
+    // M-HAT only: enable channel 2 of the UART switch (TX/RX/CTS/RTS). No-op
+    // on platforms without the switch; kept identical to the Serial1 variant
+    // so the two binaries diverge only at Tether.bind().
+    pinMode(A0, OUTPUT);
+    digitalWrite(A0, HIGH);
+
+    Cellular.on();
+    assertTrue(waitFor(Cellular.isOn, 60000));
+    Cellular.connect();
+    assertTrue(waitFor(Cellular.ready, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
+
+    Tether.bind(TetherUSBConfig());
+    Tether.on();
+    Tether.connect();
+
+    // Particle.connect proves the cellular data path is up before we hand
+    // off to the JS fixture. The fixture polls ppp0 separately on the host.
+    Particle.connect();
+    assertTrue(waitFor(Particle.connected, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
+}
+
+test(02_TETHERING_USB_test_download_speeds) {
+    // Host-side: JS fixture spawns the tethering docker container.
+}

--- a/user/tests/wiring/tethering_usb/tethering_usb.spec.js
+++ b/user/tests/wiring/tethering_usb/tethering_usb.spec.js
@@ -1,0 +1,138 @@
+'use strict';
+/* eslint no-undef: 'off' */
+
+// Tethering-specific glue. The helpers below (constants, rig loader,
+// runTetheringTest) are duplicated in ../tethering_serial1/tethering_serial1.spec.js
+// because the two scenarios share most of the host-side setup but pass a
+// different `mode` and live in sibling test directories. The only thing
+// hoisted out is generic docker plumbing (integration/test/docker.js).
+// If you change one copy, keep the other in sync.
+//
+// Required environment (Concourse task sets these):
+//   TETHERING_RIG_FILE     — JSON: { devices: [{ id, tethering: { debuggerSerial, budgetSec } }] }
+//   TETHERING_DOCKER_IMAGE — published image tag, e.g. particle/tethering-hil:1.0.0
+//   TETHERING_SCRIPTS_DIR  — absolute path containing tethering-init.sh and
+//                            tethering-tests.sh; bind-mounted as /scripts
+//
+// Optional:
+//   TETHERING_TEST_URL — override the test download URL (default below)
+
+const fs = require('fs');
+const path = require('path');
+const docker = require('../../test/docker');
+
+const DEFAULT_URL = 'http://technobly.com/100/phrack.29.phk';
+const CONTAINER_NAME_PREFIX = 'tethering-hil';
+// Outer cap on the docker-run subprocess. The container's own
+// tethering-tests.sh enforces tighter per-step timeouts.
+const RUN_OVERHEAD_SEC = 300;
+
+function loadRigConfig() {
+    const rigFile = process.env.TETHERING_RIG_FILE;
+    if (!rigFile) {
+        throw new Error('TETHERING_RIG_FILE is not set; the Concourse task must export it');
+    }
+    return JSON.parse(fs.readFileSync(rigFile, 'utf8'));
+}
+
+function rigEntryForDevice(rig, deviceId) {
+    const entry = (rig.devices || []).find((d) => d.id === deviceId);
+    if (!entry) {
+        throw new Error(`No rig entry for device ${deviceId} in ${process.env.TETHERING_RIG_FILE}`);
+    }
+    return entry;
+}
+
+// `ctx` is the Mocha test context (i.e. `this` inside a test function).
+// `mode` is 'usb' or 'serial1'.
+async function runTetheringTest(ctx, mode) {
+    const imageRef = process.env.TETHERING_DOCKER_IMAGE;
+    if (!imageRef) {
+        throw new Error('TETHERING_DOCKER_IMAGE is not set; the Concourse task must export it');
+    }
+    const scriptsDir = process.env.TETHERING_SCRIPTS_DIR;
+    if (!scriptsDir) {
+        throw new Error('TETHERING_SCRIPTS_DIR is not set; the Concourse task must export it');
+    }
+    if (!fs.existsSync(path.join(scriptsDir, 'tethering-init.sh'))) {
+        throw new Error(`TETHERING_SCRIPTS_DIR does not contain tethering-init.sh: ${scriptsDir}`);
+    }
+
+    const devices = ctx.particle && ctx.particle.devices;
+    if (!devices || devices.length === 0) {
+        throw new Error('No devices assigned to this test (expected the device-side counterpart to run first)');
+    }
+    if (devices.length > 1) {
+        throw new Error(`Expected exactly one DUT for tethering test, got ${devices.length}`);
+    }
+    const dutId = devices[0].id;
+
+    const rigEntry = rigEntryForDevice(loadRigConfig(), dutId);
+    const tethering = rigEntry.tethering || {};
+    const debuggerSerial = tethering.debuggerSerial || '';
+    const budgetSec = tethering.budgetSec;
+    if (typeof budgetSec !== 'number') {
+        throw new Error(`Missing tethering.budgetSec for device ${dutId} in rig config`);
+    }
+    if (mode === 'serial1' && !debuggerSerial) {
+        throw new Error(`Missing tethering.debuggerSerial for device ${dutId} (required for Serial1 mode)`);
+    }
+
+    const url = process.env.TETHERING_TEST_URL || DEFAULT_URL;
+    await docker.ensureImage(imageRef);
+
+    const containerName = `${CONTAINER_NAME_PREFIX}-${mode}-${dutId.slice(-8)}-${process.pid}`;
+    const containerArgs = [
+        '--privileged',
+        '--network', 'none',
+        '--dns', '8.8.8.8', '--dns', '8.8.4.4',
+        '-e', `TETHER_MODE=${mode}`,
+        '-e', `DUT_DEVICE_ID=${dutId}`,
+        '-e', `DEBUGGER_USB_SERIAL=${debuggerSerial}`,
+        '-e', `TEST_BUDGET_SEC=${budgetSec}`,
+        '-e', `TEST_URL=${url}`,
+        '-v', `${scriptsDir}:/scripts:ro`,
+        '-v', '/dev/bus/usb:/dev/bus/usb',
+        '--tmpfs', '/run', '--tmpfs', '/run/lock'
+    ];
+    const timeoutMs = (budgetSec + RUN_OVERHEAD_SEC) * 1000;
+
+    console.log(`Running tethering ${mode} test for ${dutId} (budget ${budgetSec}s, image ${imageRef}, container ${containerName})`);
+    const result = await docker.runContainer({
+        image: imageRef,
+        name: containerName,
+        args: containerArgs,
+        stream: true,
+        timeoutMs
+    });
+
+    if (result.killed) {
+        throw new Error(
+            `Tethering ${mode} test TIMED OUT after ${timeoutMs / 1000}s for ${dutId}\n` +
+            'Tail of container output:\n' +
+            result.output.split('\n').slice(-50).join('\n')
+        );
+    }
+    if (result.code !== 0) {
+        const tail = result.output.split('\n').slice(-50).join('\n');
+        throw new Error(
+            `Tethering ${mode} test FAILED (exit ${result.code}) for ${dutId}\n` +
+            `Tail of container output:\n${tail}`
+        );
+    }
+}
+
+suite('Tethering USB');
+platform('b5som', 'msom');
+systemThread('enabled');
+tag('fixture');
+
+test('01_TETHERING_USB_setup_and_bind', async function() {
+    // Device-side handoff: the on-device test brings up cellular and binds
+    // tethering to USB CDC. By the time we get here, the device is ready.
+});
+
+test('02_TETHERING_USB_test_download_speeds', async function() {
+    this.timeout(0); // honor the fixture's own timeout (budget + overhead)
+    await runTetheringTest(this, 'usb');
+});


### PR DESCRIPTION
- [test] adds tethering usb/serial1
- Folds the standalone tethering HIL test (previously driven manually by tethering-tests-bw.sh + a docker container) into the automated 6x release pipeline.
