### PR TITLE
DVOS-35 [quectel] Fixes recovery of AT lockup when zero data while "CONNECTED" issue [sc-139209]

### DIFF
--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -378,44 +378,71 @@ int QuectelNcpClient::on() {
     return SYSTEM_ERROR_NONE;
 }
 
-int QuectelNcpClient::off() {
-    const NcpClientLock lock(this);
-    if (ncpState_ == NcpState::DISABLED) {
-        return SYSTEM_ERROR_INVALID_STATE;
+// Take the modem down. ModemOff is the ordinary off() sequence, the other reasons are faults where
+// the modem will not answer an AT command, so the sequence never issues one.
+// Caller must hold the client lock.
+int QuectelNcpClient::configModemPowerState(ModemPowerReason reason) {
+    const bool recovering = (reason != ModemPowerReason::ModemOff && reason != ModemPowerReason::Unknown);
+    int r = SYSTEM_ERROR_NONE;
+
+    if (recovering) {
+        LOG(WARN, "Resetting the modem due to %s", reason == ModemPowerReason::AtUnresponsive ?
+                "an unresponsive AT interface" : "the network registration timeout");
+        // We are going into an OFF state immediately before stopping the muxer
+        // otherwise the muxer channel state callback will disable us unnecessarily.
+        // off() deliberately leaves this until the end.
+        ncpState(NcpState::OFF);
+    } else {
+        // Try using AT command to turn off the modem first.
+        r = modemSoftPowerOff();
     }
-    // Try using AT command to turn off the modem first.
-    int r = modemSoftPowerOff();
 
     // Disable ourselves/channel, so that the muxer can potentially stop faster non-gracefully
     serial_->enabled(false);
     muxer_.stop();
     serial_->enabled(true);
 
-    // Disable voltage translator
-    modemSetUartState(false);
-
-    if (!r) {
-        LOG(TRACE, "Soft power off modem success");
-        // WARN: We assume that the modem can turn off itself reliably.
-    } else {
-        // Power down using hardware
+    if (recovering) {
+        // Not modemSoftPowerOff(), it would retry AT+QPOWD six times against a dead interface
         if (modemPowerOff() != SYSTEM_ERROR_NONE) {
-            LOG(ERROR, "Failed to turn off");
+            modemHardReset(true);
         }
-        // FIXME: There is power leakage still if powering off the modem failed.
+    } else {
+        // Disable voltage translator
+        modemSetUartState(false);
+
+        if (!r) {
+            LOG(TRACE, "Soft power off modem success");
+            // WARN: We assume that the modem can turn off itself reliably.
+        } else {
+            // Power down using hardware
+            if (modemPowerOff() != SYSTEM_ERROR_NONE) {
+                LOG(ERROR, "Failed to turn off");
+            }
+            // FIXME: There is power leakage still if powering off the modem failed.
+        }
+
+        // Disable the UART interface.
+        LOG(TRACE, "Deinit modem serial.");
+        serial_->on(false);
+
+        ready_ = false;
+        ncpState(NcpState::OFF);
     }
 
-    // Disable the UART interface.
-    LOG(TRACE, "Deinit modem serial.");
-    serial_->on(false);
-
-    ready_ = false;
-    ncpState(NcpState::OFF);
-
+    // The modem is gone, the inactivity timer must not fire and try to close the channel
     apduChannelTimer_.stop();
     apduChannel_ = 0;
 
     return SYSTEM_ERROR_NONE;
+}
+
+int QuectelNcpClient::off() {
+    const NcpClientLock lock(this);
+    if (ncpState_ == NcpState::DISABLED) {
+        return SYSTEM_ERROR_INVALID_STATE;
+    }
+    return configModemPowerState(ModemPowerReason::ModemOff);
 }
 
 int QuectelNcpClient::enable() {
@@ -2543,25 +2570,6 @@ int QuectelNcpClient::checkRunningImsi() {
     return 0;
 }
 
-// Power cycle the modem without issuing any AT command, for the faults where it will not answer one.
-// Caller must hold the client lock. Leaves the client OFF, PppNcpNetif::loop() brings it back up.
-void QuectelNcpClient::recoverModem() {
-    // We are going into an OFF state immediately before stopping the muxer
-    // otherwise the muxer channel state callback will disable us unnecessarily.
-    ncpState(NcpState::OFF);
-    // Disable ourselves/channel, so that the muxer can stop faster non-gracefully
-    serial_->enabled(false);
-    muxer_.stop();
-    serial_->enabled(true);
-    // Not off(), its modemSoftPowerOff() would retry AT+QPOWD six times first
-    if (modemPowerOff() != SYSTEM_ERROR_NONE) {
-        modemHardReset(true);
-    }
-    // The modem is gone, the inactivity timer must not fire and try to close the channel
-    apduChannelTimer_.stop();
-    apduChannel_ = 0;
-}
-
 // Periodic AT probe while CONNECTED. Returns false once the interface is declared unresponsive.
 //
 // Deliberately not CHECK_PARSER*, that would set parserError_ and route the next command into
@@ -2606,10 +2614,9 @@ int QuectelNcpClient::processEventsImpl() {
 
     // Must stay above the connState_ != CONNECTING early return below, the point is to run while CONNECTED
     if (!checkAtWhileConnected()) {
-        LOG(WARN, "Resetting the modem due to an unresponsive AT interface");
         // connectionState(CONNECTED) clears this too, but nothing does if we never reconnect
         atProbeFailStreak_ = 0;
-        recoverModem();
+        configModemPowerState(ModemPowerReason::AtUnresponsive);
         return SYSTEM_ERROR_TIMEOUT;
     }
 
@@ -2645,8 +2652,7 @@ int QuectelNcpClient::processEventsImpl() {
     CHECK_PARSER(parser_.execCommand("AT+QENG=\"servingcell\""));
 
     if (connState_ == NcpConnectionState::CONNECTING && millis() - regStartTime_ >= registrationTimeout_) {
-        LOG(WARN, "Resetting the modem due to the network registration timeout");
-        recoverModem();
+        configModemPowerState(ModemPowerReason::RegTimeout);
         return SYSTEM_ERROR_TIMEOUT;
     }
 

--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -114,6 +114,12 @@ const auto QUECTEL_NCP_PPP_CHANNEL = 2;
 
 const auto QUECTEL_NCP_SIM_SELECT_PIN = 23;
 
+// AT probe: 3s timeout every 35s, declared on the 4th consecutive failure, so ~105s.
+// Just above the 90s default command timeout, in case a command uses a shorter one.
+const auto AT_PROBE_INTERVAL = 35000;
+const auto AT_PROBE_TIMEOUT = 3000;
+const auto AT_PROBE_MAX_INTERVALS = 3u;
+
 const unsigned REGISTRATION_CHECK_INTERVAL = 15 * 1000;
 const unsigned REGISTRATION_TIMEOUT = 10 * 60 * 1000;
 const unsigned REGISTRATION_INTERVENTION_TIMEOUT = 15 * 1000;

--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -454,14 +454,18 @@ int QuectelNcpClient::disconnect() {
     if (connState_ == NcpConnectionState::DISCONNECTED) {
         return SYSTEM_ERROR_NONE;
     }
+
+    // Tear the connection state down unconditionally, on every exit path
+    SCOPE_GUARD({
+        resetRegistrationState();
+        connectionState(NcpConnectionState::DISCONNECTED);
+    });
+
     CHECK(checkParser());
     const int r = CHECK_PARSER(parser_.execCommand("AT+CFUN=0,0"));
     (void)r;
     // CHECK_TRUE(r == AtResponse::OK, SYSTEM_ERROR_UNKNOWN);
 
-    resetRegistrationState();
-
-    connectionState(NcpConnectionState::DISCONNECTED);
     return SYSTEM_ERROR_NONE;
 }
 

--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -492,6 +492,9 @@ int QuectelNcpClient::updateFirmware(InputStream* file, size_t size) {
 }
 
 int QuectelNcpClient::dataChannelWrite(int id, const uint8_t* data, size_t size) {
+    // Once disable() has been called the muxer channel is gone, but PPP does not know that yet and keeps
+    // writing until the interface is brought down. This check prevents log spam.
+    CHECK_TRUE(ncpState_ == NcpState::ON, SYSTEM_ERROR_INVALID_STATE);
     // Just in case perform some state checks to ensure that LwIP PPP implementation
     // does not write into the data channel when it's not supposed do
     CHECK_TRUE(connState_ == NcpConnectionState::CONNECTED, SYSTEM_ERROR_INVALID_STATE);
@@ -2337,6 +2340,9 @@ void QuectelNcpClient::connectionState(NcpConnectionState state) {
     connState_ = state;
 
     if (connState_ == NcpConnectionState::CONNECTED) {
+        // A streak from a previous connection must not carry into this one.
+        // atProbeTime_ is deliberately left stale so the first probe runs immediately.
+        atProbeFailStreak_ = 0;
         inFlowControl_ = false;
         // Open data channel and resume it just in case
         int r = muxer_.openChannel(QUECTEL_NCP_PPP_CHANNEL);
@@ -2531,6 +2537,59 @@ int QuectelNcpClient::checkRunningImsi() {
     return 0;
 }
 
+// Power cycle the modem without issuing any AT command, for the faults where it will not answer one.
+// Caller must hold the client lock. Leaves the client OFF, PppNcpNetif::loop() brings it back up.
+void QuectelNcpClient::recoverModem() {
+    // We are going into an OFF state immediately before stopping the muxer
+    // otherwise the muxer channel state callback will disable us unnecessarily.
+    ncpState(NcpState::OFF);
+    // Disable ourselves/channel, so that the muxer can stop faster non-gracefully
+    serial_->enabled(false);
+    muxer_.stop();
+    serial_->enabled(true);
+    // Not off(), its modemSoftPowerOff() would retry AT+QPOWD six times first
+    if (modemPowerOff() != SYSTEM_ERROR_NONE) {
+        modemHardReset(true);
+    }
+    // The modem is gone, the inactivity timer must not fire and try to close the channel
+    apduChannelTimer_.stop();
+    apduChannel_ = 0;
+}
+
+// Periodic AT probe while CONNECTED. Returns false once the interface is declared unresponsive.
+//
+// Deliberately not CHECK_PARSER*, that would set parserError_ and route the next command into
+// checkParser() -> waitReady() -> modemHardReset() instead of the reset sequence run by the caller.
+bool QuectelNcpClient::checkAtWhileConnected() {
+    if (connState_ != NcpConnectionState::CONNECTED || !ready_) {
+        // Every other state has its own recovery path, probing during them only adds noise
+        atProbeFailStreak_ = 0;
+        return true;
+    }
+    if (millis() - atProbeTime_ < (unsigned)AT_PROBE_INTERVAL) {
+        return true;
+    }
+    atProbeTime_ = millis();
+
+    // Keep the probe out of the AT log
+    const auto logEnabled = parser_.config().logEnabled();
+    parser_.logEnabled(false);
+    SCOPE_GUARD({ parser_.logEnabled(logEnabled); });
+
+    const int r = parser_.execCommand(AT_PROBE_TIMEOUT, "AT");
+    if (r == AtResponse::OK) {
+        atProbeFailStreak_ = 0;
+        return true;
+    }
+
+    if (++atProbeFailStreak_ > AT_PROBE_MAX_INTERVALS) {
+        LOG(ERROR, "AT unresponsive (%u)", atProbeFailStreak_);
+        return false;
+    }
+    LOG(WARN, "AT probe failed (%u/%u): %d", atProbeFailStreak_, (unsigned)AT_PROBE_MAX_INTERVALS, r);
+    return true;
+}
+
 int QuectelNcpClient::processEventsImpl() {
     CHECK_TRUE(ncpState_ == NcpState::ON, SYSTEM_ERROR_INVALID_STATE);
     parser_.processUrc(); // Ignore errors
@@ -2538,6 +2597,16 @@ int QuectelNcpClient::processEventsImpl() {
     interveneRegistration();
     checkRunningImsi();
     configurePlmn(); // ignore errors
+
+    // Must stay above the connState_ != CONNECTING early return below, the point is to run while CONNECTED
+    if (!checkAtWhileConnected()) {
+        LOG(WARN, "Resetting the modem due to an unresponsive AT interface");
+        // connectionState(CONNECTED) clears this too, but nothing does if we never reconnect
+        atProbeFailStreak_ = 0;
+        recoverModem();
+        return SYSTEM_ERROR_TIMEOUT;
+    }
+
     if (connState_ != NcpConnectionState::CONNECTING || millis() - regCheckTime_ < REGISTRATION_CHECK_INTERVAL) {
         return SYSTEM_ERROR_NONE;
     }
@@ -2571,14 +2640,7 @@ int QuectelNcpClient::processEventsImpl() {
 
     if (connState_ == NcpConnectionState::CONNECTING && millis() - regStartTime_ >= registrationTimeout_) {
         LOG(WARN, "Resetting the modem due to the network registration timeout");
-        // We are going into an OFF state immediately before stopping the muxer
-        // otherwise the muxer channel state callback will disable us unnecessarily.
-        ncpState(NcpState::OFF);
-        muxer_.stop();
-        int rv = modemPowerOff();
-        if (rv != 0) {
-            modemHardReset(true);
-        }
+        recoverModem();
         return SYSTEM_ERROR_TIMEOUT;
     }
 

--- a/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.cpp
@@ -197,6 +197,7 @@ int QuectelNcpClient::init(const NcpClientConfig& conf) {
     policymanSrvModeCheckTime_ = 0;
     parserError_ = 0;
     ready_ = false;
+    sleepUrcsDisabled_ = false;
     registrationTimeout_ = REGISTRATION_TIMEOUT;
     resetRegistrationState();
     if (modemPowerState()) {
@@ -488,16 +489,19 @@ int QuectelNcpClient::disconnect() {
         return SYSTEM_ERROR_NONE;
     }
 
-    // Tear the connection state down unconditionally, on every exit path
     SCOPE_GUARD({
         resetRegistrationState();
         connectionState(NcpConnectionState::DISCONNECTED);
     });
 
+    // If we disconnect due to the AT interface being dead, a forced check
+    // is required because ready_ is true and parserError_ is 0.
+    const int r = parser_.execCommand(1000, "AT");
+    if (r != AtResponse::OK) {
+        parserError_ = r;
+    }
     CHECK(checkParser());
-    const int r = CHECK_PARSER(parser_.execCommand("AT+CFUN=0,0"));
-    (void)r;
-    // CHECK_TRUE(r == AtResponse::OK, SYSTEM_ERROR_UNKNOWN);
+    CHECK_PARSER(setModuleFunctionality(CellularFunctionality::MINIMUM, false /* check */));
 
     return SYSTEM_ERROR_NONE;
 }
@@ -1114,7 +1118,7 @@ int QuectelNcpClient::setupBands() {
             } else if (retBand == 4) {
                 CHECK_PARSER_OK(parser_.execCommand("AT+QCFG=\"band\",%s,%s,%s,%s,1", qbandGsmStr, (const char*)envPreferredBands.toString(), qbandCatNbStr, qbandNtnStr));
             }
-            
+
             CHECK_PARSER_OK(setModuleFunctionality(CellularFunctionality::FULL, false /* check */));
         }
     }
@@ -2197,6 +2201,7 @@ int QuectelNcpClient::getMtu() {
 }
 
 int QuectelNcpClient::urcs(bool enable) {
+    sleepUrcsDisabled_ = !enable;
     if (enable) {
         if (ncpId() == PLATFORM_NCP_QUECTEL_BG95_S5 || ncpId() == PLATFORM_NCP_QUECTEL_BG95_M5) {
             CHECK_PARSER_OK(parser_.execCommand(QUECTEL_CFUN_TIMEOUT, "AT+QINDCFG=\"all\",1,1"));
@@ -2575,8 +2580,8 @@ int QuectelNcpClient::checkRunningImsi() {
 // Deliberately not CHECK_PARSER*, that would set parserError_ and route the next command into
 // checkParser() -> waitReady() -> modemHardReset() instead of the reset sequence run by the caller.
 bool QuectelNcpClient::checkAtWhileConnected() {
-    if (connState_ != NcpConnectionState::CONNECTED || !ready_) {
-        // Every other state has its own recovery path, probing during them only adds noise
+    if (connState_ != NcpConnectionState::CONNECTED || !ready_ || sleepUrcsDisabled_) {
+        // Every other state has its own recovery path, probing during them only adds noise.
         atProbeFailStreak_ = 0;
         return true;
     }

--- a/hal/network/ncp_client/quectel/quectel_ncp_client.h
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.h
@@ -34,12 +34,6 @@
 
 namespace particle {
 
-// AT probe: 3s timeout every 35s, declared on the 4th consecutive failure, so ~105s.
-// Just above the 90s default command timeout, in case a command uses a shorter one.
-const auto AT_PROBE_INTERVAL = 35000;
-const auto AT_PROBE_TIMEOUT = 3000;
-const auto AT_PROBE_MAX_INTERVALS = 3u;
-
 class SerialStream;
 
 class QuectelNcpClient: public CellularNcpClient {

--- a/hal/network/ncp_client/quectel/quectel_ncp_client.h
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.h
@@ -133,6 +133,10 @@ private:
     bool configuredPlmn_ = false;
     system_tick_t atProbeTime_ = 0;
     unsigned atProbeFailStreak_ = 0;
+    // Set by urcs(false) when going to sleep. On the muxer path the AT channel is suspended and a
+    // probe cannot be answered; on the BG95 QINDCFG path it would be answered but would wake the
+    // module, which is the thing sleep is trying to avoid. Suppress the probe either way.
+    bool sleepUrcsDisabled_ = false;
 
     int queryAndParseAtCops(CellularSignalQuality* qual);
     int initParser(Stream* stream);
@@ -153,7 +157,7 @@ private:
     int selectSimCard();
     int checkSimCard();
     int getModuleFunctionality();
-    int setModuleFunctionality(CellularFunctionality cfun, bool check);
+    int setModuleFunctionality(CellularFunctionality cfun, bool check = false);
     int getPolicymanServiceMode();
     int setPolicymanServiceMode(CellularPolicymanServiceMode mode, bool check);
     int set2gAttenuation3dB();

--- a/hal/network/ncp_client/quectel/quectel_ncp_client.h
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.h
@@ -102,6 +102,13 @@ private:
     CellularGlobalIdentity cgi_ = {};
     CellularAccessTechnology act_ = CellularAccessTechnology::NONE;
 
+    enum class ModemPowerReason {
+        Unknown = 0,
+        ModemOff = 1,
+        AtUnresponsive = 2,
+        RegTimeout = 3
+    };
+
     enum class ModemState {
         Unknown = 0,
         MuxerAtChannel = 1,
@@ -166,7 +173,7 @@ private:
     int processEventsImpl();
     int getIccidImpl(char* buf, size_t size);
     bool checkAtWhileConnected();
-    void recoverModem();
+    int configModemPowerState(ModemPowerReason reason);
 
     /** Is this a Quectel Cat-M1 device ? */
     bool isQuecCatM1Device();

--- a/hal/network/ncp_client/quectel/quectel_ncp_client.h
+++ b/hal/network/ncp_client/quectel/quectel_ncp_client.h
@@ -34,6 +34,12 @@
 
 namespace particle {
 
+// AT probe: 3s timeout every 35s, declared on the 4th consecutive failure, so ~105s.
+// Just above the 90s default command timeout, in case a command uses a shorter one.
+const auto AT_PROBE_INTERVAL = 35000;
+const auto AT_PROBE_TIMEOUT = 3000;
+const auto AT_PROBE_MAX_INTERVALS = 3u;
+
 class SerialStream;
 
 class QuectelNcpClient: public CellularNcpClient {
@@ -124,6 +130,8 @@ private:
     system::SystemTimer apduChannelTimer_;
     int apduChannel_ = 0;
     bool configuredPlmn_ = false;
+    system_tick_t atProbeTime_ = 0;
+    unsigned atProbeFailStreak_ = 0;
 
     int queryAndParseAtCops(CellularSignalQuality* qual);
     int initParser(Stream* stream);
@@ -163,6 +171,9 @@ private:
     int checkRunningImsi();
     int processEventsImpl();
     int getIccidImpl(char* buf, size_t size);
+    bool checkAtWhileConnected();
+    void recoverModem();
+
     /** Is this a Quectel Cat-M1 device ? */
     bool isQuecCatM1Device();
     /** Is this a Quectel Cat-1 device ? */

--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -412,35 +412,7 @@ int SaraNcpClient::off() {
     if (ncpState_ == NcpState::DISABLED) {
         return SYSTEM_ERROR_INVALID_STATE;
     }
-    // Try using AT command to turn off the modem first.
-    int r = modemSoftPowerOff();
-
-    // Disable ourselves/channel, so that the muxer can potentially stop faster non-gracefully
-    serial_->enabled(false);
-    muxer_.stop();
-    serial_->enabled(true);
-
-    // Disable voltage translator
-    modemSetUartState(false);
-
-    if (!r) {
-        LOG(TRACE, "Soft power off success");
-        // WARN: We assume that the modem can turn off itself reliably.
-    } else {
-        // Power down using hardware
-        if (modemPowerOff() != SYSTEM_ERROR_NONE) {
-            LOG(ERROR, "Failed to turn off");
-        }
-        // FIXME: There is power leakage still if powering off the modem failed.
-    }
-
-    // Disable the UART interface.
-    LOG(TRACE, "Deinit UART");
-    serial_->on(false);
-
-    ready_ = false;
-    ncpState(NcpState::OFF);
-    return SYSTEM_ERROR_NONE;
+    return configModemPowerState(ModemPowerReason::ModemOff);
 }
 
 int SaraNcpClient::enable() {
@@ -2711,20 +2683,59 @@ int SaraNcpClient::checkRunningImsi() {
     return 0;
 }
 
-// Power cycle the modem without issuing any AT command, for the faults where it will not answer one.
-// Caller must hold the client lock. Leaves the client OFF, PppNcpNetif::loop() brings it back up.
-void SaraNcpClient::recoverModem() {
-    // We are going into an OFF state immediately before stopping the muxer
-    // otherwise the muxer channel state callback will disable us unnecessarily.
-    ncpState(NcpState::OFF);
-    // Disable ourselves/channel, so that the muxer can stop faster non-gracefully
+// Take the modem down. ModemOff is the ordinary off() sequence, the other reasons are faults where
+// the modem will not answer an AT command, so the sequence never issues one.
+// Caller must hold the client lock.
+int SaraNcpClient::configModemPowerState(ModemPowerReason reason) {
+    const bool recovering = (reason != ModemPowerReason::ModemOff && reason != ModemPowerReason::Unknown);
+    int r = SYSTEM_ERROR_NONE;
+
+    if (recovering) {
+        LOG(WARN, "Resetting the modem due to %s", reason == ModemPowerReason::AtUnresponsive ?
+                "an unresponsive AT interface" : "the network registration timeout");
+        // We are going into an OFF state immediately before stopping the muxer
+        // otherwise the muxer channel state callback will disable us unnecessarily.
+        // off() deliberately leaves this until the end.
+        ncpState(NcpState::OFF);
+    } else {
+        // Try using AT command to turn off the modem first.
+        r = modemSoftPowerOff();
+    }
+
+    // Disable ourselves/channel, so that the muxer can potentially stop faster non-gracefully
     serial_->enabled(false);
     muxer_.stop();
     serial_->enabled(true);
-    // Not off(), its modemSoftPowerOff() would try to talk to the modem first
-    if (modemPowerOff() != SYSTEM_ERROR_NONE) {
-        modemHardReset(true);
+
+    if (recovering) {
+        // Not modemSoftPowerOff(), it would try to talk to a dead interface first
+        if (modemPowerOff() != SYSTEM_ERROR_NONE) {
+            modemHardReset(true);
+        }
+    } else {
+        // Disable voltage translator
+        modemSetUartState(false);
+
+        if (!r) {
+            LOG(TRACE, "Soft power off success");
+            // WARN: We assume that the modem can turn off itself reliably.
+        } else {
+            // Power down using hardware
+            if (modemPowerOff() != SYSTEM_ERROR_NONE) {
+                LOG(ERROR, "Failed to turn off");
+            }
+            // FIXME: There is power leakage still if powering off the modem failed.
+        }
+
+        // Disable the UART interface.
+        LOG(TRACE, "Deinit UART");
+        serial_->on(false);
+
+        ready_ = false;
+        ncpState(NcpState::OFF);
     }
+
+    return SYSTEM_ERROR_NONE;
 }
 
 // Periodic AT probe while CONNECTED. Returns false once the interface is declared unresponsive.
@@ -2772,10 +2783,9 @@ int SaraNcpClient::processEventsImpl() {
 
     // Must stay above the connState_ != CONNECTING early return below, the point is to run while CONNECTED
     if (!checkAtWhileConnected()) {
-        LOG(WARN, "Resetting the modem due to an unresponsive AT interface");
         // connectionState(CONNECTED) clears this too, but nothing does if we never reconnect
         atProbeFailStreak_ = 0;
-        recoverModem();
+        configModemPowerState(ModemPowerReason::AtUnresponsive);
         return SYSTEM_ERROR_TIMEOUT;
     }
 
@@ -2807,8 +2817,7 @@ int SaraNcpClient::processEventsImpl() {
 
     if (connState_ == NcpConnectionState::CONNECTING &&
             millis() - regStartTime_ >= registrationTimeout_) {
-        LOG(WARN, "Resetting the modem due to the network registration timeout");
-        recoverModem();
+        configModemPowerState(ModemPowerReason::RegTimeout);
         return SYSTEM_ERROR_TIMEOUT;
     }
     return SYSTEM_ERROR_NONE;

--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -156,6 +156,12 @@ const int UUFWINSTALL_COMPLETE = 128;
 const int UBLOX_WAIT_AT_RESPONSE_WHILE_UUFWINSTALL_TIMEOUT = 300000;
 const int UBLOX_WAIT_AT_RESPONSE_WHILE_UUFWINSTALL_PERIOD = 10000;
 
+// AT probe: 3s timeout every 35s, declared on the 4th consecutive failure, so ~105s.
+// Just above the 90s default command timeout, in case a command uses a shorter one.
+const auto AT_PROBE_INTERVAL = 35000;
+const auto AT_PROBE_TIMEOUT = 3000;
+const auto AT_PROBE_MAX_INTERVALS = 3u;
+
 const unsigned CHECK_SIM_CARD_INTERVAL = 1000;
 const unsigned CHECK_SIM_CARD_ATTEMPTS = 10;
 
@@ -526,6 +532,8 @@ int SaraNcpClient::updateFirmware(InputStream* file, size_t size) {
 * for a certain amount of time defined by UBLOX_NCP_R4_WINDOW_SIZE_MS
 */
 int SaraNcpClient::dataChannelWrite(int id, const uint8_t* data, size_t size) {
+    // The muxer channel is gone once we are OFF, but PPP keeps writing until it is brought down
+    CHECK_TRUE(ncpState_ == NcpState::ON, SYSTEM_ERROR_INVALID_STATE);
     // Just in case perform some state checks to ensure that LwIP PPP implementation
     // does not write into the data channel when it's not supposed do
     CHECK_TRUE(connState_ == NcpConnectionState::CONNECTED, SYSTEM_ERROR_INVALID_STATE);
@@ -2511,6 +2519,10 @@ void SaraNcpClient::connectionState(NcpConnectionState state) {
     }
 
     if (connState_ == NcpConnectionState::CONNECTED) {
+        // A streak from a previous connection must not carry into this one.
+        // atProbeTime_ is deliberately left stale so the first probe runs immediately.
+        atProbeFailStreak_ = 0;
+
         // Reset CGATT workaround flag
         cgattWorkaroundApplied_ = false;
 
@@ -2699,6 +2711,57 @@ int SaraNcpClient::checkRunningImsi() {
     return 0;
 }
 
+// Power cycle the modem without issuing any AT command, for the faults where it will not answer one.
+// Caller must hold the client lock. Leaves the client OFF, PppNcpNetif::loop() brings it back up.
+void SaraNcpClient::recoverModem() {
+    // We are going into an OFF state immediately before stopping the muxer
+    // otherwise the muxer channel state callback will disable us unnecessarily.
+    ncpState(NcpState::OFF);
+    // Disable ourselves/channel, so that the muxer can stop faster non-gracefully
+    serial_->enabled(false);
+    muxer_.stop();
+    serial_->enabled(true);
+    // Not off(), its modemSoftPowerOff() would try to talk to the modem first
+    if (modemPowerOff() != SYSTEM_ERROR_NONE) {
+        modemHardReset(true);
+    }
+}
+
+// Periodic AT probe while CONNECTED. Returns false once the interface is declared unresponsive.
+//
+// Deliberately not CHECK_PARSER*, that would set parserError_ and route the next command into
+// checkParser() -> waitReady() -> modemHardReset() instead of the reset sequence run by the caller.
+bool SaraNcpClient::checkAtWhileConnected() {
+    // Every other state has its own recovery path, probing during them only adds noise.
+    // An R510 firmware install stops answering AT for minutes by design, so it is not a fault.
+    if (connState_ != NcpConnectionState::CONNECTED || !ready_ || firmwareUpdateR510_) {
+        atProbeFailStreak_ = 0;
+        return true;
+    }
+    if (millis() - atProbeTime_ < (unsigned)AT_PROBE_INTERVAL) {
+        return true;
+    }
+    atProbeTime_ = millis();
+
+    // Keep the probe out of the AT log
+    const auto logEnabled = parser_.config().logEnabled();
+    parser_.logEnabled(false);
+    SCOPE_GUARD({ parser_.logEnabled(logEnabled); });
+
+    const int r = parser_.execCommand(AT_PROBE_TIMEOUT, "AT");
+    if (r == AtResponse::OK) {
+        atProbeFailStreak_ = 0;
+        return true;
+    }
+
+    if (++atProbeFailStreak_ > AT_PROBE_MAX_INTERVALS) {
+        LOG(ERROR, "AT unresponsive (%u)", atProbeFailStreak_);
+        return false;
+    }
+    LOG(WARN, "AT probe failed (%u/%u): %d", atProbeFailStreak_, (unsigned)AT_PROBE_MAX_INTERVALS, r);
+    return true;
+}
+
 int SaraNcpClient::processEventsImpl() {
     CHECK_TRUE(ncpState_ == NcpState::ON, SYSTEM_ERROR_INVALID_STATE);
     parser_.processUrc(); // Ignore errors
@@ -2706,6 +2769,16 @@ int SaraNcpClient::processEventsImpl() {
     interveneRegistration();
     checkRunningImsi();
     configurePlmn(); // ignore errors
+
+    // Must stay above the connState_ != CONNECTING early return below, the point is to run while CONNECTED
+    if (!checkAtWhileConnected()) {
+        LOG(WARN, "Resetting the modem due to an unresponsive AT interface");
+        // connectionState(CONNECTED) clears this too, but nothing does if we never reconnect
+        atProbeFailStreak_ = 0;
+        recoverModem();
+        return SYSTEM_ERROR_TIMEOUT;
+    }
+
     if (connState_ != NcpConnectionState::CONNECTING ||
             millis() - regCheckTime_ < REGISTRATION_CHECK_INTERVAL) {
         return SYSTEM_ERROR_NONE;
@@ -2735,14 +2808,7 @@ int SaraNcpClient::processEventsImpl() {
     if (connState_ == NcpConnectionState::CONNECTING &&
             millis() - regStartTime_ >= registrationTimeout_) {
         LOG(WARN, "Resetting the modem due to the network registration timeout");
-        // We are going into an OFF state immediately before stopping the muxer
-        // otherwise the muxer channel state callback will disable us unnecessarily.
-        ncpState(NcpState::OFF);
-        muxer_.stop();
-        int rv = modemPowerOff();
-        if (rv != 0) {
-            modemHardReset(true);
-        }
+        recoverModem();
         return SYSTEM_ERROR_TIMEOUT;
     }
     return SYSTEM_ERROR_NONE;

--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -216,7 +216,7 @@ int SaraNcpClient::init(const NcpClientConfig& conf) {
     firmwareInstallRespCodeR510_ = -1;
     lastFirmwareInstallRespCodeR510_ = -1;
     waitReadyRetries_ = 0;
-    sleepNoPPPWrite_ = false;
+    sleepUrcsDisabled_ = false;
     ehsExtendedTiming_ = false;
     registrationTimeout_ = REGISTRATION_TIMEOUT;
     resetRegistrationState();
@@ -529,7 +529,7 @@ int SaraNcpClient::dataChannelWrite(int id, const uint8_t* data, size_t size) {
     }
 
     int err = gsm0710::GSM0710_ERROR_NONE;
-    if (!sleepNoPPPWrite_) {
+    if (!sleepUrcsDisabled_) {
         err = muxer_.writeChannel(UBLOX_NCP_PPP_CHANNEL, data, size);
     }
     if (err == gsm0710::GSM0710_ERROR_FLOW_CONTROL) {
@@ -2437,8 +2437,8 @@ int SaraNcpClient::getMtu() {
 
 int SaraNcpClient::urcs(bool enable) {
     const NcpClientLock lock(this);
+    sleepUrcsDisabled_ = !enable;
     if (enable) {
-        sleepNoPPPWrite_ = false;
         CHECK_TRUE(muxer_.resumeChannel(UBLOX_NCP_AT_CHANNEL) == 0, SYSTEM_ERROR_INTERNAL);
         if ((ncpId() != PLATFORM_NCP_SARA_R510) ||
                 ((ncpId() == PLATFORM_NCP_SARA_R510) &&
@@ -2451,8 +2451,6 @@ int SaraNcpClient::urcs(bool enable) {
             CHECK(waitAtResponse(5000, gsm0710::proto::DEFAULT_T2));
         }
     } else {
-        sleepNoPPPWrite_ = true;
-
         // R510 may be in low power mode, wake it up so we can get our muxer data channel suspend
         // echo, before we get into sleep and potentially prematurely wake by "network activity" (RX data)
         if (ncpId() == PLATFORM_NCP_SARA_R510) {
@@ -2745,7 +2743,13 @@ int SaraNcpClient::configModemPowerState(ModemPowerReason reason) {
 bool SaraNcpClient::checkAtWhileConnected() {
     // Every other state has its own recovery path, probing during them only adds noise.
     // An R510 firmware install stops answering AT for minutes by design, so it is not a fault.
-    if (connState_ != NcpConnectionState::CONNECTED || !ready_ || firmwareUpdateR510_) {
+    // R510 runs UPSV=1: it drops to low power after ~9s of UART idle, and while CONNECTED the muxer
+    // keepalive is off and the LCP echo is stretched to 240s to set a reasonable balance between power
+    // usage and keep alive responsiveness. The probe is a second, independent wake source with no
+    // phase relationship to the echo, so it costs another ~9s awake per period no matter what
+    // interval we pick. Not worth it for a defect we have only ever seen on EG91, so skip R510 entirely.
+    if (connState_ != NcpConnectionState::CONNECTED || !ready_ || firmwareUpdateR510_ ||
+            sleepUrcsDisabled_ || ncpId() == PLATFORM_NCP_SARA_R510) {
         atProbeFailStreak_ = 0;
         return true;
     }

--- a/hal/network/ncp_client/sara/sara_ncp_client.cpp
+++ b/hal/network/ncp_client/sara/sara_ncp_client.cpp
@@ -134,6 +134,15 @@ const unsigned CHECK_IMSI_TIMEOUT = 60 * 1000;
 const system_tick_t UBLOX_COPS_TIMEOUT = 5 * 60 * 1000;
 const system_tick_t UBLOX_CFUN_TIMEOUT = 3 * 60 * 1000;
 const system_tick_t UBLOX_CIMI_TIMEOUT = 10 * 1000; // Should be immediate, but have observed 3 seconds occassionally on u-blox and rarely longer times
+
+// AT wake budget after a parser error on R510.
+//
+// R510 enables UPSV=1 Low Power mode.
+// With UPSV=1 the module sleeps its UART after ~9.2s of idle and needs a wake character, consuming
+// the first one, so a command issued cold after an idle period goes unanswered. waitReady()'s
+// default 2s budget allows only 2-3 attempts. Measured recoveries run to ~7.6s, so the modem was
+// being hard reset while it was alive and about to answer.
+const system_tick_t UBLOX_R510_UPSV_WAKE_TIMEOUT = 15 * 1000;
 const system_tick_t UBLOX_UBANDMASK_TIMEOUT = 10 * 1000;
 
 const auto UBLOX_MUXER_T1 = 2530;
@@ -1014,7 +1023,10 @@ int SaraNcpClient::waitReady(bool powerOn) {
         if (stream) {
             skipAll(stream, 1000);
             parser_.reset();
-            ready_ = waitAtResponse(2000) == 0;
+            // See UBLOX_R510_UPSV_WAKE_TIMEOUT
+            const system_tick_t atWait = (ncpId() == PLATFORM_NCP_SARA_R510)
+                    ? UBLOX_R510_UPSV_WAKE_TIMEOUT : 2000;
+            ready_ = waitAtResponse(atWait) == 0;
             if (muxer_.isRunning()) {
                 modemState = ModemState::MuxerAtChannel;
             } else {
@@ -1880,6 +1892,7 @@ int SaraNcpClient::checkRuntimeState(ModemState& state) {
     CHECK(initParser(serial_.get()));
     skipAll(serial_.get());
     parser_.reset();
+    // NOTE: Do NOT widen this for the R510 UPSV=1 wake the way waitReady()'s parser-error branch does
     if (!waitAtResponse(2000)) {
         state = ModemState::RuntimeBaudrate;
         return SYSTEM_ERROR_NONE;

--- a/hal/network/ncp_client/sara/sara_ncp_client.h
+++ b/hal/network/ncp_client/sara/sara_ncp_client.h
@@ -97,6 +97,13 @@ private:
     CellularGlobalIdentity cgi_ = {};
     CellularAccessTechnology act_ = CellularAccessTechnology::NONE;
 
+    enum class ModemPowerReason {
+        Unknown = 0,
+        ModemOff = 1,
+        AtUnresponsive = 2,
+        RegTimeout = 3
+    };
+
     enum class ModemState {
         Unknown = 0,
         MuxerAtChannel = 1,
@@ -163,7 +170,7 @@ private:
     int processEventsImpl();
     int getIccidImpl(char* buf, size_t size);
     bool checkAtWhileConnected();
-    void recoverModem();
+    int configModemPowerState(ModemPowerReason reason);
     int checkNetConfForImsi();
 
     int modemInit() const;

--- a/hal/network/ncp_client/sara/sara_ncp_client.h
+++ b/hal/network/ncp_client/sara/sara_ncp_client.h
@@ -130,7 +130,9 @@ private:
     int firmwareInstallRespCodeR510_ = 0;
     int lastFirmwareInstallRespCodeR510_ = 0;
     int waitReadyRetries_ = 0;
-    bool sleepNoPPPWrite_ = false;
+    // Set by urcs(false) when going to sleep: the AT muxer channel is suspended and the muxer
+    // keepalive is off, so neither PPP writes nor AT probes can expect anything back.
+    bool sleepUrcsDisabled_ = false;
     bool ehsExtendedTiming_ = false;
     system_tick_t lastWindow_ = 0;
     size_t bytesInWindow_ = 0;

--- a/hal/network/ncp_client/sara/sara_ncp_client.h
+++ b/hal/network/ncp_client/sara/sara_ncp_client.h
@@ -129,6 +129,8 @@ private:
     size_t bytesInWindow_ = 0;
     bool cgattWorkaroundApplied_ = false;
     bool configuredPlmn_ = false;
+    system_tick_t atProbeTime_ = 0;
+    unsigned atProbeFailStreak_ = 0;
 
     int queryAndParseAtCops(CellularSignalQuality* qual);
     int initParser(Stream* stream);
@@ -160,6 +162,8 @@ private:
     int checkRunningImsi();
     int processEventsImpl();
     int getIccidImpl(char* buf, size_t size);
+    bool checkAtWhileConnected();
+    void recoverModem();
     int checkNetConfForImsi();
 
     int modemInit() const;

--- a/user/tests/integration/wiring/no_fixture_cellular_long_running
+++ b/user/tests/integration/wiring/no_fixture_cellular_long_running
@@ -1,0 +1,1 @@
+../../wiring/no_fixture_cellular_long_running

--- a/user/tests/wiring/no_fixture_cellular_long_running/application.cpp
+++ b/user/tests/wiring/no_fixture_cellular_long_running/application.cpp
@@ -1,0 +1,23 @@
+#ifndef PARTICLE_TEST_RUNNER
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+SYSTEM_MODE(MANUAL);
+
+// make clean all TEST=wiring/no_fixture PLATFORM=boron -s COMPILE_LTO=n program-dfu DEBUG_BUILD=y
+// make clean all TEST=wiring/no_fixture PLATFORM=boron -s COMPILE_LTO=n program-dfu DEBUG_BUILD=y USE_THREADING=y
+//
+// NOTE: This log handler only for TEST=wiring/no_fixture_cellular_long_running builds
+// Serial1LogHandler logHandler(115200, LOG_LEVEL_ALL, {
+//     { "comm", LOG_LEVEL_NONE }, // filter out comm messages
+//     { "system", LOG_LEVEL_INFO } // only info level for system messages
+// });
+
+UNIT_TEST_APP();
+
+// Enable threading if compiled with "USE_THREADING=y"
+#if PLATFORM_THREADING == 1 && USE_THREADING == 1
+SYSTEM_THREAD(ENABLED);
+#endif
+
+#endif // PARTICLE_TEST_RUNNER

--- a/user/tests/wiring/no_fixture_cellular_long_running/at_recovery.cpp
+++ b/user/tests/wiring/no_fixture_cellular_long_running/at_recovery.cpp
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2026 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+#if Wiring_Cellular
+
+/* unresponsive AT interface
+ *
+ * Some Quectel firmware stops servicing the AT channel (DLCI 1) while continuing to service the
+ * muxer control channel and the PPP data channel. Data keeps flowing, so connectionState() reports
+ * CONNECTED and nothing notices. Device OS detects it with a periodic AT probe and recovers by
+ * power cycling the modem.
+ *
+ * The fault follows a PPP data mode transition (ATD*99***1# -> CONNECT), at roughly 1 in 8
+ * transitions in testing, and has never been seen at any other time. This cycles the connection to
+ * generate transitions.
+ *
+ * Pass/fail is keyed on Device OS tearing the connection down and bringing it back with a working
+ * AT interface, not on this test's own AT probe. The probe only decides when to stop cycling and
+ * wait: if Device OS does not then act, it is treated as a false alarm and cycling resumes. That way
+ * a probe that is wrong in either direction costs time rather than a spurious failure.
+ *
+ * Reproducing the fault is probabilistic, so a run that never sees it reports that and passes. A
+ * run that does see it must observe the recovery, or fail.
+ */
+
+// Serial1LogHandler at_recovery_logHandler(115200, LOG_LEVEL_ALL, {
+//     // { "comm", LOG_LEVEL_NONE }
+// });
+
+namespace {
+
+const system_tick_t AT_PROBE_TIMEOUT = 3000;
+const unsigned AT_PROBE_ATTEMPTS = 3;
+const system_tick_t CONNECT_TIMEOUT = 5 * 60 * 1000;
+const system_tick_t DISCONNECT_TIMEOUT = 60 * 1000;
+// Device OS declares the fault after ~105s and then power cycles the modem. Measured stand down to
+// modem off: ~132s.
+const system_tick_t RECOVERY_TIMEOUT = 4 * 60 * 1000;
+// Reduce strain on network during testing by limiting the cycle period
+const system_tick_t MIN_CYCLE_PERIOD = 30 * 1000;
+const system_tick_t PROVOKE_BUDGET = 15 * 60 * 1000;
+// The fault can recur on the very first data mode transition after a recovery, 7 of 45 bench
+// occurrences were on transition #1 after a power cycle. That is the same fault again, not a failed
+// recovery, so allow Device OS a few rounds to land a connection with a working AT interface.
+const unsigned MAX_RECOVERY_ROUNDS = 3;
+
+unsigned cycles = 0;
+unsigned falseAlarms = 0;
+int lastProbeResult = 0;
+bool wedgeConfirmed = false;
+system_tick_t standDownAt = 0;
+system_tick_t connectivityLostAt = 0;
+system_tick_t recoveredAt = 0;
+
+// RESP_OK on success, WAIT (-1) on timeout, RESP_ERROR (-3) if the modem answered ERROR.
+// A wedged AT interface times out: commands are swallowed with no response and no error.
+bool atResponds() {
+    for (unsigned i = 0; i < AT_PROBE_ATTEMPTS; ++i) {
+        lastProbeResult = Cellular.command(AT_PROBE_TIMEOUT, "AT\r\n");
+        if (lastProbeResult == RESP_OK) {
+            return true;
+        }
+        Log.warn("AT probe %u/%u returned %d", i + 1, AT_PROBE_ATTEMPTS, lastProbeResult);
+        delay(500);
+    }
+    return false;
+}
+
+// Waits for Device OS to act on the fault. Returns false if it does not, which means our probe was
+// wrong rather than the modem being wedged.
+//
+// Watches connectivity rather than any power or network_status signal. Two of those were tried and
+// neither works on this path: the network_status power events are gated on a DISABLED transition
+// that recovery never makes (and handleIfPowerState only logs), while Cellular.isOff() needs
+// IF_POWER_STATE_DOWN *and* !isInterfacePhyReady(), and the phy flag stays set. Connectivity does
+// drop, verifiably: IP_CONFIGURED -> IFACE_LINK_UP as soon as recovery starts, back ~15s later.
+//
+// Since we do not touch the modem while standing down, connectivity dropping can only be Device OS
+// tearing it down. Note this asserts the user-visible recovery rather than proving a power cycle
+// specifically.
+bool waitForRecovery() {
+    if (!waitForNot(Cellular.ready, RECOVERY_TIMEOUT)) {
+        return false;
+    }
+    connectivityLostAt = millis();
+    return true;
+}
+
+} // namespace
+
+test(AT_RECOVERY_00_init) {
+    Cellular.on();
+    assertTrue(waitFor(Cellular.isOn, CONNECT_TIMEOUT));
+}
+
+test(AT_RECOVERY_01_data_mode_cycling_provokes_unresponsive_at) {
+    const system_tick_t start = millis();
+    while (millis() - start < PROVOKE_BUDGET) {
+        const system_tick_t cycleStart = millis();
+        Cellular.connect();
+        assertTrue(waitFor(Cellular.ready, CONNECT_TIMEOUT));
+        ++cycles;
+        // Cross-check against the ATD*99***1# count in the AT log. If they do not match, the cycle
+        // is not producing a data mode transition and the test is not exercising anything.
+        Log.info("cycle %u connected", cycles);
+
+        if (!atResponds()) {
+            // Suspected fault. Stop touching the modem from here: calling disconnect() would take
+            // the recovery path itself and mask the probe under test.
+            Log.warn("AT unresponsive after %u transitions, standing down", cycles);
+            standDownAt = millis();
+            if (waitForRecovery()) {
+                wedgeConfirmed = true;
+                break;
+            }
+            ++falseAlarms;
+            Log.warn("No recovery within %lu ms, treating as a false alarm",
+                    (unsigned long)RECOVERY_TIMEOUT);
+        }
+
+        Cellular.disconnect();
+        waitForNot(Cellular.ready, DISCONNECT_TIMEOUT);
+
+        const system_tick_t elapsed = millis() - cycleStart;
+        if (elapsed < MIN_CYCLE_PERIOD) {
+            delay(MIN_CYCLE_PERIOD - elapsed);
+        }
+    }
+    Log.info("Ran %u data mode transitions, %u false alarms, wedge %s",
+            cycles, falseAlarms, wedgeConfirmed ? "confirmed" : "not seen");
+    assertMore(cycles, 0u);
+}
+
+test(AT_RECOVERY_02_device_os_recovers_the_modem) {
+    if (!wedgeConfirmed) {
+        assertEqual(0, pushMailboxMsg(String::format(
+                "{\"reproduced\": false, \"cycles\": %u, \"falseAlarms\": %u, \"lastProbe\": %d}",
+                cycles, falseAlarms, lastProbeResult), 30000));
+        return;
+    }
+
+    // What is under test is that Device OS keeps detecting and recovering, not that the modem stops
+    // wedging. If the fault recurs immediately, that is a fresh occurrence and must be recovered too.
+    bool recovered = false;
+    unsigned recurrences = 0;
+    for (unsigned round = 0; round < MAX_RECOVERY_ROUNDS; ++round) {
+        if (waitFor(Cellular.ready, CONNECT_TIMEOUT) && atResponds()) {
+            recovered = true;
+            break;
+        }
+        ++recurrences;
+        Log.warn("AT still unresponsive after recovery %u, waiting for the next", round + 1);
+        if (!waitForRecovery()) {
+            break;
+        }
+    }
+    recoveredAt = millis();
+
+    assertEqual(0, pushMailboxMsg(String::format(
+            "{\"reproduced\": true, \"cycles\": %u, \"falseAlarms\": %u, \"recurrences\": %u, "
+            "\"detectMs\": %lu, \"recoveryMs\": %lu}",
+            cycles, falseAlarms, recurrences,
+            (unsigned long)(connectivityLostAt - standDownAt),
+            (unsigned long)(recoveredAt - standDownAt)), 30000));
+    assertTrue(recovered);
+}
+
+#endif // Wiring_Cellular

--- a/user/tests/wiring/no_fixture_cellular_long_running/at_recovery.cpp
+++ b/user/tests/wiring/no_fixture_cellular_long_running/at_recovery.cpp
@@ -17,8 +17,9 @@
 
 #include "application.h"
 #include "unit-test/unit-test.h"
+#include "test_suite.h"
 
-#if Wiring_Cellular
+#if HAL_PLATFORM_CELLULAR
 
 /* unresponsive AT interface
  *
@@ -60,6 +61,10 @@ const system_tick_t PROVOKE_BUDGET = 15 * 60 * 1000;
 // occurrences were on transition #1 after a power cycle. That is the same fault again, not a failed
 // recovery, so allow Device OS a few rounds to land a connection with a working AT interface.
 const unsigned MAX_RECOVERY_ROUNDS = 3;
+
+// The msom platform covers both cellular and Wi-Fi devices, so a Wi-Fi one can be selected here.
+// Not retained, nothing in this suite resets the device between tests.
+bool skipTests = false;
 
 unsigned cycles = 0;
 unsigned falseAlarms = 0;
@@ -106,11 +111,24 @@ bool waitForRecovery() {
 } // namespace
 
 test(AT_RECOVERY_00_init) {
+    if (TestSuite::instance()->network() != NETWORK_INTERFACE_ALL &&
+            TestSuite::instance()->network() != NETWORK_INTERFACE_CELLULAR) {
+        skipTests = true;
+        skip();
+        return;
+    }
+    skipTests = false;
+
     Cellular.on();
     assertTrue(waitFor(Cellular.isOn, CONNECT_TIMEOUT));
 }
 
 test(AT_RECOVERY_01_data_mode_cycling_provokes_unresponsive_at) {
+    if (skipTests) {
+        skip();
+        return;
+    }
+
     const system_tick_t start = millis();
     while (millis() - start < PROVOKE_BUDGET) {
         const system_tick_t cycleStart = millis();
@@ -149,6 +167,11 @@ test(AT_RECOVERY_01_data_mode_cycling_provokes_unresponsive_at) {
 }
 
 test(AT_RECOVERY_02_device_os_recovers_the_modem) {
+    if (skipTests) {
+        skip();
+        return;
+    }
+
     if (!wedgeConfirmed) {
         assertEqual(0, pushMailboxMsg(String::format(
                 "{\"reproduced\": false, \"cycles\": %u, \"falseAlarms\": %u, \"lastProbe\": %d}",
@@ -182,4 +205,4 @@ test(AT_RECOVERY_02_device_os_recovers_the_modem) {
     assertTrue(recovered);
 }
 
-#endif // Wiring_Cellular
+#endif // HAL_PLATFORM_CELLULAR

--- a/user/tests/wiring/no_fixture_cellular_long_running/no_fixture_cellular_long_running.spec.js
+++ b/user/tests/wiring/no_fixture_cellular_long_running/no_fixture_cellular_long_running.spec.js
@@ -10,7 +10,11 @@ before(function() {
   device = this.particle.devices[0];
 });
 
-test('AT_RECOVERY_00_init', async () => {
+test('AT_RECOVERY_00_init', async function() {
+  // Selects a cellular device, so a Wi-Fi configured M-SoM is not picked up by platform('msom').
+  // Same idiom as system/cellular_env.
+  this.test.parent.particle.network = 'cellular';
+  this.test.parent.particle.suiteInitialized = false;
 });
 
 test('AT_RECOVERY_01_data_mode_cycling_provokes_unresponsive_at', async () => {

--- a/user/tests/wiring/no_fixture_cellular_long_running/no_fixture_cellular_long_running.spec.js
+++ b/user/tests/wiring/no_fixture_cellular_long_running/no_fixture_cellular_long_running.spec.js
@@ -1,0 +1,35 @@
+suite('No fixture cellular long running');
+
+platform('cellular', 'msom');
+// AT_RECOVERY_01 budgets 15 minutes of connection cycling, plus up to ~9 for the recovery rounds.
+timeout(40 * 60 * 1000);
+
+let device;
+
+before(function() {
+  device = this.particle.devices[0];
+});
+
+test('AT_RECOVERY_00_init', async () => {
+});
+
+test('AT_RECOVERY_01_data_mode_cycling_provokes_unresponsive_at', async () => {
+});
+
+test('AT_RECOVERY_02_device_os_recovers_the_modem', async () => {
+  expect(device.mailBox).to.not.be.empty;
+  const msg = JSON.parse(device.mailBox[0].d);
+  if (!msg.reproduced) {
+    // Probabilistic, roughly 1 in 8 data mode transitions. Not a regression.
+    console.log(`AT interface stayed responsive across ${msg.cycles} data mode transitions, not reproduced this run`);
+    return;
+  }
+  console.log(`Reproduced after ${msg.cycles} data mode transitions`);
+  console.log(`Stood down -> connectivity lost: ${msg.detectMs} ms`);
+  console.log(`Stood down -> AT working again: ${msg.recoveryMs} ms`);
+  if (msg.recurrences) {
+    // The fault can recur on the first transition after a recovery. Device OS recovering it again
+    // is the correct outcome, not a failure.
+    console.log(`Fault recurred ${msg.recurrences} more time(s) before a clean connection`);
+  }
+});

--- a/user/tests/wiring/no_fixture_cellular_long_running/test.mk
+++ b/user/tests/wiring/no_fixture_cellular_long_running/test.mk
@@ -1,0 +1,18 @@
+INCLUDE_DIRS += $(SOURCE_PATH)/$(USRSRC)  # add user sources to include path
+# add C and CPP files - if USRSRC is not empty, then add a slash
+CPPSRC += $(call target_files,$(USRSRC_SLASH),*.cpp)
+CSRC += $(call target_files,$(USRSRC_SLASH),*.c)
+
+APPSOURCES=$(call target_files,$(USRSRC_SLASH),*.cpp)
+APPSOURCES+=$(call target_files,$(USRSRC_SLASH),*.c)
+ifeq ($(strip $(APPSOURCES)),)
+$(error "No sources found in $(SOURCE_PATH)/$(USRSRC)")
+endif
+
+ifeq ("${USE_THREADING}","y")
+USE_THREADING_VALUE=1
+else
+USE_THREADING_VALUE=0
+endif
+
+CFLAGS += -DUSE_THREADING=${USE_THREADING_VALUE}

--- a/user/tests/wiring/no_fixture_power_saving/no_fixture_power_saving.spec.js
+++ b/user/tests/wiring/no_fixture_power_saving/no_fixture_power_saving.spec.js
@@ -11,6 +11,18 @@ let deviceId = null;
 let limits = null;
 let skipTest = false;
 let returnVal = 12345;
+let wakeCall = null;
+let sleepingDeferred = null;
+
+// Resolved from the 'mailbox' handler when the device says it is about to sleep. The runner emits
+// that event in real time from inside waitTest()'s polling loop, so it arrives while the device
+// test is still running.
+function waitForSleeping() {
+    let resolve;
+    const promise = new Promise((res) => { resolve = res; });
+    sleepingDeferred = { resolve };
+    return promise;
+}
 
 async function delayMs(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
@@ -49,6 +61,14 @@ before(function() {
         if (msg.d === "skip_test") {
             skipTest = true;
             return;
+        }
+        if (msg.d === "sleeping" && sleepingDeferred) {
+            sleepingDeferred.resolve();
+            sleepingDeferred = null;
+            return;
+        }
+        if (msg.d) {
+            console.log(msg.d); // device-side findings, e.g. the low power result
         }
     });
 });
@@ -104,7 +124,19 @@ test('POWER_SAVING_05_check_current_thread', async function () {
         return;
     }
 
-    // See power_saving_mode.cpp
+    // Arm the wake here, deliberately not awaited. The runner runs each device test inside an
+    // awaited beforeEach hook, so nothing in test 06_1's own body can run while the device sleeps.
+    // The call has to already be in flight before that hook starts. Gating on the device's own
+    // event rather than a fixed offset keeps this correct if the pre-sleep work changes length.
+    const sleeping = waitForSleeping();
+    wakeCall = (async () => {
+        await sleeping;
+        // console.log('device is asleep, waiting 30s before waking it');
+        await delayMs(30000);
+        // console.log('waking up device with a function call');
+        return api.callFunction({ deviceId, name: 'fnlp1', argument: 'argument string low power sleep', auth });
+    })();
+    wakeCall.catch(() => {}); // keep node quiet until 06_1 awaits it
 });
 
 test('POWER_SAVING_06_system_sleep_with_configuration_object_ultra_low_power_mode_wake_by_network_1', async function() {
@@ -112,23 +144,10 @@ test('POWER_SAVING_06_system_sleep_with_configuration_object_ultra_low_power_mod
         return;
     }
 
-    // See power_saving_mode.cpp
-
-    // console.log('waiting for device to enter low power');
-    await delayMs(30000);
-    // console.log('waking up device with a function call');
-    let lastError;
-    try {
-        let resp = await api.callFunction({ deviceId, name: 'fnlp1', argument: 'argument string low power sleep', auth });
-        // console.log(resp.body.return_value + ' == ' + (returnVal+1));
-        expect(resp.body.return_value).to.equal(returnVal + 1);
-    } catch (e) {
-        lastError = e;
-    }
-    if (lastError) {
-        // console.log(lastError);
-        throw lastError;
-    }
+    // Armed in test 05's body; by now it has already woken the device.
+    const resp = await wakeCall;
+    // console.log(resp.body.return_value + ' == ' + (returnVal + 1));
+    expect(resp.body.return_value).to.equal(returnVal + 1);
 });
 
 

--- a/user/tests/wiring/no_fixture_power_saving/power_saving_mode.cpp
+++ b/user/tests/wiring/no_fixture_power_saving/power_saving_mode.cpp
@@ -13,6 +13,7 @@ constexpr uint32_t WAIT_FOR_LOW_POWER_ACTIVE_MS = 20000;
 constexpr uint32_t WAIT_FOR_LOW_POWER_MEAS_MS = 10000;
 constexpr uint32_t LOW_POWER_ATTEMPTS_MAX = 10; // XXX: extreme cases take up to 2.5 minutes to drop into low power mode
 constexpr char skip_test_msg[] = "skip_test";
+constexpr char sleeping_msg[] = "sleeping";
 int ncpId = DEV_UNKNOWN;
 String fnLp1Arg;
 bool appThread = true;
@@ -30,28 +31,121 @@ int fnLp1(const String& arg) {
     return returnVal++;
 }
 
+int upsvCallback(int type, const char* buf, int len, int* mode) {
+    (void)type;
+    (void)len;
+    int m = -1;
+    if (sscanf(buf, "\r\n+UPSV: %d", &m) == 1) {
+        *mode = m;
+    }
+    return WAIT;
+}
+
+void formatLowPower(char* buf, size_t size) {
+    snprintf(buf, size, "low power mode %s after %d retries, median=%lums",
+            lowPowerResult ? "DETECTED" : "NOT DETECTED", attempts, (unsigned long)period);
+    Log.info("%s", buf);
+}
+
+// Note: Wakes the modem, so only call once a measurement window has closed.
+int readUpsvMode() {
+    int mode = -1;
+    Cellular.command(upsvCallback, &mode, 10000, "AT+UPSV?");
+    return mode;
+}
+
 } // namespace
 
-uint32_t measureAvgPeriodMs(pin_t pin, uint32_t wait_ms) {
-    int high_pulse = 0;
-    int low_pulse = 0;
-    int count = 0;
-    // Dummy read to sync pulse edge
-    pulseIn(pin, HIGH);
-    pulseIn(pin, LOW);
-    uint32_t s = millis();
-    while (millis() - s < wait_ms) {
-        // This works better without an atomic block
-        // ATOMIC_BLOCK() {
-            high_pulse += pulseIn(pin, HIGH);
-            low_pulse += pulseIn(pin, LOW);
-        // }
-        count++;
-    }
-    high_pulse = high_pulse/count;
-    low_pulse = low_pulse/count;
+namespace {
 
-    return (high_pulse + low_pulse)/1000;
+// In low power mode CTS idles HIGH and blips LOW for only ~26ms every 1.28s, which pulseIn() loses
+// whenever the app thread is preempted. An ISR catches every edge. 256 is far more than a 10s
+// window holds at 1.28s (~16), so a full buffer means the line is toggling fast.
+constexpr size_t MAX_EDGES = 256;
+volatile uint32_t edgeUs[MAX_EDGES];
+volatile size_t edgeCount = 0;
+volatile uint8_t edgeLevel[MAX_EDGES]; // level AFTER the transition
+pin_t edgePin = 0;
+uint32_t periodsUs[MAX_EDGES / 2];
+
+// digitalRead() returns 0 on a UART-owned pin (pin_mode is PIN_MODE_NONE); pinReadFast() reads the
+// GPIO IN register directly.
+void ctsIsr() {
+    const uint32_t t = micros();
+    const int level = pinReadFast(edgePin);
+    if (edgeCount < MAX_EDGES) {
+        edgeUs[edgeCount] = t;
+        edgeLevel[edgeCount] = (uint8_t)level;
+        edgeCount++;
+    }
+}
+
+} // namespace
+
+// Median rising-to-rising period over wait_ms, or 0 if the line did not toggle enough to measure
+// one. Median not mean: a missed blip merges two periods into ~2x nominal, which drags a mean over
+// a handful of samples out of band. Requires attachCtsCapture().
+uint32_t measurePeriodMs(pin_t pin, uint32_t wait_ms) {
+    (void)pin; // the ISR is already attached to CTS1 for the life of the test
+    edgeCount = 0;
+
+    // Yield rather than busy-wait, so the system thread runs normally through the window.
+    const uint32_t start = millis();
+    while (millis() - start < wait_ms) {
+        delay(1);
+    }
+
+    const size_t edges = edgeCount;
+    const uint32_t spanMs = (edges >= 2) ? (edgeUs[edges - 1] - edgeUs[0]) / 1000 : 0;
+    int n = 0;
+    int lastRising = -1;
+    for (size_t i = 0; i < edges; i++) {
+        if (!edgeLevel[i]) {
+            continue;
+        }
+        if (lastRising >= 0 && n < (int)(sizeof(periodsUs) / sizeof(periodsUs[0]))) {
+            periodsUs[n++] = edgeUs[i] - edgeUs[lastRising];
+        }
+        lastRising = (int)i;
+    }
+    if (n == 0) {
+        Log.warn("CTS1: no period, edges=%u span=%lums level=%d%s", (unsigned)edges,
+                (unsigned long)spanMs, (int)pinReadFast(CTS1),
+                (edges >= MAX_EDGES) ? " BUFFER FULL" : "");
+        return 0;
+    }
+    for (int i = 1; i < n; i++) {
+        const uint32_t v = periodsUs[i];
+        int j = i - 1;
+        while (j >= 0 && periodsUs[j] > v) {
+            periodsUs[j + 1] = periodsUs[j];
+            j--;
+        }
+        periodsUs[j + 1] = v;
+    }
+    // A wide p25..p75 means there is no consistent period and the median describes nothing real
+    Log.info("CTS1: median=%lums p25=%lu p75=%lu periods=%d edges=%u span=%lums rate=%lu/min%s",
+            (unsigned long)(periodsUs[n / 2] / 1000), (unsigned long)(periodsUs[n / 4] / 1000),
+            (unsigned long)(periodsUs[(3 * n) / 4] / 1000), n, (unsigned)edges,
+            (unsigned long)spanMs,
+            spanMs ? (unsigned long)((uint64_t)n * 60000 / spanMs) : 0UL,
+            (edges >= MAX_EDGES) ? " BUFFER FULL" : "");
+    return periodsUs[n / 2] / 1000;
+}
+
+// Attached once per run: detach ends with hal_pin_set_function(pin, PF_NONE),
+// clearing the pinmap's record that CTS belongs to the UART
+bool attachCtsCapture(pin_t pin) {
+    edgePin = pin;
+    edgeCount = 0;
+
+    // pinReadFast() is not ISR-safe on its FIRST call: fastPinGetPinmap()'s function-local static
+    // initializes via __cxa_guard_acquire, which asserts in interrupt context -> SOS 10. Prime it
+    // from thread context first.
+    (void)pinReadFast(pin);
+
+    // hal_interrupt_attach() passes skip_gpio_setup = true, so the UART keeps its pin configuration.
+    return attachInterrupt(pin, ctsIsr, CHANGE);
 }
 
 test(POWER_SAVING_00_setup) {
@@ -71,15 +165,15 @@ test(POWER_SAVING_00_setup) {
         return;
     }
 
+    assertTrue(attachCtsCapture(CTS1));
+
     Particle.disconnect();
     assertTrue(waitFor(Particle.disconnected, CLOUD_DISCONNECT_TIMEOUT));
     Particle.function("fnlp1", fnLp1);
 }
 
 test(POWER_SAVING_01_particle_publish_publishes_an_event_after_low_power_active) {
-    // TODO: Find a deterministic way to get these tests to pass
-    skip();
-    return;
+
 
     if (ncpId != PLATFORM_NCP_SARA_R510) {
         skip();
@@ -95,7 +189,7 @@ test(POWER_SAVING_01_particle_publish_publishes_an_event_after_low_power_active)
         assertTrue(waitFor(Particle.connected, CLOUD_CONNECT_TIMEOUT));
         delay(WAIT_FOR_LOW_POWER_ACTIVE_MS); // wait for UPSV=1 default delay of ~9.2s before modem drops into low power mode idle mode.
 
-        period = measureAvgPeriodMs(CTS1, WAIT_FOR_LOW_POWER_MEAS_MS);
+        period = measurePeriodMs(CTS1, WAIT_FOR_LOW_POWER_MEAS_MS);
         if (period <= 1280 + 128 && period >= 1280 - 128) { // 1.28s +/- 10% if in low power mode
             lowPowerResult = true;
         } else {
@@ -105,14 +199,18 @@ test(POWER_SAVING_01_particle_publish_publishes_an_event_after_low_power_active)
         publishResult = Particle.publish("my_event_low_power", "event data low power", PRIVATE | WITH_ACK);
         // Log.info("period: %lu, publishResult: %d", period, publishResult);
     } while (!(publishResult && lowPowerResult) && attempts++ < LOW_POWER_ATTEMPTS_MAX);
-    assertMoreOrEqual(period, 1280 - 128); // 1.28s +/- 10% if in low power mode
-    assertLessOrEqual(period, 1280 + 128);
+    // Not asserted: whether the R510 enters low power depends on paging state we do not control,
+    // so gating on it only makes the test flaky. Reported for analysis.
+    char lpMsg[96];
+    formatLowPower(lpMsg, sizeof(lpMsg));
+    pushMailboxMsg(lpMsg, 5000);
+
+    // Not deterministic that the modem enters low power; it is deterministic that Device OS set it.
+    assertEqual(readUpsvMode(), 1);
     assertTrue(publishResult);
 }
 
 test(POWER_SAVING_02_register_function_and_connect_to_cloud) {
-    skip();
-    return;
 
     if (ncpId != PLATFORM_NCP_SARA_R510) {
         skip();
@@ -127,7 +225,7 @@ test(POWER_SAVING_02_register_function_and_connect_to_cloud) {
         assertTrue(waitFor(Particle.connected, CLOUD_CONNECT_TIMEOUT));
         delay(WAIT_FOR_LOW_POWER_ACTIVE_MS); // wait for UPSV=1 default delay of ~9.2s before modem drops into low power mode idle mode.
 
-        period = measureAvgPeriodMs(CTS1, WAIT_FOR_LOW_POWER_MEAS_MS);
+        period = measurePeriodMs(CTS1, WAIT_FOR_LOW_POWER_MEAS_MS);
         if (period <= 1280 + 128 && period >= 1280 - 128) { // 1.28s +/- 10% if in low power mode
             lowPowerResult = true;
         } else {
@@ -136,13 +234,17 @@ test(POWER_SAVING_02_register_function_and_connect_to_cloud) {
         // Log.info("period: %lu", period);
 
     } while (!lowPowerResult && attempts++ < LOW_POWER_ATTEMPTS_MAX);
-    assertMoreOrEqual(period, 1280 - 128); // 1.28s +/- 10% if in low power mode
-    assertLessOrEqual(period, 1280 + 128);
+    // Not asserted: whether the R510 enters low power depends on paging state we do not control,
+    // so gating on it only makes the test flaky. Reported for analysis.
+    char lpMsg[96];
+    formatLowPower(lpMsg, sizeof(lpMsg));
+    pushMailboxMsg(lpMsg, 5000);
+
+    // Not deterministic that the modem enters low power; it is deterministic that Device OS set it.
+    assertEqual(readUpsvMode(), 1);
 }
 
 test(POWER_SAVING_03_call_function_and_check_return_value_after_low_power_active) {
-    skip();
-    return;
 
     if (ncpId != PLATFORM_NCP_SARA_R510) {
         skip();
@@ -153,8 +255,6 @@ test(POWER_SAVING_03_call_function_and_check_return_value_after_low_power_active
 }
 
 test(POWER_SAVING_04_check_function_argument_value) {
-    skip();
-    return;
 
     if (ncpId != PLATFORM_NCP_SARA_R510) {
         skip();
@@ -171,8 +271,6 @@ test(POWER_SAVING_04_check_function_argument_value) {
 }
 
 test(POWER_SAVING_05_check_current_thread) {
-    skip();
-    return;
 
     // Verify that all function calls have been performed in the application thread
     assertTrue(appThread);
@@ -186,8 +284,6 @@ system_tick_t start_06 = 0;
 }
 
 test(POWER_SAVING_06_system_sleep_with_configuration_object_ultra_low_power_mode_wake_by_network_1) {
-    skip();
-    return;
 
     if (ncpId != PLATFORM_NCP_SARA_R510) {
         skip();
@@ -198,40 +294,29 @@ test(POWER_SAVING_06_system_sleep_with_configuration_object_ultra_low_power_mode
     assertTrue(waitFor(Particle.connected, CLOUD_CONNECT_TIMEOUT));
 
     delay(15s); // a bit of delay required to avoid premature wake, even with SystemSleepFlag::WAIT_CLOUD
-    lowPowerResult = false;
-    attempts = 0;
-    period = 0;
-    do {
-        Particle.connect();
-        assertTrue(waitFor(Particle.connected, CLOUD_CONNECT_TIMEOUT));
-        delay(WAIT_FOR_LOW_POWER_ACTIVE_MS); // wait for UPSV=1 default delay of ~9.2s before modem drops into low power mode idle mode.
 
-        period = measureAvgPeriodMs(CTS1, WAIT_FOR_LOW_POWER_MEAS_MS);
-        if (period <= 1280 + 128 && period >= 1280 - 128) { // 1.28s +/- 10% if in low power mode
-            lowPowerResult = true;
-        } else {
-            lowPowerResult = false;
-        }
-        // Log.info("period: %lu", period);
+    // No low power measurement here: waking on inbound traffic does not depend on it, and tests 01
+    // and 02 cover it.
 
-    } while (!lowPowerResult && attempts++ < LOW_POWER_ATTEMPTS_MAX);
-    assertMoreOrEqual(period, 1280 - 128); // 1.28s +/- 10% if in low power mode
-    assertLessOrEqual(period, 1280 + 128);
+    // Signals the JS side that the sleep is starting; the wake call is armed from test 05's body and
+    // gated on this, because the runner runs each device test in an awaited beforeEach hook and
+    // test 06_1's own body cannot run until this sleep has ended. Sent over the mailbox (USB) so it
+    // costs no modem traffic.
+    assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::DATA).data(sleeping_msg, sizeof(sleeping_msg) - 1), 30000));
 
     assertEqual(0, pushMailbox(MailboxEntry().type(MailboxEntry::Type::RESET_PENDING), 30000));
     start_06 = millis();
     SystemSleepConfiguration config;
     config.mode(SystemSleepMode::ULTRA_LOW_POWER)
-        .duration(60s)
+        .duration(120s)
         .network(NETWORK_INTERFACE_CELLULAR);
+    detachInterrupt(CTS1);
     result_06 = System.sleep(config);
 
-    // in sleep for 60s, should wake up after 30s due to function call
+    // in sleep for 120s, should wake up after ~45s due to function call
 }
 
 test(POWER_SAVING_06_system_sleep_with_configuration_object_ultra_low_power_mode_wake_by_network_2) {
-    skip();
-    return;
 
     if (ncpId != PLATFORM_NCP_SARA_R510) {
         skip();
@@ -243,8 +328,6 @@ test(POWER_SAVING_06_system_sleep_with_configuration_object_ultra_low_power_mode
 }
 
 test(POWER_SAVING_07_check_function_argument_value) {
-    skip();
-    return;
 
     if (ncpId != PLATFORM_NCP_SARA_R510) {
         skip();
@@ -265,6 +348,8 @@ test(POWER_SAVING_99_cleanup) {
         skip();
         return;
     }
+
+    detachInterrupt(CTS1);
 
     // See no_fixture_long_running.spec.js
 }


### PR DESCRIPTION
# Problem

- A valid cellular connection with no-data due to IPX routing error at the serving cell provider results ultimately in triggering a bug in the Quectel EG91NAX modem firmware that kills the AT pre-processor, used over DLCI 1 muxer channel, while the muxer channel control is still responsive, PPP data channel and keep alive control channel are still responsive.  AT commands no longer are responded to by the modem.  The device is stuck in this condition with no way to recover other than a modem power cycle.

# Solution

- [quectel][ublox] detect and recover from an unresponsive AT interface

  - A Quectel EG91NAX firmware bug (present in both deployed and the latest available firmware, EG91NAXGAR07A03M1G_A0.005.A0.005) stops servicing the AT channel (DLCI 1) while continuing to service the muxer control channel (DLCI 0) and the PPP data channel (DLCI 2). Data keeps flowing, so `connectionState()` legitimately reports `CONNECTED`, and nothing in Device OS notices or recovers: the device stops responding to any `cellular_hal` call and never comes back without a power cycle.

  - Nothing detects it today. While `CONNECTED` the client issues no AT commands at all, everything ahead of the `connState_` != `CONNECTING` gate in `processEventsImpl()` is either one-shot (`checkRunningImsi()`, `configurePlmn()`) or a no-op. `parserError_` is therefore never set and `checkParser()`, which already implements the right escalation, is never reached. The muxer cannot see it either: both TEST and MSC keepalives are DLCI 0 control frames that the peer's multiplexer answers without involving its AT processor. Confirmed under gdb during a 49 minute stall with the MSC keepalive active, `keepAlivesMissed_` was still 0.

  - Adds `checkAtWhileConnected()`, a periodic AT probe that runs while `CONNECTED`. 3s timeout every 35s, declared on the 4th consecutive failure, so ~105s. The interval is set just above the 90s default command timeout in case a command uses a shorter one. The probe is kept out of the AT log, and deliberately does not use `CHECK_PARSER*`, which would set `parserError_` and route the next command into `checkParser()` -> `waitReady()` -> `modemHardReset()` instead of the deliberate sequence below.

  - Recovery is contained in the NCP client, in the same style as the existing network registration timeout. On declaration, `processEventsImpl()` calls a new `recoverModem()` and returns `SYSTEM_ERROR_TIMEOUT`. `PppNcpNetif::loop()` then brings the modem back through `on()` and `upImpl()` on its next pass, which is the existing chain, unchanged. No network interface changes are needed.

  - `recoverModem()` is shared with the network registration timeout, which previously inlined its own copy of the sequence. Three differences from the old inline version, all of which the registration timeout now also gets:

    1. `ncpState(OFF)` before `muxer_.stop()`, so the muxer channel state callback does not disable us unnecessarily. This also clears `ready_` and drives `connectionState(DISCONNECTED)`, taking PPP down before the muxer disappears underneath it. This part was already correct, kept as is.
    2. The muxer stop is bracketed by `serial_->enabled(false/true)`, the way `off()` does it, so it stops non-gracefully. Without this it closes every channel and waits out a CLD exchange with a modem that is not answering, measured at 1072ms of dead time. With it, 50ms.
    3. `apduChannelTimer_.stop()` and `apduChannel_` = 0, again as `off()` does. The modem is gone, so the inactivity timer must not fire and try to close the channel with AT commands. Quectel only, u-blox has no APDU channel.

  - It calls `modemPowerOff()` directly rather than `off()`, because `off()` starts with `modemSoftPowerOff()`, which asks an AT interface we have just proven dead to power itself down. On Quectel that is `AT+QPOWD` retried six times, on u-blox a single `AT+CPWROFF` at the 90s default timeout.

  - Also quietens `dataChannelWrite()`: once we are OFF the muxer channel is gone but PPP keeps writing until the interface is brought down, which produced 314 ERROR lines in 15.5s during recovery (under a heavy load soak test, but a real system will still see log spam).

  - The probe stands down while the device is asleep. `urcs(false)` suspends the AT muxer channel, so a probe issued there cannot be answered and would declare a false fault. Both clients now track this in `sleepUrcsDisabled_`, set in `urcs()`. On u-blox this is the existing `sleepNoPPPWrite_` renamed: it already marked exactly this state for the PPP write path, and now gates the probe as well, so there is one flag rather than two in lockstep. On Quectel the flag is new, and is set on both branches of `urcs()`, including the BG95 QINDCFG path where the AT channel stays up: a probe there would be answered, but it would wake the module, which is the thing sleep is trying to avoid.

  - The probe and recovery are enabled on every Quectel and u-blox part except R510 (see below), not just EG91NAX. Only EG91NAX has been seen to wedge, so everywhere else this is a safety net rather than a fix for a known fault, and the rig run below shows it does not false positive on the others.

  - The u-blox port is identical with one exception: R510 is excluded from the probe entirely. It runs `UPSV=1` and drops to low power after ~9s of UART idle, and while `CONNECTED` the muxer keepalive is disabled and the LCP echo stretched to 240s specifically to let it get there. The probe is a second, independent wake source with no phase relationship to the echo, so it costs roughly another 9s awake per period whatever interval it is given. Matching the intervals does not fix that, because nothing aligns the phase: the two timers free-run on different threads and drift, and at 180 degrees apart the longest sleep halves from ~231s to ~120s. The wedge has only ever been seen on EG91NAX, so that coverage is not worth a measurable power regression on a part that has never exhibited it.

  - The guard also stands down while `firmwareUpdateR510_` is set, because an R510 firmware install stops answering AT for up to 300s by design while `connState_` is still `CONNECTED`. That clause is redundant given the R510 exclusion above, since its only setter returns early on anything but R510. It is kept as documentation, and in case R510 probing is ever reinstated behind a phase-locked scheme.

- [hal] `quectel_ncp_client`: reset connection state on every `disconnect()` exit path

  - `resetRegistrationState()` and `connectionState(DISCONNECTED)` sat at the end of `disconnect()`, after `CHECK(checkParser())` and `CHECK_PARSER(execCommand("AT+CFUN=0,0"))`. Both early-return on failure, so if the modem stops answering AT commands, the teardown was requested but never recorded: `connState_` stayed `CONNECTED` with the modem in an unknown state.

  - That stale value disables the whole recovery chain in `PppNcpNetif::loop()`: all three branches are keyed on it, so `upImpl()` (needs `DISCONNECTED`), `downImpl()` and `off()` (needs `DISCONNECTED` before powering down) all become unreachable. The interface looks healthy and has no way out, which is one signature seen in the field: a device stopped passing data and did not recover without a power cycle.

  - Moved into a `SCOPE_GUARD` placed before `checkParser()`. `sara_ncp_client` already had this, no change needed there.

  - `disconnect()` also picks up the rest of `sara_ncp_client`'s behaviour, which it had drifted from. Two gaps, both traceable to SARA-only commits that never got a Quectel counterpart:

    1. No forced AT check. `checkParser()` short-circuits when `ready_` is true and `parserError_` is 0, which is exactly the state a wedge leaves behind, so `AT+CFUN=0,0` went out to a dead interface and blocked for the full 90s parser default. The forced 1s AT, added to SARA in `d981dcc0b` (an R510 UPSV commit), sets `parserError_` so `checkParser()` escalates instead: ~5s of probing, then `waitReady()` falls through to `modemHardReset()`, which is the recovery a wedged modem needs anyway. Note this means `disconnect()` can now hard reset the modem and leave ncpState at OFF; that is inherited from SARA rather than new behaviour, but it is heavier than the name suggests.
    2. Wrong CFUN timeout. The raw `execCommand("AT+CFUN=0,0")` used the 90s parser default, and was the only one of 14 CFUN call sites in the Quectel client not using `QUECTEL_CFUN_TIMEOUT`. The constant predates the line by a month; it was simply never picked up. Replaced with `setModuleFunctionality(CellularFunctionality::MINIMUM, false)`, matching SARA, which routes through the helper that already carries the 3 minute timeout. Identical on the wire, since MINIMUM is 0 and the helper formats `AT+CFUN`=%d,0. The Quectel declaration also gains the `check = false` default SARA already had, so the two signatures match. This drops the leftover `(void)r` and commented-out `CHECK_TRUE`, and means `disconnect()` now propagates parser errors it previously swallowed; the `SCOPE_GUARD` still tears down connection state on every path.

- [ublox] give R510 a longer AT wake budget after a parser error

  - R510 runs `UPSV=1`. The module sleeps its UART after ~9.2s of idle and needs a wake character, consuming the first one, so a command issued cold after an idle period goes unanswered. `waitReady()`'s parser-error branch allowed 2000ms, which is 2-3 AT attempts at the 1s retry period. Measured recoveries run to ~7.6s, so the modem was being hard reset while it was alive and about to answer.

  - Raised to 15s for R510 only, via `UBLOX_R510_UPSV_WAKE_TIMEOUT`, leaving every other part on the existing 2000ms. That is roughly 2x the worst recovery observed. Keyed on `ncpId()` rather than on UPSV actually being enabled, which is only equivalent because `initReady()` enables it unconditionally for R510.

  - `checkRuntimeState()` is deliberately left at 2000ms and carries a note saying so. Widening it was tried at 30s and made things strictly worse: across three affected boots the modem answered none of 30 one-per-second ATs and still needed the hard reset, so the only effect was pushing recovery from 15s out to 43s. Boot-time unresponsiveness is a different failure from the cooldown wake, where the modem always answers within 2-7s.

- [test] update and re-enable `wiring/no_fixture_power_saving`

  - Every test in this suite was disabled in `3387462de` with "TODO: Find a deterministic way to get these tests to pass". The skips are removed and the two sources of non-determinism are addressed.

  - The CTS measurement was wrong rather than merely noisy. In low power the line idles HIGH and blips LOW for only ~26ms every 1.28s (confirmed on a scope), and `pulseIn()` blocks the app thread while it waits for an edge, so any blip landing while the system thread has the CPU was simply lost. It also only accounted for the pulse widths it happened to catch, not the whole window. Replaced with a GPIOTE ISR that timestamps every transition, and a median rising-to-rising period rather than a mean, since a missed blip merges two periods into one of ~2x nominal and drags a mean out of band. Against the scope the ISR now reports median=1279ms with p25/p75 inside 1275..1284, and edge counts matching 2 per period exactly.

  - Two traps worth knowing, both commented at the point of use. `pinReadFast()` is not ISR-safe on its first call: `fastPinGetPinmap()`'s function-local static initialises via `__cxa_guard_acquire`, which asserts in interrupt context and panics SOS 10, so it is primed from thread context before the interrupt is attached. And the capture is attached once in setup rather than around each measurement, because `hal_interrupt_detach_ext()` ends with `hal_pin_set_function(pin, PF_NONE)`, clearing the pinmap's record that CTS belongs to the UART.

  - Whether the R510 enters low power is no longer asserted. It depends on paging and registration state the test does not control, so gating on it only made the suite flaky without saying anything about Device OS. It is reported instead, over the mailbox so it lands in the runner console rather than only on Serial1, alongside a diagnostic line carrying median, quartiles, edge count, span and wakes/min. What is asserted in its place is `AT+UPSV? == 1`, which is deterministic: it is Device OS's own configuration rather than modem behaviour, and it fails exactly when `initReady()` stops enabling UPSV.

  - `POWER_SAVING_06` (wake from ULP sleep by network) could not pass as written, for a structural reason rather than a flaky one. The runner runs each device test inside an awaited mocha `beforeEach` hook, and `waitTest()` only returns early when the device reports `STATUS_WAITING`, which requires an actual reset. `ULTRA_LOW_POWER` resumes in place, so the device stays `STATUS_RUNNING` for the whole sleep and the spec body that issues the waking function call cannot run until the device has already woken. `RESET_PENDING` does not change this; its job is telling the runner USB is about to detach, which is why the `HIBERNATE` tests in `sleep20` work (their wake is self-contained) and its ULP cellular test works (a BLE fixture peer supplies the stimulus).

  - Restructured so the wake is armed from test 05's spec body, not awaited, and gated on a mailbox message the device sends immediately before sleeping. Test 05's body runs before test 06_1's hook, so the call is already in flight while the device sleeps. The signal goes over the mailbox rather than a publish because a publish is UART traffic that would restart the modem's UPSV idle timer. The low power measurement was also dropped from 06 entirely: waking on inbound traffic does not depend on it, tests 01 and 02 already cover it, and it cost ~30s per run. Sleep duration raised to 120s to give the call room to land mid-sleep.


# Scope

- This only bites devices that do not otherwise talk to the modem. An application calling `Cellular.RSSI()` or `Cellular.command()` sets `parserError_` on the first timeout, and the second call escalates through `checkParser()` -> `waitReady()` -> `modemHardReset()` within roughly two command timeouts. That path exists today and is unchanged. The probe is what gives the same outcome to a PPP data-only device, which is the field signature.

# Validation

Earlier soak runs were on a slightly different shape of this change, where recovery was driven from PppNcpNetif rather than contained in the NCP client. The detector and its timing are the same, so the detection numbers carry over. Recovery times are re-measured below.

The review changes (sleep stand-down, R510 exclusion, `disconnect()` alignment) landed after the runs below and are compile-verified only. None of them touch the detector's timing or the recovery sequence on EG91NAX, so the detection and recovery numbers carry over unchanged. What is not re-measured is the `disconnect()` path against a wedged modem, which now escalates to a hard reset in ~5s instead of blocking on CFUN for 90s. R510 no longer probes at all, so the power question that motivated the exclusion needs no hardware validation.

The R510 wake budget and the power saving test are independent of the EG91NAX detector and recovery path, and are validated separately below.

- Validated the R510 wake budget and the updated suite together on the HIL rig, boron BRN404X (R510, modem firmware 03.30), both systemThread=disabled and enabled. All tests pass in both modes. Low power was detected on the first attempt in every measurement, at median 1279-1280ms and 46-47 wakes/min, with `AT+UPSV?` reading 1,2000,1 throughout.

- The wake budget was measured over a separate multi-cycle soak on esomx and boron before being set. Recoveries after a parser error clustered at 2.0-7.6s and always succeeded; with the old 2000ms budget every one of those would have been a hard reset on a live modem. `V_INT` stayed high throughout, and each of those hard resets then recovered on the first AT afterwards, which is what identified them as unnecessary.

- Builds clean with no new warnings on boron and esomx. Note that `device-os-test build` only compiles the user application, so a full modules build is needed to cover the HAL change.

- Validated on 6.4.1 over an 8.5 hour soak: 3 wedges, 3 recoveries, 94 data-mode transitions, no permanent failures. Recovery took 340/338/344s, in every case via the 5-minute cloud-failure network reset. The probe was deliberately stretched (60s x 10) for this run so the reset would win.

- Validated on 6.5.0 over a 2.4 hour soak with the probe at production values: 4 wedges, 4 recoveries, 29 data-mode transitions, no permanent failures. All four recovered via the probe rather than the cloud-failure reset (Hard resetting: 0), tripping on the 3rd consecutive failure every time, detect -> resume taking 28s in all four cases. This run used 30s/3/2s, the merged 35s/3/3s moves detection from ~90s to ~105s to sit just above the default AT command timeout.

- Validated on 6.5.0 with the probe stretched to 60s x 10 behaved identically to 6.4.1 over 6 hours: 6 wedges, 338-343s recoveries. 6.5.0's PPP TX-queue rework does not affect teardown.

- Validated on 6.5.0 with the soak removed entirely and the device pointed at an unreachable cloud IP, i.e. the shipping configuration with the probe as the sole detector: 13 data-mode transitions, 2 wedges, 2 recoveries, no MCU resets. Both recoveries were identical to within 100 ms, declared at 105.0s, a 15.5s modem power cycle, and data restored 29.6s after detection (134.6s from the first probe failure). 6 probe failures total = exactly 2 x 3, with no isolated failures, so no false positives.

- No false positives: across a separate 10.3 hour run, all 26 "AT unresponsive" declarations fell inside a genuine wedge, and all 78 probe failures were part of a streak that escalated (78 = 26 x 3), no isolated or spurious probe failures.

- Validated on the final shape on the HIL rig, b5som, both systemThread=disabled and enabled. Both reproduced and recovered, one of them twice because the fault recurred on the first transition after recovery. Declaration cadence was 105.000s from the first probe failure, unchanged. Detect -> data restored was 28.9s and 29.4s, against 30.4s before the non-graceful muxer stop was added. Breakdown of one recovery: 29ms to start the muxer stop, 50ms to stop it, 15.6s modem power off, 9.7s power on, then registration and PPP.

- Builds clean with no new warnings on every platform with a cellular NCP client: boron and esomx (u-blox), b5som, msom, tracker, trackerm and electron2 (Quectel).

- `off()` is unchanged. The refactor folded `off()` into `configModemPowerState(ModemOff)`, so the same test app was run on the branch and on released 6.5.0 and the logs compared from "Request to power off interface 4" onward. Identical line for line, the only difference being the modem's own power off duration (8584ms vs 8573ms). That includes the pre-existing second pass through `off()`: the muxer channel 0 close fires `disable()` during the first pass, so `ncpState(OFF)` is swallowed by its own `DISABLED` guard and the netif's next `enable()` re-runs `off()` 101ms later (102ms on the branch), which is where NCP state changed: 0 actually lands. Both builds do this.

- Run across the HIL rigs. Reproduced and recovered on msom "Muon" (B504e/EG91NAX) and B5SoM (B504e/EG91NAX). No reproduction on bsom, boron and esomx (R410/R510), tracker (BG96), msom (BG95-M5) or msom (BG95-S5), and no probe declarations on any of them either, so no false positives across five other modem types. The fault therefore looks specific to EG91NAX, and the probe is preventative on everything else.

# Test

- run integration test `wiring/no_fixture_cellular_long_running`
- run integration test `wiring/no_fixture_power_saving` (R510 only, skips itself on other NCPs)
