### PR TITLE
[test] fixes spurious mailbox/USB stalls during pre-sleep handshake

### DIFF
--- a/user/tests/integration/application/include/request_handler.h
+++ b/user/tests/integration/application/include/request_handler.h
@@ -48,6 +48,7 @@ private:
     int getLog(Request* req);
     int reset(Request* req);
     int readMailbox(Request* req);
+    int ackMailbox(Request* req);
 };
 
 } // namespace particle

--- a/user/tests/integration/application/src/request_handler.cpp
+++ b/user/tests/integration/application/src/request_handler.cpp
@@ -175,6 +175,8 @@ int RequestHandler::request(Request* req) {
         return getLog(req);
     } else if (cmd == "M") { // Read device->host mailbox
         return readMailbox(req);
+    } else if (cmd == "A") { // Ack mailbox message by id
+        return ackMailbox(req);
     } else if (cmd == "r") { // Reset
         return reset(req);
     } else if (req->isEmpty()) { // Ping request
@@ -288,6 +290,7 @@ int RequestHandler::readMailbox(Request* req) {
 
     CHECK(req->reply([&](JSONWriter& w) {
         w.beginObject();
+        w.name("id").value(m->id());
         w.name("t").value((int)m->type());
         const auto data = m->data();
         if (data.size() > 0) {
@@ -295,18 +298,39 @@ int RequestHandler::readMailbox(Request* req) {
         }
         w.endObject();
     }));
+    // No completion handler on readMailbox: HAL fires TX_COMPLETED when the
+    // reply DATA is on the wire, not when the host's STATUS stage completes.
+    // The runner sends an explicit c:'A' ACK after parsing the reply;
+    // ackMailbox is what completes the entry. Critically, the c:'A' transfer
+    // is also what intersperses an OUT between successive control INs. The
+    // wire pattern that prevents the USB xhci_hcd phantom-EPIPE STALL from
+    // firing on our application-level INs. Without this ACK, test runner
+    // host side reliably produces many app-level stalls per run.
+    req->done(0);
+    return 0;
+}
+
+int RequestHandler::ackMailbox(Request* req) {
+    CHECK_TRUE(req->has("id"), SYSTEM_ERROR_INVALID_ARGUMENT);
+    const int id = req->get("id").toInt();
+    const auto runner = TestRunner::instance();
+    auto m = runner->peekOutboundMailbox();
+    if (!m || m->id() != id) {
+        // Nothing to do: the mailbox is empty, or this ACK is for a message
+        // we've already handled. Safe to ignore, the runner may send the
+        // same ACK more than once if a USB retry kicks in.
+        return 0;
+    }
+    // Record ACK time and complete. The wait() loop will then hold for a brief
+    // delay after the ACK timestamp so the host's ACK response cycle has time
+    // to transmit before the test races into System.sleep. The delay lives in
+    // the test thread (wait loop), not here, so the system thread keeps
+    // servicing other USB requests during the window.
+    m->ackedAt(millis());
     if (m->waitedOn()) {
-        req->done(0, [](int, void* data) -> void {
-            auto m = static_cast<TestRunner::MailboxEntry*>(data);
-            if (m->waitedOn()) {
-                m->completed();
-            } else {
-                const auto runner = TestRunner::instance();
-                runner->popOutboundMailbox();
-            }
-        }, m);
+        m->completed(0);
     } else {
-        CHECK(runner->popOutboundMailbox());
+        runner->popOutboundMailbox();
     }
     return 0;
 }

--- a/user/tests/libraries/unit-test/ParticleFunbag.cpp
+++ b/user/tests/libraries/unit-test/ParticleFunbag.cpp
@@ -453,6 +453,7 @@ int TestRunner::testCmd(String arg) {
 int TestRunner::pushMailbox(MailboxEntry entry, system_tick_t wait) {
     auto m = new MailboxEntry(std::move(entry));
     CHECK_TRUE(m, SYSTEM_ERROR_NO_MEMORY);
+    m->setId(++nextMailboxId_);
     outMailbox_.pushBack(m);
     if (wait) {
         SCOPE_GUARD({
@@ -460,7 +461,10 @@ int TestRunner::pushMailbox(MailboxEntry entry, system_tick_t wait) {
                 popOutboundMailbox();
             }
         });
-        return m->wait(wait) ? 0 : SYSTEM_ERROR_TIMEOUT;
+        if (m->wait(wait)) {
+            return m->result();
+        }
+        return SYSTEM_ERROR_TIMEOUT;
     }
     return 0;
 }
@@ -491,6 +495,22 @@ int TestRunner::popOutboundMailbox() {
         return 0;
     }
     return SYSTEM_ERROR_NOT_FOUND;
+}
+
+int TestRunner::ackOutboundMailboxById(int id) {
+    auto m = outMailbox_.front();
+    if (!m || m->id() != id) {
+        // Nothing to do: the mailbox is empty, or this ACK is for a message
+        // we've already handled. Safe to ignore, the runner may send the
+        // same ACK more than once if a USB retry kicks in.
+        return 0;
+    }
+    if (m->waitedOn()) {
+        m->completed(0);  // unblocks pushMailbox; SCOPE_GUARD pops
+    } else {
+        popOutboundMailbox();
+    }
+    return 0;
 }
 
 void TestRunner::updateLEDStatus() {

--- a/user/tests/libraries/unit-test/unit-test.h
+++ b/user/tests/libraries/unit-test/unit-test.h
@@ -149,7 +149,11 @@ public:
                 : next(nullptr),
                   type_(Type::NONE),
                   waitedOn_(false),
-                  completed_(false) {
+                  completed_(false),
+                  result_(0),
+                  id_(0),
+                  acked_(false),
+                  ackedAt_(0) {
         }
 
         ~MailboxEntry() {
@@ -174,6 +178,12 @@ public:
             return data_;
         }
 
+        // After the device-side ACK handler fires, hold the wait loop for this
+        // many ms past the ACK timestamp before unblocking the test thread.
+        // This gives the host's ACK response cycle time to complete on the
+        // wire before the test continues into System.sleep and tears down USB.
+        static constexpr system_tick_t ACK_DELAY_MS = 100;
+
         bool wait(system_tick_t timeout) {
             waitedOn_ = true;
             SCOPE_GUARD({
@@ -181,7 +191,7 @@ public:
             });
             for (auto start = millis(); millis() - start <= timeout;) {
                 // This processes the application task queue
-                if (completed_) {
+                if (completed_ && (!acked_ || (millis() - ackedAt_) >= ACK_DELAY_MS)) {
                     return true;
                 }
                 Particle.process();
@@ -194,12 +204,30 @@ public:
             return waitedOn_;
         }
 
-        void completed() {
+        void completed(int result) {
+            result_ = result;
             completed_ = true;
         }
 
         bool isCompleted() const {
             return completed_;
+        }
+
+        int result() const {
+            return result_;
+        }
+
+        int id() const {
+            return id_;
+        }
+
+        void setId(int id) {
+            id_ = id;
+        }
+
+        void ackedAt(system_tick_t time) {
+            ackedAt_ = time;
+            acked_ = true;
         }
 
         // For IntrusiveQueue
@@ -210,6 +238,10 @@ public:
         spark::Vector<char> data_;
         bool waitedOn_;
         bool completed_;
+        int result_;
+        int id_;
+        bool acked_;
+        system_tick_t ackedAt_;
     };
 
     int pushMailbox(MailboxEntry entry, system_tick_t wait = 0);
@@ -217,6 +249,7 @@ public:
     int pushMailboxBuffer(const char* data, size_t size, system_tick_t wait = 0);
     MailboxEntry* peekOutboundMailbox();
     int popOutboundMailbox();
+    int ackOutboundMailboxById(int id);
     void flushMailbox();
 
     void expectSystemReset();
@@ -232,6 +265,7 @@ private:
     std::unique_ptr<CloudLogData> cloudLog_;
 
     IntrusiveQueue<MailboxEntry> outMailbox_;
+    int nextMailboxId_ = 0;
 
     Test* firstTest_;
     int state_;

--- a/user/tests/wiring/sleep20/sleep20_device/sleep20_device.cpp
+++ b/user/tests/wiring/sleep20/sleep20_device/sleep20_device.cpp
@@ -208,8 +208,7 @@ test(000_System_Sleep_Prepare) {
 }
 
 test(01_System_Sleep_With_Configuration_Object_Hibernate_Mode_Without_Wakeup_1) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
-    delay(3s);
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 
     SystemSleepConfiguration config;
     config.mode(SystemSleepMode::HIBERNATE);
@@ -221,8 +220,7 @@ test(01_System_Sleep_With_Configuration_Object_Hibernate_Mode_Without_Wakeup_2) 
 }
 
 test(02_System_Sleep_Mode_Deep_Without_Wakeup_1) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
-    delay(3s);
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 
     SystemSleepResult result = System.sleep(SLEEP_MODE_DEEP, SLEEP_DISABLE_WKP_PIN);
     assertEqual(result.error(), SYSTEM_ERROR_NONE);
@@ -233,8 +231,7 @@ test(02_System_Sleep_Mode_Deep_Without_Wakeup_2) {
 
 #if !HAL_PLATFORM_RTL872X
 test(03_System_Sleep_With_Configuration_Object_Hibernate_Mode_Wakeup_By_D0_1) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
-    delay(3s);
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 
     SystemSleepConfiguration config;
     config.mode(SystemSleepMode::HIBERNATE)
@@ -248,8 +245,7 @@ test(03_System_Sleep_With_Configuration_Object_Hibernate_Mode_Wakeup_By_D0_2) {
 
 // TODO: Move to wiring/sleep as this is a Sleep API 1.0 test
 test(04_System_Sleep_Mode_Deep_Wakeup_By_WKP_Pin_1) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
-    delay(3s);
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 
     SleepResult result = {};
 
@@ -267,8 +263,7 @@ test(04_System_Sleep_Mode_Deep_Wakeup_By_WKP_Pin_2) {
 }
 
 test(05_System_Sleep_With_Configuration_Object_Hibernate_Mode_Wakeup_By_Analog_Pin_1) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
-    delay(3s);
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 
     SystemSleepConfiguration config;
     config.mode(SystemSleepMode::HIBERNATE)
@@ -283,8 +278,7 @@ test(05_System_Sleep_With_Configuration_Object_Hibernate_Mode_Wakeup_By_Analog_P
 // Tracker support waking up device from hibernate mode by external RTC
 #if HAL_PLATFORM_EXTERNAL_RTC && !HAL_PLATFORM_EXTERNAL_RTC_OPTIONAL
 test(06_System_Sleep_With_Configuration_Object_Hibernate_Mode_Wakeup_By_External_Rtc) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
-    delay(3s);
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 
     SystemSleepConfiguration config;
     config.mode(SystemSleepMode::HIBERNATE)
@@ -296,8 +290,7 @@ test(06_System_Sleep_With_Configuration_Object_Hibernate_Mode_Wakeup_By_External
 }
 
 test(07_System_Sleep_Mode_Deep_Wakeup_By_External_Rtc) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
-    delay(3s);
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 
     SystemSleepResult result = System.sleep(SLEEP_MODE_DEEP, 3s);
 
@@ -309,8 +302,7 @@ test(07_System_Sleep_Mode_Deep_Wakeup_By_External_Rtc) {
 
 #if HAL_PLATFORM_RTL872X
 test(08_System_Sleep_With_Configuration_Object_Hibernate_Mode_Wakeup_By_Wkp_Pin_1) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
-    delay(3s);
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 
     SystemSleepConfiguration config;
     config.mode(SystemSleepMode::HIBERNATE)
@@ -323,8 +315,7 @@ test(08_System_Sleep_With_Configuration_Object_Hibernate_Mode_Wakeup_By_Wkp_Pin_
 }
 
 test(09_System_Sleep_With_Configuration_Object_Hibernate_Mode_Wakeup_By_Rtc) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
-    delay(3s);
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 
     SystemSleepConfiguration config;
     config.mode(SystemSleepMode::HIBERNATE)
@@ -336,8 +327,7 @@ test(09_System_Sleep_With_Configuration_Object_Hibernate_Mode_Wakeup_By_Rtc) {
 }
 
 test(10_System_Sleep_Mode_Deep_Wakeup_By_Wkp_Pin_1) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
-    delay(3s);
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 
     SystemSleepResult result = System.sleep(SLEEP_MODE_DEEP);
     assertEqual(result.error(), SYSTEM_ERROR_NONE);
@@ -347,8 +337,7 @@ test(10_System_Sleep_Mode_Deep_Wakeup_By_Wkp_Pin_2) {
 }
 
 test(11_System_Sleep_Mode_Deep_Wakeup_By_Rtc) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
-    delay(3s);
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 
     SystemSleepResult result = System.sleep(SLEEP_MODE_DEEP, 3s, SLEEP_DISABLE_WKP_PIN); // Disable WKP pin.
 
@@ -357,8 +346,7 @@ test(11_System_Sleep_Mode_Deep_Wakeup_By_Rtc) {
 }
 
 test(12_System_Sleep_With_Configuration_Object_Hibernate_Mode_Bypass_Network_Off_Execution_Time_1) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
-    delay(3s);
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 
     Network.on();
     Network.connect(); // to finally power on the modem. The Network.on() won't do that for us on Gen3 as for now.
@@ -414,8 +402,7 @@ test(15_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Without_Wake
 
 SystemSleepResult result16;
 test(16_System_Sleep_With_Configuration_Object_Stop_Mode_Wakeup_By_D0_1) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
-    delay(3s);
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 
     SystemSleepConfiguration config;
     config.mode(SystemSleepMode::STOP)
@@ -432,8 +419,7 @@ test(16_System_Sleep_With_Configuration_Object_Stop_Mode_Wakeup_By_D0_2) {
 
 SystemSleepResult result17;
 test(17_System_Sleep_With_Configuration_Object_Stop_Mode_Wakeup_By_Rtc) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
-    delay(3s);
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 
     SystemSleepConfiguration config;
     config.mode(SystemSleepMode::STOP)
@@ -458,8 +444,7 @@ test(18_System_Sleep_With_Configuration_Object_Stop_Mode_Wakeup_By_Ble_1) {
 
     assertTrue(BLE.advertising());
 
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
-    delay(3s);
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 
     SystemSleepConfiguration config;
     config.mode(SystemSleepMode::STOP)
@@ -477,8 +462,7 @@ test(18_System_Sleep_With_Configuration_Object_Stop_Mode_Wakeup_By_Ble_2) {
 // TODO: Move to wiring/sleep as this is a Sleep API 1.0 test
 SleepResult result19;
 test(19_System_Sleep_Mode_Stop_Wakeup_By_D0_1) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
-    delay(3s);
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 
     result19 = System.sleep(D0, RISING);
 
@@ -493,8 +477,7 @@ test(19_System_Sleep_Mode_Stop_Wakeup_By_D0_2) {
 // TODO: Move to wiring/sleep as this is a Sleep API 1.0 test
 SleepResult result20;
 test(20_System_Sleep_Mode_Stop_Wakeup_By_Rtc) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
-    delay(3s);
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 
     result20 = System.sleep(nullptr, 0, nullptr, 0, 3s);
 
@@ -506,8 +489,7 @@ test(20_System_Sleep_Mode_Stop_Wakeup_By_Rtc) {
 
 SystemSleepResult result21;
 test(21_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_D0_1) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
-    delay(3s);
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 
     SystemSleepConfiguration config;
     config.mode(SystemSleepMode::ULTRA_LOW_POWER)
@@ -524,8 +506,7 @@ test(21_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_D0
 
 SystemSleepResult result22;
 test(22_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_Rtc) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
-    delay(3s);
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 
     SystemSleepConfiguration config;
     config.mode(SystemSleepMode::ULTRA_LOW_POWER)
@@ -552,8 +533,7 @@ test(23_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_Bl
 
     assertTrue(BLE.advertising());
 
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
-    delay(3s);
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
     SystemSleepConfiguration config;
     config.mode(SystemSleepMode::ULTRA_LOW_POWER)
           .ble();
@@ -569,8 +549,7 @@ test(23_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_Bl
 
 SystemSleepResult result24;
 test(24_System_Sleep_With_Configuration_Object_Stop_Mode_Wakeup_By_Analog_Pin_1) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
-    delay(3s);
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 
     SystemSleepConfiguration config;
     config.mode(SystemSleepMode::STOP)
@@ -584,8 +563,7 @@ test(24_System_Sleep_With_Configuration_Object_Stop_Mode_Wakeup_By_Analog_Pin_2)
 
 SystemSleepResult result25;
 test(25_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_Analog_Pin_1) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
-    delay(3s);
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 
     SystemSleepConfiguration config;
     config.mode(SystemSleepMode::ULTRA_LOW_POWER)
@@ -599,8 +577,7 @@ test(25_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_An
 
 SystemSleepResult result26;
 test(26_System_Sleep_With_Configuration_Object_Stop_Mode_Wakeup_By_Usart_1) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
-    delay(3s);
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 
     Serial1.begin(115200);
 
@@ -617,8 +594,7 @@ test(26_System_Sleep_With_Configuration_Object_Stop_Mode_Wakeup_By_Usart_2) {
 
 SystemSleepResult result27;
 test(27_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_Usart_1) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
-    delay(3s);
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 
     Serial1.begin(115200);
 
@@ -654,7 +630,6 @@ test(28_System_Sleep_With_Configuration_Object_Stop_Mode_Wakeup_By_Cellular_1) {
     }
 
     assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
-    delay(3s);
 
     SystemSleepConfiguration config;
     config.mode(SystemSleepMode::STOP)
@@ -689,7 +664,6 @@ test(29_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_Ce
     }
 
     assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
-    delay(3s);
     SystemSleepConfiguration config;
     config.mode(SystemSleepMode::ULTRA_LOW_POWER)
           .network(Cellular);
@@ -726,7 +700,6 @@ test(30_System_Sleep_With_Configuration_Object_Stop_Mode_Wakeup_By_WiFi_1) {
     }
 
     assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
-    delay(3s);
 
     SystemSleepConfiguration config;
     config.mode(SystemSleepMode::STOP)
@@ -762,7 +735,6 @@ test(31_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_By_Wi
     }
 
     assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
-    delay(3s);
 
     SystemSleepConfiguration config;
     config.mode(SystemSleepMode::ULTRA_LOW_POWER)
@@ -811,8 +783,7 @@ test(33_System_Sleep_With_Configuration_Object_Stop_Mode_Execution_Time) {
     } else {
         sNetworkOffTimestamp = 0;
     }
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
-    delay(3s);
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 
     SystemSleepResult result = System.sleep(config);
     time32_t exit = Time.now();
@@ -850,8 +821,7 @@ test(34_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_Execu
     } else {
         sNetworkOffTimestamp = 0;
     }
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
-    delay(3s);
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 
     SystemSleepResult result = System.sleep(config);
     time32_t exit = Time.now();
@@ -871,8 +841,7 @@ test(34_System_Sleep_With_Configuration_Object_Ultra_Low_Power_Mode_Wakeup_Execu
 }
 
 test(35_System_Sleep_With_Configuration_Object_Network_Power_State_Consistent_On) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
-    delay(3s);
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 
     Particle.disconnect();
     assertTrue(waitFor(Particle.disconnected, CLOUD_CONNECT_TIMEOUT));
@@ -912,8 +881,7 @@ test(35_System_Sleep_With_Configuration_Object_Network_Power_State_Consistent_On
 }
 
 test(36_System_Sleep_With_Configuration_Object_Network_Power_State_Consistent_Off) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
-    delay(3s);
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 
     {
         // Make sure the modem is on first


### PR DESCRIPTION
## Problem

- The `wiring/sleep20` suite intermittently failed on Linux test rigs (kernel 6.8 / AMD Rembrandt USB4 XHCI) with the device-side `pushMailbox` returning success while the host-side runner observed a USB control-transfer stall on
the corresponding mailbox read. The device would then race into `System.sleep` and tear down USB before the runner could re-issue the read, de-syncing the suite and triggering a fixture-reset cascade.
- Root cause is a kernel-level `xhci_hcd` bug: the driver synthesizes `-EPIPE` (`LIBUSB_TRANSFER_STALL`) on control IN URBs even when the wire-level data stage completed and was ACKed by host hardware. Empirically, the stalls cluster on the larger-payload IN transfers (`wLength=64`, which carry actual response data) and are suppressed when a vendor control transaction with smaller-payload IN reads (no response payload, `wLength=14–15`) is interleaved between two heavy-payload exchanges. The exact xhci_hcd state being reset isn't understood; we treat the interleaved transaction as a behavioral workaround at the protocol layer rather than a known mechanism fix.

Secondary issues:

- `pushMailbox` reported success as soon as the reply DATA stage went on the wire (HAL TX_COMPLETED), not when the host actually received it.
- `pushMailbox` discarded the entry's result code, so a `SYSTEM_ERROR_CANCELLED` from the system path could not propagate to the test.
- Test bodies inserted `delay(3s)` after every `pushMailbox` as a workaround for the missing host-receipt signal, which helped but was not the fix.

## Solution

- Add an explicit `c:'A'` ACK request that the runner sends after parsing each mailbox reply. This is what completes the entry on the device side AND interleaves an additional vendor transaction (whose IN reads carry no payload, so they're the kernel-bug-safe variety) between the readMailbox and getStatus exchanges, suppressing the phantom-EPIPE stalls observed without it.
- Tag each `MailboxEntry` with a monotonic `id`; include it in the read reply and in the ACK request so completion is idempotent and can't match the wrong entry.
- Drop `readMailbox`'s TX_COMPLETED-driven completion callback. Completion now happens from the ack handler instead.
- Hold the `MailboxEntry::wait` loop for `ACK_DELAY_MS` (100 ms) past the ACK timestamp before returning, so the host's ACK response cycle finishes on the wire before the test continues into `System.sleep` and detaches USB.
- Have `pushMailbox` return `m->result()` so a cancellation propagates to the test instead of being reported as success.
- Bump every `pushMailbox(..., 10000)` site in `sleep20_device.cpp` to `20000` ms for headroom under retry.
- Remove the `delay(3s)` workaround that followed every `pushMailbox` call in `sleep20_device.cpp`; the ACK mechanism replaces what the delay was guarding against.

## Testing

- Four consecutive runs of `wiring/sleep20` on the affected rig: 46/46 tests passing, zero application-level USB stalls observed in usbmon captures.

## References

- Branch: `fix/test-runner-mailbox-usb-stall` (in `device-os`)
- Companion PR: [device-os-test-runner#44](https://github.com/particle-iot/device-os-test-runner/pull/44) on `fix/mailbox-usb-stall`