### PR TITLE
Non-blocking handshake

### DIFF
--- a/communication/inc/dtls_message_channel.h
+++ b/communication/inc/dtls_message_channel.h
@@ -32,7 +32,6 @@
 #include "mbedtls/entropy.h"
 #include "mbedtls/ctr_drbg.h"
 #include "mbedtls/pk.h"
-#include "mbedtls/timing.h"
 #include "mbedtls/debug.h"
 
 namespace particle
@@ -90,7 +89,6 @@ private:
 	mbedtls_ssl_config conf;
 	mbedtls_x509_crt clicert;
 	mbedtls_pk_context pkey;
-	mbedtls_timing_delay_context timer;
 	Callbacks callbacks;
 	uint8_t* server_public;
 	uint16_t server_public_len;
@@ -103,6 +101,25 @@ private:
 	const uint8_t* device_id;
 	bool move_session;
 	bool debug_enabled;
+
+	enum class EstablishState : uint8_t {
+		NONE,
+		HANDSHAKING
+	};
+	EstablishState establish_state;
+
+	uint8_t handshake_random[64];
+
+	enum class WaitCondition : uint8_t {
+		NONE,
+		WANT_READ,
+		WANT_WRITE
+	};
+	WaitCondition last_wait;
+
+	system_tick_t timer_start;
+	uint32_t timer_int_ms;
+	uint32_t timer_fin_ms;
 
     void init();
     void dispose();
@@ -128,7 +145,6 @@ private:
 			conf(),
 			clicert(),
 			pkey(),
-			timer(),
 			callbacks(),
 			server_public(nullptr),
 			server_public_len(0),
@@ -136,7 +152,12 @@ private:
 			coap_state(nullptr),
 			device_id(nullptr),
 			move_session(false),
-			debug_enabled(false) {
+			debug_enabled(false),
+			establish_state(EstablishState::NONE),
+			last_wait(WaitCondition::NONE),
+			timer_start(0),
+			timer_int_ms(0),
+			timer_fin_ms(0) {
 	}
 
 	ProtocolError init(const uint8_t* core_private, size_t core_private_len,
@@ -176,7 +197,18 @@ private:
 	virtual AppStateDescriptor cached_app_state_descriptor() const override;
 
 	virtual void reset() override {
+		establish_state = EstablishState::NONE;
+		last_wait = WaitCondition::NONE;
+		timer_start = 0;
+		timer_int_ms = 0;
+		timer_fin_ms = 0;
 	}
+
+	virtual bool is_establish_in_progress() const override {
+		return establish_state == EstablishState::HANDSHAKING;
+	}
+
+	system_tick_t next_handshake_delay() const;
 
 	void set_debug_enabled(bool enabled = true) override {
 		debug_enabled = enabled;

--- a/communication/inc/dtls_message_channel.h
+++ b/communication/inc/dtls_message_channel.h
@@ -112,8 +112,10 @@ private:
 
 	enum class WaitCondition : uint8_t {
 		NONE,
+		CONTINUE,
 		WANT_READ,
-		WANT_WRITE
+		WANT_WRITE,
+		CRYPTO_IN_PROGRESS
 	};
 	WaitCondition last_wait;
 
@@ -197,6 +199,8 @@ private:
 	virtual AppStateDescriptor cached_app_state_descriptor() const override;
 
 	virtual void reset() override {
+		mbedtls_ssl_free(&ssl_context);
+		mbedtls_ssl_init(&ssl_context);
 		establish_state = EstablishState::NONE;
 		last_wait = WaitCondition::NONE;
 		timer_start = 0;

--- a/communication/inc/message_channel.h
+++ b/communication/inc/message_channel.h
@@ -272,6 +272,15 @@ struct MessageChannel : public Channel
 	 * Enable/disable debugging.
 	 */
 	virtual void set_debug_enabled(bool enabled) = 0;
+
+	/**
+	 * Returns true if the channel establishment (e.g. DTLS handshake) is
+	 * in progress across multiple calls. Default is false for channels
+	 * that complete establishment synchronously.
+	 */
+	virtual bool is_establish_in_progress() const {
+		return false;
+	}
 };
 
 class AbstractMessageChannel : public MessageChannel

--- a/communication/inc/protocol.h
+++ b/communication/inc/protocol.h
@@ -136,6 +136,13 @@ class Protocol
 	uint8_t initialized;
 
 protected:
+	enum class HandshakeStage : uint8_t {
+		INIT,
+		ESTABLISH,
+		HELLO_WAIT
+	};
+	HandshakeStage handshake_stage;
+
 	/**
 	 * Protocol flags.
 	 */
@@ -350,6 +357,7 @@ public:
 			last_ack_handlers_update(0),
 			protocol_flags(0),
 			initialized(false),
+			handshake_stage(HandshakeStage::INIT),
 			max_binary_size(0), // Unlimited
 			ota_chunk_size(DEFAULT_OTA_CHUNK_SIZE),
 			system_version(0), // Unknown
@@ -457,8 +465,43 @@ public:
 
 	/**
 	 * Establish a secure connection and send and process the hello message.
+	 * Legacy blocking entry point.
 	 */
 	int begin();
+
+	enum HandshakeFlag : unsigned {
+		HANDSHAKE_FLAG_NON_BLOCKING = 0x01,
+		HANDSHAKE_FLAG_CONTINUE = 0x02
+	};
+
+	/**
+	 * Re-entrant handshake entry point.
+	 * @param flags  HANDSHAKE_FLAG_NON_BLOCKING and/or HANDSHAKE_FLAG_CONTINUE.
+	 *               Without NON_BLOCKING, spins on IN_PROGRESS in place (legacy).
+	 *               CONTINUE requires NON_BLOCKING and a prior in-progress attempt.
+	 * @param next_event_delay  Out-param: relative delay (ms) to the next event
+	 *       deadline, or 0 for no wake hint. Set to 0 on every terminal result.
+	 * @return NO_ERROR on completion, IN_PROGRESS when a step is incomplete,
+	 *         or an error code on failure.
+	 */
+	int begin(unsigned flags, system_tick_t* next_event_delay);
+
+	/**
+	 * Poll for HELLO delivery confirmation (DTLS path).
+	 * Default returns NO_ERROR (LightSSL uses hello_response() instead).
+	 * Override in DTLSProtocol to call channel.poll_confirmed().
+	 */
+	virtual ProtocolError poll_hello_delivered() {
+		return NO_ERROR;
+	}
+
+	/**
+	 * Returns the delay (ms) to the next handshake event deadline.
+	 * Default returns 0 (no hint). Override in DTLSProtocol.
+	 */
+	virtual system_tick_t next_handshake_event_delay() const {
+		return 0;
+	}
 
 	/**
 	 * Reset the protocol state and free all allocated resources.
@@ -623,7 +666,7 @@ public:
 		return -1;
 	}
 
-	system_tick_t millis() { return callbacks.millis(); }
+	system_tick_t millis() const { return callbacks.millis(); }
 
 	virtual int command(ProtocolCommands::Enum command, uint32_t value, const void* data)=0;
 

--- a/communication/inc/protocol_defs.h
+++ b/communication/inc/protocol_defs.h
@@ -61,6 +61,7 @@ enum ProtocolError
     IO_ERROR_SOCKET_RECV_FAILED = 34,
     IO_ERROR_REMOTE_END_CLOSED = 35,
     COAP_ERROR = 36,
+    IN_PROGRESS = 37, // Operation in progress, call again to continue (not an error)
     // NOTE: when adding more ProtocolError codes, be sure to update toSystemError() in protocol_defs.cpp
     UNKNOWN = 0x7FFFF
 };

--- a/communication/inc/spark_protocol_functions.h
+++ b/communication/inc/spark_protocol_functions.h
@@ -182,6 +182,20 @@ void spark_protocol_init(ProtocolFacade* protocol, const char *id,
           const SparkCallbacks &callbacks,
           const SparkDescriptor &descriptor, void* reserved=NULL);
 int spark_protocol_handshake(ProtocolFacade* protocol, void* reserved=NULL);
+
+typedef struct spark_protocol_handshake_param {
+    uint16_t size;                // sizeof(spark_protocol_handshake_param)
+    uint16_t flags;               // in: NON_BLOCKING | CONTINUE
+    uint32_t next_event_delay_ms; // out: relative delay, 0 = no wake hint
+} spark_protocol_handshake_param;
+
+PARTICLE_STATIC_ASSERT(spark_protocol_handshake_param_size, sizeof(spark_protocol_handshake_param)==8);
+
+typedef enum spark_protocol_handshake_flag {
+    SPARK_PROTOCOL_HANDSHAKE_FLAG_NON_BLOCKING = 0x01,
+    SPARK_PROTOCOL_HANDSHAKE_FLAG_CONTINUE = 0x02
+} spark_protocol_handshake_flag;
+
 bool spark_protocol_event_loop(ProtocolFacade* protocol, void* reserved=NULL);
 bool spark_protocol_is_initialized(ProtocolFacade* protocol);
 int spark_protocol_presence_announcement(ProtocolFacade* protocol, unsigned char *buf, const unsigned char *id, void* reserved=NULL);

--- a/communication/src/coap_channel.h
+++ b/communication/src/coap_channel.h
@@ -382,6 +382,13 @@ public:
 		return head!=nullptr;
 	}
 
+	/**
+	 * Returns the head of the message linked list (for iteration).
+	 */
+	CoAPMessage* head_message() const {
+		return head;
+	}
+
 	bool has_unacknowledged_requests() const;
 
 	/**
@@ -551,10 +558,24 @@ class CoAPReliableChannel : public T
 
 	DelegateChannel delegateChannel;
 
+	CoAPMessage::delivery_fn confirm_handler;
+	message_id_t confirm_id;
+	ProtocolError confirm_result;
+	bool confirm_pending;
+	bool confirm_had_client_messages;
+
 public:
 
-	CoAPReliableChannel(M m=0) : millis(m) {
+	CoAPReliableChannel(M m=0) : millis(m), confirm_id(0), confirm_result(NO_ERROR),
+			confirm_pending(false), confirm_had_client_messages(false) {
 		delegateChannel.init(this);
+		confirm_handler = [this](CoAPMessage::Delivery delivered) {
+			if (delivered == CoAPMessage::NOT_DELIVERED) {
+				confirm_result = MESSAGE_TIMEOUT;
+			} else if (delivered == CoAPMessage::DELIVERED_NACK) {
+				confirm_result = MESSAGE_RESET;
+			}
+		};
 	}
 
 	void set_millis(M m) {
@@ -574,7 +595,9 @@ public:
 	 */
 	ProtocolError establish() override
 	{
-		reset();
+		if (!channel::is_establish_in_progress()) {
+			reset();
+		}
 		return channel::establish();
 	}
 
@@ -585,6 +608,9 @@ public:
 	{
 		server.clear();
 		client.clear();
+		confirm_pending = false;
+		confirm_result = NO_ERROR;
+		confirm_id = 0;
 		channel::reset();
 	}
 
@@ -599,7 +625,7 @@ public:
 			return delegateChannel.send(msg);
 
 		if (msg.is_request() && msg.get_confirm_received())
-			return send_synchronous(msg);
+			return send_confirmed(msg);
 
 		// determine the type of message.
 		CoAPMessageStore& store = msg.is_request() ? client : server;
@@ -668,53 +694,133 @@ public:
 	}
 
 	/**
-	 * Send a message synchronously, waiting for the acknowledgement.
+	 * Send a confirmable message and arm the delivery handler.
+	 * First half of the old send_synchronous - delivery is awaited by
+	 * the caller polling poll_confirmed().
 	 */
-	ProtocolError send_synchronous(Message& msg)
+	ProtocolError send_confirmed(Message& msg)
 	{
 		message_id_t id = msg.get_id();
-		DEBUG("sending message id=%x synchronously", id);
+		DEBUG("sending message id=%x confirmed", id);
 		CoAPType::Enum coapType = CoAP::type(msg.buf());
-		const bool had_client_messages = client.has_messages();
+		confirm_had_client_messages = client.has_messages();
 		ProtocolError error = client.send(msg, millis());
 		if (!error)
 			error = delegateChannel.send(msg);
-		if (!error && coapType==CoAPType::CON)
+		if (!error && coapType == CoAPType::CON)
 		{
-			CoAPMessage::delivery_fn flag_delivered = [&error](CoAPMessage::Delivery delivered) {
-				if (delivered==CoAPMessage::NOT_DELIVERED)
-					error = MESSAGE_TIMEOUT;
-				else if (delivered==CoAPMessage::DELIVERED_NACK)
-					error = MESSAGE_RESET;
-			};
 			CoAPMessage* coapmsg = client.from_id(id);
 			if (coapmsg)
-				coapmsg->set_delivered_handler(&flag_delivered);
+				coapmsg->set_delivered_handler(&confirm_handler);
 			else
 				ERROR("no coapmessage for msg id=%x", id);
-			while (client.from_id(id)!=nullptr && !error)
-			{
-				msg.clear();
-				msg.set_length(0);
-				error = delegateChannel.receive(msg);
-				if (!error && msg.decode_id() && is_ack_or_reset(msg.buf(), msg.length()))
-				{
-					// handle acknowledgements, waiting for the one that
-					// acknowledges the original confirmation.
-					ProtocolError receive_error = client.receive(msg, delegateChannel, millis());
-					if (!error)
-						error = receive_error;
-				}
-				// drop CON messages on the floor since we cannot handle them now
-				client.process(millis(), delegateChannel);
-			}
+			confirm_id = id;
+			confirm_result = NO_ERROR;
+			confirm_pending = true;
+			// Delivery is now awaited by the caller via poll_confirmed()
+			return NO_ERROR;
 		}
+		// Non-CON or send error completes immediately
 		client.clear_message(id);
-		if (had_client_messages && !client.has_messages()) {
+		if (confirm_had_client_messages && !client.has_messages()) {
 			channel::notify_client_messages_processed();
 		}
-		// todo - if msg contains a delivery callback then call that with the outcome of this
 		return error;
+	}
+
+	/**
+	 * Poll for the confirmation of the message sent by send_confirmed().
+	 * One iteration of the old spin loop - preserves the narrow
+	 * confirmation-processing behavior (only ACK/RST fed to
+	 * client.receive(), other messages dropped, client.process() only).
+	 */
+	ProtocolError poll_confirmed()
+	{
+		if (!confirm_pending) {
+			return NO_ERROR; // nothing to poll
+		}
+
+		Message msg;
+		channel::create(msg, 0);
+		ProtocolError error = delegateChannel.receive(msg);
+		if (!error && msg.decode_id() && is_ack_or_reset(msg.buf(), msg.length()))
+		{
+			// handle acknowledgements, waiting for the one that
+			// acknowledges the original confirmation.
+			ProtocolError receive_error = client.receive(msg, delegateChannel, millis());
+			if (!error) {
+				error = receive_error;
+			}
+		}
+		// drop CON messages on the floor since we cannot handle them now
+		client.process(millis(), delegateChannel);
+
+		// Check if the message is still pending (not yet acknowledged)
+		if (client.from_id(confirm_id) != nullptr && !error && confirm_result == NO_ERROR)
+		{
+			return IN_PROGRESS; // still waiting for ACK
+		}
+
+		// Terminal: message acknowledged, timed out, reset, or error
+		client.clear_message(confirm_id);
+		if (confirm_had_client_messages && !client.has_messages()) {
+			channel::notify_client_messages_processed();
+		}
+		confirm_pending = false;
+		// Prefer the delivery handler result (MESSAGE_TIMEOUT/MESSAGE_RESET)
+		// over a receive error only when the handler fired
+		if (confirm_result != NO_ERROR) {
+			return confirm_result;
+		}
+		return error;
+	}
+
+	/**
+	 * Returns the remaining delay (ms) to the earliest retransmit
+	 * timeout in the client store, or 0 if none.
+	 *
+	 * An armed-but-expired timeout returns a 1 ms floor (not 0).
+	 */
+	system_tick_t client_next_timeout(system_tick_t now) const
+	{
+		bool found = false;
+		system_tick_t earliest = 0;
+		for (CoAPMessage* msg = client.head_message(); msg != nullptr; msg = msg->get_next())
+		{
+			const system_tick_t t = msg->get_timeout();
+			// Wrap-safe signed diff: positive = remaining, <=0 = expired
+			const int32_t diff = (int32_t)(t - now);
+			system_tick_t remaining;
+			if (diff <= 0) {
+				remaining = 1; // expired - floor
+			} else {
+				remaining = (system_tick_t)diff;
+			}
+			if (!found || remaining < earliest) {
+				earliest = remaining;
+				found = true;
+			}
+		}
+		return found ? earliest : 0;
+	}
+
+	/**
+	 * Send a message synchronously, waiting for the acknowledgement.
+	 * Wrapper: send_confirmed + spin-poll_confirmed (legacy/test callers).
+	 */
+	ProtocolError send_synchronous(Message& msg)
+	{
+		ProtocolError error = send_confirmed(msg);
+		if (error || !confirm_pending) {
+			return error;
+		}
+		while (true)
+		{
+			ProtocolError poll_err = poll_confirmed();
+			if (poll_err != IN_PROGRESS) {
+				return poll_err;
+			}
+		}
 	}
 };
 

--- a/communication/src/dtls_message_channel.cpp
+++ b/communication/src/dtls_message_channel.cpp
@@ -60,6 +60,12 @@ namespace {
 // A custom content type for session resumption packets
 const unsigned ALT_CID_CONTENT_TYPE = 253;
 
+// Retry delay (ms) when the last handshake step returned WANT_WRITE
+const system_tick_t HANDSHAKE_SEND_RETRY_MS = 50;
+
+// Floor for an armed-but-expired timer - ensures prompt re-entry
+const system_tick_t HANDSHAKE_DELAY_EXPIRED_FLOOR_MS = 1;
+
 } // namespace
 
 uint32_t compute_checksum(uint32_t(*calculate_crc)(const uint8_t* data, uint32_t len), const uint8_t* server, size_t server_len, const uint8_t* device, size_t device_len)
@@ -295,6 +301,11 @@ void DTLSMessageChannel::reset_session()
 	cancel_move_session();
 	mbedtls_ssl_session_reset(&ssl_context);
 	sessionPersist.clear(callbacks.save);
+	establish_state = EstablishState::NONE;
+	last_wait = WaitCondition::NONE;
+	timer_start = 0;
+	timer_int_ms = 0;
+	timer_fin_ms = 0;
 }
 
 inline int DTLSMessageChannel::recv(uint8_t* data, size_t len)
@@ -358,6 +369,36 @@ void DTLSMessageChannel::dispose()
 }
 
 
