### PR TITLE
Fixes race condition on entering power off mode

### DIFF
--- a/hal/shared/am18x5.cpp
+++ b/hal/shared/am18x5.cpp
@@ -40,6 +40,7 @@
 #include "exrtc_hal_internal.h"
 #include "system_cache.h"
 #include "delay_hal.h"
+#include "spark_wiring_thread.h"
 
 using namespace particle;
 namespace {
@@ -1081,25 +1082,42 @@ int Am18x5::sleep(const am18x5_sleep_config_t* config) {
         intMask &= ~INTERRUPT_AIE_MASK;
     }
 
+    // Read SLEEP_CONTROL to maintain config but set the SLP bit for immediate sleep when written back out.
+    uint8_t sleepControl = 0x00;
+    CHECK(readRegister(Am18x5Register::SLEEP_CONTROL, &sleepControl));
+    sleepControl |= (1 << SLEEP_CONTROL_SLP_SHIFT);
+
     // Read status to clear the interrupt flags
     uint8_t status = 0x00;
     CHECK(readRegister(Am18x5Register::STATUS, &status));
     // Enable interrupt
     CHECK(writeRegister(Am18x5Register::INT_MASK, intMask));
 
-    // Optionally require the EXTI wake input to be inactive before arming sleep.
-    if ((exrtcConfigFlags_ & HAL_EXRTC_CONFIG_SLEEP_EXTI_CHECK) && config->exti_polarity != Am18x5ExtiPolarity::NONE) {
-        uint8_t exin;
-        CHECK(readRegister(Am18x5Register::EXTENSION_RAM_ADDRESS, &exin));
-        bool isExtiHigh = exin & EXTENSION_RAM_EXIN_MASK;
-        if((config->exti_polarity == Am18x5ExtiPolarity::RISING && isExtiHigh) ||
-            (config->exti_polarity == Am18x5ExtiPolarity::FALLING && !isExtiHigh)) {
-            return SYSTEM_ERROR_ABORTED;
+    /*
+     * Critical window between checking EXTI for sleep abort and entering sleep needs to be minimized to handle
+     * possible race condition around EXTI as AM1805 enters sleep. AM1805 appears to handle this case but ONLY
+     * when the EXTI transition occurs within a very narrow window prior.
+     * Acquire lock and disable threading to eliminate unexpected delay from task switch extending the window.
+     */
+    WITH_LOCK(*this)
+    {
+        SINGLE_THREADED_SECTION();
+
+        // Optionally require the EXTI wake input to be inactive before arming sleep.
+        if ((exrtcConfigFlags_ & HAL_EXRTC_CONFIG_SLEEP_EXTI_CHECK) && config->exti_polarity != Am18x5ExtiPolarity::NONE) {
+            uint8_t exin;
+            CHECK(readRegister(Am18x5Register::EXTENSION_RAM_ADDRESS, &exin));
+            bool isExtiHigh = exin & EXTENSION_RAM_EXIN_MASK;
+            if((config->exti_polarity == Am18x5ExtiPolarity::RISING && isExtiHigh) ||
+                (config->exti_polarity == Am18x5ExtiPolarity::FALLING && !isExtiHigh)) {
+                return SYSTEM_ERROR_ABORTED;
+            }
         }
+
+        // Transfer to SLEEP state without any delay
+        CHECK(writeRegister(Am18x5Register::SLEEP_CONTROL, sleepControl));
     }
 
-    // Transfer to SLEEP state without any delay
-    CHECK(writeRegister(Am18x5Register::SLEEP_CONTROL, 1, false, true, SLEEP_CONTROL_SLP_MASK, SLEEP_CONTROL_SLP_SHIFT));
     /*
      * In addition, SLP cannot be set if there is an interrupt pending. Software should read the SLP bit after
      * attempting to set it. If SLP is not asserted, the attempt to set SLP was unsuccessful either because a


### PR DESCRIPTION
### Problem
When there is a falling/rsiing edge triggered on the AM18x5's EXTI pin and the source of the trigger has latched the level during entering the power off mode, the AM18x5 may miss the trigger, which may end up in infinite sleep state.

### Solution
Shorten the time it writes the SLP bit in the AM18x5's SLEEP register and add single thread protection around the operation to make sure the process is not prolonged.

### Steps to Test

Which unit/integration/application tests are applicable to this code change? (At minimum a test of some kind should be provided)

### Example App

```c
#include "application.h"
#include "bma400.h"
#include "exrtc_hal.h"

SYSTEM_MODE(MANUAL);
SerialLogHandler l(115200, LOG_LEVEL_ALL);

BMA400_INTF_RET_TYPE bmaReadFn(uint8_t reg_addr, uint8_t *reg_data, uint32_t length, void *intf_ptr) {
    uint8_t addr = *((uint8_t*)intf_ptr);
    hal_i2c_begin_transmission(HAL_I2C_INTERFACE1, addr, nullptr);
    hal_i2c_write(HAL_I2C_INTERFACE1, static_cast<uint8_t>(reg_addr), nullptr);
    hal_i2c_end_transmission(HAL_I2C_INTERFACE1, false, nullptr);
    if (hal_i2c_request(HAL_I2C_INTERFACE1, addr, length, true, nullptr) != length) {
        return BMA400_E_COM_FAIL;
    }
    for (uint32_t i = 0; i < length; ++i) {
        reg_data[i] = hal_i2c_read(HAL_I2C_INTERFACE1, nullptr);
    }
    return BMA400_OK;
}

BMA400_INTF_RET_TYPE bmaWriteFn(uint8_t reg_addr, const uint8_t *reg_data, uint32_t length, void *intf_ptr) {
    uint8_t addr = *((uint8_t*)intf_ptr);
    hal_i2c_begin_transmission(HAL_I2C_INTERFACE1, addr, nullptr);
    hal_i2c_write(HAL_I2C_INTERFACE1, static_cast<uint8_t>(reg_addr), nullptr);
    for (size_t i = 0; i < length; i++) {
        hal_i2c_write(HAL_I2C_INTERFACE1, reg_data[i], nullptr);
    }
    hal_i2c_end_transmission(HAL_I2C_INTERFACE1, true, nullptr);
    return BMA400_OK;
}

void bmaDelayUsFn(uint32_t period, void *intf_ptr) {
    delayMicroseconds(period); // Use the delay function to wait for the specified period
}

uint8_t bmaAddr = 0x14;
bma400_dev dev = {};

/* executes once at startup */
void setup() {
    waitFor(Serial.isConnected, 1000);

    Am18x5Configuration exrtcConfig_;
    int ret = Am18x5.getConfig(exrtcConfig_);
    exrtcConfig_.sleepExtiCheck(true);
    ret = Am18x5.enable(exrtcConfig_);
    if (ret != SYSTEM_ERROR_NONE) {
        Log.error("Failed to enable EXRTC, error: %d", ret);
    } else {
        Log.info("EXRTC enabled successfully");
    }

    dev.intf = BMA400_I2C_INTF; // Use I2C interface
    dev.intf_ptr = &bmaAddr;
    dev.read = bmaReadFn; // Set the read function
    dev.write = bmaWriteFn; // Set the write function
    dev.delay_us = bmaDelayUsFn; // Set the delay function
    if (bma400_init(&dev)) {
        Log.error("BMA400 initialization failed");
    } else {
        Log.info("BMA400 initialized successfully: %02X", dev.chip_id);

        int8_t ret = bma400_set_power_mode(BMA400_MODE_NORMAL, &dev); // Set the power mode to normal
        if (ret != BMA400_OK) {
            Log.error("Failed to set BMA400 power mode: %d", ret);
        } else {
            Log.info("BMA400 power mode set to normal");
            bma400_sensor_conf conf = {};

            conf.type = BMA400_ACCEL;
            bma400_get_sensor_conf(&conf, 1, &dev);
            conf.param.accel.odr = BMA400_ODR_50HZ;
            bma400_set_sensor_conf(&conf, 1, &dev);

            conf.type = BMA400_GEN1_INT;
            conf.param.gen_int.gen_int_thres = 10; // 8mg per LSB
            conf.param.gen_int.gen_int_dur = 1;
            conf.param.gen_int.axes_sel = 0x07; // Enable all axes
            conf.param.gen_int.data_src = BMA400_DATA_SRC_ACC_FILT1;
            conf.param.gen_int.criterion_sel = BMA400_INACTIVITY_INT; // Inactivity interrupt BMA400_ACTIVITY_INT;
            conf.param.gen_int.evaluate_axes = BMA400_ANY_AXES_INT;
            conf.param.gen_int.ref_update = BMA400_UPDATE_EVERY_TIME; // Update reference values every time
            conf.param.gen_int.hysteresis = BMA400_HYST_24_MG;
            conf.param.gen_int.int_thres_ref_x = 100; // No reference threshold for x
            conf.param.gen_int.int_thres_ref_y = 100; // No reference threshold for y
            conf.param.gen_int.int_thres_ref_z = 100; // No reference threshold for z
            conf.param.gen_int.int_chan = BMA400_INT_CHANNEL_1; // Map to interrupt channel 1

            ret = bma400_set_sensor_conf(&conf, 1, &dev);
            if (ret != BMA400_OK) {
                Log.error("Failed to set BMA400 sensor configuration: %d", ret);
            } else {
                Log.info("BMA400 sensor configuration set successfully");
                bma400_device_conf devConfig = {};
                devConfig.type = BMA400_INT_PIN_CONF;
                devConfig.param.int_conf.int_chan = BMA400_INT_CHANNEL_1; // Map to interrupt channel 1
                devConfig.param.int_conf.pin_conf = BMA400_INT_PUSH_PULL_ACTIVE_0;
                ret = bma400_set_device_conf(&devConfig, 1, &dev);
                if (ret != BMA400_OK) {
                    Log.error("Failed to configure BMA400 interrupt: %d", ret);
                } else {
                    Log.info("BMA400 interrupt configured successfully");
                    bma400_int_enable enable = {};
                    enable.type = BMA400_GEN1_INT_EN;
                    enable.conf = BMA400_ENABLE; // Enable the generic interrupt 1
                    ret = bma400_enable_interrupt(&enable, 1, &dev);
                    if (ret != BMA400_OK) {
                        Log.error("Failed to enable BMA400 interrupt: %d", ret);
                    } else {
                        Log.info("BMA400 interrupt enabled");
                    }

                    // use latching interrupt
                    // this allows interrupt to be temporarily cleared and then
                    // retrigger while going to sleep
                    enable.type = BMA400_LATCH_INT_EN;
                    enable.conf = BMA400_ENABLE;
                    bma400_enable_interrupt(&enable, 1, &dev);
                }
            }
        }
    }
}

void loop()
{
    Log.info("Go to sleep.");

    uint16_t status_1 = 0;
    uint16_t status_2 = 0;

    uint16_t random_delay = random(50, 300); // Random delay so that EXTI falling edge can locate during the access to the sleep control reg
    HAL_Delay_Microseconds(random_delay);
    
    // clear interrupt status on BMA400 to induce race
    bma400_get_interrupt_status(&status_1, &dev);
    bma400_get_interrupt_status(&status_2, &dev);

    // confirm interrupt is triggering and clearing
    // should see 0x4 0x0
    // 0x4 - interrupt trigger confirmed on the first read
    // 0x0 - interrupt no longer present on the second read (but should retrigger soon)
    Log.info("BMA400 interrupts: %02X %02X", status_1, status_2);

    // then again to clear as the log will normally allow enough time for retrigger
    bma400_get_interrupt_status(&status_1, &dev);

    // System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::POWER_OFF).gpio(PinType::RTC, FALLING));
    // Use the sleep command directly to eliminate the time processing unnecessary staff
    hal_exrtc_sleep_config_t sleep = {};
    sleep.version = HAL_EXRTC_API_VERSION;
    sleep.size = sizeof(sleep);
    sleep.exti_mode = FALLING;
    hal_exrtc_command(HAL_EXRTC_INSTANCE_DEFAULT, HAL_EXRTC_COMMAND_SLEEP, &sleep, 0, nullptr);

    Log.info("Failed to sleep, try again."); delay(100);
}
```

### References
N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
