### PR TITLE
[test] Fix empty env var tests

### DIFF
--- a/user/tests/integration/00_before/before.cpp
+++ b/user/tests/integration/00_before/before.cpp
@@ -57,7 +57,6 @@ enum class FirmwareUpdateStatus {
 
 auto firmwareUpdateStatus = FirmwareUpdateStatus::NONE;
 std::atomic<int> firmwareUpdateProgressCount;
-static const int ENV_VAR_OTA_TIMEOUT_MS = 30000;
 
 void firmwareUpdateEventHandler(system_event_t, int data, void*) {
     switch (data) {
@@ -119,10 +118,6 @@ void completeFirmwareUpdate(bool expectSafeMode = false) {
     System.enableReset();
 }
 
-bool firmwareUpdateComplete() {
-    return firmwareUpdateStatus == FirmwareUpdateStatus::SUCCESS;
-}
-
 } // namespace
 
 test(01_ota_self_flash_start) {
@@ -171,27 +166,14 @@ test(06_clear_env) {
 }
 
 test(07_restore_cloud_after_env_clear) {
-    prepareForFirmwareUpdate();
     Particle.disconnect(CloudDisconnectOptions().clearSession(true));
     Particle.connect();
     assertTrue(waitFor(Particle.connected, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
-    // We do not know if we will have an env var asset sent to us or none if it is empty
-}
-
-test(08_finalize_env_clear) {
-    // Wait for a potential env var asset ota to come down
-    if (waitFor(firmwareUpdateComplete, ENV_VAR_OTA_TIMEOUT_MS)) {
-        Log.info("Cloud pushed env vars down, reset expected");
-        completeFirmwareUpdate();
-    } else {
-        System.off(firmware_update);
-        System.enableReset();
-    }
 }
 
 #endif // HAL_PLATFORM_ENV
 
-test(09_disable_external_rtc) {
+test(08_disable_external_rtc) {
 #if HAL_PLATFORM_EXTERNAL_RTC
     assertEqual(ExternalTime.disable(), (int)SYSTEM_ERROR_NONE);
     expectSystemReset();
@@ -199,7 +181,7 @@ test(09_disable_external_rtc) {
 #endif
 }
 
-test(10_verify_external_rtc_default_state) {
+test(09_verify_external_rtc_default_state) {
 #if HAL_PLATFORM_EXTERNAL_RTC
     const auto status = ExternalTime.status();
     assertTrue(status.valid());
@@ -213,7 +195,7 @@ test(10_verify_external_rtc_default_state) {
 #endif
 }
 
-test(11_report_muon_presence) {
+test(10_report_muon_presence) {
 #if HAL_PLATFORM_EXTERNAL_RTC_OPTIONAL && HAL_PLATFORM_HW_FORM_FACTOR_SOM
     assertEqual(0, pushMailboxMsg(particle::test::detectMuonBoard() ? "muon=true" : "muon=false", 5000));
 #else
@@ -221,7 +203,7 @@ test(11_report_muon_presence) {
 #endif
 }
 
-test(12_configure_muon_board_and_exrtc) {
+test(11_configure_muon_board_and_exrtc) {
 #if HAL_PLATFORM_EXTERNAL_RTC_OPTIONAL && HAL_PLATFORM_HW_FORM_FACTOR_SOM
     if (!particle::test::detectMuonBoard()) {
         skip();
@@ -234,7 +216,7 @@ test(12_configure_muon_board_and_exrtc) {
 #endif
 }
 
-test(13_verify_muon_exrtc_configuration) {
+test(12_verify_muon_exrtc_configuration) {
 #if HAL_PLATFORM_EXTERNAL_RTC_OPTIONAL && HAL_PLATFORM_HW_FORM_FACTOR_SOM
     if (!particle::test::detectMuonBoard()) {
         skip();

--- a/user/tests/integration/00_before/before.cpp
+++ b/user/tests/integration/00_before/before.cpp
@@ -57,6 +57,7 @@ enum class FirmwareUpdateStatus {
 
 auto firmwareUpdateStatus = FirmwareUpdateStatus::NONE;
 std::atomic<int> firmwareUpdateProgressCount;
+static const int ENV_VAR_OTA_TIMEOUT_MS = 30000;
 
 void firmwareUpdateEventHandler(system_event_t, int data, void*) {
     switch (data) {
@@ -118,6 +119,10 @@ void completeFirmwareUpdate(bool expectSafeMode = false) {
     System.enableReset();
 }
 
+bool firmwareUpdateComplete() {
+    return firmwareUpdateStatus == FirmwareUpdateStatus::SUCCESS;
+}
+
 } // namespace
 
 test(01_ota_self_flash_start) {
@@ -170,11 +175,18 @@ test(07_restore_cloud_after_env_clear) {
     Particle.disconnect(CloudDisconnectOptions().clearSession(true));
     Particle.connect();
     assertTrue(waitFor(Particle.connected, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
-    // We are supposed to get an empty env
+    // We do not know if we will have an env var asset sent to us or none if it is empty
 }
 
 test(08_finalize_env_clear) {
-    completeFirmwareUpdate();
+    // Wait for a potential env var asset ota to come down
+    if (waitFor(firmwareUpdateComplete, ENV_VAR_OTA_TIMEOUT_MS)) {
+        Log.info("Cloud pushed env vars down, reset expected");
+        completeFirmwareUpdate();
+    } else {
+        System.off(firmware_update);
+        System.enableReset();
+    }
 }
 
 #endif // HAL_PLATFORM_ENV

--- a/user/tests/integration/00_before/before.spec.js
+++ b/user/tests/integration/00_before/before.spec.js
@@ -61,13 +61,15 @@ test('06_clear_env', async function () {
 });
 
 test('07_restore_cloud_after_env_clear', async function () {
-    await waitFlashStatusEvent(this, { status: 'success' });
+
 });
 
 test('08_finalize_env_clear', async function () {
+
 });
 
 test('09_disable_external_rtc', async function() {
+
 });
 
 test('10_verify_external_rtc_default_state', async function() {

--- a/user/tests/integration/00_before/before.spec.js
+++ b/user/tests/integration/00_before/before.spec.js
@@ -64,28 +64,24 @@ test('07_restore_cloud_after_env_clear', async function () {
 
 });
 
-test('08_finalize_env_clear', async function () {
+test('08_disable_external_rtc', async function() {
 
 });
 
-test('09_disable_external_rtc', async function() {
+test('09_verify_external_rtc_default_state', async function() {
 
 });
 
-test('10_verify_external_rtc_default_state', async function() {
-
-});
-
-test('11_report_muon_presence', async function() {
+test('10_report_muon_presence', async function() {
     const msg = device.mailBox.pop();
     console.log(`Muon detected: ${msg.d === 'muon=true' ? 'yes' : 'no'}`);
 });
 
-test('12_configure_muon_board_and_exrtc', async function() {
+test('11_configure_muon_board_and_exrtc', async function() {
 
 });
 
-test('13_verify_muon_exrtc_configuration', async function() {
+test('12_verify_muon_exrtc_configuration', async function() {
 
 });
 

--- a/user/tests/integration/ota/env/env.cpp
+++ b/user/tests/integration/ota/env/env.cpp
@@ -491,7 +491,7 @@ test(15_check_immediate_device_env_update) {
     assertEqual(System.getEnv("DEV_VAR2"), String("dev 2 ") + nonce);
 }
 
-test(97_cleanup) {
+test(98_cleanup) {
     expectSystemReset();
     System.clearEnv(false /* reset */);
     unlink("/sys/env_app");
@@ -502,24 +502,8 @@ test(97_cleanup) {
     System.reset();
 }
 
-test(98_cleanup) {
-    prepareForFirmwareUpdate();
+test(99_cleanup) {
     Particle.disconnect(CloudDisconnectOptions().clearSession(true));
     Particle.connect();
     assertTrue(waitFor(Particle.connected, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
-    // We are supposed to get an empty env
-}
-
-test(99_cleanup_1) {
-    completeFirmwareUpdate();
-}
-
-test(99_cleanup_2) {
-    if (firmwareUpdateStatus != FirmwareUpdateStatus::SUCCESS) {
-        expectSystemReset();
-        System.enableReset();
-        // Should normally be unreachable
-        delay(5000);
-        System.reset();
-    }
 }

--- a/user/tests/integration/ota/env/env.spec.js
+++ b/user/tests/integration/ota/env/env.spec.js
@@ -224,18 +224,10 @@ test('14_complete_immediate_device_env_update_2', async function() {
 test('15_check_immediate_device_env_update', async function() {
 });
 
-test('97_cleanup', async function() {
+test('98_cleanup', async function() {
 	await unsetDeviceVariables(api, deviceId);
 });
 
-test('98_cleanup', async function() {
-	await waitFlashStatusEvent(this, { status: 'success' });
+test('99_cleanup', async function() {
 });
 
-test('99_cleanup_1', async function() {
-	
-});
-
-test('99_cleanup_2', async function() {
-	
-});

--- a/user/tests/integration/slo/startup/startup-slos.cpp
+++ b/user/tests/integration/slo/startup/startup-slos.cpp
@@ -167,23 +167,7 @@ test(03_slo_startup_stats) {
 }
 
 test(98_cleanup) {
-    prepareForFirmwareUpdate();
     Particle.disconnect(CloudDisconnectOptions().clearSession(true));
     Particle.connect();
     assertTrue(waitFor(Particle.connected, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
-    // We are supposed to get an empty env
-}
-
-test(99_cleanup_1) {
-    completeFirmwareUpdate();
-}
-
-test(99_cleanup_2) {
-    if (firmwareUpdateStatus != FirmwareUpdateStatus::SUCCESS) {
-        expectSystemReset();
-        System.enableReset();
-        // Should normally be unreachable
-        delay(5000);
-        System.reset();
-    }
 }

--- a/user/tests/integration/slo/startup/startup-slos.spec.js
+++ b/user/tests/integration/slo/startup/startup-slos.spec.js
@@ -173,13 +173,4 @@ test('03_slo_startup_stats', async function () {
 });
 
 test('98_cleanup', async function() {
-    await waitFlashStatusEvent(this, { status: 'success' });
-});
-
-test('99_cleanup_1', async function() {
-
-});
-
-test('99_cleanup_2', async function() {
-
 });

--- a/user/tests/integration/system/cellular_env/cellular_env.cpp
+++ b/user/tests/integration/system/cellular_env/cellular_env.cpp
@@ -636,38 +636,13 @@ test(98_cleanup) {
         skip();
         return;
     }
-    prepareForFirmwareUpdate();
     Particle.disconnect(CloudDisconnectOptions().clearSession(true));
     Particle.connect();
     assertTrue(waitFor(Particle.connected, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
-    // We are supposed to get an empty env
-}
-
-test(99_cleanup_1) {
-    if (g_SkipTests) {
-        skip();
-        return;
-    }
-    completeFirmwareUpdate();
-}
-
-test(99_cleanup_2) {
-    if (g_SkipTests) {
-        skip();
-        return;
-    }
-
-    if (firmwareUpdateStatus != FirmwareUpdateStatus::SUCCESS) {
-        expectSystemReset();
-        System.enableReset();
-        // Should normally be unreachable
-        delay(5000);
-        System.reset();
-    }
 }
 
 #if HAL_PLATFORM_CELLULAR
-test(99_cleanup_3_verify_defaults) {
+test(99_cleanup_verify_defaults) {
     if (g_SkipTests || getModemType() == ModemType::UNSUPPORTED) {
         skip();
         return;

--- a/user/tests/integration/system/cellular_env/cellular_env.spec.js
+++ b/user/tests/integration/system/cellular_env/cellular_env.spec.js
@@ -116,18 +116,10 @@ test('97_cleanup', async function() {
 });
 
 test('98_cleanup', async function() {
-    await waitFlashStatusEvent(this, { status: 'success' });
-});
-
-test('99_cleanup_1', async function() {
 
 });
 
-test('99_cleanup_2', async function() {
-
-});
-
-test('99_cleanup_3_verify_defaults', async function () {
+test('99_cleanup_verify_defaults', async function () {
     expect(device.mailBox).to.not.be.empty;
     console.log(device.mailBox[0].d);
 });

--- a/user/tests/integration/system/env/env.cpp
+++ b/user/tests/integration/system/env/env.cpp
@@ -804,23 +804,7 @@ test(97_cleanup) {
 }
 
 test(98_cleanup) {
-    prepareForFirmwareUpdate();
     Particle.disconnect(CloudDisconnectOptions().clearSession(true));
     Particle.connect();
     assertTrue(waitFor(Particle.connected, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
-    // We are supposed to get an empty env
-}
-
-test(99_cleanup_1) {
-    completeFirmwareUpdate();
-}
-
-test(99_cleanup_2) {
-    if (firmwareUpdateStatus != FirmwareUpdateStatus::SUCCESS) {
-        expectSystemReset();
-        System.enableReset();
-        // Should normally be unreachable
-        delay(5000);
-        System.reset();
-    }
 }

--- a/user/tests/integration/system/env/env.spec.js
+++ b/user/tests/integration/system/env/env.spec.js
@@ -140,15 +140,4 @@ test('97_cleanup', async function() {
 });
 
 test('98_cleanup', async function() {
-    await waitFlashStatusEvent(this, { status: 'success' });
-});
-
-test('99_cleanup_1', async function() {
-    delete this.test.parent.particle.network;
-    this.test.parent.particle.suiteInitialized = false;
-});
-
-test('99_cleanup_2', async function() {
-    delete this.test.parent.particle.network;
-    this.test.parent.particle.suiteInitialized = false;
 });

--- a/user/tests/integration/zz_after/after.cpp
+++ b/user/tests/integration/zz_after/after.cpp
@@ -155,29 +155,14 @@ test(04_clear_env) {
 }
 
 test(05_restore_cloud_after_env_clear) {
-    prepareForFirmwareUpdate();
     Particle.disconnect(CloudDisconnectOptions().clearSession(true));
     Particle.connect();
     assertTrue(waitFor(Particle.connected, HAL_PLATFORM_MAX_CLOUD_CONNECT_TIME));
-    // We are supposed to get an empty env
 }
 
-test(06_finalize_env_clear_1) {
-    completeFirmwareUpdate();
-}
-
-test(06_finalize_env_clear_2) {
-    if (firmwareUpdateStatus != FirmwareUpdateStatus::SUCCESS) {
-        expectSystemReset();
-        System.enableReset();
-        // Should normally be unreachable
-        delay(5000);
-        System.reset();
-    }
-}
 #endif // HAL_PLATFORM_ENV
 
-test(07_disable_external_rtc) {
+test(06_disable_external_rtc) {
 #if HAL_PLATFORM_EXTERNAL_RTC
     assertEqual(ExternalTime.disable(), (int)SYSTEM_ERROR_NONE);
     expectSystemReset();
@@ -185,7 +170,7 @@ test(07_disable_external_rtc) {
 #endif
 }
 
-test(08_verify_external_rtc_default_state) {
+test(07_verify_external_rtc_default_state) {
 #if HAL_PLATFORM_EXTERNAL_RTC
     const auto status = ExternalTime.status();
     assertTrue(status.valid());
@@ -199,7 +184,7 @@ test(08_verify_external_rtc_default_state) {
 #endif
 }
 
-test(09_unconfigure_muon_board) {
+test(08_unconfigure_muon_board) {
 #if HAL_PLATFORM_EXTERNAL_RTC_OPTIONAL && HAL_PLATFORM_HW_FORM_FACTOR_SOM
     if (!particle::test::detectMuonBoard()) {
         skip();
@@ -211,7 +196,7 @@ test(09_unconfigure_muon_board) {
 #endif
 }
 
-test(10_verify_muon_board_unconfigured) {
+test(09_verify_muon_board_unconfigured) {
 #if HAL_PLATFORM_EXTERNAL_RTC_OPTIONAL && HAL_PLATFORM_HW_FORM_FACTOR_SOM
     if (!particle::test::detectMuonBoard()) {
         skip();

--- a/user/tests/integration/zz_after/after.spec.js
+++ b/user/tests/integration/zz_after/after.spec.js
@@ -39,25 +39,18 @@ test('04_clear_env', async function () {
 });
 
 test('05_restore_cloud_after_env_clear', async function () {
-    await waitFlashStatusEvent(this, { status: 'success' });
 });
 
-test('06_finalize_env_clear_1', async function () {
+test('06_disable_external_rtc', async function () {
 });
 
-test('06_finalize_env_clear_2', async function () {
+test('07_verify_external_rtc_default_state', async function () {
 });
 
-test('07_disable_external_rtc', async function () {
+test('08_unconfigure_muon_board', async function () {
 });
 
-test('08_verify_external_rtc_default_state', async function () {
-});
-
-test('09_unconfigure_muon_board', async function () {
-});
-
-test('10_verify_muon_board_unconfigured', async function () {
+test('09_verify_muon_board_unconfigured', async function () {
 });
 
 after(function() {


### PR DESCRIPTION
### Problem

Concourse tests started failing env var tests. The change is due to device service behavior when sending empty env var asset OTAs. Previously, Device Service would send an empty env var asset which would trigger a device reboot to apply it. As of August 2026 Device service no longer has this behavior so the tests should not need to account for it. 
### Solution

Remove expected reset from affected tests. Device and product level HIL organizations should always have no cloud side env vars. 


### Steps to Test

```
device-os-test --device-os-dir=path/to/dir run msom 00_before ota/env slo/startup system/cellular_env system/env zz_after
```

### References

[Discussion thread](https://s.slack.com/archives/C8QH35A73/p1787944101422009)