+system_tick_t DTLSMessageChannel::next_handshake_delay() const
+{
+	if (establish_state != EstablishState::HANDSHAKING) {
+		return 0; // no handshake in progress
+	}
+	// On WANT_WRITE, use the send-retry delay (but don't overshoot an
+	// imminent retransmit deadline)
+	if (last_wait == WaitCondition::WANT_WRITE) {
+		const system_tick_t retry = HANDSHAKE_SEND_RETRY_MS;
+		if (timer_fin_ms != 0) {
+			const system_tick_t elapsed = callbacks.millis() - timer_start;
+			if (elapsed < timer_fin_ms) {
+				const system_tick_t remaining = timer_fin_ms - elapsed;
+				return (remaining < retry) ? remaining : retry;
+			}
+			return HANDSHAKE_DELAY_EXPIRED_FLOOR_MS;
+		}
+		return retry;
+	}
+	// On WANT_READ (or NONE), use the DTLS retransmit timer
+	if (timer_fin_ms == 0) {
+		return 0; // unarmed - no wake hint
+	}
+	const system_tick_t elapsed = callbacks.millis() - timer_start;
+	if (elapsed >= timer_fin_ms) {
+		return HANDSHAKE_DELAY_EXPIRED_FLOOR_MS; // expired - re-enter promptly
+	}
+	return timer_fin_ms - elapsed;
+}
+
 ProtocolError DTLSMessageChannel::setup_context()
 {
 	int ret;
@@ -365,7 +406,30 @@ ProtocolError DTLSMessageChannel::setup_context()
 	ret = mbedtls_ssl_setup(&ssl_context, &conf);
 	EXIT_ERROR(ret, "unable to setup SSL context");
 
-	mbedtls_ssl_set_timer_cb(&ssl_context, &timer, mbedtls_timing_set_delay, mbedtls_timing_get_delay);
+	mbedtls_ssl_set_timer_cb(&ssl_context, this,
+			[](void* ctx, uint32_t int_ms, uint32_t fin_ms) {
+				auto* const ch = static_cast<DTLSMessageChannel*>(ctx);
+				ch->timer_int_ms = int_ms;
+				ch->timer_fin_ms = fin_ms;
+				if (fin_ms != 0) {
+					ch->timer_start = ch->callbacks.millis();
+				}
+			},
+			[](void* ctx) -> int {
+				auto* const ch = static_cast<DTLSMessageChannel*>(ctx);
+				if (ch->timer_fin_ms == 0) {
+					return -1; // cancelled
+				}
+				const system_tick_t elapsed = ch->callbacks.millis() - ch->timer_start;
+				if (elapsed >= ch->timer_fin_ms) {
+					return 2; // final delay passed
+				}
+				if (elapsed >= ch->timer_int_ms) {
+					return 1; // intermediate delay passed
+				}
+				return 0; // none passed
+			}
+	);
 	mbedtls_ssl_set_bio(&ssl_context, this, &DTLSMessageChannel::sendCallback, &DTLSMessageChannel::recvCallback, NULL);
 
 	if ((ssl_context.session_negotiate->peer_cert = (mbedtls_x509_crt*)calloc(1, sizeof(mbedtls_x509_crt))) == NULL)
@@ -394,63 +458,79 @@ ProtocolError DTLSMessageChannel::setup_context()
 ProtocolError DTLSMessageChannel::establish()
 {
 	int ret = 0;
-	// LOG(INFO,"setup context");
-	ProtocolError error = setup_context();
-	if (error) {
-		LOG(ERROR,"setup_context error %d", (int)error);
-		return error;
-	}
-	bool renegotiate = false;
 
-	SessionPersist::RestoreStatus restoreStatus = sessionPersist.restore(&ssl_context, renegotiate, keys_checksum, coap_state, callbacks.restore, callbacks.save);
-	LOG(INFO,"(CMPL,RENEG,NO_SESS,ERR) restoreStatus=%d", restoreStatus);
-	if (restoreStatus==SessionPersist::COMPLETE)
-	{
-		LOG(INFO,"out_ctr %d,%d,%d,%d,%d,%d,%d,%d, next_coap_id=%x", sessionPersist.out_ctr[0],
-				sessionPersist.out_ctr[1],sessionPersist.out_ctr[2],sessionPersist.out_ctr[3],
-				sessionPersist.out_ctr[4],sessionPersist.out_ctr[5],sessionPersist.out_ctr[6],
-				sessionPersist.out_ctr[7], sessionPersist.next_coap_id);
-		sessionPersist.make_persistent();
-		LOG(INFO,"restored session from persisted session data. next_msg_id=%d", *coap_state);
-		return SESSION_RESUMED;
-	}
-	else if (restoreStatus==SessionPersist::RENEGOTIATE)
-	{
-		// session partially restored, fully restored via handshake
-	}
-	else // no session or clear
-	{
+	// First entry: setup and session restore (runs once per attempt)
+	if (establish_state == EstablishState::NONE) {
+		ProtocolError error = setup_context();
+		if (error) {
+			LOG(ERROR,"setup_context error %d", (int)error);
+			return error;
+		}
+		bool renegotiate = false;
+
+		SessionPersist::RestoreStatus restoreStatus = sessionPersist.restore(&ssl_context, renegotiate, keys_checksum, coap_state, callbacks.restore, callbacks.save);
+		LOG(INFO,"(CMPL,RENEG,NO_SESS,ERR) restoreStatus=%d", restoreStatus);
+		if (restoreStatus==SessionPersist::COMPLETE)
+		{
+			LOG(INFO,"out_ctr %d,%d,%d,%d,%d,%d,%d,%d, next_coap_id=%x", sessionPersist.out_ctr[0],
+					sessionPersist.out_ctr[1],sessionPersist.out_ctr[2],sessionPersist.out_ctr[3],
+					sessionPersist.out_ctr[4],sessionPersist.out_ctr[5],sessionPersist.out_ctr[6],
+					sessionPersist.out_ctr[7], sessionPersist.next_coap_id);
+			sessionPersist.make_persistent();
+			LOG(INFO,"restored session from persisted session data. next_msg_id=%d", *coap_state);
+			return SESSION_RESUMED;
+		}
+		else if (restoreStatus==SessionPersist::RENEGOTIATE)
+		{
+			// session partially restored, fully restored via handshake
+		}
+		else // no session or clear
+		{
 		reset_session();
 		ProtocolError error = setup_context();
-		if (error)
+		if (error) {
 			return error;
-	}
-	uint8_t random[64];
-
-	do
-	{
-		while (ssl_context.state != MBEDTLS_SSL_HANDSHAKE_OVER)
-		{
-			ret = mbedtls_ssl_handshake_step(&ssl_context);
-
-			if (ret != 0)
-				break;
-
-			// we've already received the ServerHello, thus
-			// we have the random values for client and server
-			if (ssl_context.state == MBEDTLS_SSL_SERVER_KEY_EXCHANGE)
-			{
-				memcpy(random, ssl_context.handshake->randbytes, 64);
-			}
 		}
 	}
-	while(ret == MBEDTLS_ERR_SSL_WANT_READ ||
-	      ret == MBEDTLS_ERR_SSL_WANT_WRITE);
+	establish_state = EstablishState::HANDSHAKING;
+	last_wait = WaitCondition::NONE;
+}
+
+// Stepping loop: advance through as many non-IO steps as possible
+while (ssl_context.state != MBEDTLS_SSL_HANDSHAKE_OVER)
+{
+	ret = mbedtls_ssl_handshake_step(&ssl_context);
+
+	if (ret != 0) {
+		break;
+	}
+
+	// we've already received the ServerHello, thus
+	// we have the random values for client and server
+	if (ssl_context.state == MBEDTLS_SSL_SERVER_KEY_EXCHANGE)
+	{
+		memcpy(handshake_random, ssl_context.handshake->randbytes, 64);
+	}
+}
+
+	// Yield to the caller when waiting for I/O
+	if (ret == MBEDTLS_ERR_SSL_WANT_READ) {
+		last_wait = WaitCondition::WANT_READ;
+		return IN_PROGRESS;
+	}
+	if (ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
+		last_wait = WaitCondition::WANT_WRITE;
+		return IN_PROGRESS;
+	}
+
+	// Terminal: handshake complete or fatal error
+	establish_state = EstablishState::NONE;
+	last_wait = WaitCondition::NONE;
 
 	bool ok = false;
 	if (ret) {
 		LOG(ERROR, "handshake failed -%x", -ret);
-	} if (sessionPersist.prepare_save(random, keys_checksum, &ssl_context, 0)) {
+	} if (sessionPersist.prepare_save(handshake_random, keys_checksum, &ssl_context, 0)) {
 		ok = true;
 	}
 	if (!ok) {

--- a/communication/src/dtls_message_channel.cpp
+++ b/communication/src/dtls_message_channel.cpp
@@ -66,6 +66,12 @@ const system_tick_t HANDSHAKE_SEND_RETRY_MS = 50;
 // Floor for an armed-but-expired timer - ensures prompt re-entry
 const system_tick_t HANDSHAKE_DELAY_EXPIRED_FLOOR_MS = 1;
 
+const system_tick_t HANDSHAKE_PROCESSING_SLICE_MS = 20;
+
+#if defined(MBEDTLS_ECP_RESTARTABLE)
+const unsigned HANDSHAKE_ECP_MAX_OPS = 256;
+#endif
+
 } // namespace
 
 uint32_t compute_checksum(uint32_t(*calculate_crc)(const uint8_t* data, uint32_t len), const uint8_t* server, size_t server_len, const uint8_t* device, size_t device_len)
@@ -374,6 +380,10 @@ system_tick_t DTLSMessageChannel::next_handshake_delay() const
 	if (establish_state != EstablishState::HANDSHAKING) {
 		return 0; // no handshake in progress
 	}
+	if (last_wait == WaitCondition::CONTINUE ||
+			last_wait == WaitCondition::CRYPTO_IN_PROGRESS) {
+		return HANDSHAKE_DELAY_EXPIRED_FLOOR_MS;
+	}
 	// On WANT_WRITE, use the send-retry delay (but don't overshoot an
 	// imminent retransmit deadline)
 	if (last_wait == WaitCondition::WANT_WRITE) {
@@ -496,22 +506,30 @@ ProtocolError DTLSMessageChannel::establish()
 	last_wait = WaitCondition::NONE;
 }
 
-// Stepping loop: advance through as many non-IO steps as possible
-while (ssl_context.state != MBEDTLS_SSL_HANDSHAKE_OVER)
-{
-	ret = mbedtls_ssl_handshake_step(&ssl_context);
+	const system_tick_t sliceStart = callbacks.millis();
+	while (ssl_context.state != MBEDTLS_SSL_HANDSHAKE_OVER) {
+#if defined(MBEDTLS_ECP_RESTARTABLE)
+		mbedtls_ecp_set_max_ops(HANDSHAKE_ECP_MAX_OPS);
+#endif
+		ret = mbedtls_ssl_handshake_step(&ssl_context);
+#if defined(MBEDTLS_ECP_RESTARTABLE)
+		mbedtls_ecp_set_max_ops(0);
+#endif
 
-	if (ret != 0) {
-		break;
-	}
+		if (ret != 0) {
+			break;
+		}
 
-	// we've already received the ServerHello, thus
-	// we have the random values for client and server
-	if (ssl_context.state == MBEDTLS_SSL_SERVER_KEY_EXCHANGE)
-	{
-		memcpy(handshake_random, ssl_context.handshake->randbytes, 64);
+		if (ssl_context.state == MBEDTLS_SSL_SERVER_KEY_EXCHANGE) {
+			memcpy(handshake_random, ssl_context.handshake->randbytes, 64);
+		}
+
+		if (ssl_context.state != MBEDTLS_SSL_HANDSHAKE_OVER &&
+				callbacks.millis() - sliceStart >= HANDSHAKE_PROCESSING_SLICE_MS) {
+			last_wait = WaitCondition::CONTINUE;
+			return IN_PROGRESS;
+		}
 	}
-}
 
 	// Yield to the caller when waiting for I/O
 	if (ret == MBEDTLS_ERR_SSL_WANT_READ) {
@@ -522,6 +540,12 @@ while (ssl_context.state != MBEDTLS_SSL_HANDSHAKE_OVER)
 		last_wait = WaitCondition::WANT_WRITE;
 		return IN_PROGRESS;
 	}
+#if defined(MBEDTLS_ECP_RESTARTABLE)
+	if (ret == MBEDTLS_ERR_SSL_CRYPTO_IN_PROGRESS) {
+		last_wait = WaitCondition::CRYPTO_IN_PROGRESS;
+		return IN_PROGRESS;
+	}
+#endif
 
 	// Terminal: handshake complete or fatal error
 	establish_state = EstablishState::NONE;

--- a/communication/src/dtls_protocol.h
+++ b/communication/src/dtls_protocol.h
@@ -129,6 +129,21 @@ public:
 		return NO_ERROR;
 	}
 
+	// DTLS handshake hooks for re-entrant begin()
+	ProtocolError poll_hello_delivered() override {
+		return channel.poll_confirmed();
+	}
+
+	system_tick_t next_handshake_event_delay() const override {
+		if (handshake_stage == HandshakeStage::ESTABLISH) {
+			return channel.next_handshake_delay();
+		}
+		if (handshake_stage == HandshakeStage::HELLO_WAIT) {
+			return channel.client_next_timeout(millis());
+		}
+		return 0;
+	}
+
 
 	/**
 	 * Ensures that all outstanding sent coap messages have been acknowledged.

--- a/communication/src/protocol.cpp
+++ b/communication/src/protocol.cpp
@@ -474,75 +474,147 @@ AppStateDescriptor Protocol::app_state_descriptor(uint32_t stateFlags)
 
 /**
  * Establish a secure connection and send and process the hello message.
+ * Legacy blocking entry point.
  */
 int Protocol::begin()
 {
+	return begin(0, nullptr);
+}
+
+/**
+ * Re-entrant handshake stage machine.
+ */
+int Protocol::begin(unsigned flags, system_tick_t* next_event_delay)
+{
 	LOG_CATEGORY("comm.protocol.handshake");
-	LOG(INFO,"Establish secure connection");
+	const bool non_blocking = (flags & HANDSHAKE_FLAG_NON_BLOCKING);
+	const bool continuing = (flags & HANDSHAKE_FLAG_CONTINUE);
 
-	reset();
-	last_ack_handlers_update = callbacks.millis();
-
-	bool debug_enabled = LOG_ENABLED_C(TRACE, COAP_LOG_CATEGORY);
-	channel.set_debug_enabled(debug_enabled);
-
-	ProtocolError error = channel.establish();
-	const bool session_resumed = (error == SESSION_RESUMED);
-	if (error && !session_resumed) {
-		LOG(ERROR, "Handshake failed: %d", error);
-		return error;
+	// Validate control input
+	if (next_event_delay) {
+		*next_event_delay = 0;
+	}
+	if (continuing && !non_blocking) {
+		return INVALID_STATE;
+	}
+	if (continuing && handshake_stage == HandshakeStage::INIT) {
+		return INVALID_STATE;
+	}
+	// Unknown flag bits
+	if (flags & ~(HANDSHAKE_FLAG_NON_BLOCKING | HANDSHAKE_FLAG_CONTINUE)) {
+		return INVALID_STATE;
 	}
 
-	if (session_resumed) {
-		// for now, unconditionally move the session on resumption
-		channel.command(MessageChannel::MOVE_SESSION, nullptr);
-		uint32_t stateFlags = 0xffffffffu; // Check all flags, not just recognized ones
-		if (protocol_flags & ProtocolFlag::DEVICE_INITIATED_DESCRIBE) {
-			// The system controls when to send application Describe and subscriptions
-			stateFlags &= ~(AppStateDescriptor::APP_DESCRIBE_CRC | AppStateDescriptor::SUBSCRIPTIONS_CRC);
-		}
-		const auto currentState = app_state_descriptor(stateFlags);
-		const auto cachedState = channel.cached_app_state_descriptor();
-		if (currentState.equalsTo(cachedState, stateFlags)) {
-			LOG(INFO, "Skipping HELLO message");
-			error = ping(true);
-			if (error != ProtocolError::NO_ERROR) {
-				return error;
+	// A non-CONTINUE call is always a fresh attempt
+	if (!continuing) {
+		LOG(INFO, "Establish secure connection");
+		reset();
+		last_ack_handlers_update = callbacks.millis();
+		bool debug_enabled = LOG_ENABLED_C(TRACE, COAP_LOG_CATEGORY);
+		channel.set_debug_enabled(debug_enabled);
+		handshake_stage = HandshakeStage::ESTABLISH;
+	}
+
+	if (handshake_stage == HandshakeStage::ESTABLISH) {
+		ProtocolError error = channel.establish();
+		if (error == IN_PROGRESS) {
+			if (non_blocking) {
+				if (next_event_delay) {
+					*next_event_delay = next_handshake_event_delay();
+				}
+				return IN_PROGRESS;
 			}
-			return ProtocolError::SESSION_RESUMED; // Not an error
-		} else {
-			// TODO: For now, make sure application Describe and subscriptions will be sent if the
-			// system state has changed
-			channel.command(Channel::SAVE_SESSION);
-			descriptor.app_state_selector_info(SparkAppStateSelector::ALL, SparkAppStateUpdate::RESET, 0, nullptr);
-			channel.command(Channel::LOAD_SESSION);
+			// Blocking mode: spin in place (legacy behavior)
+			while (error == IN_PROGRESS) {
+				error = channel.establish();
+			}
 		}
-	}
-
-	LOG(INFO, "Sending HELLO message");
-	error = hello(descriptor.was_ota_upgrade_successful());
-	if (error) {
-		LOG(ERROR,"Could not send HELLO message: %d", error);
-		return error;
-	}
-
-	if (protocol_flags & ProtocolFlag::REQUIRE_HELLO_RESPONSE) {
-		LOG(INFO, "Receiving HELLO response");
-		error = hello_response();
-		if (error) {
+		const bool session_resumed = (error == SESSION_RESUMED);
+		if (error && !session_resumed) {
+			LOG(ERROR, "Handshake failed: %d", error);
+			handshake_stage = HandshakeStage::INIT;
 			return error;
 		}
+
+		if (session_resumed) {
+			// for now, unconditionally move the session on resumption
+			channel.command(MessageChannel::MOVE_SESSION, nullptr);
+			uint32_t stateFlags = 0xffffffffu;
+			if (protocol_flags & ProtocolFlag::DEVICE_INITIATED_DESCRIBE) {
+				stateFlags &= ~(AppStateDescriptor::APP_DESCRIBE_CRC | AppStateDescriptor::SUBSCRIPTIONS_CRC);
+			}
+			const auto currentState = app_state_descriptor(stateFlags);
+			const auto cachedState = channel.cached_app_state_descriptor();
+			if (currentState.equalsTo(cachedState, stateFlags)) {
+				LOG(INFO, "Skipping HELLO message");
+				error = ping(true);
+				if (error != ProtocolError::NO_ERROR) {
+					handshake_stage = HandshakeStage::INIT;
+					return error;
+				}
+				// Session resumed with matching state - complete
+				handshake_stage = HandshakeStage::INIT;
+				return ProtocolError::SESSION_RESUMED;
+			} else {
+				channel.command(Channel::SAVE_SESSION);
+				descriptor.app_state_selector_info(SparkAppStateSelector::ALL, SparkAppStateUpdate::RESET, 0, nullptr);
+				channel.command(Channel::LOAD_SESSION);
+			}
+		}
+
+		// Send HELLO
+		LOG(INFO, "Sending HELLO message");
+		error = hello(descriptor.was_ota_upgrade_successful());
+		if (error) {
+			LOG(ERROR, "Could not send HELLO message: %d", error);
+			handshake_stage = HandshakeStage::INIT;
+			return error;
+		}
+
+		if (protocol_flags & ProtocolFlag::REQUIRE_HELLO_RESPONSE) {
+			// LightSSL/TCP path: blocking hello_response()
+			LOG(INFO, "Receiving HELLO response");
+			error = hello_response();
+			if (error) {
+				handshake_stage = HandshakeStage::INIT;
+				return error;
+			}
+			// hello_response() completed - go straight to finalize
+			handshake_stage = HandshakeStage::INIT;
+		} else {
+			// DTLS path: poll for HELLO ACK
+			handshake_stage = HandshakeStage::HELLO_WAIT;
+		}
+	}
+
+	if (handshake_stage == HandshakeStage::HELLO_WAIT) {
+		ProtocolError error = poll_hello_delivered();
+		if (error == IN_PROGRESS) {
+			if (non_blocking) {
+				if (next_event_delay) {
+					*next_event_delay = next_handshake_event_delay();
+				}
+				return IN_PROGRESS;
+			}
+			// Blocking mode: spin in place (legacy behavior)
+			while (error == IN_PROGRESS) {
+				error = poll_hello_delivered();
+			}
+		}
+		if (error) {
+			LOG(ERROR, "HELLO confirmation failed: %d", error);
+			handshake_stage = HandshakeStage::INIT;
+			return error;
+		}
+		handshake_stage = HandshakeStage::INIT;
 	}
 
 	LOG(INFO, "Handshake completed");
 	channel.notify_established();
 
-	// An ACK or a response for the Hello message has already been received at this point, so we can
-	// update the cached session parameters
 	if (descriptor.app_state_selector_info) {
 		LOG(TRACE, "Updating cached session parameters");
 		channel.command(Channel::SAVE_SESSION);
-		// TODO: Update the underlying SessionPersist structure directly
 		descriptor.app_state_selector_info(SparkAppStateSelector::PROTOCOL_FLAGS, SparkAppStateUpdate::PERSIST, protocol_flags, nullptr);
 		descriptor.app_state_selector_info(SparkAppStateSelector::SYSTEM_MODULE_VERSION, SparkAppStateUpdate::PERSIST, system_version, nullptr);
 		descriptor.app_state_selector_info(SparkAppStateSelector::MAX_MESSAGE_SIZE, SparkAppStateUpdate::PERSIST, PROTOCOL_BUFFER_SIZE, nullptr);
@@ -552,9 +624,9 @@ int Protocol::begin()
 	}
 
 	if (protocol_flags & ProtocolFlag::DEVICE_INITIATED_DESCRIBE) {
-		// Send system Describe
-		error = post_description(DescriptionType::DESCRIBE_SYSTEM, true /* force */);
+		ProtocolError error = post_description(DescriptionType::DESCRIBE_SYSTEM, true /* force */);
 		if (error) {
+			handshake_stage = HandshakeStage::INIT;
 			return error;
 		}
 	}
@@ -576,6 +648,7 @@ void Protocol::reset() {
 	channel.reset();
 	subscription_msg_ids.clear();
 	v2::CoapChannel::instance()->close();
+	handshake_stage = HandshakeStage::INIT;
 }
 
 /**

--- a/communication/src/protocol_defs.cpp
+++ b/communication/src/protocol_defs.cpp
@@ -75,6 +75,8 @@ system_error_t toSystemError(ProtocolError error) {
         return SYSTEM_ERROR_END_OF_STREAM;
     case COAP_ERROR:
         return SYSTEM_ERROR_COAP;
+    case IN_PROGRESS:
+        return SYSTEM_ERROR_BUSY;
     default:
         return SYSTEM_ERROR_PROTOCOL; // Generic protocol error
     }

--- a/communication/src/spark_protocol_functions.cpp
+++ b/communication/src/spark_protocol_functions.cpp
@@ -88,9 +88,33 @@ void spark_protocol_init(ProtocolFacade* protocol, const char *id,
     protocol->init(id, keys, callbacks, descriptor);
 }
 
-int spark_protocol_handshake(ProtocolFacade* protocol, void*) {
+int spark_protocol_handshake(ProtocolFacade* protocol, void* reserved) {
     ASSERT_ON_SYSTEM_THREAD();
-    return protocol->begin();
+    if (!reserved) {
+        // Legacy blocking path
+        return protocol->begin();
+    }
+    // Non-blocking path: map the param struct to begin(flags, &delay)
+    auto* param = static_cast<spark_protocol_handshake_param*>(reserved);
+    if (param->size < sizeof(spark_protocol_handshake_param)) {
+        return particle::protocol::INVALID_STATE;
+    }
+    // Reject unknown flag bits
+    if (param->flags & ~(SPARK_PROTOCOL_HANDSHAKE_FLAG_NON_BLOCKING | SPARK_PROTOCOL_HANDSHAKE_FLAG_CONTINUE)) {
+        return particle::protocol::INVALID_STATE;
+    }
+
+    unsigned begin_flags = 0;
+    if (param->flags & SPARK_PROTOCOL_HANDSHAKE_FLAG_NON_BLOCKING) {
+        begin_flags |= Protocol::HandshakeFlag::HANDSHAKE_FLAG_NON_BLOCKING;
+    }
+    if (param->flags & SPARK_PROTOCOL_HANDSHAKE_FLAG_CONTINUE) {
+        begin_flags |= Protocol::HandshakeFlag::HANDSHAKE_FLAG_CONTINUE;
+    }
+    system_tick_t delay = 0;
+    const int ret = protocol->begin(begin_flags, &delay);
+    param->next_event_delay_ms = (uint32_t)delay;
+    return ret;
 }
 
 bool spark_protocol_event_loop(ProtocolFacade* protocol, void*) {

--- a/system/inc/active_object.h
+++ b/system/inc/active_object.h
@@ -31,6 +31,7 @@
 
 #include "concurrent_hal.h"
 #include "hal_platform.h"
+#include "service_debug.h"
 
 /**
  * Configuratino data for an active object.
@@ -409,7 +410,6 @@ public:
  */
 class ActiveObjectThreadQueue : public ActiveObjectQueue
 {
-
 public:
 
     ActiveObjectThreadQueue(const ActiveObjectConfiguration& config) : ActiveObjectQueue(config) {}
@@ -418,7 +418,15 @@ public:
 #if HAL_PLATFORM_SOCKET_IOCTL_NOTIFY
     virtual bool take(Item& result) override
     {
-        auto r = os_thread_wait(configuration.take_wait, nullptr);
+        // Consume the one-shot wake hint: can shorten one sleep, never extend
+        system_tick_t wait = configuration.take_wait;
+        if (next_wake_timeout != 0) {
+            if (next_wake_timeout < wait) {
+                wait = next_wake_timeout;
+            }
+            next_wake_timeout = 0;
+        }
+        auto r = os_thread_wait(wait, nullptr);
         if (!os_queue_take(queue, &result, 0, nullptr)) {
             return true;
         }
@@ -440,6 +448,14 @@ public:
             os_thread_notify(_thread, nullptr);
         }
     }
+
+    void nextWakeTimeout(system_tick_t ms)
+    {
+        SPARK_ASSERT(isCurrentThread());
+        if (next_wake_timeout == 0 || ms < next_wake_timeout) {
+            next_wake_timeout = ms;
+        }
+    }
 #endif // HAL_PLATFORM_SOCKET_IOCTL_NOTIFY
 
     void start()
@@ -447,7 +463,10 @@ public:
         createQueue();
         start_thread();
     }
-
+private:
+#if HAL_PLATFORM_SOCKET_IOCTL_NOTIFY
+    system_tick_t next_wake_timeout = 0;
+#endif // HAL_PLATFORM_SOCKET_IOCTL_NOTIFY
 };
 
 

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -1256,13 +1256,43 @@ int Send_Firmware_Update_Flags()
 
 int Spark_Handshake(bool presence_announce)
 {
-    cloud_socket_aborted = false; // Clear cancellation flag for socket operations
-    LOG(INFO,"Starting handshake: presense_announce=%d", presence_announce);
-    bool session_resumed = false;
-    // TODO: Perform the DTLS handshake and receive a response for the Hello message asynchronously
-    SPARK_CLOUD_PROTOCOL_HANDSHAKE_IN_PROGRESS = 1;
-    int err = spark_protocol_handshake(sp);
+    const bool continuing = SPARK_CLOUD_PROTOCOL_HANDSHAKE_IN_PROGRESS;
+    if (!continuing) {
+        // First entry - initial setup (runs once per attempt)
+        cloud_socket_aborted = false; // Clear cancellation flag for socket operations
+        LOG(INFO, "Starting handshake: presense_announce=%d", presence_announce);
+        SPARK_CLOUD_PROTOCOL_HANDSHAKE_IN_PROGRESS = 1;
+    }
+
+#if PLATFORM_THREADING
+    const bool nonblocking = continuing || SystemThread.isStarted();
+#else
+    const bool nonblocking = false;
+#endif
+
+    int err;
+    if (nonblocking) {
+        spark_protocol_handshake_param param = {};
+        param.size = sizeof(param);
+        param.flags = SPARK_PROTOCOL_HANDSHAKE_FLAG_NON_BLOCKING |
+                (continuing ? SPARK_PROTOCOL_HANDSHAKE_FLAG_CONTINUE : 0);
+        err = spark_protocol_handshake(sp, &param);
+        if (err == protocol::IN_PROGRESS) {
+#if PLATFORM_THREADING && HAL_PLATFORM_SOCKET_IOCTL_NOTIFY
+            if (param.next_event_delay_ms > 0) {
+                SystemThread.nextWakeTimeout(param.next_event_delay_ms);
+            }
+#endif
+            return SYSTEM_ERROR_BUSY;
+        }
+    } else {
+        // Legacy blocking path
+        err = spark_protocol_handshake(sp);
+    }
+
+    // Handshake complete (success or error)
     SPARK_CLOUD_PROTOCOL_HANDSHAKE_IN_PROGRESS = 0;
+    bool session_resumed = false;
 
 #if HAL_PLATFORM_MUXER_MAY_NEED_DELAY_IN_TX
     // XXX: Adding a delay only for platforms Boron and BSoM, because older cell versions of

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -398,11 +398,15 @@ void handle_cloud_connection(bool force_events)
                     LED_SIGNAL_STOP(CLOUD_HANDSHAKE);
                 }
             } else { // !SPARK_CLOUD_HANDSHAKE_NOTIFY_DONE
-                LED_SIGNAL_START(CLOUD_HANDSHAKE, NORMAL);
+                if (!SPARK_CLOUD_PROTOCOL_HANDSHAKE_IN_PROGRESS) {
+                    LED_SIGNAL_START(CLOUD_HANDSHAKE, NORMAL);
+                }
                 err = cloud_handshake();
             }
-            if (err)
-            {
+
+            if (err == SYSTEM_ERROR_BUSY) {
+                // Handshake in progress, re-enter next loop iteration.
+            } else if (err) {
                 if (!SPARK_WLAN_RESET && !network_listening(0, 0, 0))
                 {
                     cloud_connection_failed();
@@ -428,7 +432,8 @@ void handle_cloud_connection(bool force_events)
                 cfod_count = 0;
             }
         }
-        if (SPARK_FLASH_UPDATE || force_events || System.mode() != MANUAL || system_thread_get_state(NULL)==spark::feature::ENABLED)
+        if (!SPARK_CLOUD_PROTOCOL_HANDSHAKE_IN_PROGRESS &&
+                (SPARK_FLASH_UPDATE || force_events || System.mode() != MANUAL || system_thread_get_state(NULL)==spark::feature::ENABLED))
         {
             Spark_Process_Events();
         }
@@ -767,6 +772,7 @@ void cloud_disconnect(unsigned flags, cloud_disconnect_reason cloudReason, netwo
         SPARK_CLOUD_CONNECTED = 0;
         SPARK_CLOUD_HANDSHAKE_PENDING = 0;
         SPARK_CLOUD_HANDSHAKE_NOTIFY_DONE = 0;
+        SPARK_CLOUD_PROTOCOL_HANDSHAKE_IN_PROGRESS = 0;
         SPARK_CLOUD_SOCKETED = 0;
 
         LED_SIGNAL_STOP(CLOUD_CONNECTED);

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -404,7 +404,7 @@ void handle_cloud_connection(bool force_events)
                 err = cloud_handshake();
             }
 
-            if (err == SYSTEM_ERROR_BUSY) {
+            if (err == SYSTEM_ERROR_BUSY && SPARK_CLOUD_PROTOCOL_HANDSHAKE_IN_PROGRESS) {
                 // Handshake in progress, re-enter next loop iteration.
             } else if (err) {
                 if (!SPARK_WLAN_RESET && !network_listening(0, 0, 0))

--- a/test/unit_tests/communication/CMakeLists.txt
+++ b/test/unit_tests/communication/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable( ${target_name}
   forward_message_channel.cpp
   hal_stubs.cpp
   messages.cpp
+  nonblocking_handshake.cpp
   ping.cpp
   protocol.cpp
   publisher.cpp

--- a/test/unit_tests/communication/coap_reliability.cpp
+++ b/test/unit_tests/communication/coap_reliability.cpp
@@ -273,6 +273,16 @@ void build_message_channel_mock(Mock<MessageChannel>& mock)
 	When(Method(mock,is_unreliable)).AlwaysReturn(false);
 	When(Method(mock,command)).AlwaysReturn(NO_ERROR);
 	When(Method(mock,notify_client_messages_processed)).AlwaysReturn();
+	// poll_confirmed() calls create() to get a receive buffer
+	When(Method(mock,create)).AlwaysDo([](Message& msg, size_t) {
+		static uint8_t buf[1500];
+		msg.set_buffer(buf, sizeof(buf));
+		return NO_ERROR;
+	});
+	// establish() calls reset() which calls channel::reset()
+	When(Method(mock,reset)).AlwaysReturn();
+	// establish() calls is_establish_in_progress() to check continuation
+	When(Method(mock,is_establish_in_progress)).AlwaysReturn(false);
 }
 
 SCENARIO("an unacknowledged message is resent up to MAX_TRANSMIT times, with exponentially increasing delays, after which it is removed")
@@ -879,10 +889,12 @@ SCENARIO("sending a message and re-establishing the connection clears existing m
 				REQUIRE(CoAPMessage::messages()==1);
 				Verify(Method(mock,send)).Exactly(Once);
 			}
-			AND_WHEN("the connection is re-established")
-			{
-				When(Method(mock,establish)).Return(NO_ERROR);
-				channel.establish();
+		AND_WHEN("the connection is re-established")
+		{
+			When(Method(mock,reset)).AlwaysReturn(); // establish() calls reset()
+			When(Method(mock,is_establish_in_progress)).AlwaysReturn(false); // fresh attempt
+			When(Method(mock,establish)).Return(NO_ERROR);
+			channel.establish();
 				THEN("the message store is cleared")
 				{
 					REQUIRE(channel.client_messages().from_id(0x1234)==nullptr);		// message has been sent and registered
@@ -1118,7 +1130,7 @@ SCENARIO("a message flagged as confirm received waits synchronously for acknowle
 		{
 			When(Method(mock,send)).AlwaysReturn(NO_ERROR);
 			When(Method(mock,receive)).AlwaysDo(no_message);
-			ProtocolError error = channel.send(m);
+			ProtocolError error = channel.send_synchronous(m);
 			AND_WHEN("the request has timed out")
 			{
 				CHECK(ticks >= MAX_TRANSMIT_SPAN);
@@ -1138,7 +1150,7 @@ SCENARIO("a message flagged as confirm received waits synchronously for acknowle
 				return NO_ERROR;
 			};
 			When(Method(mock,receive)).Do(receive_nak);
-			ProtocolError error = channel.send(m);
+			ProtocolError error = channel.send_synchronous(m);
 			THEN("a MESSAGE_RESET response is returned")
 			{
 				REQUIRE(error==MESSAGE_RESET);
@@ -1150,7 +1162,7 @@ SCENARIO("a message flagged as confirm received waits synchronously for acknowle
 		{
 			When(Method(mock,send)).AlwaysReturn(NO_ERROR);
 			When(Method(mock,receive)).Do(receive_server_ack);
-			ProtocolError error = channel.send(m);
+			ProtocolError error = channel.send_synchronous(m);
 			THEN("a success response is returned")
 			{
 				REQUIRE(error==NO_ERROR);

--- a/test/unit_tests/communication/forward_message_channel.h
+++ b/test/unit_tests/communication/forward_message_channel.h
@@ -62,6 +62,11 @@ public:
 		return channel->establish();
 	}
 
+	virtual bool is_establish_in_progress() const override
+	{
+		return channel ? channel->is_establish_in_progress() : false;
+	}
+
 	virtual ProtocolError response(Message& original, Message& response, size_t required) override
 	{
 		return channel->response(original, response, required);

--- a/test/unit_tests/communication/nonblocking_handshake.cpp
+++ b/test/unit_tests/communication/nonblocking_handshake.cpp
@@ -499,11 +499,23 @@ class SteppableCoapChannel : public test::CoapMessageChannel {
 	bool establishInProgress = false;
 public:
 	unsigned establishCallCount = 0;
+	unsigned moveSessionCallCount = 0;
+	unsigned sendCallCount = 0;
 	void setEstablishResult(ProtocolError e) { establishResult_ = e; }
 	void setEstablishInProgress(bool v) { establishInProgress = v; }
 	ProtocolError establish() override {
 		establishCallCount++;
 		return establishResult_;
+	}
+	ProtocolError command(Command cmd, void* arg) override {
+		if (cmd == MOVE_SESSION) {
+			moveSessionCallCount++;
+		}
+		return test::CoapMessageChannel::command(cmd, arg);
+	}
+	ProtocolError send(Message& msg) override {
+		sendCallCount++;
+		return test::CoapMessageChannel::send(msg);
 	}
 	bool is_establish_in_progress() const override {
 		return establishInProgress;
@@ -612,6 +624,32 @@ SCENARIO("begin() zeroes next_event_delay on terminal result",
 			THEN("next_event_delay is zeroed on terminal result")
 			{
 				REQUIRE(delay == 0);
+			}
+		}
+	}
+}
+
+SCENARIO("begin() preserves the session-resumption fast path",
+         "[nonblocking_handshake]")
+{
+	GIVEN("a Protocol whose channel restores a matching session")
+	{
+		SteppableCoapChannel channel;
+		channel.setEstablishResult(SESSION_RESUMED);
+		test::ProtocolStub p(&channel);
+
+		WHEN("a non-blocking handshake is started")
+		{
+			system_tick_t delay = 999;
+			const int ret = p.begin(Protocol::HANDSHAKE_FLAG_NON_BLOCKING, &delay);
+
+			THEN("the session is moved and the resume ping is sent in the same call")
+			{
+				REQUIRE(ret == SESSION_RESUMED);
+				REQUIRE(delay == 0);
+				REQUIRE(channel.establishCallCount == 1);
+				REQUIRE(channel.moveSessionCallCount == 1);
+				REQUIRE(channel.sendCallCount == 1);
 			}
 		}
 	}

--- a/test/unit_tests/communication/nonblocking_handshake.cpp
+++ b/test/unit_tests/communication/nonblocking_handshake.cpp
@@ -1,0 +1,685 @@
+/*
+ * Copyright (c) 2025 Particle Industries, Inc.  All rights reserved.
+ *
+ * Unit tests for the non-blocking DTLS handshake changes:
+ *   - send_confirmed / poll_confirmed split (CoAPReliableChannel)
+ *   - client_next_timeout() wrap-safe arithmetic + expired floor
+ *   - Protocol::begin() stage machine (ESTABLISH → HELLO_WAIT → FINALIZE)
+ */
+
+#include <climits>
+
+#include "coap_channel.h"
+#include "forward_message_channel.h"
+#include "messages.h"
+#include "protocol.h"
+#include "util/protocol_stub.h"
+
+#include <catch2/catch.hpp>
+#include "fakeit.hpp"
+
+using namespace particle::protocol;
+using namespace fakeit;
+
+template <typename M>
+class ForwardCoAPReliableChannel: public CoAPReliableChannel<ForwardMessageChannel, M>
+{
+	using super = CoAPReliableChannel<ForwardMessageChannel, M>;
+public:
+	ForwardCoAPReliableChannel(MessageChannel& ch, M m) : super(m)
+	{
+		this->setForward(&ch);
+	}
+};
+
+static void build_message_channel_mock(Mock<MessageChannel>& mock)
+{
+	When(Method(mock,notify_established)).AlwaysReturn(NO_ERROR);
+	When(Method(mock,is_unreliable)).AlwaysReturn(false);
+	When(Method(mock,command)).AlwaysReturn(NO_ERROR);
+	When(Method(mock,notify_client_messages_processed)).AlwaysReturn();
+	// poll_confirmed() calls create() to get a receive buffer
+	When(Method(mock,create)).AlwaysDo([](Message& msg, size_t) {
+		static uint8_t buf[1500];
+		msg.set_buffer(buf, sizeof(buf));
+		return NO_ERROR;
+	});
+	// establish() calls reset() which calls channel::reset()
+	When(Method(mock,reset)).AlwaysReturn();
+	// establish() calls is_establish_in_progress() to check continuation
+	When(Method(mock,is_establish_in_progress)).AlwaysReturn(false);
+}
+
+SCENARIO("send_confirmed sends a CON message and returns NO_ERROR without waiting for ACK",
+         "[nonblocking_handshake]")
+{
+	GIVEN("a reliable channel and a confirmable message marked confirm_received")
+	{
+		Mock<MessageChannel> mock;
+		build_message_channel_mock(mock);
+		MessageChannel& delegate = mock.get();
+		auto time = []() { return system_tick_t(0); };
+		ForwardCoAPReliableChannel<decltype(time)> channel(delegate, time);
+
+		uint8_t buf[] = { 0x40, 0, 0x12, 0x34, 0xFF, 1, 2, 3, 4 };
+		Message m(buf, sizeof(buf), sizeof(buf));
+		m.set_confirm_received(true);
+		m.decode_id();
+
+		When(Method(mock, send)).AlwaysReturn(NO_ERROR);
+
+		WHEN("send_confirmed is called")
+		{
+			ProtocolError error = channel.send_confirmed(m);
+			THEN("it returns NO_ERROR immediately")
+			{
+				REQUIRE(error == NO_ERROR);
+			}
+			THEN("the message is in the client store (unacknowledged)")
+			{
+				REQUIRE(channel.client_messages().from_id(0x1234) != nullptr);
+			}
+			THEN("send was called exactly once (the initial send)")
+			{
+				Verify(Method(mock, send)).Exactly(1);
+			}
+		}
+	}
+	REQUIRE(CoAPMessage::messages() == 0);
+}
+
+SCENARIO("poll_confirmed returns IN_PROGRESS when ACK has not arrived",
+         "[nonblocking_handshake]")
+{
+	GIVEN("a message sent via send_confirmed, no ACK received")
+	{
+		Mock<MessageChannel> mock;
+		build_message_channel_mock(mock);
+		MessageChannel& delegate = mock.get();
+		auto time = []() { return system_tick_t(0); };
+		ForwardCoAPReliableChannel<decltype(time)> channel(delegate, time);
+
+		uint8_t buf[] = { 0x40, 0, 0x12, 0x34, 0xFF, 1, 2, 3, 4 };
+		Message m(buf, sizeof(buf), sizeof(buf));
+		m.set_confirm_received(true);
+		m.decode_id();
+		When(Method(mock, send)).AlwaysReturn(NO_ERROR);
+		channel.send_confirmed(m);
+
+		WHEN("poll_confirmed is called and no data is received")
+		{
+			auto receive_none = [](Message& msg) {
+				msg.set_length(0);
+				return NO_ERROR;
+			};
+			When(Method(mock, receive)).AlwaysDo(receive_none);
+
+			ProtocolError error = channel.poll_confirmed();
+			THEN("it returns IN_PROGRESS")
+			{
+				REQUIRE(error == IN_PROGRESS);
+			}
+			THEN("the message is still in the client store")
+			{
+				REQUIRE(channel.client_messages().from_id(0x1234) != nullptr);
+			}
+		}
+	}
+	REQUIRE(CoAPMessage::messages() == 0);
+}
+
+SCENARIO("poll_confirmed returns NO_ERROR when ACK arrives",
+         "[nonblocking_handshake]")
+{
+	GIVEN("a message sent via send_confirmed")
+	{
+		Mock<MessageChannel> mock;
+		build_message_channel_mock(mock);
+		MessageChannel& delegate = mock.get();
+		auto time = []() { return system_tick_t(0); };
+		ForwardCoAPReliableChannel<decltype(time)> channel(delegate, time);
+
+		uint8_t buf[] = { 0x40, 0, 0x12, 0x34, 0xFF, 1, 2, 3, 4 };
+		Message m(buf, sizeof(buf), sizeof(buf));
+		m.set_confirm_received(true);
+		m.decode_id();
+		When(Method(mock, send)).AlwaysReturn(NO_ERROR);
+		channel.send_confirmed(m);
+
+		WHEN("an ACK for the message is received")
+		{
+			uint8_t ackbuf[5];
+			auto receive_ack = [&ackbuf](Message& msg) {
+				msg.set_buffer(ackbuf, sizeof(ackbuf));
+				msg.set_length(Messages::empty_ack(ackbuf, 0x12, 0x34));
+				return NO_ERROR;
+			};
+			When(Method(mock, receive)).Do(receive_ack);
+
+			ProtocolError error = channel.poll_confirmed();
+			THEN("it returns NO_ERROR")
+			{
+				REQUIRE(error == NO_ERROR);
+			}
+			THEN("the message is purged from the client store")
+			{
+				REQUIRE(channel.client_messages().from_id(0x1234) == nullptr);
+			}
+		}
+	}
+	REQUIRE(CoAPMessage::messages() == 0);
+}
+
+SCENARIO("poll_confirmed returns MESSAGE_RESET when RST arrives",
+         "[nonblocking_handshake]")
+{
+	GIVEN("a message sent via send_confirmed")
+	{
+		Mock<MessageChannel> mock;
+		build_message_channel_mock(mock);
+		MessageChannel& delegate = mock.get();
+		auto time = []() { return system_tick_t(0); };
+		ForwardCoAPReliableChannel<decltype(time)> channel(delegate, time);
+
+		uint8_t buf[] = { 0x40, 0, 0x12, 0x34, 0xFF, 1, 2, 3, 4 };
+		Message m(buf, sizeof(buf), sizeof(buf));
+		m.set_confirm_received(true);
+		m.decode_id();
+		When(Method(mock, send)).AlwaysReturn(NO_ERROR);
+		channel.send_confirmed(m);
+
+		WHEN("a RST for the message is received")
+		{
+			uint8_t rstbuf[5];
+			auto receive_rst = [&rstbuf](Message& msg) {
+				msg.set_buffer(rstbuf, sizeof(rstbuf));
+				msg.set_length(Messages::reset(rstbuf, 0x12, 0x34));
+				return NO_ERROR;
+			};
+			When(Method(mock, receive)).Do(receive_rst);
+
+			ProtocolError error = channel.poll_confirmed();
+			THEN("it returns MESSAGE_RESET")
+			{
+				REQUIRE(error == MESSAGE_RESET);
+			}
+			THEN("the message is purged")
+			{
+				REQUIRE(channel.client_messages().from_id(0x1234) == nullptr);
+			}
+		}
+	}
+	REQUIRE(CoAPMessage::messages() == 0);
+}
+
+SCENARIO("poll_confirmed returns MESSAGE_TIMEOUT after MAX_RETRANSMIT retransmits",
+         "[nonblocking_handshake]")
+{
+	GIVEN("a message sent via send_confirmed, with fake-millis advancing time")
+	{
+		Mock<MessageChannel> mock;
+		build_message_channel_mock(mock);
+		MessageChannel& delegate = mock.get();
+		system_tick_t ticks = 0;
+		auto time = [&ticks]() { return ticks += 1000; };
+		ForwardCoAPReliableChannel<decltype(time)> channel(delegate, time);
+
+		uint8_t buf[] = { 0x40, 0, 0x12, 0x34, 0xFF, 1, 2, 3, 4 };
+		Message m(buf, sizeof(buf), sizeof(buf));
+		m.set_confirm_received(true);
+		m.decode_id();
+		When(Method(mock, send)).AlwaysReturn(NO_ERROR);
+		auto receive_none = [](Message& msg) {
+			msg.set_length(0);
+			return NO_ERROR;
+		};
+		When(Method(mock, receive)).AlwaysDo(receive_none);
+		channel.send_confirmed(m);
+
+		WHEN("poll_confirmed is called repeatedly until timeout")
+		{
+			ProtocolError error = NO_ERROR;
+			// Loop enough times for the time source to advance past
+			// MAX_TRANSMIT_SPAN. Each poll_confirmed() call advances time
+			// by ~1000ms per millis() call, and poll_confirmed calls
+			// millis() several times, so ~100 iterations is plenty.
+			for (int i = 0; i < 100; ++i) {
+				error = channel.poll_confirmed();
+				if (error != IN_PROGRESS) {
+					break;
+				}
+			}
+			THEN("it eventually returns MESSAGE_TIMEOUT")
+			{
+				REQUIRE(error == MESSAGE_TIMEOUT);
+			}
+			THEN("the message is purged")
+			{
+				REQUIRE(channel.client_messages().from_id(0x1234) == nullptr);
+			}
+		}
+	}
+	REQUIRE(CoAPMessage::messages() == 0);
+}
+
+SCENARIO("send_synchronous wrapper still works (legacy compatibility)",
+         "[nonblocking_handshake]")
+{
+	GIVEN("a confirmable message marked confirm_received")
+	{
+		Mock<MessageChannel> mock;
+		build_message_channel_mock(mock);
+		MessageChannel& delegate = mock.get();
+		auto time = []() { return system_tick_t(0); };
+		ForwardCoAPReliableChannel<decltype(time)> channel(delegate, time);
+
+		uint8_t buf[] = { 0x40, 0, 0x12, 0x34, 0xFF, 1, 2, 3, 4 };
+		Message m(buf, sizeof(buf), sizeof(buf));
+		m.set_confirm_received(true);
+		m.decode_id();
+
+		WHEN("the channel retrieves an ACK response")
+		{
+			uint8_t ackbuf[5];
+			auto receive_ack = [&ackbuf](Message& msg) {
+				msg.set_buffer(ackbuf, sizeof(ackbuf));
+				msg.set_length(Messages::empty_ack(ackbuf, 0x12, 0x34));
+				return NO_ERROR;
+			};
+			When(Method(mock, send)).AlwaysReturn(NO_ERROR);
+			When(Method(mock, receive)).Do(receive_ack);
+
+			THEN("send_synchronous returns NO_ERROR")
+			{
+				REQUIRE(channel.send_synchronous(m) == NO_ERROR);
+				REQUIRE(channel.client_messages().from_id(0x1234) == nullptr);
+			}
+		}
+	}
+	REQUIRE(CoAPMessage::messages() == 0);
+}
+
+SCENARIO("client_next_timeout returns 0 when no messages are pending",
+         "[nonblocking_handshake]")
+{
+	GIVEN("a reliable channel with no pending messages")
+	{
+		Mock<MessageChannel> mock;
+		build_message_channel_mock(mock);
+		MessageChannel& delegate = mock.get();
+		auto time = []() { return system_tick_t(0); };
+		ForwardCoAPReliableChannel<decltype(time)> channel(delegate, time);
+
+		THEN("client_next_timeout returns 0")
+		{
+			REQUIRE(channel.client_next_timeout(1000) == 0);
+		}
+	}
+}
+
+SCENARIO("client_next_timeout returns remaining time for a pending message",
+         "[nonblocking_handshake]")
+{
+	GIVEN("a channel with a sent CON message")
+	{
+		Mock<MessageChannel> mock;
+		build_message_channel_mock(mock);
+		MessageChannel& delegate = mock.get();
+		system_tick_t ticks = 0;
+		auto time = [&ticks]() { return ticks += 100; };
+		ForwardCoAPReliableChannel<decltype(time)> channel(delegate, time);
+
+		uint8_t buf[] = { 0x40, 0, 0x12, 0x34 };
+		Message m(buf, sizeof(buf), sizeof(buf));
+		m.decode_id();
+		When(Method(mock, send)).AlwaysReturn(NO_ERROR);
+		channel.send(m); // ticks is now 100 after one time() call
+
+		WHEN("queried at a time before the timeout")
+		{
+			system_tick_t timeout = channel.client_next_timeout(200);
+			THEN("it returns a positive remaining time")
+			{
+				REQUIRE(timeout > 0);
+			}
+		}
+	}
+	REQUIRE(CoAPMessage::messages() == 0);
+}
+
+SCENARIO("client_next_timeout returns 1ms floor for an expired message",
+         "[nonblocking_handshake]")
+{
+	GIVEN("a channel with a sent CON message")
+	{
+		Mock<MessageChannel> mock;
+		build_message_channel_mock(mock);
+		MessageChannel& delegate = mock.get();
+		system_tick_t ticks = 0;
+		auto time = [&ticks]() { return ticks += 100; };
+		ForwardCoAPReliableChannel<decltype(time)> channel(delegate, time);
+
+		uint8_t buf[] = { 0x40, 0, 0x12, 0x34 };
+		Message m(buf, sizeof(buf), sizeof(buf));
+		m.decode_id();
+		When(Method(mock, send)).AlwaysReturn(NO_ERROR);
+		channel.send(m); // ticks = 100
+
+		WHEN("queried at a time far in the future (expired)")
+		{
+			// The message timeout is around ACK_TIMEOUT (4000ms) from send time.
+			// Query at 10000ms - well past the deadline.
+			system_tick_t timeout = channel.client_next_timeout(10000);
+			THEN("it returns 1 (the expired floor, not 0)")
+			{
+				REQUIRE(timeout == 1);
+			}
+		}
+	}
+	REQUIRE(CoAPMessage::messages() == 0);
+}
+
+SCENARIO("client_next_timeout is wrap-safe across 32-bit tick boundary",
+         "[nonblocking_handshake]")
+{
+	GIVEN("a channel with a sent CON message whose timeout wraps")
+	{
+		Mock<MessageChannel> mock;
+		build_message_channel_mock(mock);
+		MessageChannel& delegate = mock.get();
+		// Use a time source near the wrap boundary
+		system_tick_t ticks = 0xFFFFFFF0;
+		auto time = [&ticks]() { return ticks += 100; };
+		ForwardCoAPReliableChannel<decltype(time)> channel(delegate, time);
+
+		uint8_t buf[] = { 0x40, 0, 0x12, 0x34 };
+		Message m(buf, sizeof(buf), sizeof(buf));
+		m.decode_id();
+		When(Method(mock, send)).AlwaysReturn(NO_ERROR);
+		channel.send(m); // ticks wraps to ~0x50
+
+		WHEN("queried at a time after the wrap")
+		{
+			// The timeout should be a small positive number (remaining time
+			// after the wrap), not a huge number from unsigned underflow
+			system_tick_t timeout = channel.client_next_timeout(0x60);
+			THEN("it returns a reasonable positive value (not a wrap artifact)")
+			{
+				// Should be > 0 and < ACK_TIMEOUT * ACK_RANDOM_FACTOR
+				REQUIRE(timeout > 0);
+				REQUIRE(timeout < ACK_TIMEOUT * ACK_RANDOM_FACTOR);
+			}
+		}
+	}
+	REQUIRE(CoAPMessage::messages() == 0);
+}
+
+// A ForwardMessageChannel that can fake is_establish_in_progress()
+class TestForwardChannel : public ForwardMessageChannel {
+	bool establishInProgress = false;
+public:
+	TestForwardChannel() : ForwardMessageChannel() {}
+	void setEstablishInProgress(bool v) { establishInProgress = v; }
+	bool is_establish_in_progress() const override { return establishInProgress; }
+	ProtocolError establish() override { return NO_ERROR; }
+};
+
+SCENARIO("CoAPReliableChannel::establish() clears message stores on fresh attempt",
+         "[nonblocking_handshake]")
+{
+	GIVEN("a reliable channel with a pending message, establish NOT in progress")
+	{
+		Mock<MessageChannel> mock;
+		build_message_channel_mock(mock);
+		MessageChannel& delegate = mock.get();
+		auto time = []() { return system_tick_t(0); };
+		ForwardCoAPReliableChannel<decltype(time)> channel(delegate, time);
+
+		uint8_t buf[] = { 0x40, 0, 0x12, 0x34, 0xFF, 1, 2, 3, 4 };
+		Message m(buf, sizeof(buf), sizeof(buf));
+		m.decode_id();
+		When(Method(mock, send)).AlwaysReturn(NO_ERROR);
+		channel.send(m);
+		REQUIRE(channel.client_messages().from_id(0x1234) != nullptr);
+
+		WHEN("establish() is called (fresh attempt, is_establish_in_progress=false)")
+		{
+			When(Method(mock, establish)).Return(NO_ERROR);
+			channel.establish();
+
+			THEN("the message store is cleared")
+			{
+				REQUIRE(channel.client_messages().from_id(0x1234) == nullptr);
+			}
+		}
+	}
+	REQUIRE(CoAPMessage::messages() == 0);
+}
+
+SCENARIO("CoAPReliableChannel::establish() preserves message stores when establish is in progress",
+         "[nonblocking_handshake]")
+{
+	GIVEN("a reliable channel with a pending message, establish IN progress")
+	{
+		// TestForwardChannel needs a forward target for send_confirmed()
+		Mock<MessageChannel> mock;
+		build_message_channel_mock(mock);
+		MessageChannel& delegate = mock.get();
+
+		TestForwardChannel forward;
+		forward.setForward(&delegate);
+		forward.setEstablishInProgress(true);
+		auto time = []() { return system_tick_t(0); };
+		ForwardCoAPReliableChannel<decltype(time)> channel(forward, time);
+
+		uint8_t buf[] = { 0x40, 0, 0x12, 0x34, 0xFF, 1, 2, 3, 4 };
+		Message m(buf, sizeof(buf), sizeof(buf));
+		m.decode_id();
+		When(Method(mock, send)).AlwaysReturn(NO_ERROR);
+		// Send directly via send_confirmed to populate the store
+		channel.send_confirmed(m);
+		REQUIRE(channel.client_messages().from_id(0x1234) != nullptr);
+
+		WHEN("establish() is called (continuation, is_establish_in_progress=true)")
+		{
+			channel.establish();
+
+			THEN("the message store is preserved (not reset)")
+			{
+				REQUIRE(channel.client_messages().from_id(0x1234) != nullptr);
+			}
+		}
+	}
+	REQUIRE(CoAPMessage::messages() == 0);
+}
+
+// A CoapMessageChannel that can return IN_PROGRESS from establish()
+class SteppableCoapChannel : public test::CoapMessageChannel {
+	ProtocolError establishResult_ = NO_ERROR;
+	bool establishInProgress = false;
+public:
+	unsigned establishCallCount = 0;
+	void setEstablishResult(ProtocolError e) { establishResult_ = e; }
+	void setEstablishInProgress(bool v) { establishInProgress = v; }
+	ProtocolError establish() override {
+		establishCallCount++;
+		return establishResult_;
+	}
+	bool is_establish_in_progress() const override {
+		return establishInProgress;
+	}
+};
+
+SCENARIO("begin() with NON_BLOCKING returns IN_PROGRESS when establish is IN_PROGRESS",
+         "[nonblocking_handshake]")
+{
+	GIVEN("a Protocol with a channel that returns IN_PROGRESS from establish()")
+	{
+		SteppableCoapChannel channel;
+		channel.setEstablishResult(IN_PROGRESS);
+		channel.setEstablishInProgress(true);
+		test::ProtocolStub p(&channel);
+
+		WHEN("begin() is called with NON_BLOCKING flag")
+		{
+			system_tick_t delay = 0;
+			int ret = p.begin(Protocol::HANDSHAKE_FLAG_NON_BLOCKING, &delay);
+
+			THEN("it returns IN_PROGRESS")
+			{
+				REQUIRE(ret == IN_PROGRESS);
+			}
+		}
+	}
+}
+
+SCENARIO("begin() CONTINUE without NON_BLOCKING is INVALID_STATE",
+         "[nonblocking_handshake]")
+{
+	GIVEN("a Protocol")
+	{
+		SteppableCoapChannel channel;
+		test::ProtocolStub p(&channel);
+
+		WHEN("begin() is called with CONTINUE but not NON_BLOCKING")
+		{
+			int ret = p.begin(Protocol::HANDSHAKE_FLAG_CONTINUE, nullptr);
+
+			THEN("it returns INVALID_STATE")
+			{
+				REQUIRE(ret == INVALID_STATE);
+			}
+		}
+	}
+}
+
+SCENARIO("begin() CONTINUE at INIT is INVALID_STATE",
+         "[nonblocking_handshake]")
+{
+	GIVEN("a Protocol with no prior handshake in progress")
+	{
+		SteppableCoapChannel channel;
+		test::ProtocolStub p(&channel);
+
+		WHEN("begin() is called with CONTINUE + NON_BLOCKING but no prior attempt")
+		{
+			int ret = p.begin(
+				Protocol::HANDSHAKE_FLAG_NON_BLOCKING | Protocol::HANDSHAKE_FLAG_CONTINUE,
+				nullptr);
+
+			THEN("it returns INVALID_STATE")
+			{
+				REQUIRE(ret == INVALID_STATE);
+			}
+		}
+	}
+}
+
+SCENARIO("begin() rejects unknown flag bits",
+         "[nonblocking_handshake]")
+{
+	GIVEN("a Protocol")
+	{
+		SteppableCoapChannel channel;
+		test::ProtocolStub p(&channel);
+
+		WHEN("begin() is called with an unknown flag bit")
+		{
+			int ret = p.begin(0x80, nullptr); // bit 7 is not a valid flag
+
+			THEN("it returns INVALID_STATE")
+			{
+				REQUIRE(ret == INVALID_STATE);
+			}
+		}
+	}
+}
+
+SCENARIO("begin() zeroes next_event_delay on terminal result",
+         "[nonblocking_handshake]")
+{
+	GIVEN("a Protocol with a channel that resumes session (skips hello)")
+	{
+		SteppableCoapChannel channel;
+		channel.setEstablishResult(SESSION_RESUMED);
+		test::ProtocolStub p(&channel);
+
+		WHEN("begin() is called with NON_BLOCKING and session resumes")
+		{
+			system_tick_t delay = 999; // non-zero initial value
+			int ret = p.begin(Protocol::HANDSHAKE_FLAG_NON_BLOCKING, &delay);
+
+			THEN("next_event_delay is zeroed on terminal result")
+			{
+				REQUIRE(delay == 0);
+			}
+		}
+	}
+}
+
+SCENARIO("begin() CONTINUE re-enters establish() without fresh reset",
+         "[nonblocking_handshake]")
+{
+	GIVEN("a Protocol where the first begin() returns IN_PROGRESS")
+	{
+		SteppableCoapChannel channel;
+		channel.setEstablishResult(IN_PROGRESS);
+		channel.setEstablishInProgress(true);
+		test::ProtocolStub p(&channel);
+
+		// First call: fresh attempt → establish() called once
+		system_tick_t delay = 0;
+		int ret1 = p.begin(Protocol::HANDSHAKE_FLAG_NON_BLOCKING, &delay);
+		REQUIRE(ret1 == IN_PROGRESS);
+		REQUIRE(channel.establishCallCount == 1);
+
+		WHEN("the channel is flipped to succeed and begin(CONTINUE) is called")
+		{
+			// Use SESSION_RESUMED to skip hello() (ProtocolStub::build_hello
+			// returns 0, which would crash channel.send())
+			channel.setEstablishResult(SESSION_RESUMED);
+			channel.setEstablishInProgress(false);
+			int ret2 = p.begin(
+				Protocol::HANDSHAKE_FLAG_NON_BLOCKING | Protocol::HANDSHAKE_FLAG_CONTINUE,
+				&delay);
+
+			THEN("establish() is called again (continuation, not fresh reset)")
+			{
+				REQUIRE(channel.establishCallCount == 2);
+				// SESSION_RESUMED skips hello and returns SESSION_RESUMED
+				REQUIRE(ret2 == SESSION_RESUMED);
+			}
+		}
+	}
+}
+
+SCENARIO("begin() fresh restart after terminal error",
+         "[nonblocking_handshake]")
+{
+	GIVEN("a Protocol where the first begin() returns an establish error")
+	{
+		SteppableCoapChannel channel;
+		channel.setEstablishResult(IO_ERROR_GENERIC_ESTABLISH);
+		test::ProtocolStub p(&channel);
+
+		// First call: establish fails → terminal error
+		int ret1 = p.begin(Protocol::HANDSHAKE_FLAG_NON_BLOCKING, nullptr);
+		REQUIRE(ret1 != NO_ERROR);
+		REQUIRE(ret1 != IN_PROGRESS);
+		REQUIRE(channel.establishCallCount == 1);
+
+		WHEN("a second begin() is called without CONTINUE")
+		{
+			// Use SESSION_RESUMED to skip hello() (ProtocolStub::build_hello
+			// returns 0, which would crash channel.send())
+			channel.setEstablishResult(SESSION_RESUMED);
+			int ret2 = p.begin(Protocol::HANDSHAKE_FLAG_NON_BLOCKING, nullptr);
+
+			THEN("it's a fresh attempt (establish() called again from scratch)")
+			{
+				REQUIRE(channel.establishCallCount == 2);
+				REQUIRE(ret2 == SESSION_RESUMED);
+			}
+		}
+	}
+}

--- a/user/tests/integration/communication/handshake/handshake.cpp
+++ b/user/tests/integration/communication/handshake/handshake.cpp
@@ -16,12 +16,39 @@
  */
 
 #include "application.h"
+#include "scope_guard.h"
 #include "test.h"
 
 namespace {
 
-const unsigned MAX_SYNC_RTT_DURING_HANDSHAKE = 2000; // ms
+const unsigned MAX_SYNC_RTT_DURING_HANDSHAKE = 500;
 const unsigned SYNC_PROBE_INTERVAL = 50; // ms
+const int GET_CLOUD_SOCKET_HANDLE_INTERNAL_ID = 3;
+
+struct HandshakeState {
+    volatile int type = -1;
+
+    bool operator()() const {
+        return type != -1;
+    }
+
+    void reset() {
+        type = -1;
+    }
+};
+
+HandshakeState handshakeState;
+
+void cloudStatusHandler(system_event_t event, int param, void*) {
+    if (event == cloud_status && (param == cloud_status_handshake ||
+            param == cloud_status_session_resume) && handshakeState.type == -1) {
+        handshakeState.type = param;
+    }
+}
+
+sock_handle_t cloudSocket() {
+    return (sock_handle_t)system_internal(GET_CLOUD_SOCKET_HANDLE_INTERNAL_ID, nullptr);
+}
 
 unsigned measureSyncRtt() {
     auto t1 = millis();
@@ -38,13 +65,19 @@ bool measuredDuringHandshake = false;
 
 } // namespace
 
-test(01_handshake_nonblocking_sync_rtt_during_full_handshake) {
+test(01_full_handshake_nonblocking_sync_rtt) {
     if (system_thread_get_state(nullptr) != spark::feature::ENABLED) {
         skip();
         return;
     }
     maxSyncRtt = 0;
     measuredDuringHandshake = false;
+    handshakeState.reset();
+
+    System.on(cloud_status, cloudStatusHandler);
+    SCOPE_GUARD({
+        System.off(cloud_status, cloudStatusHandler);
+    });
 
     Particle.disconnect();
     assertTrue(waitFor(Particle.disconnected, 30000));
@@ -53,21 +86,25 @@ test(01_handshake_nonblocking_sync_rtt_during_full_handshake) {
 
     Particle.connect();
     auto connectStart = millis();
-    while (!Particle.connected() && millis() - connectStart < HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME) {
-        auto rtt = measureSyncRtt();
-        if (rtt > 0) {
-            measuredDuringHandshake = true;
-            if (rtt > maxSyncRtt) {
-                maxSyncRtt = rtt;
+    while (!handshakeState() && millis() - connectStart < HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME) {
+        if (socket_handle_valid(cloudSocket())) {
+            auto rtt = measureSyncRtt();
+            if (rtt > 0) {
+                measuredDuringHandshake = true;
+                if (rtt > maxSyncRtt) {
+                    maxSyncRtt = rtt;
+                }
             }
         }
         Particle.process();
         delay(SYNC_PROBE_INTERVAL);
     }
-    assertTrue(Particle.connected());
+    assertTrue(handshakeState());
+    assertEqual((int)cloud_status_handshake, (int)handshakeState.type);
+    assertTrue(waitFor(Particle.connected, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
 }
 
-test(02_handshake_nonblocking_sync_rtt_within_bounds) {
+test(02_full_handshake_sync_rtt_within_bounds) {
     if (system_thread_get_state(nullptr) != spark::feature::ENABLED) {
         skip();
         return;
@@ -77,33 +114,31 @@ test(02_handshake_nonblocking_sync_rtt_within_bounds) {
     assertLess(maxSyncRtt, MAX_SYNC_RTT_DURING_HANDSHAKE);
 }
 
-test(03_handshake_nonblocking_session_resume_not_blocked) {
+test(03_handshake_session_resumes_after_socket_failure) {
     if (system_thread_get_state(nullptr) != spark::feature::ENABLED) {
         skip();
         return;
     }
-    Particle.disconnect();
-    assertTrue(waitFor(Particle.disconnected, 30000));
+    assertTrue(waitFor(Particle.connected, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
 
-    maxSyncRtt = 0;
-    measuredDuringHandshake = false;
+    handshakeState.reset();
+    System.on(cloud_status, cloudStatusHandler);
+    SCOPE_GUARD({
+        System.off(cloud_status, cloudStatusHandler);
+    });
 
-    Particle.connect();
-    auto connectStart = millis();
-    while (!Particle.connected() && millis() - connectStart < HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME) {
-        auto rtt = measureSyncRtt();
-        if (rtt > 0) {
-            measuredDuringHandshake = true;
-            if (rtt > maxSyncRtt) {
-                maxSyncRtt = rtt;
-            }
-        }
-        Particle.process();
-        delay(SYNC_PROBE_INTERVAL);
-    }
-    assertTrue(Particle.connected());
-    assertTrue(measuredDuringHandshake);
-    assertLess(maxSyncRtt, MAX_SYNC_RTT_DURING_HANDSHAKE);
+    const auto sock = cloudSocket();
+    assertTrue(socket_handle_valid(sock));
+#if HAL_USE_SOCKET_HAL_POSIX
+    assertEqual(0, sock_close(sock));
+#else
+    assertEqual(0, socket_close(sock));
+#endif
+    (void)Particle.publish("test", "test");
+
+    assertTrue(waitFor(handshakeState, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
+    assertEqual((int)cloud_status_session_resume, (int)handshakeState.type);
+    assertTrue(waitFor(Particle.connected, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
 }
 
 test(04_handshake_nonblocking_disconnect_during_handshake) {

--- a/user/tests/integration/communication/handshake/handshake.cpp
+++ b/user/tests/integration/communication/handshake/handshake.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "application.h"
+#include "test.h"
+
+namespace {
+
+const unsigned MAX_SYNC_RTT_DURING_HANDSHAKE = 2000; // ms
+const unsigned SYNC_PROBE_INTERVAL = 50; // ms
+
+unsigned measureSyncRtt() {
+    auto t1 = millis();
+    int result = Particle.getKeepAlive();
+    auto t2 = millis();
+    if (result <= 0) {
+        return 0;
+    }
+    return t2 - t1;
+}
+
+unsigned maxSyncRtt = 0;
+bool measuredDuringHandshake = false;
+
+} // namespace
+
+test(01_handshake_nonblocking_sync_rtt_during_full_handshake) {
+    if (system_thread_get_state(nullptr) != spark::feature::ENABLED) {
+        skip();
+        return;
+    }
+    maxSyncRtt = 0;
+    measuredDuringHandshake = false;
+
+    Particle.disconnect();
+    assertTrue(waitFor(Particle.disconnected, 30000));
+    Particle.disconnect(CloudDisconnectOptions().clearSession(true));
+    assertTrue(waitFor(Particle.disconnected, 30000));
+
+    Particle.connect();
+    auto connectStart = millis();
+    while (!Particle.connected() && millis() - connectStart < HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME) {
+        auto rtt = measureSyncRtt();
+        if (rtt > 0) {
+            measuredDuringHandshake = true;
+            if (rtt > maxSyncRtt) {
+                maxSyncRtt = rtt;
+            }
+        }
+        Particle.process();
+        delay(SYNC_PROBE_INTERVAL);
+    }
+    assertTrue(Particle.connected());
+}
+
+test(02_handshake_nonblocking_sync_rtt_within_bounds) {
+    if (system_thread_get_state(nullptr) != spark::feature::ENABLED) {
+        skip();
+        return;
+    }
+    assertTrue(measuredDuringHandshake);
+    assertMore(maxSyncRtt, 0);
+    assertLess(maxSyncRtt, MAX_SYNC_RTT_DURING_HANDSHAKE);
+}
+
+test(03_handshake_nonblocking_session_resume_not_blocked) {
+    if (system_thread_get_state(nullptr) != spark::feature::ENABLED) {
+        skip();
+        return;
+    }
+    Particle.disconnect();
+    assertTrue(waitFor(Particle.disconnected, 30000));
+
+    maxSyncRtt = 0;
+    measuredDuringHandshake = false;
+
+    Particle.connect();
+    auto connectStart = millis();
+    while (!Particle.connected() && millis() - connectStart < HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME) {
+        auto rtt = measureSyncRtt();
+        if (rtt > 0) {
+            measuredDuringHandshake = true;
+            if (rtt > maxSyncRtt) {
+                maxSyncRtt = rtt;
+            }
+        }
+        Particle.process();
+        delay(SYNC_PROBE_INTERVAL);
+    }
+    assertTrue(Particle.connected());
+    assertTrue(measuredDuringHandshake);
+    assertLess(maxSyncRtt, MAX_SYNC_RTT_DURING_HANDSHAKE);
+}
+
+test(04_handshake_nonblocking_disconnect_during_handshake) {
+    Particle.disconnect();
+    assertTrue(waitFor(Particle.disconnected, 30000));
+    Particle.disconnect(CloudDisconnectOptions().clearSession(true));
+    assertTrue(waitFor(Particle.disconnected, 30000));
+
+    Particle.connect();
+    delay(2000);
+
+    Particle.disconnect();
+    assertTrue(waitFor(Particle.disconnected, 30000));
+    assertFalse(Particle.connected());
+
+    Particle.connect();
+    assertTrue(waitFor(Particle.connected, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
+}

--- a/user/tests/integration/communication/handshake/handshake.spec.js
+++ b/user/tests/integration/communication/handshake/handshake.spec.js
@@ -1,0 +1,15 @@
+suite('Cloud handshake (non-blocking)');
+
+platform('gen3', 'gen4');
+
+test('01_handshake_nonblocking_sync_rtt_during_full_handshake', async function() {
+});
+
+test('02_handshake_nonblocking_sync_rtt_within_bounds', async function() {
+});
+
+test('03_handshake_nonblocking_session_resume_not_blocked', async function() {
+});
+
+test('04_handshake_nonblocking_disconnect_during_handshake', async function() {
+});

--- a/user/tests/integration/communication/handshake/handshake.spec.js
+++ b/user/tests/integration/communication/handshake/handshake.spec.js
@@ -2,13 +2,13 @@ suite('Cloud handshake (non-blocking)');
 
 platform('gen3', 'gen4');
 
-test('01_handshake_nonblocking_sync_rtt_during_full_handshake', async function() {
+test('01_full_handshake_nonblocking_sync_rtt', async function() {
 });
 
-test('02_handshake_nonblocking_sync_rtt_within_bounds', async function() {
+test('02_full_handshake_sync_rtt_within_bounds', async function() {
 });
 
-test('03_handshake_nonblocking_session_resume_not_blocked', async function() {
+test('03_handshake_session_resumes_after_socket_failure', async function() {
 });
 
 test('04_handshake_nonblocking_disconnect_during_handshake', async function() {


### PR DESCRIPTION
### Problem

The cloud handshake blocks the system thread for up to ~135 s worst case.

1. DTLS phase: `DTLSMessageChannel::establish()` already drives mbedTLS stepwise over non-blocking socket BIOs, but then spins in a `do...while` on `WANT_READ`/`WANT_WRITE` until the mbedTLS retransmit budget (3/6/12/24 s) expires - up to ~45 s of busy-wait.
2. CoAP HELLO phase: HELLO is a CoAP CON sent via `CoAPReliableChannel::send_synchronous()`, which spins for the ACK across 4/8/16/32 s retransmits (+ jitter) - up to ~60-90 s.
3. While blocked, the SystemThread queue isn't drained: every `SYSTEM_THREAD_CONTEXT_SYNC` app call stalls, and network connection management, the BLE control channel, listening-mode entry and firmware update processing all stop.

### Solution

Each call into the handshake now does a bounded amount of work and returns "in progress"; the system loop re-enters it.

1. New `IN_PROGRESS = 37` protocol error code (not an error), mapped to `SYSTEM_ERROR_BUSY`.
2. `DTLSMessageChannel::establish()` is re-entrant: context setup and session restore run once per attempt, the stepping loop returns `IN_PROGRESS` on `WANT_READ`/`WANT_WRITE` (and after a 20 ms processing slice). The stock mbedTLS timing callbacks are replaced with `millis()`-based ones - this also drops the hidden `gettimeofday()` -> RTC dependency - and provide `next_handshake_delay()`, so the next deadline is queryable. `reset()` clears the continuation state.
3. HELLO confirmation is split in `CoAPReliableChannel`: `send_confirmed()` arms a delivery handler, `poll_confirmed()` runs one iteration of the old spin, preserving its narrow ACK/RST-only receive processing. `send_synchronous()` is kept as a wrapper for legacy/test callers.
4. `Protocol::begin(flags, &delay)` is a stage machine (ESTABLISH -> HELLO_WAIT -> complete). The session-resumption fast path is unchanged and never returns `IN_PROGRESS`. LightSSL/TCP keeps the blocking `hello_response()`.
5. Mode and continuation state are carried through the existing reserved argument: `spark_protocol_handshake_param` with `NON_BLOCKING`/`CONTINUE` flags and a `next_event_delay_ms` out-param. No new dynalib function; `reserved == nullptr` keeps the blocking path.
6. `Spark_Handshake()` is re-entrant, using the existing `SPARK_CLOUD_PROTOCOL_HANDSHAKE_IN_PROGRESS` latch. Non-blocking is enabled only when the system thread was actually started (`SystemThread.isStarted()`); non-threaded builds keep the blocking handshake. `handle_cloud_connection()` treats `BUSY` as "re-enter next loop iteration" (no backoff or connection-failed handling), does not restart the handshake LED per iteration and keeps the protocol event pump off mid-handshake; `cloud_disconnect()` clears the latch.
7. Deadline-based wake, no software timers: comms reports the delay to the next event (remaining DTLS retransmit delay, 50 ms `WANT_WRITE` send retry, or next CoAP retransmit) and `ActiveObjectThreadQueue::nextWakeTimeout()` shortens one idle sleep of the system thread - it can only shorten the 100 ms tick, never extend it. Socket RX already wakes the thread immediately.

### Steps to Test

- unit tests
- `device-os-test run -v <platform> communication/handshake`

The suite measures sync RTT to the system thread during the handshake (`Particle.getKeepAlive()` while the socket is up but the handshake is still running, must stay under 500 ms), plus session resumption after a socket failure and a disconnect mid-handshake.

### References

N/A