### PR TITLE
Do not test network connections if no networks are ready

### DIFF
--- a/system/src/system_connection_manager.cpp
+++ b/system/src/system_connection_manager.cpp
@@ -529,6 +529,11 @@ int ConnectionTester::generateTestPacket(ConnectionMetrics* metrics) {
 }
 
 int ConnectionTester::pollSockets(struct pollfd* pfds, int socketCount) {
+    if (socketCount <= 0) {
+        // No sockets to poll, skip calling sock_poll()
+        return 0;
+    }
+
     int pollCount = sock_poll(pfds, socketCount, 1 /* ms */);
 
     if (pollCount < 0) {
@@ -688,6 +693,11 @@ int ConnectionTester::prepare(bool fullTest, bool lastTestFailed) {
             r = SYSTEM_ERROR_NONE;
             break;
         }
+    }
+
+    // No networks are Ready
+    if (!r && socketCount == 0) {
+        r = SYSTEM_ERROR_NETWORK;
     }
 
     if (!r) {


### PR DESCRIPTION
### Problem

It is possible to prepare a network connection test in response to a cloud connection error and have no networks in the Ready state by the time the background connection test runs. This results in lwip errors when trying to poll when no sockets are connected. 

### Solution

Confirm we have connected sockets when preparing a network connection test. Fail if we do not. This should be reported and logged in `handle_cfod()`

Add another check to `pollSockets()` to return error if asked to poll 0 socket count. 

### Steps to Test
Force an `Internet_Test()` when no interfaces are ready, but the system cloud address is cached. This will let prepare() proceed to the case where 0 socket poll descriptors should be created, caught and returned as an errror

### Example App
any
