### PR TITLE
Implements power manager env vars, [gen 3] reclaim >3KB flash w/`-flto-partition=one` [sc-139793]

### DIFF
--- a/build/arm-tools.mk
+++ b/build/arm-tools.mk
@@ -124,8 +124,8 @@ endif
 CFLAGS += --specs=nano.specs
 
 ifneq ($(LTO_EXTRA_OPTIMIZATIONS),)
-CFLAGS += -fmerge-all-constants
-LDFLAGS += -fmerge-all-constants
+CFLAGS += -fmerge-all-constants -flto-partition=one
+LDFLAGS += -fmerge-all-constants -flto-partition=one
 endif
 
 ifneq ($(LINKER_NON_CONT_REGIONS),)

--- a/modules/b5som/system-part1/makefile
+++ b/modules/b5som/system-part1/makefile
@@ -7,6 +7,7 @@ PLATFORM_DFU = 0x28000
 
 export FORCE_LTO=1
 export LINKER_NON_CONT_REGIONS=1
+export LTO_EXTRA_OPTIMIZATIONS=1
 
 DEPENDENCIES = newlib_nano modules/b5som/user-part modules/b5som/system-part1 dynalib services hal platform system wiring communication rt-dynalib crypto proto_defs wiring_globals
 LIB_DEPENDENCIES = services system wiring communication hal platform crypto proto_defs wiring_globals

--- a/modules/boron/system-part1/makefile
+++ b/modules/boron/system-part1/makefile
@@ -7,6 +7,7 @@ PLATFORM_DFU = 0x28000
 
 export FORCE_LTO=1
 export LINKER_NON_CONT_REGIONS=1
+export LTO_EXTRA_OPTIMIZATIONS=1
 
 DEPENDENCIES = newlib_nano modules/boron/user-part modules/boron/system-part1 dynalib services hal platform system wiring communication rt-dynalib crypto proto_defs wiring_globals
 LIB_DEPENDENCIES = services system wiring communication hal platform crypto proto_defs wiring_globals

--- a/modules/tracker/system-part1/makefile
+++ b/modules/tracker/system-part1/makefile
@@ -7,6 +7,7 @@ PLATFORM_DFU = 0x28000
 
 export FORCE_LTO=1
 export LINKER_NON_CONT_REGIONS=1
+export LTO_EXTRA_OPTIMIZATIONS=1
 
 DEPENDENCIES = newlib_nano modules/tracker/user-part modules/tracker/system-part1 dynalib services hal platform system wiring communication rt-dynalib crypto proto_defs wiring_globals
 LIB_DEPENDENCIES = services system wiring communication hal platform crypto proto_defs wiring_globals

--- a/system/src/system_power_manager.cpp
+++ b/system/src/system_power_manager.cpp
@@ -26,6 +26,7 @@ LOG_SOURCE_CATEGORY("sys.power");
 #include "debug.h"
 #include "spark_wiring_platform.h"
 #include "pinmap_hal.h"
+#include "system_env.h"
 
 #if (HAL_PLATFORM_PMIC_BQ24195 && HAL_PLATFORM_FUELGAUGE_MAX17043)
 
@@ -70,6 +71,9 @@ constexpr uint16_t PMIC_FAULT_TERM_CHARGE_CURRENT = 128; // mA
 constexpr system_tick_t BATTERY_REPEATED_CHARGED_WINDOW = 5000; // ms
 constexpr uint8_t BATTERY_REPEATED_CHARGED_COUNT = 2;
 constexpr uint16_t AUX_PWR_EN_INPUT_CURRENT_THRESHOLD = 500; // mA
