### PR TITLE
[test] Add OTA flash to ensure device service OTA attempts are reset

### DIFF
--- a/user/tests/integration/00_before/before.cpp
+++ b/user/tests/integration/00_before/before.cpp
@@ -120,7 +120,17 @@ void completeFirmwareUpdate(bool expectSafeMode = false) {
 
 } // namespace
 
-test(01_erase_factory_module) {
+test(01_ota_self_flash_start) {
+    prepareForFirmwareUpdate();
+    Particle.connect();
+    assertTrue(waitFor(Particle.connected, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
+}
+
+test(02_ota_self_flash_finalize) {
+    completeFirmwareUpdate();
+}
+
+test(03_erase_factory_module) {
     // Determine the factory reset module start address from the platform flash modules
     hal_module_t factoryModule = {};
     bool isFactoryModule = getFactoryModule(&factoryModule);
@@ -134,17 +144,17 @@ test(01_erase_factory_module) {
     }
 }
 
-test(02_remove_static_ip) {
+test(04_remove_static_ip) {
     // Easiest way to erase all NETWORK_CONFIG settings, and default to dynamic IP
     unlink("/sys/network.dat");
 }
 
-test(03_enable_listening_mode) {
+test(05_enable_listening_mode) {
     System.disableFeature(FEATURE_DISABLE_LISTENING_MODE);
 }
 
 #if HAL_PLATFORM_ENV
-test(04_clear_env) {
+test(06_clear_env) {
     System.clearEnv(false /* reset */);
     unlink("/sys/env_app");
     unlink("/sys/env_app.staged");
@@ -155,7 +165,7 @@ test(04_clear_env) {
     System.reset();
 }
 
-test(05_restore_cloud_after_env_clear) {
+test(07_restore_cloud_after_env_clear) {
     prepareForFirmwareUpdate();
     Particle.disconnect(CloudDisconnectOptions().clearSession(true));
     Particle.connect();
@@ -163,13 +173,13 @@ test(05_restore_cloud_after_env_clear) {
     // We are supposed to get an empty env
 }
 
-test(06_finalize_env_clear) {
+test(08_finalize_env_clear) {
     completeFirmwareUpdate();
 }
 
 #endif // HAL_PLATFORM_ENV
 
-test(07_disable_external_rtc) {
+test(09_disable_external_rtc) {
 #if HAL_PLATFORM_EXTERNAL_RTC
     assertEqual(ExternalTime.disable(), (int)SYSTEM_ERROR_NONE);
     expectSystemReset();
@@ -177,7 +187,7 @@ test(07_disable_external_rtc) {
 #endif
 }
 
-test(08_verify_external_rtc_default_state) {
+test(10_verify_external_rtc_default_state) {
 #if HAL_PLATFORM_EXTERNAL_RTC
     const auto status = ExternalTime.status();
     assertTrue(status.valid());
@@ -191,7 +201,7 @@ test(08_verify_external_rtc_default_state) {
 #endif
 }
 
-test(09_report_muon_presence) {
+test(11_report_muon_presence) {
 #if HAL_PLATFORM_EXTERNAL_RTC_OPTIONAL && HAL_PLATFORM_HW_FORM_FACTOR_SOM
     assertEqual(0, pushMailboxMsg(particle::test::detectMuonBoard() ? "muon=true" : "muon=false", 5000));
 #else
@@ -199,7 +209,7 @@ test(09_report_muon_presence) {
 #endif
 }
 
-test(10_configure_muon_board_and_exrtc) {
+test(12_configure_muon_board_and_exrtc) {
 #if HAL_PLATFORM_EXTERNAL_RTC_OPTIONAL && HAL_PLATFORM_HW_FORM_FACTOR_SOM
     if (!particle::test::detectMuonBoard()) {
         skip();
@@ -212,7 +222,7 @@ test(10_configure_muon_board_and_exrtc) {
 #endif
 }
 
-test(11_verify_muon_exrtc_configuration) {
+test(13_verify_muon_exrtc_configuration) {
 #if HAL_PLATFORM_EXTERNAL_RTC_OPTIONAL && HAL_PLATFORM_HW_FORM_FACTOR_SOM
     if (!particle::test::detectMuonBoard()) {
         skip();

--- a/user/tests/integration/00_before/before.spec.js
+++ b/user/tests/integration/00_before/before.spec.js
@@ -6,7 +6,8 @@ systemThread('enabled');
 const { unsetDeviceVariables } = require('../test/env');
 const Particle = require('particle-api-js');
 
-const { waitFlashStatusEvent } = require('../test/ota');
+const { waitFlashStatusEvent, flash } = require('../test/ota');
+const { readFile } = require('fs').promises;
 
 let device;
 let deviceId;
@@ -29,46 +30,60 @@ after(function() {
     device.removeAllListeners('mailbox');
 });
 
-test('01_erase_factory_module', async function () {
+test('01_ota_self_flash_start', async function () {
+    this.timeout(10 * 60 * 1000);
+    const appData = await readFile(device.testAppBinFile);
+    // Reset device-service OTA flash attempt count by OTA flashing the current app test binary.
+    // This should ensure that subsequent OTA downloads (like repeated empty env var asset OTAs) 
+    // should succeed for the duration of the test runner suites as long as we do not exceed the
+    // device service maxSameBinaryAttempts threshold (defaults to 30).
+    await flash(this, appData, { filename: '00_before.bin' });
+});
+
+test('02_ota_self_flash_finalize', async function () {
 
 });
 
-test('02_remove_static_ip', async function () {
+test('03_erase_factory_module', async function () {
 
 });
 
-test('03_enable_listening_mode', async function () {
+test('04_remove_static_ip', async function () {
 
 });
 
-test('04_clear_env', async function () {
+test('05_enable_listening_mode', async function () {
+
+});
+
+test('06_clear_env', async function () {
     await unsetDeviceVariables(api, deviceId);
 });
 
-test('05_restore_cloud_after_env_clear', async function () {
+test('07_restore_cloud_after_env_clear', async function () {
     await waitFlashStatusEvent(this, { status: 'success' });
 });
 
-test('06_finalize_env_clear', async function () {
+test('08_finalize_env_clear', async function () {
 });
 
-test('07_disable_external_rtc', async function() {
+test('09_disable_external_rtc', async function() {
 });
 
-test('08_verify_external_rtc_default_state', async function() {
+test('10_verify_external_rtc_default_state', async function() {
 
 });
 
-test('09_report_muon_presence', async function() {
+test('11_report_muon_presence', async function() {
     const msg = device.mailBox.pop();
     console.log(`Muon detected: ${msg.d === 'muon=true' ? 'yes' : 'no'}`);
 });
 
-test('10_configure_muon_board_and_exrtc', async function() {
+test('12_configure_muon_board_and_exrtc', async function() {
 
 });
 
-test('11_verify_muon_exrtc_configuration', async function() {
+test('13_verify_muon_exrtc_configuration', async function() {
 
 });
 


### PR DESCRIPTION
### Problem

On repeated test-runner runs, its possible for devices to hit the device service `maxSameBinaryAttempts` threshold and no longer initiate OTA updates. This mostly affects env var tests since they generate multiple empty env var asset OTAs which are counted as identical OTA binary attempts since they are indeed the same asset being sent multiple times. 

Once a device hits this count, it is not reset until a new app/asset binary is sent. In this state, the device tests will timeout waiting for OTA event completions since the server blocked the OTA attempt in the first place. This will typically manifest as failures in the `99_cleanup_XX` tests.

### Solution

At the start of the test runner suite, do a dummy OTA flash update in order to reset the `maxSameBinaryAttempts` counter. This will give the suite a budget of repeat OTA attempts and hopefully avoid devices getting stuck in this state. 

### Steps to Test
```
device-os-test  --device-os-dir=/path/to/device-os build msom 00_before -- -fixture
device-os-test  --device-os-dir=/path/to/device-os run msom 00_before -- -fixture
```

### Example App


### References

Links to the Community, Docs, Other Issues, etc..

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
