### PR TITLE
[build] working -jXX and ccache support; faster CI builds

### DIFF
--- a/.buildpackrc
+++ b/.buildpackrc
@@ -5,7 +5,7 @@
 # Additionally release/prerelease information is used to automatically create
 # build targets in Particle Cloud when pushing a tag.
 
-export BUILDPACK_BUILDER_VERSION=0.2.3
+export BUILDPACK_BUILDER_VERSION=0.2.4
 
 # GCC version is no longer managed by this variable.
 # GCC dependencies come from .workbench/manifest.json

--- a/.buildpackrc
+++ b/.buildpackrc
@@ -5,7 +5,7 @@
 # Additionally release/prerelease information is used to automatically create
 # build targets in Particle Cloud when pushing a tag.
 
-export BUILDPACK_BUILDER_VERSION=0.2.2
+export BUILDPACK_BUILDER_VERSION=0.2.3
 
 # GCC version is no longer managed by this variable.
 # GCC dependencies come from .workbench/manifest.json

--- a/.buildpackrc
+++ b/.buildpackrc
@@ -5,7 +5,7 @@
 # Additionally release/prerelease information is used to automatically create
 # build targets in Particle Cloud when pushing a tag.
 
-export BUILDPACK_BUILDER_VERSION=0.2.4
+export BUILDPACK_BUILDER_VERSION=0.3.0
 
 # GCC version is no longer managed by this variable.
 # GCC dependencies come from .workbench/manifest.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,7 +240,7 @@ jobs:
             TIMESTAMP_FILE=timestamp_$RANDOM
             mkdir -p $HOME/workspace/release
             date +%s > $HOME/workspace/release/$TIMESTAMP_FILE
-            apk -q update && apk -q add bash curl xz
+            apk -q update && apk -q add bash
       - run:
           name: "Fetch dependencies"
           shell: /bin/bash
@@ -268,19 +268,7 @@ jobs:
             export BUILD_PLATFORM="<< parameters.platform >>"
             export BUILDPACK_NORM=1
             export BUILD_PLATFORM_NORMALIZED=$(echo "$BUILD_PLATFORM" | sed 's/ /_/g')
-            # stage a modern ccache into the build container: the one shipped in ubuntu 20.04 (3.7.7)
-            # cannot share cache entries between objects with different output paths
-            CCACHE_ARG=""
-            if curl -fsSL --retry 3 -o /tmp/ccache.tar.xz https://github.com/ccache/ccache/releases/download/v4.11.3/ccache-4.11.3-linux-x86_64.tar.xz \
-                && echo "7766991b91b3a5a177ab33fa043fe09e72c68586d5a86d20a563a05b74f119c0  /tmp/ccache.tar.xz" | sha256sum -c -s -; then
-              tar xf /tmp/ccache.tar.xz -C /tmp
-              docker volume create ccache_ext
-              docker create -v ccache_ext:/ccache-ext --name ccseed alpine true
-              docker cp /tmp/ccache-4.11.3-linux-x86_64/ccache ccseed:/ccache-ext/ccache
-              docker rm ccseed
-              CCACHE_ARG="--volume ccache_ext:/ccache-ext --env CCACHE=/ccache-ext/ccache"
-            fi
-            export EXTRA_ARG="--env DEVICE_OS_CI_API_TOKEN=$DEVICE_OS_CI_API_TOKEN --env CI_BUILD_RELEASE=1 --name build --env VERSION=$TAG --env MAKE_JOBS=nproc ${CCACHE_ARG}"
+            export EXTRA_ARG="--env DEVICE_OS_CI_API_TOKEN=$DEVICE_OS_CI_API_TOKEN --env CI_BUILD_RELEASE=1 --name build --env VERSION=$TAG --env MAKE_JOBS=nproc"
             mkdir -p $HOME/workspace/release/$BUILD_PLATFORM_NORMALIZED
             export BUILD_START=$(date +%s)
             $HOME/firmware-buildpack-builder/scripts/ci | tee $HOME/workspace/release/$BUILD_PLATFORM_NORMALIZED/log | tee >(grep -E '^has_failures [0-9]+ ' > $HOME/failures/has_failures); export TMPRESULT=${PIPESTATUS[0]}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,7 +270,9 @@ jobs:
             export BUILD_PLATFORM_NORMALIZED=$(echo "$BUILD_PLATFORM" | sed 's/ /_/g')
             export EXTRA_ARG="--env DEVICE_OS_CI_API_TOKEN=$DEVICE_OS_CI_API_TOKEN --env CI_BUILD_RELEASE=1 --name build --env VERSION=$TAG"
             mkdir -p $HOME/workspace/release/$BUILD_PLATFORM_NORMALIZED
+            export BUILD_START=$(date +%s)
             $HOME/firmware-buildpack-builder/scripts/ci | tee $HOME/workspace/release/$BUILD_PLATFORM_NORMALIZED/log | tee >(grep -E '^has_failures [0-9]+ ' > $HOME/failures/has_failures); export TMPRESULT=${PIPESTATUS[0]}