+constexpr uint16_t ENV_OVERRIDE_MAX_CURRENT = 1500; // mA
+constexpr uint16_t ENV_OVERRIDE_MIN_INPUT_CURRENT = 500; // mA, IINLIM step below the 900mA default
+constexpr uint16_t ENV_OVERRIDE_MIN_CHARGE_CURRENT = 512; // mA, BQ24195 ICHG base offset (hardware floor)
 
 constexpr hal_power_config defaultPowerConfig = {
   .flags = 0,
@@ -142,7 +146,7 @@ PowerManager* PowerManager::instance() {
 
 void PowerManager::enableAuxPwr() {
   if (!auxPwrEnabled_ && config_.version >= HAL_POWER_CONFIG_VERSION_1 && config_.aux_pwr_ctrl_pin != PIN_INVALID) {
-    LOG(INFO, "Enable auxiliary power");
+    LOG(INFO, "Enable aux power");
     hal_gpio_mode(config_.aux_pwr_ctrl_pin, OUTPUT);
     hal_gpio_write(config_.aux_pwr_ctrl_pin, config_.aux_pwr_ctrl_pin_level);
     auxPwrEnabled_ = true;
@@ -190,7 +194,7 @@ void PowerManager::init() {
 #endif // HAL_PLATFORM_POWER_MANAGEMENT_OPTIONAL
 
   if (config_.flags & HAL_POWER_MANAGEMENT_DISABLE) {
-    LOG(WARN, "Disabled by configuration");
+    LOG(WARN, "Disabled by config");
     // NOTE: We should at least apply the config in DCT in case of Safe mode.
     // Do not run DPDM, since the event loop will not be started.
     // User application should still call System.setPowerConfiguration() to set
@@ -925,7 +929,7 @@ void PowerManager::logStat(uint8_t stat, uint8_t fault) {
 bool PowerManager::detect() {
   // Check if runtime detection enabled
   if (!(config_.flags & HAL_POWER_PMIC_DETECTION)) {
-    LOG(INFO, "Runtime PMIC/FuelGauge detection is not enabled");
+    LOG(INFO, "PMIC/FuelGauge detection disabled");
     return false;
   }
 
@@ -972,7 +976,7 @@ void PowerManager::resetBus() {
 }
 
 void PowerManager::deinit() {
-  LOG(WARN, "Disabling system power manager");
+  LOG(WARN, "Disabling power manager");
 #if HAL_PLATFORM_POWER_MANAGEMENT_OPTIONAL
   if (detect_) {
 #else
@@ -1068,6 +1072,22 @@ void PowerManager::loadConfig() {
   config_.size = sizeof(config_);
   int err = getConfig(&config_);
   (void)err;
+
+#if HAL_PLATFORM_ENV
+  // Power env vars override any user firmware or default settings.
+  // Values are bounded to practical limits for each parameter and are mapped to
+  // the supported PMIC register values when applied. If the charge current exceeds
+  // the input current limit, the PMIC's VINDPM loop will throttle charging.
+  int value = 0;
+  if (!system_get_env_int("PARTICLE_POWER_INPUT_CURRENT", &value, nullptr) &&
+      value >= ENV_OVERRIDE_MIN_INPUT_CURRENT && value <= ENV_OVERRIDE_MAX_CURRENT) {
+    config_.vin_max_current = (uint16_t)value;
+  }
+  if (!system_get_env_int("PARTICLE_POWER_CHARGE_CURRENT", &value, nullptr) &&
+      value >= ENV_OVERRIDE_MIN_CHARGE_CURRENT && value <= ENV_OVERRIDE_MAX_CURRENT) {
+    config_.charge_current = (uint16_t)value;
+  }
+#endif // HAL_PLATFORM_ENV
 
   logCurrentConfig();
 }

--- a/user/tests/integration/ota/assets/assets.cpp
+++ b/user/tests/integration/ota/assets/assets.cpp
@@ -237,7 +237,7 @@ test(02_ad_hoc_ota_wait_1) {
 
 test(02_ad_hoc_ota_wait_2) {
     System.off(all_events);
-    pushMailbox(MailboxEntry().type(MailboxEntry::Type::SAFE_MODE_PENDING), 5000);
+    pushMailbox(MailboxEntry().type(MailboxEntry::Type::SAFE_MODE_PENDING), 20000);
     System.enableReset();
     // Should not reach normally
     delay(5000);
@@ -299,7 +299,7 @@ test(05_ad_hoc_ota_asset_repeat_wait_1) {
 test(05_ad_hoc_ota_asset_repeat_wait_2) {
     testAsset.reset();
     System.off(all_events);
-    pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 5000);
+    pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000);
     System.enableReset();
     // Should not reach normally
     delay(5000);
@@ -359,7 +359,7 @@ test(09_product_ota_wait_1) {
 
 test(09_product_ota_wait_2) {
     System.off(all_events);
-    pushMailbox(MailboxEntry().type(MailboxEntry::Type::SAFE_MODE_PENDING), 5000);
+    pushMailbox(MailboxEntry().type(MailboxEntry::Type::SAFE_MODE_PENDING), 20000);
     System.enableReset();
     // Should not reach normally
     delay(5000);
@@ -376,7 +376,7 @@ test(10_product_ota_complete) {
 
 test(11_product_ota_complete_handled) {
     System.assetsHandled(true);
-    pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 5000);
+    pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000);
     System.reset();
 }
 
@@ -448,7 +448,7 @@ test(17_assets_add_extra_asset_wait_1) {
 
 test(17_assets_add_extra_asset_wait_2) {
     System.off(all_events);
-    pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 5000);
+    pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000);
     System.enableReset();
     // Should not reach normally
     delay(5000);

--- a/user/tests/integration/ota/env/env.cpp
+++ b/user/tests/integration/ota/env/env.cpp
@@ -124,7 +124,7 @@ test(01_init) {
     Random rand;
     rand.genBase32(nonce, sizeof(nonce) - 1);
     nonce[sizeof(nonce) - 1] = '\0';
-    pushMailboxMsg(nonce, 5000 /* wait */);
+    pushMailboxMsg(nonce, 20000 /* wait */);
 
     // Clear the env vars and reset to apply the changes
     System.clearEnv(false /* reset */);

--- a/user/tests/integration/ota/factory_reset/factory_reset.cpp
+++ b/user/tests/integration/ota/factory_reset/factory_reset.cpp
@@ -200,7 +200,7 @@ test(03_move_ota_binary_to_factory_slot) {
 };
 
 test(04_device_factory_reset) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 5000));
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
     System.factoryReset();
 }
 

--- a/user/tests/integration/runner/mailbox/mailbox.cpp
+++ b/user/tests/integration/runner/mailbox/mailbox.cpp
@@ -32,7 +32,7 @@ test(01_mailbox) {
 
 
 test(02_mailbox_reset) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
     // We've waited up to 10 seconds for test runner to understand that we are going to reset
     System.reset();
 }
@@ -44,7 +44,7 @@ test(03_mailbox) {
 }
 
 test(04_mailbox_reset_postponed) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
     // We've waited up to 10 seconds for test runner to understand that we are going to reset
     auto t = new Thread("test", [](void* param) -> os_thread_return_t {
         delay(5000);

--- a/user/tests/integration/system/cellular_env/cellular_env.cpp
+++ b/user/tests/integration/system/cellular_env/cellular_env.cpp
@@ -294,7 +294,7 @@ test(1_particle_cellular_preferred_bands_init) {
         CellularBandMask preferred = makeExpectedPostEnvBandMask();
         Log.info("Computed preferred bands mask: %s", (const char*)preferred.toString());
         pushMailboxMsg(String::format("PARTICLE_CELLULAR_PREFERRED_BANDS=%s",
-                (const char*)preferred.toString()), 5000 /* wait */);
+                (const char*)preferred.toString()), 20000 /* wait */);
 
         Cellular.disconnect();
         waitForNot(Cellular.ready, 60000);
@@ -396,7 +396,7 @@ test(4_particle_cellular_forbidden_bands_init) {
     CellularBandMask forbidden = ~makeExpectedPostEnvBandMask();
     Log.info("Computed forbidden bands mask: %s", (const char*)forbidden.toString());
     pushMailboxMsg(String::format("PARTICLE_CELLULAR_FORBIDDEN_BANDS=%s",
-            (const char*)forbidden.toString()), 5000 /* wait */);
+            (const char*)forbidden.toString()), 20000 /* wait */);
 
     Cellular.disconnect();
     waitForNot(Cellular.ready, 60000);

--- a/user/tests/integration/system/env/env.cpp
+++ b/user/tests/integration/system/env/env.cpp
@@ -655,9 +655,14 @@ bool waitAppliedPmicConfig(uint16_t inputLimit, uint16_t chargeCurrent, system_t
 
 test(18_particle_power_env_init) {
 #if POWER_ENV_TESTS
-    PMIC power(true);
-    power.begin();
-    skipPowerEnv = (power.getVersion() != BQ24195_VERSION);
+    {
+        // Scope the PMIC lock to the presence probe: holding it across
+        // System.setPowerConfiguration() can deadlock with the power manager
+        // thread, which takes the same lock while processing events
+        PMIC power(true);
+        power.begin();
+        skipPowerEnv = (power.getVersion() != BQ24195_VERSION);
+    }
     if (skipPowerEnv) {
         skip();
         return;
@@ -671,6 +676,7 @@ test(18_particle_power_env_init) {
     conf.feature(SystemPowerFeature::PMIC_DETECTION);
 #endif
     assertEqual(System.setPowerConfiguration(conf), 0);
+    System.enableFeature(FEATURE_RESET_INFO); // For the reset reason check in the next test
     System.clearEnv(false /* reset */);
     expectSystemReset();
     System.reset();
@@ -685,6 +691,9 @@ test(19_particle_power_env_default) {
         skip();
         return;
     }
+    // Diagnostic: distinguish a clean reset (RESET_REASON_USER) from a crash
+    // (RESET_REASON_PANIC) in the preceding init test
+    Test::out->printlnf("resetReason: %d", (int)System.resetReason());
     assertFalse(System.hasEnv("PARTICLE_POWER_INPUT_CURRENT"));
     assertFalse(System.hasEnv("PARTICLE_POWER_CHARGE_CURRENT"));
 

--- a/user/tests/integration/system/env/env.cpp
+++ b/user/tests/integration/system/env/env.cpp
@@ -613,6 +613,176 @@ test(17_particle_ethernet_enable_cleanup) {
 }
 #endif // HAL_PLATFORM_ETHERNET
 
+#if HAL_PLATFORM_POWER_MANAGEMENT && HAL_PLATFORM_PMIC_BQ24195 && HAL_PLATFORM_FUELGAUGE_MAX17043
+#define POWER_ENV_TESTS 1
+#else
+#define POWER_ENV_TESTS 0
+#endif
+
+#if POWER_ENV_TESTS
+
+namespace {
+
+// Default power configuration values as applied to the PMIC
+const uint16_t DEFAULT_PMIC_INPUT_CURRENT_LIMIT = 900; // mA
+const uint16_t DEFAULT_PMIC_CHARGE_CURRENT = 896; // mA
+
+// Env var override values (see env.spec.js)
+const uint16_t POWER_ENV_INPUT_CURRENT_LIMIT = 1200; // mA
+const uint16_t POWER_ENV_CHARGE_CURRENT = 1024; // mA
+// 1408mA exceeds the 1200mA input current limit and is applied as requested (it falls
+// exactly on the 64mA ICHG grid); the PMIC's VINDPM loop throttles charging at runtime
+const uint16_t POWER_ENV_EXCESSIVE_CHARGE_CURRENT = 1408; // mA
+
+constexpr uint8_t BQ24195_VERSION = 0x23;
+
+retained bool skipPowerEnv = false;
+
+bool waitAppliedPmicConfig(uint16_t inputLimit, uint16_t chargeCurrent, system_tick_t timeout = 10000) {
+    for (auto start = millis(); millis() - start <= timeout;) {
+        PMIC power(true);
+        if (power.getInputCurrentLimit() == inputLimit && power.getChargeCurrentValue() == chargeCurrent) {
+            return true;
+        }
+        delay(250);
+    }
+    return false;
+}
+
+} // anonymous
+
+#endif // POWER_ENV_TESTS
+
+test(18_particle_power_env_init) {
+#if POWER_ENV_TESTS
+    PMIC power(true);
+    power.begin();
+    skipPowerEnv = (power.getVersion() != BQ24195_VERSION);
+    if (skipPowerEnv) {
+        skip();
+        return;
+    }
+    // Reset the power configuration to defaults and use the VIN settings also when
+    // powered by a USB host, so that the applied input current limit is deterministic
+    // on the test rig regardless of the power source
+    SystemPowerConfiguration conf;
+    conf.feature(SystemPowerFeature::USE_VIN_SETTINGS_WITH_USB_HOST);
+#if HAL_PLATFORM_POWER_MANAGEMENT_OPTIONAL
+    conf.feature(SystemPowerFeature::PMIC_DETECTION);
+#endif
+    assertEqual(System.setPowerConfiguration(conf), 0);
+    System.clearEnv(false /* reset */);
+    expectSystemReset();
+    System.reset();
+#else
+    skip();
+#endif // POWER_ENV_TESTS
+}
+
+test(19_particle_power_env_default) {
+#if POWER_ENV_TESTS
+    if (skipPowerEnv) {
+        skip();
+        return;
+    }
+    assertFalse(System.hasEnv("PARTICLE_POWER_INPUT_CURRENT"));
+    assertFalse(System.hasEnv("PARTICLE_POWER_CHARGE_CURRENT"));
+
+    // The stored configuration reports the defaults
+    auto conf = System.getPowerConfiguration();
+    assertEqual((int)conf.powerSourceMaxCurrent(), (int)DEFAULT_PMIC_INPUT_CURRENT_LIMIT);
+    assertEqual((int)conf.batteryChargeCurrent(), (int)DEFAULT_PMIC_CHARGE_CURRENT);
+
+    // The defaults are applied to the PMIC
+    assertTrue(waitAppliedPmicConfig(DEFAULT_PMIC_INPUT_CURRENT_LIMIT, DEFAULT_PMIC_CHARGE_CURRENT));
+#else
+    skip();
+#endif // POWER_ENV_TESTS
+}
+
+test(20_particle_power_env_override) {
+#if POWER_ENV_TESTS
+    if (skipPowerEnv) {
+        skip();
+        return;
+    }
+    int value = 0;
+    assertTrue(System.hasEnv("PARTICLE_POWER_INPUT_CURRENT"));
+    assertTrue(System.getEnv("PARTICLE_POWER_INPUT_CURRENT", value));
+    assertEqual(value, (int)POWER_ENV_INPUT_CURRENT_LIMIT);
+    assertTrue(System.hasEnv("PARTICLE_POWER_CHARGE_CURRENT"));
+    assertTrue(System.getEnv("PARTICLE_POWER_CHARGE_CURRENT", value));
+    assertEqual(value, (int)POWER_ENV_CHARGE_CURRENT);
+
+    // The env var values are applied to the PMIC
+    assertTrue(waitAppliedPmicConfig(POWER_ENV_INPUT_CURRENT_LIMIT, POWER_ENV_CHARGE_CURRENT));
+
+    // The stored configuration is not modified by the env var override
+    auto conf = System.getPowerConfiguration();
+    assertEqual((int)conf.powerSourceMaxCurrent(), (int)DEFAULT_PMIC_INPUT_CURRENT_LIMIT);
+    assertEqual((int)conf.batteryChargeCurrent(), (int)DEFAULT_PMIC_CHARGE_CURRENT);
+#else
+    skip();
+#endif // POWER_ENV_TESTS
+}
+
+test(21_particle_power_env_charge_above_input_limit) {
+#if POWER_ENV_TESTS
+    if (skipPowerEnv) {
+        skip();
+        return;
+    }
+    int value = 0;
+    assertTrue(System.getEnv("PARTICLE_POWER_INPUT_CURRENT", value));
+    assertEqual(value, (int)POWER_ENV_INPUT_CURRENT_LIMIT);
+    assertTrue(System.getEnv("PARTICLE_POWER_CHARGE_CURRENT", value));
+    assertEqual(value, (int)POWER_ENV_EXCESSIVE_CHARGE_CURRENT);
+
+    // The charge current is applied as requested even above the input current limit;
+    // the PMIC's VINDPM loop throttles charging at runtime
+    assertTrue(waitAppliedPmicConfig(POWER_ENV_INPUT_CURRENT_LIMIT, POWER_ENV_EXCESSIVE_CHARGE_CURRENT));
+#else
+    skip();
+#endif // POWER_ENV_TESTS
+}
+
+test(22_particle_power_env_restore_init) {
+#if POWER_ENV_TESTS
+    if (skipPowerEnv) {
+        skip();
+        return;
+    }
+    System.clearEnv(false /* reset */);
+    expectSystemReset();
+    System.reset();
+#else
+    skip();
+#endif // POWER_ENV_TESTS
+}
+
+test(23_particle_power_env_restore) {
+#if POWER_ENV_TESTS
+    if (skipPowerEnv) {
+        skip();
+        return;
+    }
+    assertFalse(System.hasEnv("PARTICLE_POWER_INPUT_CURRENT"));
+    assertFalse(System.hasEnv("PARTICLE_POWER_CHARGE_CURRENT"));
+
+    // The defaults are restored
+    assertTrue(waitAppliedPmicConfig(DEFAULT_PMIC_INPUT_CURRENT_LIMIT, DEFAULT_PMIC_CHARGE_CURRENT));
+
+    // Restore the default power configuration
+    SystemPowerConfiguration conf;
+#if HAL_PLATFORM_POWER_MANAGEMENT_OPTIONAL
+    conf.feature(SystemPowerFeature::PMIC_DETECTION);
+#endif
+    assertEqual(System.setPowerConfiguration(conf), 0);
+#else
+    skip();
+#endif // POWER_ENV_TESTS
+}
+
 test(97_cleanup) {
     System.clearEnv(false /* reset */);
     unlink("/sys/env_app");

--- a/user/tests/integration/system/env/env.cpp
+++ b/user/tests/integration/system/env/env.cpp
@@ -615,6 +615,7 @@ test(17_particle_ethernet_enable_cleanup) {
 
 #if HAL_PLATFORM_POWER_MANAGEMENT && HAL_PLATFORM_PMIC_BQ24195 && HAL_PLATFORM_FUELGAUGE_MAX17043
 #define POWER_ENV_TESTS 1
+#include "system_power.h"
 #else
 #define POWER_ENV_TESTS 0
 #endif
@@ -624,8 +625,8 @@ test(17_particle_ethernet_enable_cleanup) {
 namespace {
 
 // Default power configuration values as applied to the PMIC
-const uint16_t DEFAULT_PMIC_INPUT_CURRENT_LIMIT = 900; // mA
-const uint16_t DEFAULT_PMIC_CHARGE_CURRENT = 896; // mA
+const uint16_t DEFAULT_PMIC_INPUT_CURRENT_LIMIT = particle::power::DEFAULT_INPUT_CURRENT_LIMIT;
+const uint16_t DEFAULT_PMIC_CHARGE_CURRENT = particle::power::DEFAULT_CHARGE_CURRENT;
 
 // Env var override values (see env.spec.js)
 const uint16_t POWER_ENV_INPUT_CURRENT_LIMIT = 1200; // mA

--- a/user/tests/integration/system/env/env.spec.js
+++ b/user/tests/integration/system/env/env.spec.js
@@ -108,6 +108,32 @@ test('17_particle_ethernet_enable_cleanup', async function () {
 
 });
 
+test('18_particle_power_env_init', async function() {
+});
+
+test('19_particle_power_env_default', async function() {
+    await setEnvVarsAndFlash({
+        PARTICLE_POWER_INPUT_CURRENT: '1200',
+        PARTICLE_POWER_CHARGE_CURRENT: '1024'
+    });
+});
+
+test('20_particle_power_env_override', async function() {
+    await setEnvVarsAndFlash({
+        PARTICLE_POWER_INPUT_CURRENT: '1200',
+        PARTICLE_POWER_CHARGE_CURRENT: '1408'
+    });
+});
+
+test('21_particle_power_env_charge_above_input_limit', async function() {
+});
+
+test('22_particle_power_env_restore_init', async function() {
+});
+
+test('23_particle_power_env_restore', async function() {
+});
+
 test('97_cleanup', async function() {
     delete this.test.parent.particle.network;
     this.test.parent.particle.suiteInitialized = false;

--- a/user/tests/libraries/unit-test/ParticleFunbag.cpp
+++ b/user/tests/libraries/unit-test/ParticleFunbag.cpp
@@ -530,14 +530,14 @@ void TestRunner::updateLEDStatus() {
 }
 
 void TestRunner::expectSystemReset() {
-    int r = pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 5000);
+    int r = pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000);
     if (r < 0 && Test::current) {
         Test::current->fail();
     }
 }
 
 void TestRunner::expectSafeMode() {
-    int r = pushMailbox(MailboxEntry().type(MailboxEntry::Type::SAFE_MODE_PENDING), 5000);
+    int r = pushMailbox(MailboxEntry().type(MailboxEntry::Type::SAFE_MODE_PENDING), 20000);
     if (r < 0 && Test::current) {
         Test::current->fail();
     }

--- a/user/tests/wiring/acm/acm.cpp
+++ b/user/tests/wiring/acm/acm.cpp
@@ -184,7 +184,7 @@ test(ACM_00_prepare_ethernet) {
     }
 #endif // HAL_PLATFORM_HW_FORM_FACTOR_SOM
     // Notify about a pending reset
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 5000));
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
     System.reset();
 }
 #endif // HAL_PLATFORM_ETHERNET
@@ -393,7 +393,7 @@ test(ACM_14_disable_ethernet) {
     }
 #endif // HAL_PLATFORM_HW_FORM_FACTOR_SOM
     // Notify about a pending reset
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 5000));
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
     System.reset();
 }
 

--- a/user/tests/wiring/ble_central_peripheral/ble_central/central.cpp
+++ b/user/tests/wiring/ble_central_peripheral/ble_central/central.cpp
@@ -81,7 +81,7 @@ void onDisconnectRequested(const char *eventName, const char *data) {
 test(BLE_0000_Check_Feature_Disable_Listening_Mode) {
     if (System.featureEnabled(FEATURE_DISABLE_LISTENING_MODE)) {
         System.disableFeature(FEATURE_DISABLE_LISTENING_MODE);
-        assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 5000));
+        assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
         System.reset();
     }
 }

--- a/user/tests/wiring/ble_central_peripheral/ble_peripheral/peripheral.cpp
+++ b/user/tests/wiring/ble_central_peripheral/ble_peripheral/peripheral.cpp
@@ -76,7 +76,7 @@ test(BLE_0000_Check_Feature_Disable_Listening_Mode) {
     // System.enableFeature(FEATURE_DISABLE_LISTENING_MODE);
     if (System.featureEnabled(FEATURE_DISABLE_LISTENING_MODE)) {
         System.disableFeature(FEATURE_DISABLE_LISTENING_MODE);
-        assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 5000));
+        assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
         System.reset();
     }
 }

--- a/user/tests/wiring/ble_scanner_broadcaster/ble_broadcaster/broadcaster.cpp
+++ b/user/tests/wiring/ble_scanner_broadcaster/ble_broadcaster/broadcaster.cpp
@@ -32,7 +32,7 @@ using namespace particle::test;
 test(BLE_0000_Check_Feature_Disable_Listening_Mode) {
     if (System.featureEnabled(FEATURE_DISABLE_LISTENING_MODE)) {
         System.disableFeature(FEATURE_DISABLE_LISTENING_MODE);
-        assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 5000));
+        assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
         System.reset();
     }
 }

--- a/user/tests/wiring/ble_scanner_broadcaster/ble_scanner/scanner.cpp
+++ b/user/tests/wiring/ble_scanner_broadcaster/ble_scanner/scanner.cpp
@@ -40,7 +40,7 @@ using namespace particle::test;
 test(BLE_0000_Check_Feature_Disable_Listening_Mode) {
     if (System.featureEnabled(FEATURE_DISABLE_LISTENING_MODE)) {
         System.disableFeature(FEATURE_DISABLE_LISTENING_MODE);
-        assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 5000));
+        assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
         System.reset();
     }
 }

--- a/user/tests/wiring/exrtc/exrtc.cpp
+++ b/user/tests/wiring/exrtc/exrtc.cpp
@@ -662,7 +662,7 @@ test(EXRTC_09_power_off_should_succeed_1) {
     assertEqual(ExternalTime.setConfig(config), (int)SYSTEM_ERROR_NONE);
     dumpExrtcConfig("powerOffShouldSucceed");
 
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
     const auto result = System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::POWER_OFF).duration(10s));
     Test::out->printlnf("powerOffShouldSucceed: sleep error=%d", result.error());
     assertEqual(result.error(), (int)SYSTEM_ERROR_NONE);

--- a/user/tests/wiring/network_config/network_config.cpp
+++ b/user/tests/wiring/network_config/network_config.cpp
@@ -379,7 +379,7 @@ test(NETWORK_CONFIG_ETH_01_enable_feature) {
     }
 #endif // HAL_PLATFORM_HW_FORM_FACTOR_SOM
     // Notify about a pending reset
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 5000));
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
     System.reset();
 }
 
@@ -706,7 +706,7 @@ test(NETWORK_CONFIG_ETH_97_reset_cache) {
     // This will reset ethernet pin config to default settings if any were there before
     unlink("/sys/cache.dat");
 
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 5000));
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
     System.reset();
 }
 
@@ -751,7 +751,7 @@ test(NETWORK_CONFIG_ETH_99_disable_feature) {
     }
 #endif // HAL_PLATFORM_HW_FORM_FACTOR_SOM
     // Notify about a pending reset
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 5000));
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
     System.reset();
 }
 #endif // HAL_PLATFORM_ETHERNET

