### PR TITLE
[tests] Fix default cloud keep alives

### DIFF
--- a/system/src/system_cloud_connection.cpp
+++ b/system/src/system_cloud_connection.cpp
@@ -365,7 +365,11 @@ int system_cloud_get_netif_keepalive(network_interface_t netif, unsigned* value,
         netIfKeepAlive *= 1000;
     } else {
         // If no env vars, use default keep alives
+#if HAL_PLATFORM_CELLULAR
         netIfKeepAlive = (netif == NETWORK_INTERFACE_CELLULAR ? HAL_PLATFORM_CELLULAR_CLOUD_KEEPALIVE_INTERVAL : HAL_PLATFORM_DEFAULT_CLOUD_KEEPALIVE_INTERVAL);
+#else
+        netIfKeepAlive =  HAL_PLATFORM_DEFAULT_CLOUD_KEEPALIVE_INTERVAL;
+#endif
     }
 
     *source = netIfSource;

--- a/user/tests/integration/system/cellular_env/cellular_env.cpp
+++ b/user/tests/integration/system/cellular_env/cellular_env.cpp
@@ -31,8 +31,8 @@
 namespace {
 
 static const int CELLULAR_KEEPALIVE_SECONDS = 60;
-static const int GLOBAL_KEEPALIVE_SECONDS = 70;
-static const int PLATFORM_CELLULAR_KEEPALIVE_SECONDS_DEFAULT = HAL_PLATFORM_CELLULAR_CLOUD_KEEPALIVE_INTERVAL / 1000;
+static const int DEFAULT_KEEPALIVE_SECONDS = 70;
+static const int PLATFORM_CELLULAR_KEEPALIVE_SECONDS = HAL_PLATFORM_CELLULAR_CLOUD_KEEPALIVE_INTERVAL / 1000;
 
 retained bool g_SkipTests = false;
 
@@ -568,6 +568,11 @@ test(9_particle_cellular_preferred_plmn_set) {
 }
 
 test(10_particle_cellular_keepalive_init) {
+    if (g_SkipTests) {
+        skip();
+        return;
+    }
+
     assertFalse(System.hasEnv("PARTICLE_CELLULAR_CLOUD_KEEP_ALIVE"));
     assertFalse(System.hasEnv("PARTICLE_CLOUD_KEEP_ALIVE"));
 
@@ -578,10 +583,15 @@ test(10_particle_cellular_keepalive_init) {
     Particle.connect();
     assertTrue(waitFor(Particle.connected, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
 
-    assertEqual(Particle.getKeepAlive(), PLATFORM_CELLULAR_KEEPALIVE_SECONDS_DEFAULT);
+    assertEqual(Particle.getKeepAlive(), PLATFORM_CELLULAR_KEEPALIVE_SECONDS);
 }
 
 test(11_particle_cellular_keepalive) {
+    if (g_SkipTests) {
+        skip();
+        return;
+    }
+
     assertTrue(System.hasEnv("PARTICLE_CELLULAR_CLOUD_KEEP_ALIVE"));
     int keepAlive = 0;
     assertTrue(System.getEnv("PARTICLE_CELLULAR_CLOUD_KEEP_ALIVE", keepAlive));
@@ -590,7 +600,7 @@ test(11_particle_cellular_keepalive) {
     assertTrue(System.hasEnv("PARTICLE_CLOUD_KEEP_ALIVE"));
     int globalKeepAlive = 0;
     assertTrue(System.getEnv("PARTICLE_CLOUD_KEEP_ALIVE", globalKeepAlive));
-    assertEqual(globalKeepAlive, GLOBAL_KEEPALIVE_SECONDS);
+    assertEqual(globalKeepAlive, DEFAULT_KEEPALIVE_SECONDS);
 
     Cellular.on();
     assertTrue(waitFor(Cellular.isOn, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
@@ -601,12 +611,15 @@ test(11_particle_cellular_keepalive) {
 
     assertEqual(Particle.getKeepAlive(), CELLULAR_KEEPALIVE_SECONDS);
     assertEqual(Particle.getKeepAlive(Cellular), CELLULAR_KEEPALIVE_SECONDS);
+#if HAL_PLATFORM_WIFI
+    assertEqual(Particle.getKeepAlive(WiFi), DEFAULT_KEEPALIVE_SECONDS);
+#endif
     Particle.disconnect();
     Cellular.disconnect();
     waitForNot(Cellular.ready, 60000);
 }
 
-test(12_particle_cellular_preferred_plmn_cleanup) {
+test(12_particle_cellular_env_var_cleanup) {
     if (g_SkipTests || getModemType() == ModemType::UNSUPPORTED) {
         skip();
         return;
@@ -670,7 +683,7 @@ test(13_particle_cellular_env_vars_cleared_verify_defaults) {
 
     Particle.connect();
     assertTrue(waitFor(Particle.connected, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
-    assertEqual(Particle.getKeepAlive(), PLATFORM_CELLULAR_KEEPALIVE_SECONDS_DEFAULT);
+    assertEqual(Particle.getKeepAlive(), PLATFORM_CELLULAR_KEEPALIVE_SECONDS);
 
     Cellular.disconnect();
     waitForNot(Cellular.ready, 60000);

--- a/user/tests/integration/system/cellular_env/cellular_env.cpp
+++ b/user/tests/integration/system/cellular_env/cellular_env.cpp
@@ -32,7 +32,7 @@ namespace {
 
 static const int CELLULAR_KEEPALIVE_SECONDS = 60;
 static const int GLOBAL_KEEPALIVE_SECONDS = 70;
-static const int CELLULAR_KEEPALIVE_SECONDS_DEFAULT = HAL_PLATFORM_CELLULAR_CLOUD_KEEPALIVE_INTERVAL / 1000;
+static const int PLATFORM_CELLULAR_KEEPALIVE_SECONDS_DEFAULT = HAL_PLATFORM_CELLULAR_CLOUD_KEEPALIVE_INTERVAL / 1000;
 
 retained bool g_SkipTests = false;
 
@@ -567,7 +567,21 @@ test(9_particle_cellular_preferred_plmn_set) {
     waitForNot(Cellular.ready, 60000);
 }
 
-test(10_particle_cellular_keepalive) {
+test(10_particle_cellular_keepalive_init) {
+    assertFalse(System.hasEnv("PARTICLE_CELLULAR_CLOUD_KEEP_ALIVE"));
+    assertFalse(System.hasEnv("PARTICLE_CLOUD_KEEP_ALIVE"));
+
+    Cellular.on();
+    assertTrue(waitFor(Cellular.isOn, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
+    Cellular.connect();
+    assertTrue(waitFor(Cellular.ready, HAL_PLATFORM_CELLULAR_CONN_TIMEOUT));
+    Particle.connect();
+    assertTrue(waitFor(Particle.connected, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
+
+    assertEqual(Particle.getKeepAlive(), PLATFORM_CELLULAR_KEEPALIVE_SECONDS_DEFAULT);
+}
+
+test(11_particle_cellular_keepalive) {
     assertTrue(System.hasEnv("PARTICLE_CELLULAR_CLOUD_KEEP_ALIVE"));
     int keepAlive = 0;
     assertTrue(System.getEnv("PARTICLE_CELLULAR_CLOUD_KEEP_ALIVE", keepAlive));
@@ -591,7 +605,7 @@ test(10_particle_cellular_keepalive) {
     waitForNot(Cellular.ready, 60000);
 }
 
-test(11_particle_cellular_preferred_plmn_cleanup) {
+test(12_particle_cellular_preferred_plmn_cleanup) {
     if (g_SkipTests || getModemType() == ModemType::UNSUPPORTED) {
         skip();
         return;
@@ -602,7 +616,7 @@ test(11_particle_cellular_preferred_plmn_cleanup) {
     System.reset();
 }
 
-test(12_particle_cellular_env_vars_cleared_verify_defaults) {
+test(13_particle_cellular_env_vars_cleared_verify_defaults) {
     if (g_SkipTests || getModemType() == ModemType::UNSUPPORTED) {
         skip();
         return;
@@ -653,7 +667,7 @@ test(12_particle_cellular_env_vars_cleared_verify_defaults) {
 
     Particle.connect();
     assertTrue(waitFor(Particle.connected, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
-    assertEqual(Particle.getKeepAlive(), CELLULAR_KEEPALIVE_SECONDS_DEFAULT);
+    assertEqual(Particle.getKeepAlive(), PLATFORM_CELLULAR_KEEPALIVE_SECONDS_DEFAULT);
 
     Cellular.disconnect();
     waitForNot(Cellular.ready, 60000);

--- a/user/tests/integration/system/cellular_env/cellular_env.cpp
+++ b/user/tests/integration/system/cellular_env/cellular_env.cpp
@@ -586,7 +586,7 @@ test(10_particle_cellular_keepalive_init) {
     assertEqual(Particle.getKeepAlive(), PLATFORM_CELLULAR_KEEPALIVE_SECONDS);
 }
 
-test(11_particle_cellular_keepalive) {
+test(11_particle_cellular_keepalive_set) {
     if (g_SkipTests) {
         skip();
         return;

--- a/user/tests/integration/system/cellular_env/cellular_env.cpp
+++ b/user/tests/integration/system/cellular_env/cellular_env.cpp
@@ -601,6 +601,7 @@ test(11_particle_cellular_keepalive) {
 
     assertEqual(Particle.getKeepAlive(), CELLULAR_KEEPALIVE_SECONDS);
     assertEqual(Particle.getKeepAlive(Cellular), CELLULAR_KEEPALIVE_SECONDS);
+    Particle.disconnect();
     Cellular.disconnect();
     waitForNot(Cellular.ready, 60000);
 }

--- a/user/tests/integration/system/cellular_env/cellular_env.cpp
+++ b/user/tests/integration/system/cellular_env/cellular_env.cpp
@@ -625,6 +625,8 @@ test(13_particle_cellular_env_vars_cleared_verify_defaults) {
     assertFalse(System.hasEnv("PARTICLE_CELLULAR_PREFERRED_BANDS"));
     assertFalse(System.hasEnv("PARTICLE_CELLULAR_FORBIDDEN_BANDS"));
     assertFalse(System.hasEnv("PARTICLE_CELLULAR_PREFERRED_PLMN"));
+    assertFalse(System.hasEnv("PARTICLE_CELLULAR_CLOUD_KEEP_ALIVE"));
+    assertFalse(System.hasEnv("PARTICLE_CLOUD_KEEP_ALIVE"));
 
     Cellular.on();
     assertTrue(waitFor(Cellular.isOn, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));

--- a/user/tests/integration/system/cellular_env/cellular_env.cpp
+++ b/user/tests/integration/system/cellular_env/cellular_env.cpp
@@ -572,18 +572,6 @@ test(10_particle_cellular_keepalive_init) {
         skip();
         return;
     }
-
-    assertFalse(System.hasEnv("PARTICLE_CELLULAR_CLOUD_KEEP_ALIVE"));
-    assertFalse(System.hasEnv("PARTICLE_CLOUD_KEEP_ALIVE"));
-
-    Cellular.on();
-    assertTrue(waitFor(Cellular.isOn, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
-    Cellular.connect();
-    assertTrue(waitFor(Cellular.ready, HAL_PLATFORM_CELLULAR_CONN_TIMEOUT));
-    Particle.connect();
-    assertTrue(waitFor(Particle.connected, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
-
-    assertEqual(Particle.getKeepAlive(), PLATFORM_CELLULAR_KEEPALIVE_SECONDS);
 }
 
 test(11_particle_cellular_keepalive_set) {
@@ -606,6 +594,14 @@ test(11_particle_cellular_keepalive_set) {
     assertTrue(waitFor(Cellular.isOn, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
     Cellular.connect();
     assertTrue(waitFor(Cellular.ready, HAL_PLATFORM_CELLULAR_CONN_TIMEOUT));
+
+    System.disableUpdates();
+    SCOPE_GUARD({
+        Particle.disconnect();
+        waitForNot(Particle.connected, 1000);
+        System.enableUpdates();
+    });
+
     Particle.connect();
     assertTrue(waitFor(Particle.connected, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
 
@@ -618,77 +614,6 @@ test(11_particle_cellular_keepalive_set) {
     Cellular.disconnect();
     waitForNot(Cellular.ready, 60000);
 }
-
-test(12_particle_cellular_env_var_cleanup) {
-    if (g_SkipTests || getModemType() == ModemType::UNSUPPORTED) {
-        skip();
-        return;
-    }
-
-    System.clearEnv(false /* reset */);
-    expectSystemReset();
-    System.reset();
-}
-
-test(13_particle_cellular_env_vars_cleared_verify_defaults) {
-    if (g_SkipTests || getModemType() == ModemType::UNSUPPORTED) {
-        skip();
-        return;
-    }
-
-    assertFalse(System.hasEnv("PARTICLE_CELLULAR_PREFERRED_BANDS"));
-    assertFalse(System.hasEnv("PARTICLE_CELLULAR_FORBIDDEN_BANDS"));
-    assertFalse(System.hasEnv("PARTICLE_CELLULAR_PREFERRED_PLMN"));
-    assertFalse(System.hasEnv("PARTICLE_CELLULAR_CLOUD_KEEP_ALIVE"));
-    assertFalse(System.hasEnv("PARTICLE_CLOUD_KEEP_ALIVE"));
-
-    Cellular.on();
-    assertTrue(waitFor(Cellular.isOn, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
-    Cellular.connect();
-    assertTrue(waitFor(Cellular.ready, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
-
-    int ncpId = getNcpId();
-
-    CellularBandMask bands;
-    CpolCallbackData data = {};
-    SCOPE_GUARD({
-        if (getModemType() != ModemType::UNSUPPORTED &&
-                ncpId != PLATFORM_NCP_SARA_R410 &&
-                ncpId != PLATFORM_NCP_QUECTEL_BG96) {
-            pushMailboxMsg(String::format("Band mask after env clear: %s\nAT+CPOL response after env clear: %s",
-                    (const char*)bands.toString(), data.response.length() ? data.response.c_str() : "empty"), 5000 /* wait */);
-        } else {
-            pushMailboxMsg(String::format("Band mask after env clear: %s", (const char*)bands.toString()), 5000 /* wait */);
-        }
-    });
-
-    if ((modemType == ModemType::UBLOX && isUbandmaskSupported()) ||
-            (modemType == ModemType::QUECTEL)) {
-
-        bands = readCurrentLteMask();
-        assertFalse(bands.isEmpty());
-        assertEqual((const char*)bands.toString(), (const char*)makeDefaultBandMask(true /* readMode */).toString());
-    }
-
-    if (getModemType() != ModemType::UNSUPPORTED &&
-                ncpId != PLATFORM_NCP_SARA_R410 &&
-                ncpId != PLATFORM_NCP_QUECTEL_BG96) {
-        // UPLMN list: 310410, 310260, 311480 should no longer be set
-        Cellular.command(cbCPOL, &data, 10000, "AT+CPOL?\r\n");
-        bool anyPlmn = (data.response.indexOf("310410") >= 0) ||
-                (data.response.indexOf("310260") >= 0) ||
-                (data.response.indexOf("311480") >= 0);
-        assertFalse(anyPlmn);
-    }
-
-    Particle.connect();
-    assertTrue(waitFor(Particle.connected, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
-    assertEqual(Particle.getKeepAlive(), PLATFORM_CELLULAR_KEEPALIVE_SECONDS);
-
-    Cellular.disconnect();
-    waitForNot(Cellular.ready, 60000);
-}
-
 #endif // HAL_PLATFORM_CELLULAR
 
 test(97_cleanup) {
@@ -740,3 +665,68 @@ test(99_cleanup_2) {
         System.reset();
     }
 }
+
+#if HAL_PLATFORM_CELLULAR
+test(99_cleanup_3_verify_defaults) {
+    if (g_SkipTests || getModemType() == ModemType::UNSUPPORTED) {
+        skip();
+        return;
+    }
+
+    assertFalse(System.hasEnv("PARTICLE_CELLULAR_PREFERRED_BANDS"));
+    assertFalse(System.hasEnv("PARTICLE_CELLULAR_FORBIDDEN_BANDS"));
+    assertFalse(System.hasEnv("PARTICLE_CELLULAR_PREFERRED_PLMN"));
+    assertFalse(System.hasEnv("PARTICLE_CELLULAR_CLOUD_KEEP_ALIVE"));
+    assertFalse(System.hasEnv("PARTICLE_CLOUD_KEEP_ALIVE"));
+
+    Cellular.on();
+    assertTrue(waitFor(Cellular.isOn, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
+    Cellular.connect();
+    assertTrue(waitFor(Cellular.ready, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
+
+    int ncpId = getNcpId();
+
+    CellularBandMask bands;
+    CpolCallbackData data = {};
+    SCOPE_GUARD({
+        if (getModemType() != ModemType::UNSUPPORTED &&
+                ncpId != PLATFORM_NCP_SARA_R410 &&
+                ncpId != PLATFORM_NCP_QUECTEL_BG96) {
+            pushMailboxMsg(String::format("Band mask after env clear: %s\nAT+CPOL response after env clear: %s",
+                    (const char*)bands.toString(), data.response.length() ? data.response.c_str() : "empty"), 5000 /* wait */);
+        } else {
+            pushMailboxMsg(String::format("Band mask after env clear: %s", (const char*)bands.toString()), 5000 /* wait */);
+        }
+    });
+
+    if ((modemType == ModemType::UBLOX && isUbandmaskSupported()) ||
+            (modemType == ModemType::QUECTEL)) {
+
+        bands = readCurrentLteMask();
+        assertFalse(bands.isEmpty());
+        assertEqual((const char*)bands.toString(), (const char*)makeDefaultBandMask(true /* readMode */).toString());
+    }
+
+    if (getModemType() != ModemType::UNSUPPORTED &&
+                ncpId != PLATFORM_NCP_SARA_R410 &&
+                ncpId != PLATFORM_NCP_QUECTEL_BG96) {
+        // UPLMN list: 310410, 310260, 311480 should no longer be set
+        Cellular.command(cbCPOL, &data, 10000, "AT+CPOL?\r\n");
+        bool anyPlmn = (data.response.indexOf("310410") >= 0) ||
+                (data.response.indexOf("310260") >= 0) ||
+                (data.response.indexOf("311480") >= 0);
+        assertFalse(anyPlmn);
+    }
+
+    System.disableUpdates();
+    SCOPE_GUARD({
+        Particle.disconnect();
+        waitForNot(Particle.connected, 1000);
+        System.enableUpdates();
+    });
+
+    Particle.connect();
+    assertTrue(waitFor(Particle.connected, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
+    assertEqual(Particle.getKeepAlive(), PLATFORM_CELLULAR_KEEPALIVE_SECONDS);
+}
+#endif // HAL_PLATFORM_CELLULAR

--- a/user/tests/integration/system/cellular_env/cellular_env.spec.js
+++ b/user/tests/integration/system/cellular_env/cellular_env.spec.js
@@ -110,18 +110,9 @@ test('11_particle_cellular_keepalive_set', async function () {
 
 });
 
-test('12_particle_cellular_env_var_cleanup', async function () {
+test('97_cleanup', async function() {
     delete this.test.parent.particle.network;
     this.test.parent.particle.suiteInitialized = false;
-});
-
-test('13_particle_cellular_env_vars_cleared_verify_defaults', async function () {
-    expect(device.mailBox).to.not.be.empty;
-    console.log(device.mailBox[0].d);
-});
-
-test('97_cleanup', async function() {
-
 });
 
 test('98_cleanup', async function() {
@@ -134,4 +125,9 @@ test('99_cleanup_1', async function() {
 
 test('99_cleanup_2', async function() {
 
+});
+
+test('99_cleanup_3_verify_defaults', async function () {
+    expect(device.mailBox).to.not.be.empty;
+    console.log(device.mailBox[0].d);
 });

--- a/user/tests/integration/system/cellular_env/cellular_env.spec.js
+++ b/user/tests/integration/system/cellular_env/cellular_env.spec.js
@@ -97,23 +97,25 @@ test('8_particle_cellular_preferred_plmn_default', async function () {
 test('9_particle_cellular_preferred_plmn_set', async function () {
     expect(device.mailBox).to.not.be.empty;
     console.log(device.mailBox[0].d);
+});
 
+test('10_particle_cellular_keepalive_init', async function () {
     await setEnvVarsAndFlash({
         PARTICLE_CELLULAR_CLOUD_KEEP_ALIVE: '60',
         PARTICLE_CLOUD_KEEP_ALIVE: '70'
     });
 });
 
-test('10_particle_cellular_keepalive', async function () {
+test('11_particle_cellular_keepalive', async function () {
 
 });
 
-test('11_particle_cellular_preferred_plmn_cleanup', async function () {
+test('12_particle_cellular_preferred_plmn_cleanup', async function () {
     delete this.test.parent.particle.network;
     this.test.parent.particle.suiteInitialized = false;
 });
 
-test('12_particle_cellular_env_vars_cleared_verify_defaults', async function () {
+test('13_particle_cellular_env_vars_cleared_verify_defaults', async function () {
     expect(device.mailBox).to.not.be.empty;
     console.log(device.mailBox[0].d);
 });

--- a/user/tests/integration/system/cellular_env/cellular_env.spec.js
+++ b/user/tests/integration/system/cellular_env/cellular_env.spec.js
@@ -106,7 +106,7 @@ test('10_particle_cellular_keepalive_init', async function () {
     });
 });
 
-test('11_particle_cellular_keepalive', async function () {
+test('11_particle_cellular_keepalive_set', async function () {
 
 });
 

--- a/user/tests/integration/system/cellular_env/cellular_env.spec.js
+++ b/user/tests/integration/system/cellular_env/cellular_env.spec.js
@@ -110,7 +110,7 @@ test('11_particle_cellular_keepalive', async function () {
 
 });
 
-test('12_particle_cellular_preferred_plmn_cleanup', async function () {
+test('12_particle_cellular_env_var_cleanup', async function () {
     delete this.test.parent.particle.network;
     this.test.parent.particle.suiteInitialized = false;
 });

--- a/user/tests/integration/system/env/env.cpp
+++ b/user/tests/integration/system/env/env.cpp
@@ -31,6 +31,7 @@ namespace {
 static const int WIFI_KEEPALIVE_SECONDS = 30;
 static const int ETHERNET_KEEPALIVE_SECONDS = 40;
 static const int DEFAULT_KEEPALIVE_SECONDS = 50;
+static const int PLATFORM_DEFAULT_KEEPALIVE_SECONDS = HAL_PLATFORM_DEFAULT_CLOUD_KEEPALIVE_INTERVAL / 1000;
 
 #if HAL_PLATFORM_ETHERNET
 
@@ -328,6 +329,7 @@ test(07_particle_wifi_enable_default) {
     Particle.connect();
     assertTrue(waitFor(WiFi.ready, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
     assertTrue(waitFor(Particle.connected, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
+    assertEqual(Particle.getKeepAlive(), PLATFORM_DEFAULT_KEEPALIVE_SECONDS);
 
 #if HAL_PLATFORM_BLE
     // BLE is not affected

--- a/user/tests/integration/system/env/env.cpp
+++ b/user/tests/integration/system/env/env.cpp
@@ -371,6 +371,9 @@ test(08_particle_wifi_enable_true) {
 
     assertEqual(Particle.getKeepAlive(), WIFI_KEEPALIVE_SECONDS);
     assertEqual(Particle.getKeepAlive(WiFi), WIFI_KEEPALIVE_SECONDS);
+#if HAL_PLATFORM_CELLULAR
+    assertEqual(Particle.getKeepAlive(Cellular), DEFAULT_KEEPALIVE_SECONDS);
+#endif
 
 #if HAL_PLATFORM_BLE
     // BLE is not affected


### PR DESCRIPTION
### Note: 
- This PR only fixes an unreleased issue from this previous PR: https://github.com/particle-iot/device-os/pull/2916 Thus this is an `internal` change.

### Problem

Default platform keep alive values are broken for wifi platforms. Tests should also explicitly catch this.
MSOM in wifi only mode should skip cellular tests

### Solution

Fix default wifi cloud keep alive logic. (ie when no env var or user keepalive set). Add tests for wifi and cellular cloud connections. Multi network devices like msom should verify the cellular keep alive is set for cellular and the default keep alive for wifi. 

### Steps to Test
Run on device tests
```
device-os-test --device-os-dir=/Users/scottbrust/develop/device-os run msom 00_before system/cellular_env system/env -- -fixture
```

### Logs

MSOM + MUON + Ethernet (IE HAL_PLATFORM_CELLULAR and HAL_PLATFORM_WIFI)
```
LOG_LEVEL=debug device-os-test  --device-os-dir=/Users/scottbrust/develop/device-os run msom system/cellular_env system/env -- -fixture
<snip>
  Cellular env vars
    msom
      Target device: 0a10aced202194944a04b000 (scott-us-msom-bg95m5-dvt1-03)
      Flashing application: cellular_env.bin
      Opening USB device
      Getting device tests
      Opening USB device
      systemThread=disabled
          Initializing device test suite
          Running device test: 1_particle_cellular_preferred_bands_init
          Opening USB device
          Mailbox message {
            id: 1,
            t: 2,
            d: 'PARTICLE_CELLULAR_PREFERRED_BANDS=100000000000000f0e189c'
          }
          Mailbox message { id: 2, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
PARTICLE_CELLULAR_PREFERRED_BANDS=100000000000000f0e189c
        ✓ 1_particle_cellular_preferred_bands_init (9.4s)
          Initializing device test suite
          Running device test: 2_particle_cellular_preferred_bands_default
          Opening USB device
          Mailbox message {
            id: 1,
            t: 2,
            d: 'Default LTE band mask (QUECTEL): 100002000000000f0e189f'
          }
          Device test passed
Default LTE band mask (QUECTEL): 100002000000000f0e189f
        ✓ 2_particle_cellular_preferred_bands_default (6.3s)
          Initializing device test suite
          Opening USB device
          Running device test: 3_particle_cellular_preferred_bands_set
          Mailbox message {
            id: 1,
            t: 2,
            d: 'LTE band mask after PREFERRED_BANDS env var (QUECTEL): 100000000000000f0e189c'
          }
          Device test passed
LTE band mask after PREFERRED_BANDS env var (QUECTEL): 100000000000000f0e189c
        ✓ 3_particle_cellular_preferred_bands_set (2s)
          Running device test: 4_particle_cellular_forbidden_bands_init
          Mailbox message {
            id: 2,
            t: 2,
            d: 'PARTICLE_CELLULAR_FORBIDDEN_BANDS=ffffffffffeffffffffffffff0f1e763'
          }
          Mailbox message { id: 3, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
PARTICLE_CELLULAR_FORBIDDEN_BANDS=ffffffffffeffffffffffffff0f1e763
        ✓ 4_particle_cellular_forbidden_bands_init (5s)
          Initializing device test suite
          Running device test: 5_particle_cellular_forbidden_bands_default
          Mailbox message {
            id: 1,
            t: 2,
            d: 'Default LTE band mask (QUECTEL): 100002000000000f0e189f'
          }
          Device test passed
Default LTE band mask (QUECTEL): 100002000000000f0e189f
        ✓ 5_particle_cellular_forbidden_bands_default (8.2s)
          Initializing device test suite
          Opening USB device
          Running device test: 6_particle_cellular_forbidden_bands_set
          Mailbox message {
            id: 1,
            t: 2,
            d: 'LTE band mask after FORBIDDEN_BANDS env var (QUECTEL): 100000000000000f0e189c'
          }
          Device test passed
LTE band mask after FORBIDDEN_BANDS env var (QUECTEL): 100000000000000f0e189c
        ✓ 6_particle_cellular_forbidden_bands_set (2.5s)
          Running device test: 7_particle_cellular_preferred_plmn_init
          Mailbox message { id: 2, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 7_particle_cellular_preferred_plmn_init (4.1s)
          Initializing device test suite
          Running device test: 8_particle_cellular_preferred_plmn_default
          Mailbox message { id: 1, t: 2, d: 'Default CPOL response: empty' }
          Device test passed
Default CPOL response: empty
        ✓ 8_particle_cellular_preferred_plmn_default (13.8s)
          Initializing device test suite
          Opening USB device
          Running device test: 9_particle_cellular_preferred_plmn_set
          Mailbox message {
            id: 1,
            t: 2,
            d: 'AT+CPOL response after PREFERRED_PLMN env var: \r\n' +
              '+CPOL: 1,2,"310410",0,0,0,1\r\n' +
              '\r\n' +
              '+CPOL: 2,2,"310260",0,0,0,1\r\n' +
              '\r\n' +
              '+CPOL: 3,2,"311480",0,0,0,1\r\n'
          }
          Device test passed
AT+CPOL response after PREFERRED_PLMN env var:
+CPOL: 1,2,"310410",0,0,0,1

+CPOL: 2,2,"310260",0,0,0,1

+CPOL: 3,2,"311480",0,0,0,1

        ✓ 9_particle_cellular_preferred_plmn_set (54.8s)
          Running device test: 10_particle_cellular_keepalive_init
          Device test passed
        ✓ 10_particle_cellular_keepalive_init
          Initializing device test suite
          Opening USB device
          Running device test: 11_particle_cellular_keepalive_set
          Device test passed
        ✓ 11_particle_cellular_keepalive_set (7.4s)
          Running device test: 97_cleanup
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 97_cleanup (4.1s)
          Initializing device test suite
          Running device test: 98_cleanup
          Opening USB device
          Device test passed
          Waiting cloud event: spark/flash/status
spark/flash/status started
          Waiting cloud event: spark/flash/status
spark/flash/status success
        ✓ 98_cleanup (58.3s)
          Running device test: 99_cleanup_1
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 99_cleanup_1 (3.9s)
          Running device test: 99_cleanup_2
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 99_cleanup_2 (8.7s)
          Running device test: 99_cleanup_3_verify_defaults
          Mailbox message {
            id: 1,
            t: 2,
            d: 'Band mask after env clear: 100002000000000f0e189f\n' +
              'AT+CPOL response after env clear: empty'
          }
          Device test passed
Band mask after env clear: 100002000000000f0e189f
AT+CPOL response after env clear: empty
        ✓ 99_cleanup_3_verify_defaults (4.6s)
      systemThread=enabled
          Initializing device test suite
          Running device test: 1_particle_cellular_preferred_bands_init
          Opening USB device
          Mailbox message {
            id: 1,
            t: 2,
            d: 'PARTICLE_CELLULAR_PREFERRED_BANDS=100000000000000f0e189c'
          }
          Mailbox message { id: 2, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
PARTICLE_CELLULAR_PREFERRED_BANDS=100000000000000f0e189c
        ✓ 1_particle_cellular_preferred_bands_init (9.4s)
          Initializing device test suite
          Running device test: 2_particle_cellular_preferred_bands_default
          Opening USB device
          Mailbox message {
            id: 1,
            t: 2,
            d: 'Default LTE band mask (QUECTEL): 100002000000000f0e189f'
          }
          Device test passed
Default LTE band mask (QUECTEL): 100002000000000f0e189f
        ✓ 2_particle_cellular_preferred_bands_default (6.4s)
          Initializing device test suite
          Opening USB device
          Running device test: 3_particle_cellular_preferred_bands_set
          Mailbox message {
            id: 1,
            t: 2,
            d: 'LTE band mask after PREFERRED_BANDS env var (QUECTEL): 100000000000000f0e189c'
          }
          Device test passed
LTE band mask after PREFERRED_BANDS env var (QUECTEL): 100000000000000f0e189c
        ✓ 3_particle_cellular_preferred_bands_set (1.9s)
          Running device test: 4_particle_cellular_forbidden_bands_init
          Mailbox message {
            id: 2,
            t: 2,
            d: 'PARTICLE_CELLULAR_FORBIDDEN_BANDS=ffffffffffeffffffffffffff0f1e763'
          }
          Mailbox message { id: 3, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
PARTICLE_CELLULAR_FORBIDDEN_BANDS=ffffffffffeffffffffffffff0f1e763
        ✓ 4_particle_cellular_forbidden_bands_init (5s)
          Initializing device test suite
          Running device test: 5_particle_cellular_forbidden_bands_default
          Mailbox message {
            id: 1,
            t: 2,
            d: 'Default LTE band mask (QUECTEL): 100002000000000f0e189f'
          }
          Device test passed
Default LTE band mask (QUECTEL): 100002000000000f0e189f
        ✓ 5_particle_cellular_forbidden_bands_default (5.1s)
          Initializing device test suite
          Opening USB device
          Running device test: 6_particle_cellular_forbidden_bands_set
          Mailbox message {
            id: 1,
            t: 2,
            d: 'LTE band mask after FORBIDDEN_BANDS env var (QUECTEL): 100000000000000f0e189c'
          }
          Device test passed
LTE band mask after FORBIDDEN_BANDS env var (QUECTEL): 100000000000000f0e189c
        ✓ 6_particle_cellular_forbidden_bands_set (2.4s)
          Running device test: 7_particle_cellular_preferred_plmn_init
          Mailbox message { id: 2, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 7_particle_cellular_preferred_plmn_init (4.2s)
          Initializing device test suite
          Running device test: 8_particle_cellular_preferred_plmn_default
          Mailbox message { id: 1, t: 2, d: 'Default CPOL response: empty' }
          Device test passed
Default CPOL response: empty
        ✓ 8_particle_cellular_preferred_plmn_default (5.8s)
          Initializing device test suite
          Opening USB device
          Running device test: 9_particle_cellular_preferred_plmn_set
          Mailbox message {
            id: 1,
            t: 2,
            d: 'AT+CPOL response after PREFERRED_PLMN env var: \r\n' +
              '+CPOL: 1,2,"310410",0,0,0,1\r\n' +
              '\r\n' +
              '+CPOL: 2,2,"310260",0,0,0,1\r\n' +
              '\r\n' +
              '+CPOL: 3,2,"311480",0,0,0,1\r\n'
          }
          Device test passed
AT+CPOL response after PREFERRED_PLMN env var:
+CPOL: 1,2,"310410",0,0,0,1

+CPOL: 2,2,"310260",0,0,0,1

+CPOL: 3,2,"311480",0,0,0,1

        ✓ 9_particle_cellular_preferred_plmn_set (6.1s)
          Running device test: 10_particle_cellular_keepalive_init
          Device test passed
        ✓ 10_particle_cellular_keepalive_init
          Initializing device test suite
          Opening USB device
          Running device test: 11_particle_cellular_keepalive_set
          Device test passed
        ✓ 11_particle_cellular_keepalive_set (8.5s)
          Running device test: 97_cleanup
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 97_cleanup (4s)
          Initializing device test suite
          Running device test: 98_cleanup
          Opening USB device
          Device test passed
          Waiting cloud event: spark/flash/status
spark/flash/status started
          Waiting cloud event: spark/flash/status
spark/flash/status success
        ✓ 98_cleanup (31.9s)
          Running device test: 99_cleanup_1
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 99_cleanup_1 (3.9s)
          Running device test: 99_cleanup_2
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 99_cleanup_2 (8.7s)
          Running device test: 99_cleanup_3_verify_defaults
          Mailbox message {
            id: 1,
            t: 2,
            d: 'Band mask after env clear: 100002000000000f0e189f\n' +
              'AT+CPOL response after env clear: empty'
          }
          Device test passed
Band mask after env clear: 100002000000000f0e189f
AT+CPOL response after env clear: empty
        ✓ 99_cleanup_3_verify_defaults (8.3s)
      Resetting device

  System level env vars
    msom
      Target device: 0a10aced202194944a04b000 (scott-us-msom-bg95m5-dvt1-03)
      Flashing application: env.bin
      Opening USB device
      Getting device tests
      Opening USB device
      systemThread=disabled
          Initializing device test suite
          Running device test: 01_particle_ble_enable_init
          Opening USB device
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 01_particle_ble_enable_init (8.1s)
          Running device test: 02_particle_ble_enable_default
          Device test passed
        ✓ 02_particle_ble_enable_default (7.4s)
          Initializing device test suite
          Opening USB device
          Running device test: 03_particle_ble_enable_true
          Device test passed
        ✓ 03_particle_ble_enable_true (7.4s)
          Initializing device test suite
          Opening USB device
          Running device test: 04_particle_ble_enable_false
          Device test passed
        ✓ 04_particle_ble_enable_false (13.3s)
          Initializing device test suite
          Opening USB device
          Running device test: 05_particle_default_cloud_keepalive
          Device test passed
        ✓ 05_particle_default_cloud_keepalive (6.8s)
          Running device test: 06_particle_wifi_enable_init
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 06_particle_wifi_enable_init (4.2s)
          Initializing device test suite
          Running device test: 07_particle_wifi_enable_default
          Opening USB device
          Device test passed
        ✓ 07_particle_wifi_enable_default (22.2s)
          Initializing device test suite
          Opening USB device
          Running device test: 08_particle_wifi_enable_true
          Device test passed
        ✓ 08_particle_wifi_enable_true (17s)
          Initializing device test suite
          Opening USB device
          Running device test: 09_particle_wifi_enable_false
          Device test passed
        ✓ 09_particle_wifi_enable_false (17.5s)
          Initializing device test suite
          Running device test: 10_particle_wifi_enable_false_connect_through_other_ifaces
          Opening USB device
          Device test passed
        ✓ 10_particle_wifi_enable_false_connect_through_other_ifaces (22.6s)
          Running device test: 11_particle_wifi_enable_cleanup
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 11_particle_wifi_enable_cleanup (4.1s)
          Running device test: 12_particle_ethernet_enable_init
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 12_particle_ethernet_enable_init (4.6s)
          Initializing device test suite
          Running device test: 13_particle_ethernet_enable_default
          Opening USB device
          Device test passed
        ✓ 13_particle_ethernet_enable_default (8.9s)
          Initializing device test suite
          Opening USB device
          Running device test: 14_particle_ethernet_enable_true
          Device test passed
        ✓ 14_particle_ethernet_enable_true (4.2s)
          Initializing device test suite
          Opening USB device
          Running device test: 15_particle_ethernet_enable_false
          Device test passed
        ✓ 15_particle_ethernet_enable_false
          Initializing device test suite
          Running device test: 16_particle_ethernet_enable_false_connect_through_other_ifaces
          Opening USB device
          Device test passed
        ✓ 16_particle_ethernet_enable_false_connect_through_other_ifaces (15.1s)
          Running device test: 17_particle_ethernet_enable_cleanup
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 17_particle_ethernet_enable_cleanup (4.1s)
          Running device test: 97_cleanup
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 97_cleanup (4.1s)
          Initializing device test suite
          Running device test: 98_cleanup
          Device test passed
          Waiting cloud event: spark/flash/status
spark/flash/status started
          Waiting cloud event: spark/flash/status
spark/flash/status success
        ✓ 98_cleanup (6.2s)
          Running device test: 99_cleanup_1
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 99_cleanup_1 (4s)
          Initializing device test suite
          Running device test: 99_cleanup_2
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 99_cleanup_2 (8.9s)
      systemThread=enabled
          Initializing device test suite
          Running device test: 01_particle_ble_enable_init
          Opening USB device
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 01_particle_ble_enable_init (8.1s)
          Running device test: 02_particle_ble_enable_default
          Device test passed
        ✓ 02_particle_ble_enable_default (9s)
          Initializing device test suite
          Opening USB device
          Running device test: 03_particle_ble_enable_true
          Device test passed
        ✓ 03_particle_ble_enable_true (9s)
          Initializing device test suite
          Opening USB device
          Running device test: 04_particle_ble_enable_false
          Device test passed
        ✓ 04_particle_ble_enable_false (10.8s)
          Initializing device test suite
          Opening USB device
          Running device test: 05_particle_default_cloud_keepalive
          Device test passed
        ✓ 05_particle_default_cloud_keepalive (8.3s)
          Running device test: 06_particle_wifi_enable_init
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 06_particle_wifi_enable_init (4.2s)
          Initializing device test suite
          Running device test: 07_particle_wifi_enable_default
          Opening USB device
          Device test passed
        ✓ 07_particle_wifi_enable_default (26.6s)
          Initializing device test suite
          Opening USB device
          Running device test: 08_particle_wifi_enable_true
          Device test passed
        ✓ 08_particle_wifi_enable_true (19s)
          Initializing device test suite
          Opening USB device
          Running device test: 09_particle_wifi_enable_false
          Device test passed
        ✓ 09_particle_wifi_enable_false (18.3s)
          Initializing device test suite
          Running device test: 10_particle_wifi_enable_false_connect_through_other_ifaces
          Opening USB device
          Device test passed
        ✓ 10_particle_wifi_enable_false_connect_through_other_ifaces (24.7s)
          Running device test: 11_particle_wifi_enable_cleanup
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 11_particle_wifi_enable_cleanup (4s)
          Running device test: 12_particle_ethernet_enable_init
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 12_particle_ethernet_enable_init (4.6s)
          Initializing device test suite
          Running device test: 13_particle_ethernet_enable_default
          Opening USB device
          Device test passed
        ✓ 13_particle_ethernet_enable_default (10.2s)
          Initializing device test suite
          Opening USB device
          Running device test: 14_particle_ethernet_enable_true
          Device test passed
        ✓ 14_particle_ethernet_enable_true (4.9s)
          Initializing device test suite
          Opening USB device
          Running device test: 15_particle_ethernet_enable_false
          Device test passed
        ✓ 15_particle_ethernet_enable_false
          Initializing device test suite
          Running device test: 16_particle_ethernet_enable_false_connect_through_other_ifaces
          Opening USB device
          Device test passed
        ✓ 16_particle_ethernet_enable_false_connect_through_other_ifaces (14.9s)
          Running device test: 17_particle_ethernet_enable_cleanup
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 17_particle_ethernet_enable_cleanup (4.1s)
          Running device test: 97_cleanup
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 97_cleanup (4.1s)
          Initializing device test suite
          Running device test: 98_cleanup
          Device test passed
          Waiting cloud event: spark/flash/status
spark/flash/status started
          Waiting cloud event: spark/flash/status
spark/flash/status success
        ✓ 98_cleanup (11.3s)
          Running device test: 99_cleanup_1
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 99_cleanup_1 (4.1s)
          Initializing device test suite
          Running device test: 99_cleanup_2
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 99_cleanup_2 (8.9s)
      Resetting device


  74 passing (14m)
```


P2 (IE HAL_PLATFORM_WIFI only)

```
LOG_LEVEL=debug device-os-test  --device-os-dir=/Users/scottbrust/develop/device-os run p2 system/cellular_env system/env -- -fixture
<snip>
  System level env vars
    p2
      Target device: 0a10aced202194944a040930 (laser_chameleon)
      Flashing application: env.bin
      Opening USB device
      Getting device tests
      Opening USB device
      systemThread=disabled
          Initializing device test suite
          Running device test: 01_particle_ble_enable_init
          Opening USB device
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 01_particle_ble_enable_init (8.4s)
          Running device test: 02_particle_ble_enable_default
          Device test passed
        ✓ 02_particle_ble_enable_default (7.4s)
          Initializing device test suite
          Opening USB device
          Running device test: 03_particle_ble_enable_true
          Device test passed
        ✓ 03_particle_ble_enable_true (7.4s)
          Initializing device test suite
          Opening USB device
          Running device test: 04_particle_ble_enable_false
          Device test passed
        ✓ 04_particle_ble_enable_false (13.2s)
          Initializing device test suite
          Opening USB device
          Running device test: 05_particle_default_cloud_keepalive
          Device test passed
        ✓ 05_particle_default_cloud_keepalive (20.9s)
          Running device test: 06_particle_wifi_enable_init
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 06_particle_wifi_enable_init (4.7s)
          Initializing device test suite
          Running device test: 07_particle_wifi_enable_default
          Opening USB device
          Device test passed
        ✓ 07_particle_wifi_enable_default (21.6s)
          Initializing device test suite
          Opening USB device
          Running device test: 08_particle_wifi_enable_true
          Device test passed
        ✓ 08_particle_wifi_enable_true (18.2s)
          Initializing device test suite
          Opening USB device
          Running device test: 09_particle_wifi_enable_false
          Device test passed
        ✓ 09_particle_wifi_enable_false (17.5s)
          Initializing device test suite
          Running device test: 10_particle_wifi_enable_false_connect_through_other_ifaces
          Opening USB device
          Device test skipped
          sync skip; aborting execution
        - 10_particle_wifi_enable_false_connect_through_other_ifaces
          Initializing device test suite
          Running device test: 11_particle_wifi_enable_cleanup
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 11_particle_wifi_enable_cleanup (3.9s)
          Running device test: 12_particle_ethernet_enable_init
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 12_particle_ethernet_enable_init (4.9s)
          Initializing device test suite
          Running device test: 13_particle_ethernet_enable_default
          Opening USB device
          Device test skipped
          sync skip; aborting execution
        - 13_particle_ethernet_enable_default
          Initializing device test suite
          Running device test: 14_particle_ethernet_enable_true
          Device test skipped
          sync skip; aborting execution
        - 14_particle_ethernet_enable_true
          Initializing device test suite
          Running device test: 15_particle_ethernet_enable_false
          Device test skipped
          sync skip; aborting execution
        - 15_particle_ethernet_enable_false
          Initializing device test suite
          Running device test: 16_particle_ethernet_enable_false_connect_through_other_ifaces
          Device test skipped
          sync skip; aborting execution
        - 16_particle_ethernet_enable_false_connect_through_other_ifaces
          Initializing device test suite
          Running device test: 17_particle_ethernet_enable_cleanup
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 17_particle_ethernet_enable_cleanup (4s)
          Running device test: 97_cleanup
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 97_cleanup (3.8s)
          Initializing device test suite
          Running device test: 98_cleanup
          Opening USB device
          Device test passed
          Waiting cloud event: spark/flash/status
spark/flash/status started
          Waiting cloud event: spark/flash/status
spark/flash/status success
        ✓ 98_cleanup (18.4s)
          Running device test: 99_cleanup_1
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 99_cleanup_1 (4s)
          Initializing device test suite
          Running device test: 99_cleanup_2
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 99_cleanup_2 (8.9s)
      systemThread=enabled
          Initializing device test suite
          Running device test: 01_particle_ble_enable_init
          Opening USB device
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 01_particle_ble_enable_init (8.4s)
          Running device test: 02_particle_ble_enable_default
          Device test passed
        ✓ 02_particle_ble_enable_default (9s)
          Initializing device test suite
          Opening USB device
          Running device test: 03_particle_ble_enable_true
          Device test passed
        ✓ 03_particle_ble_enable_true (9s)
          Initializing device test suite
          Opening USB device
          Running device test: 04_particle_ble_enable_false
          Device test passed
        ✓ 04_particle_ble_enable_false (12.6s)
          Initializing device test suite
          Opening USB device
          Running device test: 05_particle_default_cloud_keepalive
          Device test passed
        ✓ 05_particle_default_cloud_keepalive (21.6s)
          Running device test: 06_particle_wifi_enable_init
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 06_particle_wifi_enable_init (4.8s)
          Initializing device test suite
          Running device test: 07_particle_wifi_enable_default
          Opening USB device
          Device test passed
        ✓ 07_particle_wifi_enable_default (23.6s)
          Initializing device test suite
          Opening USB device
          Running device test: 08_particle_wifi_enable_true
          Device test passed
        ✓ 08_particle_wifi_enable_true (19.8s)
          Initializing device test suite
          Opening USB device
          Running device test: 09_particle_wifi_enable_false
          Device test passed
        ✓ 09_particle_wifi_enable_false (18.3s)
          Initializing device test suite
          Running device test: 10_particle_wifi_enable_false_connect_through_other_ifaces
          Opening USB device
          Device test skipped
          sync skip; aborting execution
        - 10_particle_wifi_enable_false_connect_through_other_ifaces
          Initializing device test suite
          Running device test: 11_particle_wifi_enable_cleanup
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 11_particle_wifi_enable_cleanup (3.9s)
          Running device test: 12_particle_ethernet_enable_init
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 12_particle_ethernet_enable_init (4.9s)
          Initializing device test suite
          Running device test: 13_particle_ethernet_enable_default
          Opening USB device
          Device test skipped
          sync skip; aborting execution
        - 13_particle_ethernet_enable_default
          Initializing device test suite
          Running device test: 14_particle_ethernet_enable_true
          Device test skipped
          sync skip; aborting execution
        - 14_particle_ethernet_enable_true
          Initializing device test suite
          Running device test: 15_particle_ethernet_enable_false
          Device test skipped
          sync skip; aborting execution
        - 15_particle_ethernet_enable_false
          Initializing device test suite
          Running device test: 16_particle_ethernet_enable_false_connect_through_other_ifaces
          Device test skipped
          sync skip; aborting execution
        - 16_particle_ethernet_enable_false_connect_through_other_ifaces
          Initializing device test suite
          Running device test: 17_particle_ethernet_enable_cleanup
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 17_particle_ethernet_enable_cleanup (4s)
          Running device test: 97_cleanup
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 97_cleanup (3.8s)
          Initializing device test suite
          Running device test: 98_cleanup
          Opening USB device
          Device test passed
          Waiting cloud event: spark/flash/status
spark/flash/status started
          Waiting cloud event: spark/flash/status
spark/flash/status success
        ✓ 98_cleanup (25.8s)
          Running device test: 99_cleanup_1
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 99_cleanup_1 (4.1s)
          Initializing device test suite
          Running device test: 99_cleanup_2
          Mailbox message { id: 1, t: 1 }
          Device test notified about expected reset
          Opening USB device
          Device test passed
        ✓ 99_cleanup_2 (8.9s)
      Resetting device


  32 passing (7m)
  10 pending
```

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
