### PR TITLE
wiring/usbserial: add multi-byte USBSerial write overload

### DIFF
--- a/hal/inc/hal_dynalib_usb.h
+++ b/hal/inc/hal_dynalib_usb.h
@@ -107,6 +107,13 @@ DYNALIB_FN(BASE_IDX4 + 1, hal_usb, HAL_USB_HID_Set_State, uint8_t(uint8_t, uint8
 
 #ifdef USB_VENDOR_REQUEST_ENABLE
 DYNALIB_FN(BASE_IDX5 + 0, hal_usb, HAL_USB_Set_Vendor_Request_State_Callback, void(HAL_USB_Vendor_Request_State_Callback, void*))
+# define BASE_IDX6 (BASE_IDX5 + 1)
+#else
+# define BASE_IDX6 BASE_IDX5
+#endif
+
+#ifdef USB_CDC_ENABLE
+DYNALIB_FN_WRAP(BASE_IDX6 + 0, hal_usb, HAL_USB_USART_Send_Data_Buffer, protected, int32_t(HAL_USB_USART_Serial, const uint8_t*, uint32_t))
 #endif
 
 DYNALIB_END(hal_usb)
@@ -117,5 +124,6 @@ DYNALIB_END(hal_usb)
 #undef BASE_IDX3
 #undef BASE_IDX4
 #undef BASE_IDX5
+#undef BASE_IDX6
 
 #endif  /* HAL_DYNALIB_USB_H */

--- a/hal/inc/usb_hal.h
+++ b/hal/inc/usb_hal.h
@@ -210,6 +210,7 @@ SECURITY_MODE_PROTECTED_FN(int32_t, HAL_USB_USART_Available_Data, (HAL_USB_USART
 SECURITY_MODE_PROTECTED_FN(int32_t, HAL_USB_USART_Available_Data_For_Write, (HAL_USB_USART_Serial serial));
 SECURITY_MODE_PROTECTED_FN(int32_t, HAL_USB_USART_Receive_Data, (HAL_USB_USART_Serial serial, uint8_t peek));
 SECURITY_MODE_PROTECTED_FN(int32_t, HAL_USB_USART_Send_Data, (HAL_USB_USART_Serial serial, uint8_t data));
+SECURITY_MODE_PROTECTED_FN(int32_t, HAL_USB_USART_Send_Data_Buffer, (HAL_USB_USART_Serial serial, const uint8_t* data, uint32_t size));
 SECURITY_MODE_PROTECTED_FN(void, HAL_USB_USART_Flush_Data, (HAL_USB_USART_Serial serial));
 bool HAL_USB_USART_Is_Enabled(HAL_USB_USART_Serial serial);
 bool HAL_USB_USART_Is_Connected(HAL_USB_USART_Serial serial);

--- a/hal/src/rtl872x/usb_hal.cpp
+++ b/hal/src/rtl872x/usb_hal.cpp
@@ -266,6 +266,15 @@ int32_t HAL_USB_USART_Send_Data_protected(HAL_USB_USART_Serial serial, uint8_t d
     return HAL_USB_USART_Send_Data(serial, data);
 }
 
+int32_t HAL_USB_USART_Send_Data_Buffer(HAL_USB_USART_Serial serial, const uint8_t* data, uint32_t size) {
+    return HAL_USB_USART_Send_Data_Multiple(serial, data, size);
+}
+
+int32_t HAL_USB_USART_Send_Data_Buffer_protected(HAL_USB_USART_Serial serial, const uint8_t* data, uint32_t size) {
+    CHECK_SECURITY_MODE_PROTECTED();
+    return HAL_USB_USART_Send_Data_Buffer(serial, data, size);
+}
+
 void HAL_USB_USART_Flush_Data(HAL_USB_USART_Serial serial) {
     if (serial != HAL_USB_USART_SERIAL) {
         return;

--- a/wiring/inc/spark_wiring_usbserial.h
+++ b/wiring/inc/spark_wiring_usbserial.h
@@ -52,6 +52,7 @@ public:
 	int peek();
 
 	virtual size_t write(uint8_t byte);
+	virtual size_t write(const uint8_t* buffer, size_t size) override;
 	virtual int read();
 	virtual int availableForWrite(void);
 	virtual int available();

--- a/wiring/src/spark_wiring_usbserial.cpp
+++ b/wiring/src/spark_wiring_usbserial.cpp
@@ -86,6 +86,17 @@ size_t USBSerial::write(uint8_t byte)
   return 0;
 }
 
+size_t USBSerial::write(const uint8_t* buffer, size_t size)
+{
+  if (!buffer || !size) {
+    return 0;
+  }
+  if (_blocking || HAL_USB_USART_Available_Data_For_Write(_serial) > 0) {
+    return std::max(0, (int)HAL_USB_USART_Send_Data_Buffer(_serial, buffer, size));
+  }
+  return 0;
+}
+
 void USBSerial::flush()
 {
   HAL_USB_USART_Flush_Data(_serial);


### PR DESCRIPTION
### Problem

Essential the same class of issue as [2924](https://github.com/particle-iot/device-os/pull/2924). `Serial.write(buf, len)` on `USBSerial` does not use a native buffer-write path. It falls back to `Print::write(const uint8_t*, size_t)`, which iterates through `write(uint8_t)` one byte at a time.

On P2 / Photon 2 this causes buffered USB Serial writes,  including writes performed through `SerialLogHandler`, to be fed into the HAL one byte at a time, which makes `Serial.write(buf, len)` take much longer than expected.

### Solution

Add a native `USBSerial::write(const uint8_t* buffer, size_t size)` overload and route it to a public `HAL_USB_USART_Send_Data_Buffer()` HAL entrypoint. On `rtl872x`, that entrypoint is implemented as a thin wrapper around the existing `HAL_USB_USART_Send_Data_Multiple()` bulk transmit path.

Files changed:
* [hal/inc/hal_dynalib_usb.h](https://github.com/particle-iot/device-os/compare/develop...TJett:device-os:usb-multi-byte-write?expand=1#diff-23aea32471ed7a61e1cd594e7524edfb3e9ec8677de9b7a8c3196ebe956cdf65)
* [hal/inc/usb_hal.h](https://github.com/particle-iot/device-os/compare/develop...TJett:device-os:usb-multi-byte-write?expand=1#diff-23c01ed1d3457276901379cbaf35132303ef82aaca4983b86ee91d55e81a72fe)
* [hal/src/rtl872x/usb_hal.cpp](https://github.com/particle-iot/device-os/compare/develop...TJett:device-os:usb-multi-byte-write?expand=1#diff-595be23ff45c9247aa19264257b5fe3bcb169f6529559fa84cfc3a788e9473a8)
* [wiring/inc/spark_wiring_usbserial.h](https://github.com/particle-iot/device-os/compare/develop...TJett:device-os:usb-multi-byte-write?expand=1#diff-7a2c50bcaad512341483f5f94be38455342d2c955ca1282cbd5cce2f72288e25)
* [wiring/src/spark_wiring_usbserial.cpp](https://github.com/particle-iot/device-os/compare/develop...TJett:device-os:usb-multi-byte-write?expand=1#diff-13b3a52478d346bbd0a079f10ce7d168da3e549abd10d3255d6eae2f79d2bf62)

### Steps to Test

Application-level testing on P2 / Photon 2:
* Build unmodified Device OS and run the example app below.
* Measure the duration of `Log.write(buf, len)` using `micros()`.
* Repeat with this PR applied.

Expected results:

* Before the fix:
  * Large USB log writes take significantly longer
* After the fix:
  * the logging call returns much sooner because the data is queued through the bulk USB write path
  
When running the example code below, I got the following results:

Before, on 6.4.1:
* Log.write avg=57267 us over 75 samples (230-byte packets)

After:
* Log.write avg=545 us over 460 samples (230-byte packets)

_Over a 100x speedup! From effectively 4 kB/s to 400 kB/s through the log handler_

I also ran
* `wiring/usbserial`
* `wiring/no_fixture/`

### Example App

```c
#include "Particle.h"

SYSTEM_MODE(MANUAL);

SerialLogHandler logHandler(LOG_LEVEL_INFO);

constexpr size_t WRITE_SIZE = 230;

uint8_t tx[WRITE_SIZE];
system_tick_t sampleStart = 0;
uint32_t samples = 0;
uint64_t totalWriteUs = 0;

void setup() {
    for (size_t i = 0; i < WRITE_SIZE; ++i) {
        tx[i] = 'A' + (i % 26);
    }

    sampleStart = millis();
}

void loop() {
    system_tick_t startUs = micros();
    Log.write((const char*) tx, sizeof(tx));
    system_tick_t elapsedUs = micros() - startUs;

    totalWriteUs += elapsedUs;
    ++samples;

    if (millis() - sampleStart >= 5000) {
        if (samples > 0) {
            Log.info("Log.write avg=%lu us over %lu samples (%u-byte packets)",
                    (unsigned long)(totalWriteUs / samples),
                    (unsigned long)samples,
                    (unsigned)WRITE_SIZE);
        }
        delay(5000);
        totalWriteUs = 0;
        samples = 0;
        sampleStart = millis();
    }

    delay(10);
}
```

### References

* [Related Particle community thread: Photon 2 Slow UART Serial TX Speeds](https://community.particle.io/t/photon-2-slow-uart-serial-tx-speeds/71260)

### AI Disclosure

I used Codex/GPT-5.4 to assist me in making this PR.

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