--- a/user/tests/wiring/no_fixture/i2c.cpp
+++ b/user/tests/wiring/no_fixture/i2c.cpp
@@ -336,7 +336,7 @@ hal_i2c_config_t acquireWireBuffer()
     return config;
 }
 test(I2C_06_I2c_FuelGauge_Works_After_Buffer_Config_Disables_Interface_Reset) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
     System.reset();
 }
 

--- a/user/tests/wiring/no_fixture/system.cpp
+++ b/user/tests/wiring/no_fixture/system.cpp
@@ -490,7 +490,7 @@ test(SYSTEM_10_system_ticks_delay) {
 
 #ifdef PARTICLE_TEST_RUNNER
 test(SYSTEM_11_system_reset) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
     System.reset();
 }
 #endif // PARTICLE_TEST_RUNNER

--- a/user/tests/wiring/no_fixture_stress/exflash.cpp
+++ b/user/tests/wiring/no_fixture_stress/exflash.cpp
@@ -206,7 +206,7 @@ test(EXFLASH_02_rtl872x_validate_mode) {
 }
 
 test(EXFLASH_03_rtl872x_validate_mode_after_stop_sleep_and_read_write) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
     SystemSleepResult result = System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::STOP).duration(10s));
     assertEqual(result.error(), SYSTEM_ERROR_NONE);
 
