### PR TITLE
[gen3] [rtl872x] Fix hal malloc deadlocks

### DIFF
--- a/hal/src/nRF52840/core_hal.c
+++ b/hal/src/nRF52840/core_hal.c
@@ -747,6 +747,9 @@ static void init_malloc_mutex(void) {
 
 void __malloc_lock(struct _reent *ptr) {
     if (malloc_mutex) {
+#ifdef DEBUG_BUILD
+        SPARK_ASSERT(xTaskGetSchedulerState() != taskSCHEDULER_SUSPENDED);
+#endif
         if (!xSemaphoreTakeRecursive(malloc_mutex, MALLOC_LOCK_TIMEOUT_MS)) {
             PANIC(HeapError, "Semaphore Lock Timeout");
             while (1);

--- a/hal/src/nRF52840/core_hal.c
+++ b/hal/src/nRF52840/core_hal.c
@@ -747,9 +747,9 @@ static void init_malloc_mutex(void) {
 
 void __malloc_lock(struct _reent *ptr) {
     if (malloc_mutex) {
-#ifdef DEBUG_BUILD
-        SPARK_ASSERT(xTaskGetSchedulerState() != taskSCHEDULER_SUSPENDED);
-#endif
+        if (xTaskGetSchedulerState() == taskSCHEDULER_SUSPENDED) {
+            PANIC(HeapError, "malloc while suspended");
+        }
         if (!xSemaphoreTakeRecursive(malloc_mutex, MALLOC_LOCK_TIMEOUT_MS)) {
             PANIC(HeapError, "Semaphore Lock Timeout");
             while (1);

--- a/hal/src/nRF52840/i2c_hal.cpp
+++ b/hal/src/nRF52840/i2c_hal.cpp
@@ -327,14 +327,23 @@ static bool isConfigValid(const hal_i2c_config_t* config) {
 
 int hal_i2c_init(hal_i2c_interface_t i2c, const hal_i2c_config_t* config) {
     CHECK_TRUE(i2c < HAL_PLATFORM_I2C_NUM, SYSTEM_ERROR_INVALID_ARGUMENT);
-    // Disable threading to create the I2C mutex
-    os_thread_scheduling(false, nullptr);
+
     if (i2cMap[i2c].mutex == nullptr) {
-        os_mutex_recursive_create(&i2cMap[i2c].mutex);
+        os_mutex_recursive_t mutex = nullptr;
+        CHECK_TRUE(os_mutex_recursive_create(&mutex) == 0, SYSTEM_ERROR_NO_MEMORY);
+
+        os_thread_scheduling(false, nullptr);
+        if (i2cMap[i2c].mutex == nullptr) {
+            std::swap(mutex, i2cMap[i2c].mutex);
+        }
+        os_thread_scheduling(true, nullptr);
+
+        if (mutex) {
+            // Another thread got here first, destroy ours
+            os_mutex_recursive_destroy(mutex);
+        }
     }
 
-    // Re-enable threading and capture the mutex
-    os_thread_scheduling(true, nullptr);
     I2cLock lk(i2c);
 
 // sc-137389

--- a/hal/src/nRF52840/spi_hal.cpp
+++ b/hal/src/nRF52840/spi_hal.cpp
@@ -342,11 +342,26 @@ static void spiTransferCancel(hal_spi_interface_t spi) {
 }
 
 void hal_spi_init(hal_spi_interface_t spi) {
-    os_thread_scheduling(false, nullptr);
-    if (spiMap[spi].mutex == nullptr) {
-        os_mutex_recursive_create(&spiMap[spi].mutex);
+    if (spi >= HAL_PLATFORM_SPI_NUM) {
+        return;
     }
-    os_thread_scheduling(true, nullptr);
+
+    if (spiMap[spi].mutex == nullptr) {
+        os_mutex_recursive_t mutex = nullptr;
+        os_mutex_recursive_create(&mutex);
+        SPARK_ASSERT(mutex);
+
+        os_thread_scheduling(false, nullptr);
+        if (spiMap[spi].mutex == nullptr) {
+            std::swap(spiMap[spi].mutex, mutex);
+        }
+        os_thread_scheduling(true, nullptr);
+
+        if (mutex) {
+            // Another thread got here first, destroy ours
+            os_mutex_recursive_destroy(mutex);
+        }
+    }
 
     hal_spi_acquire(spi, nullptr);
 

--- a/hal/src/rtl872x/core_hal.c
+++ b/hal/src/rtl872x/core_hal.c
@@ -684,6 +684,9 @@ static void init_malloc_mutex(void) {
 
 void __malloc_lock(struct _reent *ptr) {
     if (malloc_mutex) {
+#ifdef DEBUG_BUILD
+        SPARK_ASSERT(xTaskGetSchedulerState() != taskSCHEDULER_SUSPENDED);
+#endif
         if (!xSemaphoreTakeRecursive(malloc_mutex, MALLOC_LOCK_TIMEOUT_MS)) {
             PANIC(HeapError, "Semaphore Lock Timeout");
             while (1);

--- a/hal/src/rtl872x/core_hal.c
+++ b/hal/src/rtl872x/core_hal.c
@@ -684,9 +684,9 @@ static void init_malloc_mutex(void) {
 
 void __malloc_lock(struct _reent *ptr) {
     if (malloc_mutex) {
-#ifdef DEBUG_BUILD
-        SPARK_ASSERT(xTaskGetSchedulerState() != taskSCHEDULER_SUSPENDED);
-#endif
+        if (xTaskGetSchedulerState() == taskSCHEDULER_SUSPENDED) {
+            PANIC(HeapError, "malloc while suspended");
+        }
         if (!xSemaphoreTakeRecursive(malloc_mutex, MALLOC_LOCK_TIMEOUT_MS)) {
             PANIC(HeapError, "Semaphore Lock Timeout");
             while (1);

--- a/hal/src/rtl872x/i2c_hal.cpp
+++ b/hal/src/rtl872x/i2c_hal.cpp
@@ -87,11 +87,22 @@ public:
     }
 
     int init(const hal_i2c_config_t* conf) {
-        os_thread_scheduling(false, nullptr);
-        if (!mutex_) {
-            os_mutex_recursive_create(&mutex_);
+        if (mutex_ == nullptr) {
+            os_mutex_recursive_t mutex = nullptr;
+            CHECK_TRUE(os_mutex_recursive_create(&mutex) == 0, SYSTEM_ERROR_NO_MEMORY);
+
+            os_thread_scheduling(false, nullptr);
+            if (mutex_ == nullptr) {
+                std::swap(mutex, mutex_);
+            }
+            os_thread_scheduling(true, nullptr);
+
+            if (mutex) {
+                // Another thread got here first, destroy ours
+                os_mutex_recursive_destroy(mutex);
+            }
         }
-        os_thread_scheduling(true, nullptr);
+
         lock();
         if (state_ != HAL_I2C_STATE_NOT_INITIALIZED) {
             // Configured, but new buffers are invalid

--- a/hal/src/rtl872x/spi_hal.cpp
+++ b/hal/src/rtl872x/spi_hal.cpp
@@ -188,11 +188,21 @@ public:
     }
 
     int init() {
-        os_thread_scheduling(false, nullptr);
         if (mutex_ == nullptr) {
-            os_mutex_recursive_create(&mutex_);
+            os_mutex_recursive_t mutex = nullptr;
+            CHECK_TRUE(os_mutex_recursive_create(&mutex) == 0, SYSTEM_ERROR_NO_MEMORY);
+
+            os_thread_scheduling(false, nullptr);
+            if (mutex_ == nullptr) {
+                std::swap(mutex, mutex_);
+            }
+            os_thread_scheduling(true, nullptr);
+
+            if (mutex) {
+                // Another thread got here first, destroy ours
+                os_mutex_recursive_destroy(mutex);
+            }
         }
-        os_thread_scheduling(true, nullptr);
 
         // Enable SPI Clock
         if (rtlSpiIndex_ == 0) {
@@ -213,7 +223,15 @@ public:
 
     int deinit() {
         end();
-        os_mutex_recursive_destroy(&mutex_);
+
+        os_thread_scheduling(false, nullptr);
+        auto mutex = mutex_;
+        mutex_ = nullptr;
+        os_thread_scheduling(true, nullptr);
+
+        if (mutex) {
+            os_mutex_recursive_destroy(mutex);
+        }
         return SYSTEM_ERROR_NONE;
     }
 

--- a/hal/src/rtl872x/spi_hal.cpp
+++ b/hal/src/rtl872x/spi_hal.cpp
@@ -221,20 +221,6 @@ public:
         return SYSTEM_ERROR_NONE;
     }
 
-    int deinit() {
-        end();
-
-        os_thread_scheduling(false, nullptr);
-        auto mutex = mutex_;
-        mutex_ = nullptr;
-        os_thread_scheduling(true, nullptr);
-
-        if (mutex) {
-            os_mutex_recursive_destroy(mutex);
-        }
-        return SYSTEM_ERROR_NONE;
-    }
-
     int setSettings(const SpiConfig& config, const hal_spi_config_t* spiConfig = nullptr, bool force = false) {
         CHECK_TRUE(validateConfig(rtlSpiIndex_, config), SYSTEM_ERROR_INVALID_ARGUMENT);
         // Save config

--- a/wiring/src/spark_wiring_tcpserver_posix.cpp
+++ b/wiring/src/spark_wiring_tcpserver_posix.cpp
@@ -61,10 +61,14 @@ TCPServer::TCPServer(uint16_t port, network_interface_t nif)
           _nif(nif),
           _sock(-1),
           _client(-1) {
-    SINGLE_THREADED_BLOCK() {
-        if (!s_invalid_client) {
-            s_invalid_client = new TCPClient(-1);
+    if (!s_invalid_client) {
+        auto client = new TCPClient(-1);
+        SINGLE_THREADED_BLOCK() {
+            if (!s_invalid_client) {
+                std::swap(s_invalid_client, client);
+            }
         }
+        delete client;
     }
 }
 


### PR DESCRIPTION
### Problem

I observed a deadlock on boot with an MSOM. 

The backtrace showed contention on the malloc mutex between system thread and user application thread. Something was trying to malloc with scheduling disabled, which resulted in the deadlock.

### Solution

Investigation showed that its possible to deadlock during SPI and I2C hal initialization if the auxiliary power setting and ethernet detection is enabled on an msom (for example, on muon configuration). The Wiznet ethernet 'probe' is deferred to the user thread. If it happens to execute while the system thread holds the malloc mutex it can dead lock.

The solution is to allocate the HAL mutexes without disabling scheduling, and then swapping the created mutexes as needed under the section with scheduling disabled. 

This problem was present in a couple of places and was fixed similarly in all of them. 

Also, added an explicit assert in the malloc lock to PANIC if this condition is detected going forward. 

### Steps to Test
This condition is easy to replicate if you stress the malloc critical section see below

### Example App
This snippet when added to user app generates deadlocks reliably. With these PR changes it does not.

```c
static os_thread_t s_hammer;
static void mallocHammer(void*) {
    for (;;) { void* p = malloc(64); free(p); }
}

void setup()
{
    // Enable configuration at least once
    SystemPowerConfiguration powerConfig = System.getPowerConfiguration();
    powerConfig.auxiliaryPowerControlPin(D7).interruptPin(A7);
    System.setPowerConfiguration(powerConfig);

    System.enableFeature(FEATURE_ETHERNET_DETECTION);

    os_thread_create(&s_hammer, "hammer", OS_THREAD_PRIORITY_DEFAULT, mallocHammer, nullptr, 1024);
    SPI1.begin();
    Wire.begin();
...
}

```

### References

[Internal discussion](https://s.slack.com/archives/C8QH35A73/p1788478919392809)

