### PR TITLE
MSoM: fixes power leakage when devices are in STOP/ULP mode

### DIFF
--- a/bootloader/prebootloader/src/rtl872x/part1/sleep_handler.cpp
+++ b/bootloader/prebootloader/src/rtl872x/part1/sleep_handler.cpp
@@ -358,15 +358,20 @@ void sleepProcess(void) {
                 configureSleepWakeupSource(config);
 
 #if PLATFORM_ID != PLATFORM_TRACKERM
-                // There is a user LED connected on D7, which is PA27 (SWD-DAT). There is an internal
-                // pull-up resister on this I/O, which will turn on the user LED when enter the stop/ulp mode.
                 bool swdEnabled = false;
                 if (HAL_READ32(SYSTEM_CTRL_BASE_LP, REG_SWD_PMUX_EN) & BIT_LSYS_SWD_PMUX_EN) {
                     // Disable SWD
                     Pinmux_Swdoff();
                     // Configure it as input pulldown
                     GPIOA_BASE->PORT[0].DDR &= (~(1 << 27));
+#if PLATFORM_ID == PLATFORM_P2
+                    // There is a user LED connected on D7, which is PA27 (SWD-DAT). There is an internal
+                    // pull-up resister on this I/O, which will turn on the user LED when enter the stop/ulp mode.
                     PAD_PullCtrl(27, GPIO_PuPd_DOWN);
+#else // PLATFORM_MSOM
+                    // For MSoM, there is an external pull-up resistor
+                    PAD_PullCtrl(27, GPIO_PuPd_UP);
+#endif
                     swdEnabled = true;
                 }
 #endif


### PR DESCRIPTION
### Problem
MSoMs will leak current on PB12 (QSPI_IO3) and SWD_DATA when the device is in STOP/ULP mode.

### Solution
1. There is no external pull-up resistor on PB12. Configuring PB12 as pull-up before sleep and restore it to no-pull after waking up can reduce ~1mA.
2. There is an external pull-up resistor on SWD_DATA. Configures SWD_DATA to pull-up before entering sleep mode can save us ~100uA.

### Steps to Test
Flash the following user app to estimate the STOP mode power consumption.

### Example App

```c
#include "Particle.h"

SYSTEM_MODE(SEMI_AUTOMATIC);

Serial1LogHandler logHandler(115200, LOG_LEVEL_ALL);

void setup() {
    delay(5s);
    System.sleep(SystemSleepConfiguration().mode(SystemSleepMode::STOP).gpio(D0, FALLING));
}

void loop() {

}
```

### References
N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