@@ -237,7 +237,7 @@ test(EXFLASH_03_rtl872x_validate_mode_after_stop_sleep_and_read_write) {
 }
 
 test(EXFLASH_04_rtl872x_validate_mode_after_hibernate_sleep_and_read_write) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
     SystemSleepResult result = System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::HIBERNATE).duration(10s));
     assertEqual(result.error(), SYSTEM_ERROR_NONE);
 }

--- a/user/tests/wiring/watchdog/watchdog.cpp
+++ b/user/tests/wiring/watchdog/watchdog.cpp
@@ -105,7 +105,7 @@ test(WATCHDOG_02_default_1) {
     checkState(WatchdogState::CONFIGURED);
 
     // Notify about a pending reset
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 5000));
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 
     assertEqual(0, Watchdog.start());
     assertEqual(0, Watchdog.getInfo(info));
@@ -131,7 +131,7 @@ test(WATCHDOG_02_default_2) {
 test(WATCHDOG_03_stopped_in_hibernate_mode_1) {
     startWatchdog(WatchdogConfiguration().timeout(5s));
     // Notify about a pending reset
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
     System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::HIBERNATE).duration(10s));
 }
 
@@ -142,7 +142,7 @@ test(WATCHDOG_03_stopped_in_hibernate_mode_2) {
 #endif
 
 test(WATCHDOG_04_continue_running_after_waking_up_from_none_hibernate_mode_1) {
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 5000));
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
     startWatchdog(WatchdogConfiguration().timeout(5s).capabilities(WatchdogCap::RESET)); // SLEEP_RUNNING is cleared
     System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::STOP).duration(10s));
     Watchdog.refresh();