+            echo $(( $(date +%s) - BUILD_START )) > $HOME/workspace/release/$BUILD_PLATFORM_NORMALIZED/duration
             cp -r $HOME/failures/* $HOME/workspace/release/$BUILD_PLATFORM_NORMALIZED/ || true
             export RESULT=${TMPRESULT}
             echo ${RESULT}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,7 +268,7 @@ jobs:
             export BUILD_PLATFORM="<< parameters.platform >>"
             export BUILDPACK_NORM=1
             export BUILD_PLATFORM_NORMALIZED=$(echo "$BUILD_PLATFORM" | sed 's/ /_/g')
-            export EXTRA_ARG="--env DEVICE_OS_CI_API_TOKEN=$DEVICE_OS_CI_API_TOKEN --env CI_BUILD_RELEASE=1 --name build --env VERSION=$TAG"
+            export EXTRA_ARG="--env DEVICE_OS_CI_API_TOKEN=$DEVICE_OS_CI_API_TOKEN --env CI_BUILD_RELEASE=1 --name build --env VERSION=$TAG --env MAKE_JOBS=nproc"
             mkdir -p $HOME/workspace/release/$BUILD_PLATFORM_NORMALIZED
             export BUILD_START=$(date +%s)
             $HOME/firmware-buildpack-builder/scripts/ci | tee $HOME/workspace/release/$BUILD_PLATFORM_NORMALIZED/log | tee >(grep -E '^has_failures [0-9]+ ' > $HOME/failures/has_failures); export TMPRESULT=${PIPESTATUS[0]}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,7 +240,7 @@ jobs:
             TIMESTAMP_FILE=timestamp_$RANDOM
             mkdir -p $HOME/workspace/release
             date +%s > $HOME/workspace/release/$TIMESTAMP_FILE
-            apk -q update && apk -q add bash
+            apk -q update && apk -q add bash curl xz
       - run:
           name: "Fetch dependencies"
           shell: /bin/bash
@@ -268,7 +268,19 @@ jobs:
             export BUILD_PLATFORM="<< parameters.platform >>"
             export BUILDPACK_NORM=1
             export BUILD_PLATFORM_NORMALIZED=$(echo "$BUILD_PLATFORM" | sed 's/ /_/g')
-            export EXTRA_ARG="--env DEVICE_OS_CI_API_TOKEN=$DEVICE_OS_CI_API_TOKEN --env CI_BUILD_RELEASE=1 --name build --env VERSION=$TAG --env MAKE_JOBS=nproc"
+            # stage a modern ccache into the build container: the one shipped in ubuntu 20.04 (3.7.7)
+            # cannot share cache entries between objects with different output paths
+            CCACHE_ARG=""
+            if curl -fsSL --retry 3 -o /tmp/ccache.tar.xz https://github.com/ccache/ccache/releases/download/v4.11.3/ccache-4.11.3-linux-x86_64.tar.xz \
+                && echo "7766991b91b3a5a177ab33fa043fe09e72c68586d5a86d20a563a05b74f119c0  /tmp/ccache.tar.xz" | sha256sum -c -s -; then
+              tar xf /tmp/ccache.tar.xz -C /tmp
+              docker volume create ccache_ext
+              docker create -v ccache_ext:/ccache-ext --name ccseed alpine true
+              docker cp /tmp/ccache-4.11.3-linux-x86_64/ccache ccseed:/ccache-ext/ccache
+              docker rm ccseed
+              CCACHE_ARG="--volume ccache_ext:/ccache-ext --env CCACHE=/ccache-ext/ccache"
+            fi
+            export EXTRA_ARG="--env DEVICE_OS_CI_API_TOKEN=$DEVICE_OS_CI_API_TOKEN --env CI_BUILD_RELEASE=1 --name build --env VERSION=$TAG --env MAKE_JOBS=nproc ${CCACHE_ARG}"
             mkdir -p $HOME/workspace/release/$BUILD_PLATFORM_NORMALIZED
             export BUILD_START=$(date +%s)
             $HOME/firmware-buildpack-builder/scripts/ci | tee $HOME/workspace/release/$BUILD_PLATFORM_NORMALIZED/log | tee >(grep -E '^has_failures [0-9]+ ' > $HOME/failures/has_failures); export TMPRESULT=${PIPESTATUS[0]}

--- a/bootloader/prebootloader/makefile
+++ b/bootloader/prebootloader/makefile
@@ -21,7 +21,14 @@ clean: $(makefiles)
 
 $(makefiles):
 	$(call,echo,'Making module $@')
+ifneq (,$(filter clean,$(SUBDIR_GOALS)))
+	$(VERBOSE)$(MAKE) -C $(dir $@) clean $(MAKE_ARGS) $(MAKEOVERRIDES)
+ifneq (,$(strip $(filter-out clean,$(SUBDIR_GOALS))))
+	$(VERBOSE)$(MAKE) -C $(dir $@) $(filter-out clean,$(SUBDIR_GOALS)) $(MAKE_ARGS) $(MAKEOVERRIDES)
+endif
+else
 	$(VERBOSE)$(MAKE) -C $(dir $@) $(SUBDIR_GOALS) $(MAKE_ARGS) $(MAKEOVERRIDES)
+endif
 
 
 .NOTPARALLEL:

--- a/bootloader/prebootloader/makefile
+++ b/bootloader/prebootloader/makefile
@@ -22,4 +22,6 @@ $(makefiles):
 	$(VERBOSE)$(MAKE) -C $(dir $@) $(SUBDIR_GOALS) $(MAKE_ARGS) $(MAKEOVERRIDES)
 
 
+.NOTPARALLEL:
+
 .PHONY: clean all $(makefiles)

--- a/bootloader/prebootloader/makefile
+++ b/bootloader/prebootloader/makefile
@@ -17,6 +17,8 @@ SUBDIR_GOALS := $(MAKECMDGOALS)
 
 all: $(makefiles)
 
+clean: $(makefiles)
+
 $(makefiles):
 	$(call,echo,'Making module $@')
 	$(VERBOSE)$(MAKE) -C $(dir $@) $(SUBDIR_GOALS) $(MAKE_ARGS) $(MAKEOVERRIDES)

--- a/build/arm-tools.mk
+++ b/build/arm-tools.mk
@@ -113,7 +113,7 @@ USE_LTO=1
 endif
 
 ifeq ($(USE_LTO),1)
-LDFLAGS += -flto -Os -fuse-linker-plugin
+LDFLAGS += -flto=auto -Os -fuse-linker-plugin
 CFLAGS += -fuse-linker-plugin
 else
 # Be explicit and disable LTO

--- a/build/arm-tools.mk
+++ b/build/arm-tools.mk
@@ -121,7 +121,10 @@ LDFLAGS += -fno-lto
 endif
 
 # We are using newlib-nano for all the platforms
-CFLAGS += --specs=nano.specs
+# resolved to a full path, as ccache cannot hash a bare specs file name and
+# falls back to the real compiler for every invocation
+NANO_SPECS := $(or $(shell $(CC) -print-file-name=nano.specs 2>/dev/null),nano.specs)
+CFLAGS += --specs=$(NANO_SPECS)
 
 ifneq ($(LTO_EXTRA_OPTIMIZATIONS),)
 CFLAGS += -fmerge-all-constants -flto-partition=one

--- a/build/macros.mk
+++ b/build/macros.mk
@@ -1,6 +1,11 @@
 include $(COMMON_BUILD)/os.mk
 include $(COMMON_BUILD)/verbose.mk
 
+# opt out with CCACHE=
+ifeq ($(origin CCACHE),undefined)
+CCACHE := $(shell command -v ccache > /dev/null 2>&1 && echo ccache)
+endif
+
 # recursively finds files matching the given pattern
 # $1 is the directory to search for files (should end with a slash)
 # $2 is the wildcard specifying the files to find

--- a/build/module.mk
+++ b/build/module.mk
@@ -105,7 +105,7 @@ none:
 ifeq ($(PLATFORM_MCU),rtl872x)
 .PHONY: rtl-flash
 rtl_module_start_address = $(subst 0x08,0x00,$(call get_module_start_address))
-rtl-flash:
+rtl-flash: | $(TARGET_BASE).bin
 	$(PROJECT_ROOT)/scripts/flash.sh $(PROJECT_ROOT)/scripts/rtl872x.tcl $(TARGET_BASE).bin $(call rtl_module_start_address)
 endif
 

--- a/build/module.mk
+++ b/build/module.mk
@@ -320,9 +320,13 @@ ifneq (,$(filter-out clean,$(MAKECMDGOALS)))
 endif
 endif
 
-# elf_fi relinks and replaces $(TARGET_BASE).elf in place
 ifneq ("$(findstring elf_fi,$(TARGET))","")
 $(TARGET_BASE).bin $(TARGET_BASE).hex $(TARGET_BASE).lst size: | $(TARGET_BASE)_fi.elf
+.NOTPARALLEL:
+endif
+
+ifneq (,$(filter bin,$(TARGET)))
+$(TARGET_BASE).hex $(TARGET_BASE).lst size: | $(TARGET_BASE).bin
 endif
 
 

--- a/build/module.mk
+++ b/build/module.mk
@@ -306,6 +306,19 @@ MAKEFLAGS += --no-builtin-rules
 
 include $(COMMON_BUILD)/recurse.mk
 
+ifneq ($(strip $(ALLOBJ) $(LIB_DEPS) $(LINKER_DEPS)),)
+$(sort $(ALLOBJ) $(LIB_DEPS) $(LINKER_DEPS)): | $(MAKE_DEPENDENCIES) prebuild
+endif
+ifneq ($(strip $(MAKE_DEPENDENCIES)),)
+$(MAKE_DEPENDENCIES): | prebuild
+endif
+postbuild: | $(TARGET)
+
+# elf_fi relinks and replaces $(TARGET_BASE).elf in place
+ifneq ("$(findstring elf_fi,$(TARGET))","")
+$(TARGET_BASE).bin $(TARGET_BASE).hex $(TARGET_BASE).lst size: | $(TARGET_BASE)_fi.elf
+endif
+
 
 # Include auto generated dependency files
 ifneq ("MAKECMDGOALS","clean")

--- a/build/module.mk
+++ b/build/module.mk
@@ -315,7 +315,9 @@ endif
 postbuild: | $(TARGET)
 
 ifneq (,$(filter clean,$(MAKECMDGOALS)))
-prebuild $(MAKE_DEPENDENCIES): | clean
+ifneq (,$(filter-out clean,$(MAKECMDGOALS)))
+.NOTPARALLEL:
+endif
 endif
 
 # elf_fi relinks and replaces $(TARGET_BASE).elf in place

--- a/build/module.mk
+++ b/build/module.mk
@@ -314,6 +314,10 @@ $(MAKE_DEPENDENCIES): | prebuild
 endif
 postbuild: | $(TARGET)
 
+ifneq (,$(filter clean,$(MAKECMDGOALS)))
+prebuild $(MAKE_DEPENDENCIES): | clean
+endif
+
 # elf_fi relinks and replaces $(TARGET_BASE).elf in place
 ifneq ("$(findstring elf_fi,$(TARGET))","")
 $(TARGET_BASE).bin $(TARGET_BASE).hex $(TARGET_BASE).lst size: | $(TARGET_BASE)_fi.elf

--- a/build/recurse.mk
+++ b/build/recurse.mk
@@ -9,7 +9,14 @@ export MODULAR_FIRMWARE
 
 $(MAKE_DEPENDENCIES):
 	$(call,echo,'Making module $@')
+ifneq (,$(filter clean,$(SUBDIR_GOALS)))
+	$(VERBOSE)$(MAKE) -C $(PROJECT_ROOT)/$@ clean
+ifneq (,$(strip $(filter-out clean,$(SUBDIR_GOALS))))
+	$(VERBOSE)$(MAKE) -C $(PROJECT_ROOT)/$@ $(filter-out clean,$(SUBDIR_GOALS))
+endif
+else
 	$(VERBOSE)$(MAKE) -C $(PROJECT_ROOT)/$@ $(SUBDIR_GOALS)
+endif
 
 $(CLEAN_DEPENDENCIES):
 	$(VERBOSE)$(MAKE) -C $(PROJECT_ROOT)/$(patsubst clean_%,%,$@) clean

--- a/build/release-tests.sh
+++ b/build/release-tests.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+MAKE_JOBS=${MAKE_JOBS:-1}
+if [ "$MAKE_JOBS" = "nproc" ]; then
+    MAKE_JOBS=$(nproc)
+fi
+
 function display_help ()
 {
     echo '
@@ -213,7 +218,7 @@ for test_object in $(jq '.platforms[] | select(.platform == "'${PLATFORM}'") | .
     mkdir -p $TEST_DIRECTORY
 
     # Base strings
-    MAKE_COMMAND="make -s all PLATFORM_ID=$PLATFORM_ID"
+    MAKE_COMMAND="make -s -j $MAKE_JOBS all PLATFORM_ID=$PLATFORM_ID"
     QUALIFIED_FILENAME="${PLATFORM}-$(json $test_object .name)@${VERSION}"
 
     # Compose make command and file name

--- a/build/release.sh
+++ b/build/release.sh
@@ -2,6 +2,10 @@
 set -o errexit -o pipefail -o noclobber -o nounset
 
 VERSION=${VERSION:="6.5.0"}
+MAKE_JOBS=${MAKE_JOBS:-1}
+if [ "$MAKE_JOBS" = "nproc" ]; then
+    MAKE_JOBS=$(nproc)
+fi
 
 function display_help ()
 {
@@ -366,8 +370,9 @@ if [ $PLATFORM_ID -eq 12 ] || [ $PLATFORM_ID -eq 13 ] || [ $PLATFORM_ID -eq 15 ]
 
     for app in ${apps[@]}; do
         # Compose, echo and execute the `make` command
-        MAKE_COMMAND="make -s clean all PLATFORM_ID=$PLATFORM_ID COMPILE_LTO=n DEBUG_BUILD=$DEBUG_BUILD MODULAR=$MODULAR USE_SWD_JTAG=$USE_SWD_JTAG USE_SWD=n"
-        MAKE_COMMAND+=" APP=$app"
+        MAKE_ARGS="PLATFORM_ID=$PLATFORM_ID COMPILE_LTO=n DEBUG_BUILD=$DEBUG_BUILD MODULAR=$MODULAR USE_SWD_JTAG=$USE_SWD_JTAG USE_SWD=n"
+        MAKE_ARGS+=" APP=$app"
+        MAKE_COMMAND="make -s clean $MAKE_ARGS && make -s -j $MAKE_JOBS all $MAKE_ARGS"
         echo $MAKE_COMMAND
         eval $MAKE_COMMAND
 
@@ -407,7 +412,8 @@ else
 fi
 
 # Compose, echo and execute the `make` command
-MAKE_COMMAND="make -s clean all PLATFORM_ID=$PLATFORM_ID COMPILE_LTO=$COMPILE_LTO DEBUG_BUILD=$DEBUG_BUILD USE_SWD_JTAG=$USE_SWD_JTAG USE_SWD=n"
+MAKE_ARGS="PLATFORM_ID=$PLATFORM_ID COMPILE_LTO=$COMPILE_LTO DEBUG_BUILD=$DEBUG_BUILD USE_SWD_JTAG=$USE_SWD_JTAG USE_SWD=n"
+MAKE_COMMAND="make -s clean $MAKE_ARGS && make -s -j $MAKE_JOBS all $MAKE_ARGS"
 echo $MAKE_COMMAND
 eval $MAKE_COMMAND
 
@@ -422,7 +428,8 @@ COMPILE_LTO="n"
 DEBUG_BUILD="n"
 SUFFIX="-m"
 
-MAKE_COMMAND="make -s clean all PLATFORM_ID=$PLATFORM_ID COMPILE_LTO=$COMPILE_LTO"
+MAKE_ARGS="PLATFORM_ID=$PLATFORM_ID COMPILE_LTO=$COMPILE_LTO"
+MAKE_COMMAND="make -s clean $MAKE_ARGS && make -s -j $MAKE_JOBS all $MAKE_ARGS"
 echo $MAKE_COMMAND
 eval $MAKE_COMMAND
 

--- a/build/verbose.mk
+++ b/build/verbose.mk
@@ -3,7 +3,9 @@
 # $(VERBOSE) expands to empty or @ to suppress echoing commands in recipes
 # $(call,echo,text) conditionally outputs text if verbose is enabled
 
-ifeq ("$(subst s,,$(MAKEFLAGS))","$(MAKEFLAGS)")
+# short single-letter flags are the first word of MAKEFLAGS; long options
+# (e.g. --jobserver-auth under -j) must not be matched
+ifeq (,$(findstring s,$(firstword $(filter-out --%,$(MAKEFLAGS)))))
 v=1
 else
 v=0

--- a/ci/cf_generate_message.sh
+++ b/ci/cf_generate_message.sh
@@ -24,15 +24,32 @@ flash_suffix() {
         'BEGIN { printf " (%d/%d KiB, %s%%)", int((u + 1023) / 1024), int((a + 1023) / 1024), p }'
 }
 
+time_suffix() {
+    local platform="$1"
+    local duration_file duration
+
+    duration_file="${RELEASE_DIR}/${platform}/duration"
+    if [ ! -f "$duration_file" ]; then
+        return 0
+    fi
+
+    duration="$(tr -cd '0-9' < "$duration_file")"
+    if [ -z "$duration" ]; then
+        return 0
+    fi
+
+    printf ' %dm%02ds' $((duration / 60)) $((duration % 60))
+}
+
 platform_msg() {
     local label="$1"
     local platform
     platform="$(printf '%s' "$label" | tr '[:upper:]' '[:lower:]')"
 
     if echo -e "${failures}" | grep -q "PLATFORM=\"${platform}\""; then
-        echo ":scrum_closed: ${label}$(flash_suffix "${platform}")\\n"
+        echo ":scrum_closed: ${label}$(flash_suffix "${platform}")$(time_suffix "${platform}")\\n"
     else
-        echo ":scrum_finished: ${label}$(flash_suffix "${platform}")\\n"
+        echo ":scrum_finished: ${label}$(flash_suffix "${platform}")$(time_suffix "${platform}")\\n"
     fi
 }
 

--- a/ci/cf_generate_message.sh
+++ b/ci/cf_generate_message.sh
@@ -21,7 +21,7 @@ flash_suffix() {
 
     pct="$(awk -v u="$used" -v a="$available" 'BEGIN { printf "%.1f", (u * 100.0) / a }')"
     awk -v u="$used" -v a="$available" -v p="$pct" \
-        'BEGIN { printf " (%d/%d KiB, %s%%)", int((u + 1023) / 1024), int((a + 1023) / 1024), p }'
+        'BEGIN { printf " %d/%dK %s%%", int((u + 1023) / 1024), int((a + 1023) / 1024), p }'
 }
 
 time_suffix() {
@@ -38,7 +38,7 @@ time_suffix() {
         return 0
     fi
 
-    printf ' %dm%02ds' $((duration / 60)) $((duration % 60))
+    awk -v d="$duration" 'BEGIN { printf " %.1fm", d / 60.0 }'
 }
 
 platform_msg() {

--- a/ci/ci_release.sh
+++ b/ci/ci_release.sh
@@ -33,7 +33,7 @@ for PLATFORM in $CI_RELEASE_PLATFORMS; do
     popd
     ls -laR $TEST_DIR
     rm -rf /firmware/build/target
-    device-os-test --device-os-dir=/firmware --target-dir=$TEST_DIR --binary-dir=$TEST_DIR --config-file=/tmp/test.config.json build $PLATFORM
+    MAKEFLAGS=-j$(nproc) device-os-test --device-os-dir=/firmware --target-dir=$TEST_DIR --binary-dir=$TEST_DIR --config-file=/tmp/test.config.json build $PLATFORM
     testcase "0 PLATFORM=\"$PLATFORM\" device-os-test"
     pushd /firmware/user/tests/integration
     find -L ./ -name '*.spec.js' -exec cp --parents {} $TEST_DIR/$PLATFORM \;

--- a/ci/install_gcovr.sh
+++ b/ci/install_gcovr.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
-#
-# Prerequisites:
-#   git
-#   python
-#   pip
+
 KERNEL_NAME=$(uname -s)
 
 # Fail on errors
@@ -11,34 +7,12 @@ set -e
 
 # MacOS Support
 if [ "${KERNEL_NAME}" == "Darwin" ]; then
-  brew install git python
+  brew install gcovr
 
 # Debian Support
 else
   (apt-get -qq update &&
-  apt-get -qq install git python3-pip libxml2-dev libxslt-dev)
+  apt-get -qq install gcovr zlib1g-dev)
 fi
-
-python3 --version
-
-# get the last version of pip compatible with python 3.5
-# pip3 install --upgrade pip==20.3.4 
-
-pip3 --version
-
-pip3 install requests
-
-# FIXME: Bug with the latest jinja2 (https://github.com/gcovr/gcovr/pull/576) so we'll downgrade for now.
-#        Remove once this is fixed in a new release of gcovr (>5.0)
-pip3 install jinja2==3.0.3
-
-# install a specific gcovr version. May not work if that version isn't compatible with the pip3 version
-pip3 install gcovr==5.0
-
-# install latest stable gcovr version
-# pip3 install gcovr
-
-# install gcovr latest develop branch directly from github
-# pip3 install git+https://github.com/gcovr/gcovr.git
 
 gcovr --version

--- a/main/makefile
+++ b/main/makefile
@@ -72,6 +72,7 @@ include $(COMMON_BUILD)/common-tools.mk
 include $(COMMON_BUILD)/recurse.mk
 include $(COMMON_BUILD)/verbose.mk
 
+.NOTPARALLEL:
 
 .PHONY: program-dfu clean all
 

--- a/makefile
+++ b/makefile
@@ -28,5 +28,6 @@ include $(COMMON_BUILD)/verbose.mk
 clean: clean_deps
 	$(VERBOSE)$(RMDIR) $(BUILD_PATH_BASE)
 
+.NOTPARALLEL:
 
 .PHONY: all

--- a/makefile
+++ b/makefile
@@ -28,6 +28,10 @@ include $(COMMON_BUILD)/verbose.mk
 clean: clean_deps
 	$(VERBOSE)$(RMDIR) $(BUILD_PATH_BASE)
 
+ifneq (,$(filter clean,$(MAKECMDGOALS)))
+$(MAKE_DEPENDENCIES): | clean
+endif
+
 .NOTPARALLEL:
 
 .PHONY: all

--- a/modules/argon/makefile
+++ b/modules/argon/makefile
@@ -1,4 +1,7 @@
 include modular.mk
 
-%:
-	$(MAKE) -C .. $(MAKECMDGOALS) 
+GOALS := $(if $(MAKECMDGOALS),$(MAKECMDGOALS),all)
+.PHONY: $(GOALS) submake
+$(GOALS): submake ;
+submake:
+	$(MAKE) -C .. $(MAKECMDGOALS)

--- a/modules/b5som/makefile
+++ b/modules/b5som/makefile
@@ -1,4 +1,7 @@
 include modular.mk
 
-%:
-	$(MAKE) -C .. $(MAKECMDGOALS) 
+GOALS := $(if $(MAKECMDGOALS),$(MAKECMDGOALS),all)
+.PHONY: $(GOALS) submake
+$(GOALS): submake ;
+submake:
+	$(MAKE) -C .. $(MAKECMDGOALS)

--- a/modules/boron/makefile
+++ b/modules/boron/makefile
@@ -1,4 +1,7 @@
 include modular.mk
 
-%:
-	$(MAKE) -C .. $(MAKECMDGOALS) 
+GOALS := $(if $(MAKECMDGOALS),$(MAKECMDGOALS),all)
+.PHONY: $(GOALS) submake
+$(GOALS): submake ;
+submake:
+	$(MAKE) -C .. $(MAKECMDGOALS)

--- a/modules/electron2/makefile
+++ b/modules/electron2/makefile
@@ -1,4 +1,7 @@
 include modular.mk
 
-%:
-	$(MAKE) -C .. $(MAKECMDGOALS) 
+GOALS := $(if $(MAKECMDGOALS),$(MAKECMDGOALS),all)
+.PHONY: $(GOALS) submake
+$(GOALS): submake ;
+submake:
+	$(MAKE) -C .. $(MAKECMDGOALS)

--- a/modules/makefile
+++ b/modules/makefile
@@ -48,7 +48,14 @@ combined-app:
 
 $(makefiles):
 	$(call,echo,'Making module $@')
+ifneq (,$(filter clean,$(SUBDIR_GOALS)))
+	$(VERBOSE)$(MAKE) -C $(dir $@) clean $(MAKE_ARGS) $(MAKEOVERRIDES)
+ifneq (,$(strip $(filter-out clean,$(SUBDIR_GOALS))))
+	$(VERBOSE)$(MAKE) -C $(dir $@) $(filter-out clean,$(SUBDIR_GOALS)) $(MAKE_ARGS) $(MAKEOVERRIDES)
+endif
+else
 	$(VERBOSE)$(MAKE) -C $(dir $@) $(SUBDIR_GOALS) $(MAKE_ARGS) $(MAKEOVERRIDES)
+endif
 
 make_deps: $(makefiles)
 

--- a/modules/makefile
+++ b/modules/makefile
@@ -52,4 +52,6 @@ $(makefiles):
 
 make_deps: $(makefiles)
 
+.NOTPARALLEL:
+
 .PHONY: system program-dfu clean make_deps $(makefiles)

--- a/modules/msom/makefile
+++ b/modules/msom/makefile
@@ -1,4 +1,7 @@
 include modular.mk
 
-%:
-	$(MAKE) -C .. $(MAKECMDGOALS) 
+GOALS := $(if $(MAKECMDGOALS),$(MAKECMDGOALS),all)
+.PHONY: $(GOALS) submake
+$(GOALS): submake ;
+submake:
+	$(MAKE) -C .. $(MAKECMDGOALS)

--- a/modules/msom/user-part/makefile
+++ b/modules/msom/user-part/makefile
@@ -34,10 +34,11 @@ elf_fi: $(TARGET_BASE)_fi.elf
 prebuild: $(SHARED_MODULAR)/build_linker_script.mk
 	$(call echo,)
 	$(VERBOSE)$(RM) $(MODULE_USER_MEMORY_FILE_GEN)
-	$(VERBOSE)$(RM) $(TARGET_BASE).elf
 	$(VERBOSE)$(MKDIR) $(dir $(MODULE_USER_MEMORY_FILE_GEN))
 	$(VERBOSE)$(MAKE) -f $(SHARED_MODULAR)/build_linker_script.mk PREBUILD=1
 	$(call echo,)
+
+$(TARGET_BASE).elf: prebuild
 
 
 postbuild:

--- a/modules/tracker/makefile
+++ b/modules/tracker/makefile
@@ -1,4 +1,7 @@
 include modular.mk
 
-%:
-	$(MAKE) -C .. $(MAKECMDGOALS) 
+GOALS := $(if $(MAKECMDGOALS),$(MAKECMDGOALS),all)
+.PHONY: $(GOALS) submake
+$(GOALS): submake ;
+submake:
+	$(MAKE) -C .. $(MAKECMDGOALS)

--- a/modules/trackerm/makefile
+++ b/modules/trackerm/makefile
@@ -1,4 +1,7 @@
 include modular.mk
 
-%:
-	$(MAKE) -C .. $(MAKECMDGOALS) 
+GOALS := $(if $(MAKECMDGOALS),$(MAKECMDGOALS),all)
+.PHONY: $(GOALS) submake
+$(GOALS): submake ;
+submake:
+	$(MAKE) -C .. $(MAKECMDGOALS)

--- a/modules/trackerm/user-part/makefile
+++ b/modules/trackerm/user-part/makefile
@@ -34,10 +34,11 @@ elf_fi: $(TARGET_BASE)_fi.elf
 prebuild: $(SHARED_MODULAR)/build_linker_script.mk
 	$(call echo,)
 	$(VERBOSE)$(RM) $(MODULE_USER_MEMORY_FILE_GEN)
-	$(VERBOSE)$(RM) $(TARGET_BASE).elf
 	$(VERBOSE)$(MKDIR) $(dir $(MODULE_USER_MEMORY_FILE_GEN))
 	$(VERBOSE)$(MAKE) -f $(SHARED_MODULAR)/build_linker_script.mk PREBUILD=1
 	$(call echo,)
+
+$(TARGET_BASE).elf: prebuild
 
 
 postbuild:

--- a/modules/tron/makefile
+++ b/modules/tron/makefile
@@ -1,4 +1,7 @@
 include modular.mk
 
-%:
-	$(MAKE) -C .. $(MAKECMDGOALS) 
+GOALS := $(if $(MAKECMDGOALS),$(MAKECMDGOALS),all)
+.PHONY: $(GOALS) submake
+$(GOALS): submake ;
+submake:
+	$(MAKE) -C .. $(MAKECMDGOALS)

--- a/modules/tron/user-part/makefile
+++ b/modules/tron/user-part/makefile
@@ -34,10 +34,11 @@ elf_fi: $(TARGET_BASE)_fi.elf
 prebuild: $(SHARED_MODULAR)/build_linker_script.mk
 	$(call echo,)
 	$(VERBOSE)$(RM) $(MODULE_USER_MEMORY_FILE_GEN)
-	$(VERBOSE)$(RM) $(TARGET_BASE).elf
 	$(VERBOSE)$(MKDIR) $(dir $(MODULE_USER_MEMORY_FILE_GEN))
 	$(VERBOSE)$(MAKE) -f $(SHARED_MODULAR)/build_linker_script.mk PREBUILD=1
 	$(call echo,)
+
+$(TARGET_BASE).elf: prebuild
 
 
 postbuild:


### PR DESCRIPTION
### Problem

1. `make -jXX` has never worked. Recursive make relies on positional ordering of prerequisites in `all: prebuild $(MAKE_DEPENDENCIES) $(TARGET) postbuild`, which only holds for serial builds. Under `-j` the dependency libraries have no rule in the parent make instance (`No rule to make target 'libservices.a'`), submakes race each other in shared build directories and `make clean all -jXX` runs both goals in parallel, cleaning from under an ongoing build.
2. ccache has never worked either: `$(CCACHE)` is referenced in every `module.mk` recipe, but is not defined anywhere. Even when defined manually, bare `--specs=nano.specs` makes ccache bail out on every single compile (`Result: bad_compiler_arguments` - it tries to stat the specs file by its bare name), so nothing was ever cached.
3. CI builds everything single-threaded and rebuilds the same shared unit-test library sources for every one of ~37 test apps per platform. There is also no visibility into per-platform build times.
4. Bonus: CI builds have been running under GNU make 3.82 (2010) all this time - buildtools ships its own `make` into `/root/.particle/bin` which shadows the distro one.

### Solution

Build system:
1. Explicit order-only edges in `module.mk`: `$(ALLOBJ) $(LIB_DEPS) $(LINKER_DEPS): | $(MAKE_DEPENDENCIES) prebuild` and friends, so ordering no longer depends on serial make.
2. `.NOTPARALLEL` in coordinator makefiles that fan out submakes with overlapping dependency graphs (top-level, `modules/`, `main/`, prebootloader). The jobserver is still passed down, so each submake compiles at full `-j`.
3. A single make process cannot safely clean and rebuild the same files (make caches file timestamps across the clean), so coordinators split `clean` into a separate submake invocation and leaf makefiles fall back to serial goal processing when `clean` is combined with build goals.
4. `modules/<platform>/makefile` delegates matched every goal with `%:` and ran the full goal list once per goal (`clean all program-dfu` = three full builds, concurrent under `-j`). Now delegates once.
5. user-part is linked twice (`elf_fi` relinks with a generated RAM layout and replaces the ELF in place) - this flow is not parallel-safe by design, so these modules run their own recipes serially. rtl872x user-part prebuild was also deleting the intermediate ELF mid-run, which under `-j` meant make never relinked it - replaced with a forced relink via a phony prerequisite.
6. `rtl-flash` had no prerequisites at all and could flash a stale binary; `size`/`hex`/`lst` now run after `bin` (the bin recipe post-processes the ELF in place).
7. LTO link uses `-flto=auto` - parallel LTRANS where partitioning allows, no-op with `-flto-partition=one`.
8. `verbose.mk` considered any submake of a `-j` build silent, because `--jobserver-auth` in MAKEFLAGS contains an 's' :sigh:
9. ccache is auto-detected in `macros.mk` (opt out with `CCACHE=`), `--specs` is resolved to a full path so compiles are actually cacheable.

CI:
1. Release builds and device-os-test builds run with `-j$(nproc)`.
2. Buildpack builder bumped to 0.3.0: 26.04 base image used with ccache and removes the buildtools make 3.82 shim, so the distro make is used.
3. Per-platform build times in the Slack report.

Local numbers (16 cores, M SoM):

```
make -C modules PLATFORM=msom APP=tinker clean all       7m03s
make -C modules PLATFORM=msom APP=tinker clean all -j16  1m04s
```

Binaries are bit-identical between serial and `-jXX` builds (`system-part1.bin`/`tinker.bin` sha256-compared on both Gen3  and Gen 4 platforms).

CircleCI per-platform times (serial baseline -> this branch):

```
Argon     38m04s -> 20m45s
Boron     38m36s -> 20m45s
BSoM      46m18s -> 20m32s
B5SoM     42m59s -> 21m17s
Tracker   37m41s -> 18m57s
TrackerM  38m35s -> 18m48s
ESomX     39m08s -> 20m37s
P2        36m09s -> 19m14s
MSoM      34m16s -> 17m34s
Electron2 40m15s -> 19m49s
```

### Steps to Test

- `make PLATFORM=<platform> clean all -jXX` out of `modules/`, `main/`, `bootloader/`, `bootloader/prebootloader/`, also in combination with `program-dfu`
- Incremental `-jXX` builds, `TEST=`/`APP=` builds