### PR TITLE
USB Serial/UART serial buffer read/write/peek + wait event

### DIFF
--- a/hal/inc/hal_dynalib_usart.h
+++ b/hal/inc/hal_dynalib_usart.h
@@ -81,6 +81,10 @@ DYNALIB_FN(BASE_IDX2 + 3, hal_usart, hal_usart_break_detected, uint8_t(hal_usart
 DYNALIB_FN(BASE_IDX2 + 4, hal_usart, hal_usart_sleep, int(hal_usart_interface_t serial, bool, void*))
 DYNALIB_FN(BASE_IDX2 + 5, hal_usart, hal_usart_init_ex, int(hal_usart_interface_t, const hal_usart_buffer_config_t*, void*))
 DYNALIB_FN(BASE_IDX2 + 6, hal_usart, hal_usart_get_features, int(hal_usart_interface_t, uint32_t*, void*))
+DYNALIB_FN(BASE_IDX2 + 7, hal_usart, hal_usart_write_buffer, int(hal_usart_interface_t, const void*, size_t, size_t))
+DYNALIB_FN(BASE_IDX2 + 8, hal_usart, hal_usart_read_buffer, int(hal_usart_interface_t, void*, size_t, size_t))
+DYNALIB_FN(BASE_IDX2 + 9, hal_usart, hal_usart_peek_buffer, int(hal_usart_interface_t, void*, size_t, size_t))
+DYNALIB_FN(BASE_IDX2 + 10, hal_usart, hal_usart_wait_event, int(hal_usart_interface_t, uint32_t, system_tick_t, void*))
 
 DYNALIB_END(hal_usart)
 

--- a/hal/inc/hal_dynalib_usb.h
+++ b/hal/inc/hal_dynalib_usb.h
@@ -107,6 +107,16 @@ DYNALIB_FN(BASE_IDX4 + 1, hal_usb, HAL_USB_HID_Set_State, uint8_t(uint8_t, uint8
 
 #ifdef USB_VENDOR_REQUEST_ENABLE
 DYNALIB_FN(BASE_IDX5 + 0, hal_usb, HAL_USB_Set_Vendor_Request_State_Callback, void(HAL_USB_Vendor_Request_State_Callback, void*))
+# define BASE_IDX6 (BASE_IDX5 + 1)
+#else
+# define BASE_IDX6 BASE_IDX5
+#endif
+
+#ifdef USB_CDC_ENABLE
+DYNALIB_FN_WRAP(BASE_IDX6 + 0, hal_usb, HAL_USB_USART_Send_Buffer, protected, int32_t(HAL_USB_USART_Serial, const void*, size_t))
+DYNALIB_FN_WRAP(BASE_IDX6 + 1, hal_usb, HAL_USB_USART_Receive_Buffer, protected, int32_t(HAL_USB_USART_Serial, void*, size_t))
+DYNALIB_FN_WRAP(BASE_IDX6 + 2, hal_usb, HAL_USB_USART_Peek_Buffer, protected, int32_t(HAL_USB_USART_Serial, void*, size_t))
+DYNALIB_FN_WRAP(BASE_IDX6 + 3, hal_usb, HAL_USB_USART_Wait_Event, protected, int(HAL_USB_USART_Serial, uint32_t, system_tick_t, void*))
 #endif
 
 DYNALIB_END(hal_usb)
@@ -117,5 +127,6 @@ DYNALIB_END(hal_usb)
 #undef BASE_IDX3
 #undef BASE_IDX4
 #undef BASE_IDX5
+#undef BASE_IDX6
 
 #endif  /* HAL_DYNALIB_USB_H */

--- a/hal/inc/usart_hal.h
+++ b/hal/inc/usart_hal.h
@@ -31,6 +31,7 @@
 #include <unistd.h>
 #include "platforms.h"
 #include "hal_platform.h"
+#include "system_tick_hal.h"
 
 /* Includes ------------------------------------------------------------------*/
 // #include "pinmap_hal.h"
@@ -163,11 +164,18 @@ void hal_usart_send_break(hal_usart_interface_t serial, void* reserved);
 uint8_t hal_usart_break_detected(hal_usart_interface_t serial);
 int hal_usart_sleep(hal_usart_interface_t serial, bool sleep, void* reserved);
 
-ssize_t hal_usart_write_buffer(hal_usart_interface_t serial, const void* buffer, size_t size, size_t elementSize);
-ssize_t hal_usart_read_buffer(hal_usart_interface_t serial, void* buffer, size_t size, size_t elementSize);
-ssize_t hal_usart_peek_buffer(hal_usart_interface_t serial, void* buffer, size_t size, size_t elementSize);
+int hal_usart_write_buffer(hal_usart_interface_t serial, const void* buffer, size_t size, size_t elementSize);
+int hal_usart_read_buffer(hal_usart_interface_t serial, void* buffer, size_t size, size_t elementSize);
+int hal_usart_peek_buffer(hal_usart_interface_t serial, void* buffer, size_t size, size_t elementSize);
 
 int hal_usart_get_features(hal_usart_interface_t serial, uint32_t* features, void* reserved);
+
+typedef enum hal_usart_event_t {
+    HAL_USART_EVENT_READABLE = 0x01,
+    HAL_USART_EVENT_WRITABLE = 0x02,
+} hal_usart_event_t;
+
+int hal_usart_wait_event(hal_usart_interface_t serial, uint32_t events, system_tick_t timeout, void* reserved);
 
 #ifdef __cplusplus
 }

--- a/hal/inc/usb_hal.h
+++ b/hal/inc/usb_hal.h
@@ -30,6 +30,7 @@
 /* Includes ------------------------------------------------------------------*/
 #include <stdint.h>
 #include <stdbool.h>
+#include <sys/types.h>
 /* Exported types ------------------------------------------------------------*/
 
 /* Exported constants --------------------------------------------------------*/
@@ -37,6 +38,7 @@
 /* Exported macros ------------------------------------------------------------*/
 
 #include "usb_config_hal.h"
+#include "system_tick_hal.h"
 
 #ifdef USE_STDPERIPH_DRIVER
 // this is one way to determine if the platform module is being used or not
@@ -214,6 +216,17 @@ SECURITY_MODE_PROTECTED_FN(void, HAL_USB_USART_Flush_Data, (HAL_USB_USART_Serial
 bool HAL_USB_USART_Is_Enabled(HAL_USB_USART_Serial serial);
 bool HAL_USB_USART_Is_Connected(HAL_USB_USART_Serial serial);
 int32_t HAL_USB_USART_LineCoding_BitRate_Handler(void (*handler)(uint32_t bitRate), void* reserved);
+
+SECURITY_MODE_PROTECTED_FN(int32_t, HAL_USB_USART_Send_Buffer, (HAL_USB_USART_Serial serial, const void* data, size_t size));
+SECURITY_MODE_PROTECTED_FN(int32_t, HAL_USB_USART_Receive_Buffer, (HAL_USB_USART_Serial serial, void* data, size_t size));
+SECURITY_MODE_PROTECTED_FN(int32_t, HAL_USB_USART_Peek_Buffer, (HAL_USB_USART_Serial serial, void* data, size_t size));
+
+typedef enum HAL_USB_USART_Event {
+    HAL_USB_USART_EVENT_READABLE = 0x01,
+    HAL_USB_USART_EVENT_WRITABLE = 0x02,
+} HAL_USB_USART_Event;
+
+SECURITY_MODE_PROTECTED_FN(int, HAL_USB_USART_Wait_Event, (HAL_USB_USART_Serial serial, uint32_t events, system_tick_t timeout, void* reserved));
 #endif
 
 #ifdef USB_HID_ENABLE

--- a/hal/shared/serial_usb_stream.cpp
+++ b/hal/shared/serial_usb_stream.cpp
@@ -83,7 +83,7 @@ int SerialUSBStream::read(char* data, size_t size) {
     if (size == 0) {
         return 0;
     }
-    
+
     return hal_usb_cdc_pvt_recv_data(data, size);
 }
 
@@ -93,17 +93,8 @@ int SerialUSBStream::peek(char* data, size_t size) {
     }
     if (size == 0) {
         return 0;
-    } else if (size > 1) {
-        // Only support peeking first byte
-        return SYSTEM_ERROR_NOT_SUPPORTED;
     }
-
-    auto r = HAL_USB_USART_Receive_Data(serial_, 1);
-    if (r >= 0) {
-        *data = r;
-    }
-
-    return r;
+    return HAL_USB_USART_Peek_Buffer(serial_, data, size);
 }
 
 int SerialUSBStream::skip(size_t size) {

--- a/hal/src/gcc/socket_hal.cpp
+++ b/hal/src/gcc/socket_hal.cpp
@@ -296,6 +296,14 @@ sock_result_t socket_receive(sock_handle_t sd, void* buffer, socklen_t len, syst
     return result;
 }
 
+sock_result_t socket_native_fd(sock_handle_t sd)
+{
+    auto& handle = tcp_from(sd);
+    if (!is_valid(handle))
+        return -1;
+    return handle.native_handle();
+}
+
 sock_result_t socket_send(sock_handle_t sd, const void* buffer, socklen_t len)
 {
     auto& socket = tcp_from(sd);

--- a/hal/src/gcc/usart_hal.cpp
+++ b/hal/src/gcc/usart_hal.cpp
@@ -2,6 +2,10 @@
 #include "usart_hal.h"
 #include "system_error.h"
 #include "socket_hal.h"
+#include <sys/poll.h>
+#include <stdint.h>
+
+sock_result_t socket_native_fd(sock_handle_t sd);
 
 struct UsartRingBuffer {
     uint8_t* buffer;
@@ -18,6 +22,8 @@ struct Usart {
     virtual int32_t availableForWrite()=0;
     virtual int32_t read()=0;
     virtual int32_t peek()=0;
+    virtual int32_t peekAt(uint16_t offset)=0;
+    virtual sock_handle_t socketHandle()=0;
     virtual uint32_t write(uint8_t byte)=0;
     virtual void flush()=0;
 
@@ -107,6 +113,16 @@ class SocketUsartBase : public Usart
         virtual int32_t peek() override {
             fillFromSocketIfNeeded();
             return read_char(true);
+        }
+        virtual int32_t peekAt(uint16_t offset) override {
+            fillFromSocketIfNeeded();
+            if (((rx.size + rx.head - rx.tail) % rx.size) <= offset) {
+                return -1;
+            }
+            return rx.buffer[(rx.tail + offset) % rx.size];
+        }
+        virtual sock_handle_t socketHandle() override {
+            return socket;
         }
         virtual uint32_t write(uint8_t byte) override {
             if (!initSocket())
@@ -314,8 +330,8 @@ int hal_usart_peek_buffer(hal_usart_interface_t serial, void* buffer, size_t siz
     }
     uint8_t* p = (uint8_t*)buffer;
     size_t n = 0;
-    while (n < size) {
-        int32_t c = hal_usart_peek(serial);
+    while (n < size && n <= UINT16_MAX) {
+        int32_t c = usartMap(serial).peekAt((uint16_t)n);
         if (c < 0) {
             break;
         }
@@ -325,5 +341,38 @@ int hal_usart_peek_buffer(hal_usart_interface_t serial, void* buffer, size_t siz
 }
 
 int hal_usart_wait_event(hal_usart_interface_t serial, uint32_t events, system_tick_t timeout, void* reserved) {
-    return SYSTEM_ERROR_NOT_SUPPORTED;
+    if (!events) {
+        return 0;
+    }
+    uint32_t res = 0;
+    if ((events & HAL_USART_EVENT_READABLE) && hal_usart_available(serial) > 0) {
+        res |= HAL_USART_EVENT_READABLE;
+    }
+    if ((events & HAL_USART_EVENT_WRITABLE) && hal_usart_available_data_for_write(serial) > 0) {
+        res |= HAL_USART_EVENT_WRITABLE;
+    }
+    if (res || timeout == 0 || !(events & HAL_USART_EVENT_READABLE)) {
+        return res;
+    }
+    int fd = socket_native_fd(usartMap(serial).socketHandle());
+    if (fd >= 0) {
+        struct pollfd rd = {
+            .fd = fd,
+            .events = POLLIN | POLLRDBAND | POLLRDNORM | POLLPRI,
+            .revents = 0
+        };
+        int pollTimeout = timeout > (system_tick_t)INT32_MAX ? -1 : (int)timeout;
+        if (poll(&rd, 1, pollTimeout) > 0 && hal_usart_available(serial) > 0) {
+            res |= HAL_USART_EVENT_READABLE;
+        }
+    } else {
+        for (system_tick_t waited = 0; waited < timeout; waited++) {
+            usleep(1000);
+            if (hal_usart_available(serial) > 0) {
+                res |= HAL_USART_EVENT_READABLE;
+                break;
+            }
+        }
+    }
+    return res;
 }

--- a/hal/src/gcc/usart_hal.cpp
+++ b/hal/src/gcc/usart_hal.cpp
@@ -1,5 +1,6 @@
 /* Includes ------------------------------------------------------------------*/
 #include "usart_hal.h"
+#include "system_error.h"
 #include "socket_hal.h"
 
 struct UsartRingBuffer {
@@ -278,4 +279,51 @@ uint8_t hal_usart_break_detected(hal_usart_interface_t serial)
 int hal_usart_sleep(hal_usart_interface_t serial, bool sleep, void* reserved)
 {
     return 0;
+}
+
+int hal_usart_write_buffer(hal_usart_interface_t serial, const void* buffer, size_t size, size_t elementSize) {
+    if (elementSize != sizeof(uint8_t)) {
+        return SYSTEM_ERROR_NOT_SUPPORTED;
+    }
+    const uint8_t* p = (const uint8_t*)buffer;
+    for (size_t i = 0; i < size; i++) {
+        hal_usart_write(serial, p[i]);
+    }
+    return size;
+}
+
+int hal_usart_read_buffer(hal_usart_interface_t serial, void* buffer, size_t size, size_t elementSize) {
+    if (elementSize != sizeof(uint8_t)) {
+        return SYSTEM_ERROR_NOT_SUPPORTED;
+    }
+    uint8_t* p = (uint8_t*)buffer;
+    size_t n = 0;
+    while (n < size) {
+        int32_t c = hal_usart_read(serial);
+        if (c < 0) {
+            break;
+        }
+        p[n++] = (uint8_t)c;
+    }
+    return n;
+}
+
+int hal_usart_peek_buffer(hal_usart_interface_t serial, void* buffer, size_t size, size_t elementSize) {
+    if (elementSize != sizeof(uint8_t)) {
+        return SYSTEM_ERROR_NOT_SUPPORTED;
+    }
+    uint8_t* p = (uint8_t*)buffer;
+    size_t n = 0;
+    while (n < size) {
+        int32_t c = hal_usart_peek(serial);
+        if (c < 0) {
+            break;
+        }
+        p[n++] = (uint8_t)c;
+    }
+    return n;
+}
+
+int hal_usart_wait_event(hal_usart_interface_t serial, uint32_t events, system_tick_t timeout, void* reserved) {
+    return SYSTEM_ERROR_NOT_SUPPORTED;
 }

--- a/hal/src/gcc/usb_hal.cpp
+++ b/hal/src/gcc/usb_hal.cpp
@@ -25,6 +25,7 @@
 
 /* Includes ------------------------------------------------------------------*/
 #include "usb_hal.h"
+#include "system_error.h"
 #include <stdint.h>
 #include <iostream>
 #include <stdio.h>
@@ -209,6 +210,44 @@ void USB_USART_LineCoding_BitRate_Handler(void (*handler)(uint32_t bitRate))
 int32_t USB_USART_Flush_Output(unsigned timeout, void* reserved)
 {
     return 0;
+}
+
+int32_t HAL_USB_USART_Send_Buffer(HAL_USB_USART_Serial serial, const void* data, size_t size) {
+    const uint8_t* p = (const uint8_t*)data;
+    for (size_t i = 0; i < size; i++) {
+        HAL_USB_USART_Send_Data(serial, p[i]);
+    }
+    return size;
+}
+
+int32_t HAL_USB_USART_Receive_Buffer(HAL_USB_USART_Serial serial, void* data, size_t size) {
+    uint8_t* p = (uint8_t*)data;
+    size_t n = 0;
+    while (n < size) {
+        int32_t c = HAL_USB_USART_Receive_Data(serial, false);
+        if (c < 0) {
+            break;
+        }
+        p[n++] = (uint8_t)c;
+    }
+    return n;
+}
+
+int32_t HAL_USB_USART_Peek_Buffer(HAL_USB_USART_Serial serial, void* data, size_t size) {
+    uint8_t* p = (uint8_t*)data;
+    size_t n = 0;
+    while (n < size) {
+        int32_t c = HAL_USB_USART_Receive_Data(serial, true);
+        if (c < 0) {
+            break;
+        }
+        p[n++] = (uint8_t)c;
+    }
+    return n;
+}
+
+int HAL_USB_USART_Wait_Event(HAL_USB_USART_Serial serial, uint32_t events, system_tick_t timeout, void* reserved) {
+    return SYSTEM_ERROR_NOT_SUPPORTED;
 }
 
 #ifdef USB_VENDOR_REQUEST_ENABLE

--- a/hal/src/gcc/usb_hal.cpp
+++ b/hal/src/gcc/usb_hal.cpp
@@ -234,20 +234,41 @@ int32_t HAL_USB_USART_Receive_Buffer(HAL_USB_USART_Serial serial, void* data, si
 }
 
 int32_t HAL_USB_USART_Peek_Buffer(HAL_USB_USART_Serial serial, void* data, size_t size) {
-    uint8_t* p = (uint8_t*)data;
-    size_t n = 0;
-    while (n < size) {
-        int32_t c = HAL_USB_USART_Receive_Data(serial, true);
-        if (c < 0) {
-            break;
-        }
-        p[n++] = (uint8_t)c;
+    if (size == 0) {
+        return 0;
     }
-    return n;
+    int32_t c = HAL_USB_USART_Receive_Data(serial, true);
+    if (c < 0) {
+        return 0;
+    }
+    *(uint8_t*)data = (uint8_t)c;
+    return 1;
 }
 
 int HAL_USB_USART_Wait_Event(HAL_USB_USART_Serial serial, uint32_t events, system_tick_t timeout, void* reserved) {
-    return SYSTEM_ERROR_NOT_SUPPORTED;
+    if (!events) {
+        return 0;
+    }
+    uint32_t res = 0;
+    if (events & HAL_USB_USART_EVENT_WRITABLE) {
+        res |= HAL_USB_USART_EVENT_WRITABLE;
+    }
+    if (events & HAL_USB_USART_EVENT_READABLE) {
+        if (last >= 0) {
+            res |= HAL_USB_USART_EVENT_READABLE;
+        } else {
+            struct pollfd stdin_poll = {
+                .fd = STDIN_FILENO,
+                .events = POLLIN | POLLRDBAND | POLLRDNORM | POLLPRI,
+                .revents = 0
+            };
+            int pollTimeout = timeout > (system_tick_t)INT32_MAX ? -1 : (int)timeout;
+            if (poll(&stdin_poll, 1, res ? 0 : pollTimeout) > 0) {
+                res |= HAL_USB_USART_EVENT_READABLE;
+            }
+        }
+    }
+    return res;
 }
 
 #ifdef USB_VENDOR_REQUEST_ENABLE

--- a/hal/src/nRF52840/usart_hal.cpp
+++ b/hal/src/nRF52840/usart_hal.cpp
@@ -937,20 +937,20 @@ bool hal_usart_is_enabled(hal_usart_interface_t serial) {
     return usart->isEnabled();
 }
 
-ssize_t hal_usart_write_buffer(hal_usart_interface_t serial, const void* buffer, size_t size, size_t elementSize) {
+int hal_usart_write_buffer(hal_usart_interface_t serial, const void* buffer, size_t size, size_t elementSize) {
     auto usart = CHECK_TRUE_RETURN(getInstance(serial), SYSTEM_ERROR_NOT_FOUND);
     CHECK_TRUE(elementSize == sizeof(uint8_t), SYSTEM_ERROR_INVALID_ARGUMENT);
     usart->pump();
     return usart->write((const uint8_t*)buffer, size);
 }
 
-ssize_t hal_usart_read_buffer(hal_usart_interface_t serial, void* buffer, size_t size, size_t elementSize) {
+int hal_usart_read_buffer(hal_usart_interface_t serial, void* buffer, size_t size, size_t elementSize) {
     auto usart = CHECK_TRUE_RETURN(getInstance(serial), SYSTEM_ERROR_NOT_FOUND);
     CHECK_TRUE(elementSize == sizeof(uint8_t), SYSTEM_ERROR_INVALID_ARGUMENT);
     return usart->read((uint8_t*)buffer, size);
 }
 
-ssize_t hal_usart_peek_buffer(hal_usart_interface_t serial, void* buffer, size_t size, size_t elementSize) {
+int hal_usart_peek_buffer(hal_usart_interface_t serial, void* buffer, size_t size, size_t elementSize) {
     auto usart = CHECK_TRUE_RETURN(getInstance(serial), SYSTEM_ERROR_NOT_FOUND);
     CHECK_TRUE(elementSize == sizeof(uint8_t), SYSTEM_ERROR_INVALID_ARGUMENT);
     return usart->peek((uint8_t*)buffer, size);
@@ -1017,6 +1017,11 @@ int hal_usart_pvt_disable_event(hal_usart_interface_t serial, HAL_USART_Pvt_Even
 int hal_usart_pvt_wait_event(hal_usart_interface_t serial, uint32_t events, system_tick_t timeout) {
     auto usart = CHECK_TRUE_RETURN(getInstance(serial), SYSTEM_ERROR_NOT_FOUND);
     return usart->waitEvent(events, timeout);
+}
+
+int hal_usart_wait_event(hal_usart_interface_t serial, uint32_t events, system_tick_t timeout, void* reserved) {
+    (void)reserved;
+    return hal_usart_pvt_wait_event(serial, events, timeout);
 }
 
 int hal_usart_sleep(hal_usart_interface_t serial, bool sleep, void* reserved) {

--- a/hal/src/nRF52840/usb_hal.cpp
+++ b/hal/src/nRF52840/usb_hal.cpp
@@ -155,15 +155,7 @@ int32_t HAL_USB_USART_Peek_Buffer(HAL_USB_USART_Serial serial, void* data, size_
     if (size == 0) {
         return 0;
     }
-    int32_t available = usb_uart_available_rx_data();
-    if (available <= 0) {
-        return 0;
-    }
-    size_t toPeek = std::min((size_t)available, size);
-    for (size_t i = 0; i < toPeek; i++) {
-        ((uint8_t*)data)[i] = usb_uart_peek_rx_data(i);
-    }
-    return toPeek;
+    return usb_uart_peek_rx_buffer((uint8_t*)data, size);
 }
 
 int HAL_USB_USART_Wait_Event(HAL_USB_USART_Serial serial, uint32_t events, system_tick_t timeout, void* reserved) {

--- a/hal/src/nRF52840/usb_hal.cpp
+++ b/hal/src/nRF52840/usb_hal.cpp
@@ -18,7 +18,9 @@
 #include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
+#include <algorithm>
 #include "usb_hal.h"
+#include "usb_hal_private.h"
 #include "usb_hal_cdc.h"
 #include "usb_settings.h"
 #include <mutex>
@@ -130,6 +132,66 @@ int32_t HAL_USB_USART_Send_Data(HAL_USB_USART_Serial serial, uint8_t data) {
 int32_t HAL_USB_USART_Send_Data_protected(HAL_USB_USART_Serial serial, uint8_t data) {
     CHECK_SECURITY_MODE_PROTECTED();
     return HAL_USB_USART_Send_Data(serial, data);
+}
+
+int32_t HAL_USB_USART_Send_Buffer(HAL_USB_USART_Serial serial, const void* data, size_t size) {
+    if (serial != HAL_USB_USART_SERIAL) {
+        return SYSTEM_ERROR_INVALID_ARGUMENT;
+    }
+    return hal_usb_cdc_pvt_send_data((const char*)data, size);
+}
+
+int32_t HAL_USB_USART_Receive_Buffer(HAL_USB_USART_Serial serial, void* data, size_t size) {
+    if (serial != HAL_USB_USART_SERIAL) {
+        return SYSTEM_ERROR_INVALID_ARGUMENT;
+    }
+    return hal_usb_cdc_pvt_recv_data((char*)data, size);
+}
+
+int32_t HAL_USB_USART_Peek_Buffer(HAL_USB_USART_Serial serial, void* data, size_t size) {
+    if (serial != HAL_USB_USART_SERIAL) {
+        return SYSTEM_ERROR_INVALID_ARGUMENT;
+    }
+    if (size == 0) {
+        return 0;
+    }
+    int32_t available = usb_uart_available_rx_data();
+    if (available <= 0) {
+        return 0;
+    }
+    size_t toPeek = std::min((size_t)available, size);
+    for (size_t i = 0; i < toPeek; i++) {
+        ((uint8_t*)data)[i] = usb_uart_peek_rx_data(i);
+    }
+    return toPeek;
+}
+
+int HAL_USB_USART_Wait_Event(HAL_USB_USART_Serial serial, uint32_t events, system_tick_t timeout, void* reserved) {
+    if (serial != HAL_USB_USART_SERIAL) {
+        return SYSTEM_ERROR_INVALID_ARGUMENT;
+    }
+    (void)reserved;
+    return hal_usb_cdc_pvt_wait_event(events, timeout);
+}
+
+int32_t HAL_USB_USART_Send_Buffer_protected(HAL_USB_USART_Serial serial, const void* data, size_t size) {
+    CHECK_SECURITY_MODE_PROTECTED();
+    return HAL_USB_USART_Send_Buffer(serial, data, size);
+}
+
+int32_t HAL_USB_USART_Receive_Buffer_protected(HAL_USB_USART_Serial serial, void* data, size_t size) {
+    CHECK_SECURITY_MODE_PROTECTED();
+    return HAL_USB_USART_Receive_Buffer(serial, data, size);
+}
+
+int32_t HAL_USB_USART_Peek_Buffer_protected(HAL_USB_USART_Serial serial, void* data, size_t size) {
+    CHECK_SECURITY_MODE_PROTECTED();
+    return HAL_USB_USART_Peek_Buffer(serial, data, size);
+}
+
+int HAL_USB_USART_Wait_Event_protected(HAL_USB_USART_Serial serial, uint32_t events, system_tick_t timeout, void* reserved) {
+    CHECK_SECURITY_MODE_PROTECTED();
+    return HAL_USB_USART_Wait_Event(serial, events, timeout, reserved);
 }
 
 void HAL_USB_USART_Flush_Data(HAL_USB_USART_Serial serial) {

--- a/hal/src/nRF52840/usb_hal_cdc.c
+++ b/hal/src/nRF52840/usb_hal_cdc.c
@@ -679,6 +679,24 @@ uint8_t usb_uart_peek_rx_data(uint8_t index) {
     return data;
 }
 
+int usb_uart_peek_rx_buffer(uint8_t* buffer, size_t size) {
+    if (usb_cdc_copy_from_rx_buffer()) {
+        m_usb_instance.rx_data_size = 0;
+        m_usb_instance.rx_done = false;
+    }
+
+    size_t available = FIFO_LENGTH(&m_usb_instance.rx_fifo);
+    if (size > available) {
+        size = available;
+    }
+    for (size_t i = 0; i < size; i++) {
+        if (app_fifo_peek(&m_usb_instance.rx_fifo, (uint16_t)i, &buffer[i])) {
+            return i;
+        }
+    }
+    return size;
+}
+
 void usb_uart_flush_rx_data(void) {
     app_fifo_flush(&m_usb_instance.rx_fifo);
 }

--- a/hal/src/nRF52840/usb_hal_cdc.h
+++ b/hal/src/nRF52840/usb_hal_cdc.h
@@ -2,6 +2,7 @@
 #define  _USB_HAL_CDC_H
 
 #include <stdint.h>
+#include <stddef.h>
 #include "usb_hal.h"
 
 #ifdef __cplusplus
@@ -23,6 +24,7 @@ void usb_hal_detach(void);
 int usb_uart_available_rx_data(void);
 uint8_t usb_uart_get_rx_data(void);
 uint8_t usb_uart_peek_rx_data(uint8_t index);
+int usb_uart_peek_rx_buffer(uint8_t* buffer, size_t size);
 void usb_uart_flush_rx_data(void);
 void usb_uart_flush_tx_data(void);
 int usb_uart_available_tx_data(void);

--- a/hal/src/rtl872x/usart_hal.cpp
+++ b/hal/src/rtl872x/usart_hal.cpp
@@ -1155,19 +1155,19 @@ bool hal_usart_is_enabled(hal_usart_interface_t serial) {
     return usart->isEnabled();
 }
 
-ssize_t hal_usart_write_buffer(hal_usart_interface_t serial, const void* buffer, size_t size, size_t elementSize) {
+int hal_usart_write_buffer(hal_usart_interface_t serial, const void* buffer, size_t size, size_t elementSize) {
     auto usart = CHECK_TRUE_RETURN(Usart::getInstance(serial), SYSTEM_ERROR_NOT_FOUND);
     CHECK_TRUE(elementSize == sizeof(uint8_t), SYSTEM_ERROR_INVALID_ARGUMENT);
     return usart->write((const uint8_t*)buffer, size);
 }
 
-ssize_t hal_usart_read_buffer(hal_usart_interface_t serial, void* buffer, size_t size, size_t elementSize) {
+int hal_usart_read_buffer(hal_usart_interface_t serial, void* buffer, size_t size, size_t elementSize) {
     auto usart = CHECK_TRUE_RETURN(Usart::getInstance(serial), SYSTEM_ERROR_NOT_FOUND);
     CHECK_TRUE(elementSize == sizeof(uint8_t), SYSTEM_ERROR_INVALID_ARGUMENT);
     return usart->read((uint8_t*)buffer, size);
 }
 
-ssize_t hal_usart_peek_buffer(hal_usart_interface_t serial, void* buffer, size_t size, size_t elementSize) {
+int hal_usart_peek_buffer(hal_usart_interface_t serial, void* buffer, size_t size, size_t elementSize) {
     auto usart = CHECK_TRUE_RETURN(Usart::getInstance(serial), SYSTEM_ERROR_NOT_FOUND);
     CHECK_TRUE(elementSize == sizeof(uint8_t), SYSTEM_ERROR_INVALID_ARGUMENT);
     return usart->peek((uint8_t*)buffer, size);
@@ -1237,6 +1237,11 @@ int hal_usart_pvt_disable_event(hal_usart_interface_t serial, HAL_USART_Pvt_Even
 int hal_usart_pvt_wait_event(hal_usart_interface_t serial, uint32_t events, system_tick_t timeout) {
     auto usart = CHECK_TRUE_RETURN(Usart::getInstance(serial), SYSTEM_ERROR_NOT_FOUND);
     return usart->waitEvent(events, timeout);
+}
+
+int hal_usart_wait_event(hal_usart_interface_t serial, uint32_t events, system_tick_t timeout, void* reserved) {
+    (void)reserved;
+    return hal_usart_pvt_wait_event(serial, events, timeout);
 }
 
 int hal_usart_sleep(hal_usart_interface_t serial, bool sleep, void* reserved) {

--- a/hal/src/rtl872x/usb_hal.cpp
+++ b/hal/src/rtl872x/usb_hal.cpp
@@ -21,6 +21,7 @@
 #include "usbd_control.h"
 #include "usbd_driver.h"
 #include "usbd_cdc.h"
+#include <algorithm>
 #include <mutex>
 #include "usb_settings.h"
 #include "usbd_hid.h"
@@ -338,15 +339,81 @@ int hal_usb_cdc_pvt_get_event_group_handle(EventGroupHandle_t* handle) {
 }
 
 int hal_usb_cdc_pvt_wait_event(uint32_t events, system_tick_t timeout) {
-    return getCdcClassDriver().waitEvent(events, timeout);
+    return HAL_USB_USART_Wait_Event(HAL_USB_USART_SERIAL, events, timeout, nullptr);
 }
 
 int hal_usb_cdc_pvt_send_data(const char* data, size_t size) {
-    return HAL_USB_USART_Send_Data_Multiple(HAL_USB_USART_SERIAL, (uint8_t*)data, size);
+    return HAL_USB_USART_Send_Buffer(HAL_USB_USART_SERIAL, data, size);
 }
 
 int hal_usb_cdc_pvt_recv_data(char* data, size_t size) {
-    return HAL_USB_USART_Receive_Data_Multiple(HAL_USB_USART_SERIAL, (uint8_t*)data, size);
+    return HAL_USB_USART_Receive_Buffer(HAL_USB_USART_SERIAL, data, size);
+}
+
+int32_t HAL_USB_USART_Send_Buffer(HAL_USB_USART_Serial serial, const void* data, size_t size) {
+    if (serial != HAL_USB_USART_SERIAL) {
+        return SYSTEM_ERROR_INVALID_ARGUMENT;
+    }
+    if (size == 0) {
+        return 0;
+    }
+    int32_t available = HAL_USB_USART_Available_Data_For_Write(serial);
+    if (available <= 0 || !HAL_USB_USART_Is_Connected(serial)) {
+        return 0;
+    }
+    size_t writeSize = std::min((size_t)available, size);
+    return getCdcClassDriver().write((const uint8_t*)data, writeSize);
+}
+
+int32_t HAL_USB_USART_Receive_Buffer(HAL_USB_USART_Serial serial, void* data, size_t size) {
+    if (serial != HAL_USB_USART_SERIAL) {
+        return SYSTEM_ERROR_INVALID_ARGUMENT;
+    }
+    if (size == 0) {
+        return 0;
+    }
+    return getCdcClassDriver().read((uint8_t*)data, size);
+}
+
+int32_t HAL_USB_USART_Peek_Buffer(HAL_USB_USART_Serial serial, void* data, size_t size) {
+    if (serial != HAL_USB_USART_SERIAL) {
+        return SYSTEM_ERROR_INVALID_ARGUMENT;
+    }
+    if (size == 0) {
+        return 0;
+    }
+    return getCdcClassDriver().peek((uint8_t*)data, size);
+}
+
+int32_t HAL_USB_USART_Wait_Event(HAL_USB_USART_Serial serial, uint32_t events, system_tick_t timeout, void* reserved) {
+    if (serial != HAL_USB_USART_SERIAL) {
+        return SYSTEM_ERROR_INVALID_ARGUMENT;
+    }
+    (void)reserved;
+    if (!events) {
+        return 0;
+    }
+    return getCdcClassDriver().waitEvent(events, timeout);
+}
+
+int32_t HAL_USB_USART_Send_Buffer_protected(HAL_USB_USART_Serial serial, const void* data, size_t size) {
+    CHECK_SECURITY_MODE_PROTECTED();
+    return HAL_USB_USART_Send_Buffer(serial, data, size);
+}
+
+int32_t HAL_USB_USART_Receive_Buffer_protected(HAL_USB_USART_Serial serial, void* data, size_t size) {
+    CHECK_SECURITY_MODE_PROTECTED();
+    return HAL_USB_USART_Receive_Buffer(serial, data, size);
+}
+
+int32_t HAL_USB_USART_Peek_Buffer_protected(HAL_USB_USART_Serial serial, void* data, size_t size) {
+    CHECK_SECURITY_MODE_PROTECTED();
+    return HAL_USB_USART_Peek_Buffer(serial, data, size);
+}
+
+int HAL_USB_USART_Wait_Event_protected(HAL_USB_USART_Serial serial, uint32_t events, system_tick_t timeout, void* reserved) {
+    CHECK_SECURITY_MODE_PROTECTED();
+    return HAL_USB_USART_Wait_Event(serial, events, timeout, reserved);
 }
 #ifdef __cplusplus
 }

--- a/hal/src/rtl872x/usb_hal.cpp
+++ b/hal/src/rtl872x/usb_hal.cpp
@@ -350,8 +350,17 @@ int32_t HAL_USB_USART_Send_Buffer(HAL_USB_USART_Serial serial, const void* data,
     if (size == 0) {
         return 0;
     }
+    if ((__get_PRIMASK() & 1) || (__get_BASEPRI() != 0)) {
+        return SYSTEM_ERROR_INVALID_STATE;
+    }
+    if (!HAL_USB_USART_Is_Connected(serial)) {
+        return SYSTEM_ERROR_INVALID_STATE;
+    }
     int32_t available = HAL_USB_USART_Available_Data_For_Write(serial);
-    if (available <= 0 || !HAL_USB_USART_Is_Connected(serial)) {
+    if (available < 0) {
+        return SYSTEM_ERROR_INVALID_STATE;
+    }
+    if (available == 0) {
         return 0;
     }
     size_t writeSize = std::min((size_t)available, size);

--- a/hal/src/rtl872x/usb_hal.cpp
+++ b/hal/src/rtl872x/usb_hal.cpp
@@ -231,13 +231,6 @@ int32_t HAL_USB_USART_Receive_Data_protected(HAL_USB_USART_Serial serial, uint8_
     return HAL_USB_USART_Receive_Data(serial, peek);
 }
 
-static int32_t HAL_USB_USART_Receive_Data_Multiple(HAL_USB_USART_Serial serial, uint8_t* data, size_t size) {
-    if (serial != HAL_USB_USART_SERIAL) {
-        return SYSTEM_ERROR_INVALID_ARGUMENT;
-    }
-    return getCdcClassDriver().read(data, size);
-}
-
 static int32_t HAL_USB_USART_Send_Data_Multiple(HAL_USB_USART_Serial serial, const uint8_t* data, size_t size) {
     if (serial != HAL_USB_USART_SERIAL) {
         return SYSTEM_ERROR_INVALID_ARGUMENT;
@@ -385,7 +378,7 @@ int32_t HAL_USB_USART_Peek_Buffer(HAL_USB_USART_Serial serial, void* data, size_
     return getCdcClassDriver().peek((uint8_t*)data, size);
 }
 
-int32_t HAL_USB_USART_Wait_Event(HAL_USB_USART_Serial serial, uint32_t events, system_tick_t timeout, void* reserved) {
+int HAL_USB_USART_Wait_Event(HAL_USB_USART_Serial serial, uint32_t events, system_tick_t timeout, void* reserved) {
     if (serial != HAL_USB_USART_SERIAL) {
         return SYSTEM_ERROR_INVALID_ARGUMENT;
     }

--- a/third_party/coremark/build.mk
+++ b/third_party/coremark/build.mk
@@ -1,5 +1,7 @@
 TARGET_COREMARK_SRC_PATH = $(COREMARK_MODULE_PATH)/coremark
 
+CFLAGS += -Wno-int-to-pointer-cast -Wno-pointer-to-int-cast
+
 # C source files included in this build.
 CSRC += $(TARGET_COREMARK_SRC_PATH)/core_list_join.c
 CSRC += $(TARGET_COREMARK_SRC_PATH)/core_main.c

--- a/user/applications/tinker/application.cpp
+++ b/user/applications/tinker/application.cpp
@@ -84,7 +84,9 @@ const PinMapping g_pinmap[] = {
 #  else
 #  error Unsupported HAL_PLATFORM_RTL872X platform
 #  endif
-#else // HAL_PLATFORM_RTL872X
+#elif PLATFORM_ID == PLATFORM_GCC
+// Ok
+#else
 # error Unsupported platform
 #endif // HAL_PLATFORM_NRF52840
 };

--- a/user/tests/wiring/serial_loopback2/loopback.cpp
+++ b/user/tests/wiring/serial_loopback2/loopback.cpp
@@ -103,6 +103,41 @@ void runLoopback(size_t buffer_size_min, size_t buffer_size_max, bool sleep, boo
     assertTrue(!strncmp(txBuf, rxBuf, bufferSize));
 }
 
+void runLoopbackMultiByte(size_t buffer_size_min, size_t buffer_size_max) {
+    particle::Random rand;
+
+    size_t bufferSize = random(buffer_size_min, buffer_size_max);
+    char txBuf[bufferSize] = {};
+    rand.genBase32(txBuf, bufferSize);
+
+    Serial1.write((const uint8_t*)txBuf, bufferSize);
+    Serial1.flush();
+
+    char rxBuf[bufferSize] = {};
+    Serial1.setTimeout(1000);
+    size_t read = Serial1.readBytes(rxBuf, bufferSize);
+    assertEqual(read, bufferSize);
+    assertTrue(!strncmp(txBuf, rxBuf, bufferSize));
+
+    char peekBuf[bufferSize] = {};
+    // Refill for peek test
+    Serial1.write((const uint8_t*)txBuf, bufferSize);
+    Serial1.flush();
+    // Wait for data to arrive
+    while (Serial1.available() < (int)bufferSize) {
+        delay(1);
+    }
+    int peeked = Serial1.peek(peekBuf, bufferSize);
+    assertEqual(peeked, (int)bufferSize);
+    assertTrue(!strncmp(txBuf, peekBuf, bufferSize));
+    // peek must not consume
+    assertEqual(Serial1.available(), (int)bufferSize);
+    // drain
+    size_t drained = Serial1.readBytes(rxBuf, bufferSize);
+    assertEqual(drained, bufferSize);
+    assertTrue(!strncmp(txBuf, rxBuf, bufferSize));
+}
+
 test(SERIAL_000_Prepare) {
     pinMode(A2, OUTPUT); // ACTIVE LOW
     digitalWrite(A2, LOW);
@@ -119,6 +154,20 @@ test(SERIAL_00_LoopbackNoDataLossAndAvailableIsCorrect) {
 
     for (unsigned i = 0; i < ITERATIONS; ++i) {
         runLoopback(TEST_BUFFER_SIZE_MIN, TEST_BUFFER_SIZE_MAX, false);
+    }
+}
+
+test(SERIAL_00b_LoopbackMultiByteNoDataLoss) {
+    const size_t TEST_BUFFER_SIZE_MIN = 8;
+    const size_t TEST_BUFFER_SIZE_MAX = USE_BUFFER_SIZE / 2;
+    const unsigned ITERATIONS = 1000;
+    const unsigned BAUD_RATE = 115200;
+
+    Serial1.end();
+    Serial1.begin(BAUD_RATE);
+
+    for (unsigned i = 0; i < ITERATIONS; ++i) {
+        runLoopbackMultiByte(TEST_BUFFER_SIZE_MIN, TEST_BUFFER_SIZE_MAX);
     }
 }
 

--- a/wiring/inc/spark_wiring_usartserial.h
+++ b/wiring/inc/spark_wiring_usartserial.h
@@ -53,6 +53,9 @@ public:
   virtual void flush(void);
   size_t write(uint16_t);
   virtual size_t write(uint8_t);
+  virtual size_t write(const uint8_t *buffer, size_t size);
+  virtual size_t readBytes(char *buffer, size_t length);
+  virtual int peek(char *buffer, size_t size);
 
   // LIN
   void breakTx(void);

--- a/wiring/inc/spark_wiring_usbserial.h
+++ b/wiring/inc/spark_wiring_usbserial.h
@@ -52,10 +52,13 @@ public:
 	int peek();
 
 	virtual size_t write(uint8_t byte);
+	virtual size_t write(const uint8_t *buffer, size_t size);
 	virtual int read();
 	virtual int availableForWrite(void);
 	virtual int available();
 	virtual void flush();
+	virtual size_t readBytes(char *buffer, size_t length);
+	virtual int peek(char *buffer, size_t size);
 
 	virtual void blockOnOverrun(bool);
 

--- a/wiring/src/spark_wiring_usartserial.cpp
+++ b/wiring/src/spark_wiring_usartserial.cpp
@@ -125,7 +125,7 @@ size_t USARTSerial::write(const uint8_t *buffer, size_t size)
     if (!_blocking) {
       break;
     }
-    if (hal_usart_wait_event(_serial, HAL_USART_EVENT_WRITABLE, 0, nullptr) < 0) {
+    if (hal_usart_wait_event(_serial, HAL_USART_EVENT_WRITABLE, 100, nullptr) < 0) {
       break;
     }
   }
@@ -150,7 +150,7 @@ size_t USARTSerial::readBytes(char *buffer, size_t length)
     if (_timeout == 0) {
       break;
     }
-    if (hal_usart_wait_event(_serial, HAL_USART_EVENT_READABLE, _timeout, nullptr) < 0) {
+    if (hal_usart_wait_event(_serial, HAL_USART_EVENT_READABLE, _timeout, nullptr) <= 0) {
       break;
     }
   }

--- a/wiring/src/spark_wiring_usartserial.cpp
+++ b/wiring/src/spark_wiring_usartserial.cpp
@@ -27,6 +27,7 @@
 #include "spark_wiring_usartserial.h"
 #include "spark_wiring_constants.h"
 #include "module_info.h"
+#include "system_error.h"
 #include <algorithm>
 
 // Constructors ////////////////////////////////////////////////////////////////
@@ -104,6 +105,64 @@ size_t USARTSerial::write(uint8_t c)
 size_t USARTSerial::write(uint16_t c)
 {
   return hal_usart_write_nine_bits(_serial, c);
+}
+
+size_t USARTSerial::write(const uint8_t *buffer, size_t size)
+{
+  if (size == 0) {
+    return 0;
+  }
+  size_t written = 0;
+  while (written < size) {
+    auto r = hal_usart_write_buffer(_serial, buffer + written, size - written, sizeof(char));
+    if (r > 0) {
+      written += r;
+      continue;
+    }
+    if (r < 0 && r != SYSTEM_ERROR_NO_MEMORY) {
+      break;
+    }
+    if (!_blocking) {
+      break;
+    }
+    if (hal_usart_wait_event(_serial, HAL_USART_EVENT_WRITABLE, 0, nullptr) < 0) {
+      break;
+    }
+  }
+  return written;
+}
+
+size_t USARTSerial::readBytes(char *buffer, size_t length)
+{
+  if (length == 0) {
+    return 0;
+  }
+  size_t total = 0;
+  while (total < length) {
+    auto r = hal_usart_read_buffer(_serial, buffer + total, length - total, sizeof(char));
+    if (r > 0) {
+      total += r;
+      continue;
+    }
+    if (r < 0 && r != SYSTEM_ERROR_NO_MEMORY) {
+      break;
+    }
+    if (_timeout == 0) {
+      break;
+    }
+    if (hal_usart_wait_event(_serial, HAL_USART_EVENT_READABLE, _timeout, nullptr) < 0) {
+      break;
+    }
+  }
+  return total;
+}
+
+int USARTSerial::peek(char *buffer, size_t size)
+{
+  if (size == 0) {
+    return 0;
+  }
+  return hal_usart_peek_buffer(_serial, buffer, size, sizeof(char));
 }
 
 USARTSerial::operator bool() {

--- a/wiring/src/spark_wiring_usbserial.cpp
+++ b/wiring/src/spark_wiring_usbserial.cpp
@@ -26,6 +26,7 @@
 
 #include "spark_wiring_usbserial.h"
 #include "platform_headers.h"
+#include "system_error.h"
 
 //
 // Constructor
@@ -99,6 +100,64 @@ void USBSerial::blockOnOverrun(bool block)
 int USBSerial::peek()
 {
 	return std::max(-1, (int)HAL_USB_USART_Receive_Data(_serial, true));
+}
+
+size_t USBSerial::write(const uint8_t *buffer, size_t size)
+{
+  if (size == 0) {
+    return 0;
+  }
+  size_t written = 0;
+  while (written < size) {
+    auto r = HAL_USB_USART_Send_Buffer(_serial, buffer + written, size - written);
+    if (r > 0) {
+      written += r;
+      continue;
+    }
+    if (r < 0 && r != SYSTEM_ERROR_NO_MEMORY) {
+      break;
+    }
+    if (!_blocking) {
+      break;
+    }
+    if (HAL_USB_USART_Wait_Event(_serial, HAL_USB_USART_EVENT_WRITABLE, 0, nullptr) < 0) {
+      break;
+    }
+  }
+  return written;
+}
+
+size_t USBSerial::readBytes(char *buffer, size_t length)
+{
+  if (length == 0) {
+    return 0;
+  }
+  size_t total = 0;
+  while (total < length) {
+    auto r = HAL_USB_USART_Receive_Buffer(_serial, buffer + total, length - total);
+    if (r > 0) {
+      total += r;
+      continue;
+    }
+    if (r < 0 && r != SYSTEM_ERROR_NO_MEMORY) {
+      break;
+    }
+    if (_timeout == 0) {
+      break;
+    }
+    if (HAL_USB_USART_Wait_Event(_serial, HAL_USB_USART_EVENT_READABLE, _timeout, nullptr) < 0) {
+      break;
+    }
+  }
+  return total;
+}
+
+int USBSerial::peek(char *buffer, size_t size)
+{
+  if (size == 0) {
+    return 0;
+  }
+  return HAL_USB_USART_Peek_Buffer(_serial, buffer, size);
 }
 
 USBSerial::operator bool() {

--- a/wiring/src/spark_wiring_usbserial.cpp
+++ b/wiring/src/spark_wiring_usbserial.cpp
@@ -120,7 +120,7 @@ size_t USBSerial::write(const uint8_t *buffer, size_t size)
     if (!_blocking) {
       break;
     }
-    if (HAL_USB_USART_Wait_Event(_serial, HAL_USB_USART_EVENT_WRITABLE, 0, nullptr) < 0) {
+    if (HAL_USB_USART_Wait_Event(_serial, HAL_USB_USART_EVENT_WRITABLE, 100, nullptr) < 0) {
       break;
     }
   }
@@ -145,7 +145,7 @@ size_t USBSerial::readBytes(char *buffer, size_t length)
     if (_timeout == 0) {
       break;
     }
-    if (HAL_USB_USART_Wait_Event(_serial, HAL_USB_USART_EVENT_READABLE, _timeout, nullptr) < 0) {
+    if (HAL_USB_USART_Wait_Event(_serial, HAL_USB_USART_EVENT_READABLE, _timeout, nullptr) <= 0) {
       break;
     }
   }


### PR DESCRIPTION
## Targets #2932! Change base before merging.

### Description

#2932 fixes the main issue that made non-DMA UARTs on Gen 4 platforms slow:
> USART (rtl872x): fix interrupt-mode enableEvent to re-assert READABLE/WRITABLE from current buffer state (mirrors DMA branch). Fix FIFO overflow handling under RTS flow control (don't drain-and-discard on ring-full, let the FIFO fill so auto-RTS holds the peer). Fix slow-clock-domain MCR RMW losing AFE bits (single combined write). Add IER shadow register so interrupt config writes go through a critical-section RMW instead of a direct register RMW that loses bits on the slow clock domain. Line-status ISR now falls through to the RX drain path instead of starving RX under sustained error conditions.

This PR additionally makes a minimal set of changes to support buffered read/write/peek for UART and USB Serial.

### References

- #2932
- Supersedes #2924 #2925