@@ -152,7 +152,7 @@ test(WATCHDOG_04_continue_running_after_waking_up_from_none_hibernate_mode_2) {
     checkState(WatchdogState::STARTED);
     Watchdog.refresh();
     // Notify about a pending reset
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 5000));
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
     delay(10000);
     // This should be unreachable, we should get a watchdog reset before the delay expires
     assertFalse(true);
@@ -165,7 +165,7 @@ test(WATCHDOG_04_continue_running_after_waking_up_from_none_hibernate_mode_3) {
 
 test(WATCHDOG_05_system_reset_will_disable_watchdog_1) {
     startWatchdog(WatchdogConfiguration().timeout(5s));
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 1000));
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
     System.reset();
 }
 
@@ -179,7 +179,7 @@ test(WATCHDOG_05_system_reset_will_disable_watchdog_2) {
 test(WATCHDOG_06_default_running_in_none_hibernate_mode_1) {
     startWatchdog(WatchdogConfiguration().timeout(5s));
     // Notify about a pending reset
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 5000));
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
     System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::STOP).duration(10s));
 }
 
@@ -197,7 +197,7 @@ test(WATCHDOG_07_notify_1) {
     });
     startWatchdog(WatchdogConfiguration().timeout(5s).capabilities(WatchdogCap::NOTIFY));
     // Notify about a pending reset
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 5000));
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 }
 
 test(WATCHDOG_07_notify_2) {
@@ -252,7 +252,7 @@ test(WATCHDOG_08_reconfigurable) {
     startWatchdog(WatchdogConfiguration().timeout(10s));
     delay(5s);
     // Notify about a pending reset
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 5000));
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 }
 
 static void checkError(system_tick_t expectedTo) {
@@ -318,7 +318,7 @@ test(WATCHDOG_EXT_02_timeout_reset) {
     assertEqual(0, ExternalWatchdog.init(WatchdogConfiguration().timeout(5s)));
     checkExternalWatchdogState(WatchdogState::CONFIGURED);
 
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 5000));
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 
     assertEqual(0, ExternalWatchdog.start());
     assertEqual(0, ExternalWatchdog.getInfo(info));
@@ -354,7 +354,7 @@ test(WATCHDOG_EXT_04_reconfigurable) {
     delay(4s);
     startExternalWatchdog(WatchdogConfiguration().timeout(10s));
     delay(5s);
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 5000));
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
 }
 
 test(WATCHDOG_EXT_05_hibernate_mode_running) {
@@ -363,7 +363,7 @@ test(WATCHDOG_EXT_05_hibernate_mode_running) {
         return;
     }
     startExternalWatchdog(WatchdogConfiguration().timeout(5s));
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
     System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::HIBERNATE));
     assertFalse(true);
 }
@@ -375,7 +375,7 @@ test(WATCHDOG_EXT_06_running_after_waking_up) {
     }
     startExternalWatchdog(WatchdogConfiguration().timeout(10s));
 
-    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 10000));
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 20000));
     auto result = System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::STOP).duration(5s));
     assertEqual((int)result.wakeupReason(), (int)SystemSleepWakeupReason::BY_RTC);
 


### PR DESCRIPTION
### Feature

- Implements power manager env vars
  - Implements two new env vars for Power Manager, `PARTICLE_POWER_INPUT_CURRENT` and `PARTICLE_POWER_CHARGE_CURRENT` which may be used to override default or user set `SystemPowerConfiguration ::powerSourceMaxCurrent` and `SystemPowerConfiguration:: batteryChargeCurrent` respectively.  Values will be checked and validated by System Power Manager when configuration is loaded.  Please use official documentation to set values appropriately.

### Internal

- #### [gen 3] reclaim >3KB flash w/`-flto-partition=one`

#### What

Add `-flto-partition=one` to the LTO_EXTRA_OPTIMIZATIONS link flags in `build/arm-tools.mk` (the `USE_LTO=1`
branch). Affects only LTO-enabled links `system-part1` on the Gen 3 platforms (minus argon)
that set `FORCE_LTO=1`. Non-LTO builds are untouched.

```diff
ifneq ($(LTO_EXTRA_OPTIMIZATIONS),)
-CFLAGS += -fmerge-all-constants
-LDFLAGS += -fmerge-all-constants
+CFLAGS += -fmerge-all-constants -flto-partition=one
+LDFLAGS += -fmerge-all-constants -flto-partition=one
endif
```

#### Why

`system-part1` is at the flash ceiling on boron, bsom, b5som, tracker, esomx.  Recent changes have overflowed
`APP_FLASH` on bsom.

By default GCC splits LTO code generation into ~32 partitions. Partition boundaries are
optimization barriers: cross-partition calls can't inline and identical constants/strings
can't merge.

`-flto-partition=one` generates code in a single partition: no boundaries.

#### Result (bsom, exact CI flags, gcc-arm 10.2.1)

| | default (~32 partitions) | `-flto-partition=one` | Δ |
|---|---|---|---|
| system-part1.bin | 573,072 | 569,960 | **−3,112 bytes** |
| headroom (573,440 region) | 368 | 3,480 | ~9.5× |

Recovers >3 KB on the most constrained platforms

#### Trade-offs / risk

- **Link time & memory**: single-partition codegen is serial and holds the whole program in
  one process, minutes-scale, hundreds of MB. Watch CI builder memory on first run.
  Fallback if it bites: `-flto-partition=balanced --param lto-partitions=8` (deterministic
  count, parallel, most of the size win).
- More aggressive inlining can surface latent bugs (same risk class as a toolchain bump), 
  will validate with a complete HIL test on all platforms.

### Steps to Test

- Run `system/env` tests
- Run all HIL tests

### References

- [sc-139793]